### PR TITLE
feat(#44): support for read-only mode

### DIFF
--- a/docker/evita-configuration.yaml
+++ b/docker/evita-configuration.yaml
@@ -4,6 +4,7 @@ server:
   threadPriority: ${server.threadPriority:5}
   queueSize: ${server.queueSize:100}
   closeSessionsAfterSecondsOfInactivity: ${server.closeSessionsAfterSecondsOfInactivity:60}
+  readOnly: ${server.readOnly:false}
 
 storage:
   storageDirectory: ${storage.storageDirectory:null}

--- a/docs/user/en/operate/configure.md
+++ b/docs/user/en/operate/configure.md
@@ -17,6 +17,7 @@ server:                                           # [see Server configuration](#
   threadPriority: 5
   queueSize: 100
   closeSessionsAfterSecondsOfInactivity: 60
+  readOnly: false
 
 storage:                                          # [see Storage configuration](#storage-configuration)
   storageDirectory: null
@@ -234,6 +235,12 @@ This section contains general settings for the evitaDB server. It allows configu
         <p>It specifies the maximum acceptable period of 
         <SourceClass>evita_api/src/main/java/io/evitadb/api/EvitaSessionContract.java</SourceClass> inactivity before 
         it is forcibly closed by the server side.</p>
+    </dd>
+    <dt>readOnly</dt>
+    <dd>
+        <p>**Default: `false`**</p>
+        <p>It switches the evitaDB server into read-only mode, where no updates are allowed and the server only provides 
+           read access to the data of the catalogs present in the data directory at the start of the server instance.</p>
     </dd>
 </dl>
 

--- a/evita_api/src/main/java/io/evitadb/api/configuration/ServerOptions.java
+++ b/evita_api/src/main/java/io/evitadb/api/configuration/ServerOptions.java
@@ -23,6 +23,8 @@
 
 package io.evitadb.api.configuration;
 
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.requestResponse.data.EntityContract;
 import lombok.ToString;
 
 /**
@@ -39,6 +41,9 @@ import lombok.ToString;
  * @param queueSize                             maximum amount of task accepted to thread pool to wait for a free thread
  * @param closeSessionsAfterSecondsOfInactivity sets the timeout in seconds after which the session is closed
  *                                              automatically if there is no activity observed on it
+ * @param readOnly                              starts the database in full read-only mode that forbids to execute write
+ *                                              operations on {@link EntityContract} level and open read-write
+ *                                              {@link EvitaSessionContract}
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public record ServerOptions(
@@ -46,7 +51,8 @@ public record ServerOptions(
 	int maxThreadCount,
 	int threadPriority,
 	int queueSize,
-	int closeSessionsAfterSecondsOfInactivity
+	int closeSessionsAfterSecondsOfInactivity,
+	boolean readOnly
 ) {
 
 	public static final int DEFAULT_CORE_THREAD_COUNT = Runtime.getRuntime().availableProcessors() * 10;
@@ -68,7 +74,8 @@ public record ServerOptions(
 			DEFAULT_MAX_THREAD_COUNT,
 			DEFAULT_THREAD_PRIORITY,
 			DEFAULT_QUEUE_SIZE,
-			DEFAULT_CLOSE_SESSIONS_AFTER_SECONDS_OF_INACTIVITY
+			DEFAULT_CLOSE_SESSIONS_AFTER_SECONDS_OF_INACTIVITY,
+			false
 		);
 	}
 
@@ -82,6 +89,7 @@ public record ServerOptions(
 		private int threadPriority = DEFAULT_THREAD_PRIORITY;
 		private int queueSize = DEFAULT_QUEUE_SIZE;
 		private int closeSessionsAfterSecondsOfInactivity = DEFAULT_CLOSE_SESSIONS_AFTER_SECONDS_OF_INACTIVITY;
+		private boolean readOnly = false;
 
 		Builder() {
 		}
@@ -111,13 +119,19 @@ public record ServerOptions(
 			return this;
 		}
 
+		public ServerOptions.Builder readOnly(boolean readOnly) {
+			this.readOnly = readOnly;
+			return this;
+		}
+
 		public ServerOptions build() {
 			return new ServerOptions(
 				coreThreadCount,
 				maxThreadCount,
 				threadPriority,
 				queueSize,
-				closeSessionsAfterSecondsOfInactivity
+				closeSessionsAfterSecondsOfInactivity,
+				readOnly
 			);
 		}
 

--- a/evita_api/src/main/java/io/evitadb/api/exception/ReadOnlyException.java
+++ b/evita_api/src/main/java/io/evitadb/api/exception/ReadOnlyException.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/main/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.exception;
+
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.exception.EvitaInvalidUsageException;
+
+import java.io.Serial;
+
+/**
+ * Exception is thrown when the global {@link ServerOptions#readOnly()} flag is enabled and the client attempts
+ * to update evitaDB data.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
+ */
+public class ReadOnlyException extends EvitaInvalidUsageException {
+	@Serial private static final long serialVersionUID = 8880217332792347590L;
+
+	public ReadOnlyException() {
+		super("The evitaDB server is started in read-only mode. No updates are allowed!");
+	}
+
+}

--- a/evita_functional_tests/src/test/java/io/evitadb/core/ReadOnlyEvitaTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/core/ReadOnlyEvitaTest.java
@@ -1,0 +1,136 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/main/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.SessionTraits;
+import io.evitadb.api.SessionTraits.SessionFlags;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.exception.ReadOnlyException;
+import io.evitadb.core.sequence.SequenceService;
+import io.evitadb.test.Entities;
+import io.evitadb.test.TestFileSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * This test contains integration tests for read-only {@link Evita}.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
+ */
+class ReadOnlyEvitaTest implements TestFileSupport {
+	public static final String ATTRIBUTE_NAME = "name";
+	public static final String ATTRIBUTE_URL = "url";
+	private static final String TEST_CATALOG = "testCatalog";
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() throws IOException {
+		SequenceService.reset();
+		cleanTestDirectory();
+		evita = new Evita(
+			getEvitaConfiguration(false)
+		);
+		evita.defineCatalog(TEST_CATALOG);
+		/* first update the catalog the standard way */
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withAttribute(ATTRIBUTE_NAME, String.class)
+					.withDescription("Test")
+					.updateVia(session);
+				session.createNewEntity(Entities.PRODUCT)
+					.setAttribute(ATTRIBUTE_NAME, "someProduct")
+					.upsertVia(session);
+				session.goLiveAndClose();
+			}
+		);
+		evita.close();
+
+		evita = new Evita(
+			getEvitaConfiguration(true)
+		);
+	}
+
+	@Test
+	void shouldFailToCreateCatalog() {
+		assertThrows(ReadOnlyException.class, () -> evita.defineCatalog("differentCatalog"));
+	}
+
+	@Test
+	void shouldFailToDropExistingCatalog() {
+		assertThrows(ReadOnlyException.class, () -> evita.deleteCatalogIfExists(TEST_CATALOG));
+	}
+
+	@Test
+	void shouldFailToRenameExistingCatalog() {
+		assertThrows(ReadOnlyException.class, () -> evita.renameCatalog(TEST_CATALOG, "differentCatalog"));
+	}
+
+	@Test
+	void shouldFailToUpdateExistingCatalog() {
+		assertThrows(ReadOnlyException.class, () -> evita.updateCatalog(TEST_CATALOG, EvitaSessionContract::getCatalogSchema));
+	}
+
+	@Test
+	void shouldFailToCreateReadWriteSessionToExistingCatalog() {
+		assertThrows(ReadOnlyException.class, () -> evita.createReadWriteSession(TEST_CATALOG));
+	}
+
+	@Test
+	void shouldFailToCreateReadWriteSessionViaTraitsToExistingCatalog() {
+		assertThrows(ReadOnlyException.class, () -> evita.createSession(new SessionTraits(TEST_CATALOG, SessionFlags.READ_WRITE)));
+	}
+
+	@Test
+	void shouldAllowToQueryExistingCatalog() {
+		assertNotNull(evita.queryCatalog(TEST_CATALOG, EvitaSessionContract::getCatalogSchema));
+	}
+
+	@Nonnull
+	private EvitaConfiguration getEvitaConfiguration(boolean readOnly) {
+		return EvitaConfiguration.builder()
+			.server(
+				ServerOptions.builder()
+					.readOnly(readOnly)
+					.build()
+			)
+			.storage(
+				StorageOptions.builder()
+					.storageDirectory(getTestDirectory())
+					.build()
+			)
+			.build();
+	}
+
+}

--- a/evita_test_support/src/main/resources/evita-configuration.yaml
+++ b/evita_test_support/src/main/resources/evita-configuration.yaml
@@ -4,6 +4,7 @@ server:
   threadPriority: ${server.threadPriority:5}
   queueSize: ${server.queueSize:100}
   closeSessionsAfterSecondsOfInactivity: ${server.closeSessionsAfterSecondsOfInactivity:60}
+  readOnly: ${server.readOnly:false}
 
 storage:
   storageDirectory: ${java.io.tmpdir}/evita


### PR DESCRIPTION
We want to open access to our test dataset directly on https://evitadb.io for all to play. In order to avoid server / catalog pollution we want to allow read-only access. Until https://github.com/FgForrest/evitaDB/issues/25 is finalized we plan to add simple boolean flag that will start the server in full read-only mode that doesn't allow clients to:

- create / update / delete catalog schemas
- open read-write sessions

This will effectively mean that the clients would not be able to alter the demo data and can only play with read queries.