### PR TITLE
fix: when schema is not found exception must not be thrown

### DIFF
--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -779,9 +779,9 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 			final StringBuilder stats = new StringBuilder("Catalog `" + catalogHeader.getCatalogHeader().getCatalogName() + "` " + operation + " and ");
 			final Map<String, EntityCollectionHeader> collectionHeaders = catalogHeader.getCollectionHeaders();
 			if (collectionHeaders.isEmpty()) {
-				stats.append(" it's empty.");
+				stats.append("it's empty.");
 			} else {
-				stats.append(" it contains:");
+				stats.append("it contains:");
 				for (EntityCollectionHeader entityTypeHeader : collectionHeaders.values()) {
 					stats.append("\n\t- ")
 						.append(entityTypeHeader.getEntityType())

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/schema/serializer/CatalogSchemaSerializer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/schema/serializer/CatalogSchemaSerializer.java
@@ -31,7 +31,6 @@ import io.evitadb.api.CatalogContract;
 import io.evitadb.api.requestResponse.schema.CatalogEvolutionMode;
 import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.dto.CatalogSchema;
-import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.store.entity.model.schema.CatalogSchemaStoragePart;
 import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.NamingConvention;
@@ -95,7 +94,7 @@ public class CatalogSchemaSerializer extends Serializer<CatalogSchema> {
 			attributeSchema,
 			entityType -> theCatalog
 				.getEntitySchema(entityType)
-				.orElseThrow(() -> new EvitaInternalError("Entity `" + entityType + "` schema unexpectedly not found!"))
+				.orElse(null)
 		);
 	}
 


### PR DESCRIPTION
The caller code wraps the result into an optional and exception is not expected.