### PR TITLE
fix: corrected GlobalUniqueIndexSerializer for array types

### DIFF
--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/GlobalUniqueIndexStoragePartSerializer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/GlobalUniqueIndexStoragePartSerializer.java
@@ -56,7 +56,8 @@ public class GlobalUniqueIndexStoragePartSerializer extends Serializer<GlobalUni
 		Assert.notNull(uniquePartId, "Unique part id should have been computed by now!");
 		output.writeVarLong(uniquePartId, true);
 		output.writeVarInt(keyCompressor.getId(uniqueIndex.getAttributeKey()), true);
-		kryo.writeClass(output, uniqueIndex.getType());
+		final Class plainType = uniqueIndex.getType().isArray() ? uniqueIndex.getType().getComponentType() : uniqueIndex.getType();
+		kryo.writeClass(output, plainType);
 
 		final Map<Serializable, EntityWithTypeTuple> uniqueValueToRecordId = uniqueIndex.getUniqueValueToRecordId();
 		output.writeVarInt(uniqueValueToRecordId.size(), true);


### PR DESCRIPTION
The serialized value is always a plain type, but the value read was array type which caused CorruptedRecordException.