### PR TITLE
feat(#299): Allow to override host name the evitaDB uses

### DIFF
--- a/docker/evita-configuration.yaml
+++ b/docker/evita-configuration.yaml
@@ -28,6 +28,7 @@ cache:
   cacheSizeInBytes: ${cache.cacheSizeInBytes:null}
 
 api:
+  exposedOn: ${api.exposedOn:null}
   ioThreads: ${api.ioThreads:4}
   certificate:
     generateAndUseSelfSigned: ${api.certificate.generateAndUseSelfSigned:true}
@@ -40,22 +41,26 @@ api:
     system:
       enabled: ${api.endpoints.system.enabled:true}
       host: ${api.endpoints.system.host:localhost:5557}
+      exposedHost: ${api.endpoints.system.exposedHost:null}
       tlsEnabled: ${api.endpoints.system.tlsEnabled:false}
       allowedOrigins: ${api.endpoints.system.allowedOrigins:null}
     graphQL:
       enabled: ${api.endpoints.graphQL.enabled:true}
       host: ${api.endpoints.graphQL.host:localhost:5555}
+      exposedHost: ${api.endpoints.graphQL.exposedHost:null}
       tlsEnabled: ${api.endpoints.graphQL.tlsEnabled:true}
       allowedOrigins: ${api.endpoints.graphQL.allowedOrigins:null}
       parallelize: ${api.endpoints.graphQL.parallelize:true}
     rest:
       enabled: ${api.endpoints.rest.enabled:true}
       host: ${api.endpoints.rest.host:localhost:5555}
+      exposedHost: ${api.endpoints.rest.exposedHost:null}
       tlsEnabled: ${api.endpoints.rest.tlsEnabled:true}
       allowedOrigins: ${api.endpoints.rest.allowedOrigins:null}
     gRPC:
       enabled: ${api.endpoints.gRPC.enabled:true}
       host: ${api.endpoints.gRPC.host:localhost:5556}
+      exposedHost: ${api.endpoints.gRPC.exposedHost:null}
       mTLS:
         enabled: ${api.endpoints.gRPC.mTLS.enabled:false}
         allowedClientCertificatePaths: ${api.endpoints.gRPC.mTLS.allowedClientCertificatesPaths:[]}

--- a/documentation/user/en/operate/configure.md
+++ b/documentation/user/en/operate/configure.md
@@ -40,6 +40,7 @@ cache:                                            # [see Cache configuration](#c
   cacheSizeInBytes: null
 
 api:                                              # [see API configuration](#api-configuration)
+  exposedOn: null
   ioThreads: 4
   certificate:                                    # [see TLS configuration](#tls-configuration) 
     generateAndUseSelfSigned: true
@@ -406,7 +407,23 @@ is resolved.
 
 ## API configuration
 
-This section of the configuration allows you to selectively enable, disable, and tweak specific APIs. 
+This section of the configuration allows you to selectively enable, disable, and tweak specific APIs.
+
+<dl>
+    <dt>ioThreads</dt>
+    <dd>
+        <p>**Default:** `4`</p>
+        <p>Defines the number of IO threads that will be used by Undertow for accept and send HTTP payload.</p>
+    </dd>
+    <dt>exposedOn</dt>
+    <dd>
+        <p>When evitaDB is running in a Docker container and the ports are exposed on the host systems 
+           the internally resolved local host name and port usually don't match the host name and port 
+           evitaDB is available on that host system. By specifying the `exposedOn` property you can specify
+           the name (without port) of the host system host name that will be used by all API endpoints without
+           specific `exposedHost` configuration property to use that host name and appropriate port.</p>
+    </dd>
+</dl>
 
 ### TLS configuration
 
@@ -483,6 +500,13 @@ provide an unsecured connection for security reasons.
         <p>It specifies the host and port that the GraphQL API should listen on. The value may be identical to the REST 
         API, but not to the gRPC or System API.</p>
     </dd>
+    <dt>exposedHost</dt>
+    <dd>
+        <p>When evitaDB is running in a Docker container and the ports are exposed on the host systems 
+           the internally resolved local host name and port usually don't match the host name and port 
+           evitaDB is available on that host system. If you specify this property, the `exposeOn` global property
+           is no longer used.</p>
+    </dd>
     <dt>tlsEnabled</dt>
     <dd>
         <p>**Default:** `true`</p>
@@ -517,6 +541,13 @@ provide an unsecured connection for security reasons.
         <p>It specifies the host and port that the GraphQL API should listen on. The value may be identical to the GraphQL 
         API, but not to the gRPC or System API.</p>
     </dd>
+    <dt>exposedHost</dt>
+    <dd>
+        <p>When evitaDB is running in a Docker container and the ports are exposed on the host systems 
+           the internally resolved local host name and port usually don't match the host name and port 
+           evitaDB is available on that host system. If you specify this property, the `exposeOn` global property
+           is no longer used.</p>
+    </dd>
     <dt>tlsEnabled</dt>
     <dd>
         <p>**Default:** `true`</p>
@@ -545,6 +576,13 @@ provide an unsecured connection for security reasons.
         <p>**Default:** `localhost:5555`</p>
         <p>It specifies the host and port that the GraphQL API should listen on. The value must be different from all 
         other APIs because gRPC internally uses completely different web server.</p>
+    </dd>
+    <dt>exposedHost</dt>
+    <dd>
+        <p>When evitaDB is running in a Docker container and the ports are exposed on the host systems 
+           the internally resolved local host name and port usually don't match the host name and port 
+           evitaDB is available on that host system. If you specify this property, the `exposeOn` global property
+           is no longer used.</p>
     </dd>
 </dl>
 
@@ -620,6 +658,13 @@ Besides that, it can also serve an entire evitaLab web client as its copy is bui
         <p>**Default:** `localhost:5555`</p>
         <p>It specifies the host and port that the evitaLab API/evitaLab web client should listen on.
         The value may be identical to the GraphQL API and REST API, but not to the gRPC or System API.</p>
+    </dd>
+    <dt>exposedHost</dt>
+    <dd>
+        <p>When evitaDB is running in a Docker container and the ports are exposed on the host systems 
+           the internally resolved local host name and port usually don't match the host name and port 
+           evitaDB is available on that host system. If you specify this property, the `exposeOn` global property
+           is no longer used.</p>
     </dd>
     <dt>tlsEnabled</dt>
     <dd>

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/configuration/ApiOptions.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/configuration/ApiOptions.java
@@ -42,12 +42,14 @@ import static java.util.Optional.ofNullable;
 /**
  * This DTO record encapsulates common settings shared among all the API endpoints.
  *
+ * @param exposedOn   the name of the host the APIs will be exposed on when evitaDB is running inside a container
  * @param ioThreads   defines the number of IO thread will be used by Undertow for accept and send HTTP payload
  * @param endpoints   contains specific configuration for all the API endpoints
  * @param certificate defines the certificate settings that will be used to secure connections to the web servers providing APIs
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public record ApiOptions(
+	@Nonnull String exposedOn,
 	@Nullable Integer ioThreads,
 	@Nonnull CertificateSettings certificate,
 	@Nonnull Map<String, AbstractApiConfiguration> endpoints
@@ -61,7 +63,7 @@ public record ApiOptions(
 	}
 
 	public ApiOptions() {
-		this(null, new CertificateSettings(), new HashMap<>(8));
+		this(null, null, new CertificateSettings(), new HashMap<>(8));
 	}
 
 	/**
@@ -90,8 +92,8 @@ public record ApiOptions(
 		private final Map<String, Class<?>> apiProviders;
 		private final Map<String, AbstractApiConfiguration> enabledProviders;
 		private CertificateSettings certificate;
-		@Nullable
-		private Integer ioThreads;
+		@Nullable private String exposedOn;
+		@Nullable private Integer ioThreads;
 
 		Builder() {
 			//noinspection unchecked
@@ -105,6 +107,12 @@ public record ApiOptions(
 				);
 			enabledProviders = CollectionUtils.createHashMap(apiProviders.size());
 			certificate = new CertificateSettings.Builder().build();
+		}
+
+		@Nonnull
+		public ApiOptions.Builder exposedOn(@Nonnull String exposedOn) {
+			this.exposedOn = exposedOn;
+			return this;
 		}
 
 		@Nonnull
@@ -153,7 +161,7 @@ public record ApiOptions(
 		@Nonnull
 		public ApiOptions build() {
 			return new ApiOptions(
-				ioThreads, certificate, enabledProviders
+				exposedOn, ioThreads, certificate, enabledProviders
 			);
 		}
 	}

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiServer.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiServer.java
@@ -505,7 +505,7 @@ public class ExternalApiServer implements AutoCloseable {
 			ConsoleWriter.write(
 				StringUtils.rightPad("API `" + registeredApiProvider.getCode() + "` listening on ", " ", PADDING_START_UP)
 			);
-			final String[] baseUrls = configuration.getBaseUrls();
+			final String[] baseUrls = configuration.getBaseUrls(apiOptions.exposedOn());
 			for (int i = 0; i < baseUrls.length; i++) {
 				final String url = baseUrls[i];
 				if (i > 0) {

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/configuration/GraphQLConfig.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/configuration/GraphQLConfig.java
@@ -77,12 +77,13 @@ public class GraphQLConfig extends AbstractApiConfiguration implements ApiWithSp
 	public GraphQLConfig(
 		@Nullable @JsonProperty("enabled") Boolean enabled,
 		@Nonnull @JsonProperty("host") String host,
+		@Nullable @JsonProperty("exposedHost") String exposedHost,
 		@Nullable @JsonProperty("tlsEnabled") Boolean tlsEnabled,
 		@Nullable @JsonProperty("prefix") String prefix,
 		@Nullable @JsonProperty("allowedOrigins") String allowedOrigins,
 		@Nullable @JsonProperty("parallelize") Boolean parallelize
 	) {
-		super(enabled, host, tlsEnabled);
+		super(enabled, host, exposedHost, tlsEnabled);
 		this.prefix = ofNullable(prefix).orElse(BASE_GRAPHQL_PATH);
 		this.parallelize = ofNullable(parallelize).orElse(false);
 		if (allowedOrigins == null) {

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/configuration/GrpcConfig.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/configuration/GrpcConfig.java
@@ -65,8 +65,9 @@ public class GrpcConfig extends AbstractApiConfiguration {
 	@JsonCreator
 	public GrpcConfig(@Nullable @JsonProperty("enabled") Boolean enabled,
 	                  @Nonnull @JsonProperty("host") String host,
+	                  @Nullable @JsonProperty("exposedHost") String exposedHost,
 	                  @Nonnull @JsonProperty("mTLS") MtlsConfiguration mtlsConfiguration) {
-		super(enabled, host);
+		super(enabled, host, exposedHost, true);
 		this.mtlsConfiguration = mtlsConfiguration;
 	}
 }

--- a/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/LabManager.java
+++ b/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/LabManager.java
@@ -98,7 +98,7 @@ public class LabManager {
 	 * Builds REST API for evitaLab and registers it into router.
 	 */
 	private void registerLabApi() {
-		final LabApiBuilder labApiBuilder = new LabApiBuilder(labConfig, evita);
+		final LabApiBuilder labApiBuilder = new LabApiBuilder(apiOptions.exposedOn(), labConfig, evita);
 		final Rest builtLabApi = labApiBuilder.build();
 		builtLabApi.endpoints().forEach(this::registerLabApiEndpoint);
 	}

--- a/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/api/LabApiBuilder.java
+++ b/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/api/LabApiBuilder.java
@@ -45,6 +45,7 @@ import io.evitadb.externalApi.rest.api.system.model.LivenessDescriptor;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static io.evitadb.externalApi.rest.api.openApi.OpenApiTypeReference.typeRefTo;
 
@@ -67,8 +68,8 @@ public class LabApiBuilder extends FinalRestBuilder<LabApiBuildingContext> {
 	/**
 	 * Creates new builder.
 	 */
-	public LabApiBuilder(@Nonnull LabConfig labConfig, @Nonnull Evita evita) {
-		super(new LabApiBuildingContext(labConfig, evita));
+	public LabApiBuilder(@Nullable String exposedOn, @Nonnull LabConfig labConfig, @Nonnull Evita evita) {
+		super(new LabApiBuildingContext(exposedOn, labConfig, evita));
 		this.endpointBuilder = new LabApiEndpointBuilder(operationPathParameterBuilderTransformer);
 
 		this.entityObjectBuilder = new GenericEntityObjectBuilder(

--- a/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/api/builder/LabApiBuildingContext.java
+++ b/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/api/builder/LabApiBuildingContext.java
@@ -29,6 +29,7 @@ import io.evitadb.externalApi.rest.api.builder.RestBuildingContext;
 import io.swagger.v3.oas.models.servers.Server;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -43,14 +44,14 @@ public class LabApiBuildingContext extends RestBuildingContext {
 
 	private static final String OPEN_API_TITLE = "Web services for managing evitaDB.";
 
-	public LabApiBuildingContext(@Nonnull LabConfig labConfig, @Nonnull Evita evita) {
-		super(labConfig, evita);
+	public LabApiBuildingContext(@Nullable String exposedOn, @Nonnull LabConfig labConfig, @Nonnull Evita evita) {
+		super(exposedOn, labConfig, evita);
 	}
 
 	@Nonnull
 	@Override
 	protected List<Server> buildOpenApiServers() {
-		return Arrays.stream(restConfig.getBaseUrls())
+		return Arrays.stream(restConfig.getBaseUrls(getExposedOn()))
 			.map(baseUrl -> new Server()
 				.url(baseUrl + LAB_API_URL_PREFIX))
 			.toList();

--- a/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/configuration/LabConfig.java
+++ b/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/configuration/LabConfig.java
@@ -74,12 +74,13 @@ public class LabConfig extends AbstractApiConfiguration implements ApiWithSpecif
 	public LabConfig(
 		@Nullable @JsonProperty("enabled") Boolean enabled,
 		@Nonnull @JsonProperty("host") String host,
+		@Nullable @JsonProperty("exposedHost") String exposedHost,
 		@Nullable @JsonProperty("tlsEnabled") Boolean tlsEnabled,
 		@Nullable @JsonProperty("prefix") String prefix,
 		@Nullable @JsonProperty("allowedOrigins") String allowedOrigins,
 		@Nullable @JsonProperty("gui") GuiConfig gui
 	) {
-		super(enabled, host, tlsEnabled);
+		super(enabled, host, exposedHost, tlsEnabled);
 		this.prefix = ofNullable(prefix).orElse(BASE_LAB_PATH);
 		if (allowedOrigins == null) {
 			this.allowedOrigins = null;

--- a/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/gui/resolver/GuiHandler.java
+++ b/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/gui/resolver/GuiHandler.java
@@ -153,9 +153,9 @@ public class GuiHandler extends ResourceHandler {
 		final EvitaDBConnection selfConnection = new EvitaDBConnection(
 			null,
 			serverName,
-			labConfig.getBaseUrls()[0] + LabManager.LAB_API_URL_PREFIX,
-			Optional.ofNullable(restConfig).map(it -> it.getBaseUrls()[0]).orElse(null),
-			Optional.ofNullable(graphQLConfig).map(it -> it.getBaseUrls()[0]).orElse(null)
+			labConfig.getBaseUrls(apiOptions.exposedOn())[0] + LabManager.LAB_API_URL_PREFIX,
+			Optional.ofNullable(restConfig).map(it -> it.getBaseUrls(apiOptions.exposedOn())[0]).orElse(null),
+			Optional.ofNullable(graphQLConfig).map(it -> it.getBaseUrls(apiOptions.exposedOn())[0]).orElse(null)
 		);
 		return List.of(selfConnection);
 	}

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/RestProviderRegistrar.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/RestProviderRegistrar.java
@@ -56,7 +56,7 @@ public class RestProviderRegistrar implements ExternalApiProviderRegistrar<RestC
 	public ExternalApiProvider<RestConfig> register(@Nonnull Evita evita,
 	                                                @Nonnull ApiOptions apiOptions,
 	                                                @Nonnull RestConfig restConfiguration) {
-		final RestManager restManager = new RestManager(evita, restConfiguration);
+		final RestManager restManager = new RestManager(evita, apiOptions.exposedOn(), restConfiguration);
 		evita.registerStructuralChangeObserver(new CatalogRestRefreshingObserver(restManager));
 		return new RestProvider(restConfiguration, restManager.getRestRouter());
 	}

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/builder/RestBuildingContext.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/builder/RestBuildingContext.java
@@ -54,6 +54,7 @@ import io.undertow.util.HttpString;
 import lombok.Getter;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -74,6 +75,7 @@ import static io.evitadb.utils.CollectionUtils.createHashMap;
 public abstract class RestBuildingContext {
 
 	@Nonnull protected final AbstractApiConfiguration restConfig;
+	@Getter @Nullable private final String exposedOn;
 	@Getter @Nonnull private final Evita evita;
 
 	/**
@@ -91,9 +93,10 @@ public abstract class RestBuildingContext {
 	@Nonnull
 	private final Map<String, Class<? extends Enum<?>>> registeredCustomEnums = createHashMap(32);
 
-	protected RestBuildingContext(@Nonnull AbstractApiConfiguration restConfig, @Nonnull Evita evita) {
+	protected RestBuildingContext(@Nonnull String exposedOn, @Nonnull AbstractApiConfiguration restConfig, @Nonnull Evita evita) {
 		this.restConfig = restConfig;
 		this.evita = evita;
+		this.exposedOn = exposedOn;
 		this.objectMapper = setupObjectMapper();
 	}
 

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/CatalogRestBuilder.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/CatalogRestBuilder.java
@@ -36,6 +36,7 @@ import io.evitadb.externalApi.rest.configuration.RestConfig;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Creates OpenAPI specification for Evita's catalog.
@@ -50,8 +51,8 @@ public class CatalogRestBuilder extends FinalRestBuilder<CatalogRestBuildingCont
 	/**
 	 * Creates new builder.
 	 */
-	public CatalogRestBuilder(@Nonnull RestConfig restConfig, @Nonnull Evita evita, @Nonnull CatalogContract catalog) {
-		super(new CatalogRestBuildingContext(restConfig, evita, catalog));
+	public CatalogRestBuilder(@Nullable String exposedOn, @Nonnull RestConfig restConfig, @Nonnull Evita evita, @Nonnull CatalogContract catalog) {
+		super(new CatalogRestBuildingContext(exposedOn, restConfig, evita, catalog));
 		this.endpointBuilder = new CatalogEndpointBuilder();
 	}
 

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/builder/CatalogRestBuildingContext.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/builder/CatalogRestBuildingContext.java
@@ -29,7 +29,6 @@ import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.api.requestResponse.schema.SealedEntitySchema;
 import io.evitadb.core.Evita;
 import io.evitadb.exception.EvitaInternalError;
-import io.evitadb.externalApi.api.ExternalApiNamingConventions;
 import io.evitadb.externalApi.rest.api.builder.RestBuildingContext;
 import io.evitadb.externalApi.rest.api.openApi.OpenApiObject;
 import io.evitadb.externalApi.rest.api.openApi.OpenApiTypeReference;
@@ -38,6 +37,7 @@ import io.swagger.v3.oas.models.servers.Server;
 import lombok.Getter;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Currency;
@@ -69,8 +69,8 @@ public class CatalogRestBuildingContext extends RestBuildingContext {
 	@Nonnull @Getter private final List<OpenApiTypeReference> localizedEntityObjects;
 
 
-	public CatalogRestBuildingContext(@Nonnull RestConfig restConfig, @Nonnull Evita evita, @Nonnull CatalogContract catalog) {
-		super(restConfig, evita);
+	public CatalogRestBuildingContext(@Nullable String exposedOn, @Nonnull RestConfig restConfig, @Nonnull Evita evita, @Nonnull CatalogContract catalog) {
+		super(exposedOn, restConfig, evita);
 		this.catalog = catalog;
 		this.supportedLocales = createHashSet(20);
 		this.supportedCurrencies = createHashSet(20);
@@ -95,7 +95,7 @@ public class CatalogRestBuildingContext extends RestBuildingContext {
 	@Nonnull
 	@Override
 	protected List<Server> buildOpenApiServers() {
-		return Arrays.stream(restConfig.getBaseUrls())
+		return Arrays.stream(restConfig.getBaseUrls(getExposedOn()))
 			.map(baseUrl -> new Server()
 				.url(baseUrl + getSchema().getName()))
 			.toList();

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/system/SystemRestBuilder.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/system/SystemRestBuilder.java
@@ -42,6 +42,7 @@ import io.evitadb.externalApi.rest.configuration.RestConfig;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static io.evitadb.externalApi.rest.api.openApi.OpenApiTypeReference.typeRefTo;
 
@@ -58,8 +59,8 @@ public class SystemRestBuilder extends FinalRestBuilder<SystemRestBuildingContex
 	/**
 	 * Creates new builder.
 	 */
-	public SystemRestBuilder(@Nonnull RestConfig restConfig, @Nonnull Evita evita) {
-		super(new SystemRestBuildingContext(restConfig, evita));
+	public SystemRestBuilder(@Nullable String exposedOn, @Nonnull RestConfig restConfig, @Nonnull Evita evita) {
+		super(new SystemRestBuildingContext(exposedOn, restConfig, evita));
 		this.endpointBuilder = new SystemEndpointBuilder(operationPathParameterBuilderTransformer);
 	}
 

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/system/builder/SystemRestBuildingContext.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/system/builder/SystemRestBuildingContext.java
@@ -30,6 +30,7 @@ import io.evitadb.externalApi.rest.configuration.RestConfig;
 import io.swagger.v3.oas.models.servers.Server;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -42,14 +43,14 @@ public class SystemRestBuildingContext extends RestBuildingContext {
 
 	private static final String OPEN_API_TITLE = "Web services for managing evitaDB.";
 
-	public SystemRestBuildingContext(@Nonnull RestConfig restConfig, @Nonnull Evita evita) {
-		super(restConfig, evita);
+	public SystemRestBuildingContext(@Nullable String exposedOn, @Nonnull RestConfig restConfig, @Nonnull Evita evita) {
+		super(exposedOn, restConfig, evita);
 	}
 
 	@Nonnull
 	@Override
 	protected List<Server> buildOpenApiServers() {
-		return Arrays.stream(restConfig.getBaseUrls())
+		return Arrays.stream(restConfig.getBaseUrls(getExposedOn()))
 			.map(baseUrl -> new Server()
 				.url(baseUrl + OpenApiSystemEndpoint.URL_PREFIX))
 			.toList();

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/configuration/RestConfig.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/configuration/RestConfig.java
@@ -69,10 +69,11 @@ public class RestConfig extends AbstractApiConfiguration implements ApiWithSpeci
 	@JsonCreator
 	public RestConfig(@Nullable @JsonProperty("enabled") Boolean enabled,
 	                  @Nonnull @JsonProperty("host") String host,
+	                  @Nullable @JsonProperty("exposedHost") String exposedHost,
 	                  @Nullable @JsonProperty("tlsEnabled") Boolean tlsEnabled,
 	                  @Nullable @JsonProperty("prefix") String prefix,
 	                  @Nullable @JsonProperty("allowedOrigins") String allowedOrigins) {
-		super(enabled, host, tlsEnabled);
+		super(enabled, host, exposedHost, tlsEnabled);
 		this.prefix = Optional.ofNullable(prefix).orElse(BASE_REST_PATH);
 		if (allowedOrigins == null) {
 			this.allowedOrigins = null;

--- a/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/SystemProvider.java
+++ b/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/SystemProvider.java
@@ -82,31 +82,52 @@ public class SystemProvider implements ExternalApiProviderWithConsoleOutput<Syst
 
 	@Override
 	public void writeToConsole() {
-		for (String serverNameUrl : serverNameUrls) {
-			ConsoleWriter.write(StringUtils.rightPad("   - server name served at: ", " ", ExternalApiServer.PADDING_START_UP));
+		ConsoleWriter.write(StringUtils.rightPad("   - server name served at: ", " ", ExternalApiServer.PADDING_START_UP));
+		for (int i = 0; i < serverNameUrls.length; i++) {
+			final String serverNameUrl = serverNameUrls[i];
+			if (i > 0) {
+				ConsoleWriter.write(", ", ConsoleColor.WHITE);
+			}
 			ConsoleWriter.write(serverNameUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
-			ConsoleWriter.write("\n", ConsoleColor.WHITE);
 		}
-		for (String certificateUrl : rootCertificateUrls) {
-			ConsoleWriter.write(StringUtils.rightPad("   - CA certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
-			ConsoleWriter.write(certificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
-			ConsoleWriter.write("\n", ConsoleColor.WHITE);
+		ConsoleWriter.write("\n", ConsoleColor.WHITE);
+		ConsoleWriter.write(StringUtils.rightPad("   - CA certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
+		for (int i = 0; i < rootCertificateUrls.length; i++) {
+			final String rootCertificateUrl = rootCertificateUrls[i];
+			if (i > 0) {
+				ConsoleWriter.write(", ", ConsoleColor.WHITE);
+			}
+			ConsoleWriter.write(rootCertificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
 		}
-		for (String certificateUrl : serverCertificateUrls) {
-			ConsoleWriter.write(StringUtils.rightPad("   - server certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
-			ConsoleWriter.write(certificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
-			ConsoleWriter.write("\n", ConsoleColor.WHITE);
+		ConsoleWriter.write("\n", ConsoleColor.WHITE);
+		ConsoleWriter.write(StringUtils.rightPad("   - server certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
+		for (int i = 0; i < serverCertificateUrls.length; i++) {
+			final String serverCertificateUrl = serverCertificateUrls[i];
+			if (i > 0) {
+				ConsoleWriter.write(", ", ConsoleColor.WHITE);
+			}
+			ConsoleWriter.write(serverCertificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
 		}
-		for (String certificateUrl : clientCertificateUrls) {
-			ConsoleWriter.write(StringUtils.rightPad("   - client certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
-			ConsoleWriter.write(certificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
-			ConsoleWriter.write("\n", ConsoleColor.WHITE);
+		ConsoleWriter.write("\n", ConsoleColor.WHITE);
+		ConsoleWriter.write(StringUtils.rightPad("   - client certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
+		for (int i = 0; i < clientCertificateUrls.length; i++) {
+			final String clientCertificateUrl = clientCertificateUrls[i];
+			if (i > 0) {
+				ConsoleWriter.write(", ", ConsoleColor.WHITE);
+			}
+			ConsoleWriter.write(clientCertificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
 		}
-		for (String clientPrivateKey : clientPrivateKeyUrls) {
-			ConsoleWriter.write(StringUtils.rightPad("   - client private key served at: ", " ", ExternalApiServer.PADDING_START_UP));
-			ConsoleWriter.write(clientPrivateKey, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
-			ConsoleWriter.write("\n", ConsoleColor.WHITE);
-			ConsoleWriter.write("""
+		ConsoleWriter.write("\n", ConsoleColor.WHITE);
+		ConsoleWriter.write(StringUtils.rightPad("   - client private key served at: ", " ", ExternalApiServer.PADDING_START_UP));
+		for (int i = 0; i < clientPrivateKeyUrls.length; i++) {
+			final String clientPrivateKeyUrl = clientPrivateKeyUrls[i];
+			if (i > 0) {
+				ConsoleWriter.write(", ", ConsoleColor.WHITE);
+			}
+			ConsoleWriter.write(clientPrivateKeyUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
+		}
+		ConsoleWriter.write("\n", ConsoleColor.WHITE);
+		ConsoleWriter.write("""
                 
                 ************************* WARNING!!! *************************
                 You use mTLS with automatically generated client certificate.
@@ -115,8 +136,7 @@ public class SystemProvider implements ExternalApiProviderWithConsoleOutput<Syst
                 ************************* WARNING!!! *************************
                 
                 """,
-				ConsoleColor.BRIGHT_RED, ConsoleDecoration.BOLD
-			);
-		}
+			ConsoleColor.BRIGHT_RED, ConsoleDecoration.BOLD
+		);
 	}
 }

--- a/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/SystemProviderRegistrar.java
+++ b/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/SystemProviderRegistrar.java
@@ -126,24 +126,24 @@ public class SystemProviderRegistrar implements ExternalApiProviderRegistrar<Sys
 						systemConfig.getAllowedOrigins()
 					)
 				),
-				Arrays.stream(systemConfig.getBaseUrls())
+				Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
 					.map(it -> it + ENDPOINT_SERVER_NAME)
 					.toArray(String[]::new),
-				Arrays.stream(systemConfig.getBaseUrls())
+				Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
 					.map(it -> it + fileName)
 					.toArray(String[]::new),
 				certificateSettings.generateAndUseSelfSigned() ?
-					Arrays.stream(systemConfig.getBaseUrls())
+					Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
 						.map(it -> it + CertificateUtils.getGeneratedServerCertificateFileName())
 						.toArray(String[]::new) :
 					new String[0],
 				certificateSettings.generateAndUseSelfSigned() ?
-					Arrays.stream(systemConfig.getBaseUrls())
+					Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
 						.map(it -> it + CertificateUtils.getGeneratedClientCertificateFileName())
 						.toArray(String[]::new) :
 					new String[0],
 				certificateSettings.generateAndUseSelfSigned() ?
-					Arrays.stream(systemConfig.getBaseUrls())
+					Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
 						.map(it -> it + CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName())
 						.toArray(String[]::new) :
 					new String[0]

--- a/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/configuration/SystemConfig.java
+++ b/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/configuration/SystemConfig.java
@@ -59,13 +59,13 @@ public class SystemConfig extends AbstractApiConfiguration implements ApiWithSpe
 	@Getter private final String[] allowedOrigins;
 
 	public SystemConfig() {
-		super(true, "0.0.0.0:" + DEFAULT_SYSTEM_PORT, false);
+		super(true, "0.0.0.0:" + DEFAULT_SYSTEM_PORT, null, false);
 		this.prefix = BASE_SYSTEM_PATH;
 		this.allowedOrigins = null;
 	}
 
 	public SystemConfig(@Nonnull String host) {
-		super(true, host, false);
+		super(true, host, null, false);
 		this.prefix = BASE_SYSTEM_PATH;
 		this.allowedOrigins = null;
 	}
@@ -73,10 +73,11 @@ public class SystemConfig extends AbstractApiConfiguration implements ApiWithSpe
 	@JsonCreator
 	public SystemConfig(@Nullable @JsonProperty("enabled") Boolean enabled,
 						@Nonnull @JsonProperty("host") String host,
+						@Nullable @JsonProperty("exposedHost") String exposedHost,
 						@Nullable @JsonProperty("tlsEnabled") Boolean tlsEnabled,
 						@Nullable @JsonProperty("prefix") String prefix,
 						@Nullable @JsonProperty("allowedOrigins") String allowedOrigins) {
-		super(enabled, host, tlsEnabled);
+		super(enabled, host, exposedHost, tlsEnabled);
 		this.prefix = Optional.ofNullable(prefix).orElse(BASE_SYSTEM_PATH);
 		if (allowedOrigins == null) {
 			this.allowedOrigins = null;

--- a/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/openApi/SchemaUtilsTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/openApi/SchemaUtilsTest.java
@@ -74,7 +74,7 @@ class SchemaUtilsTest {
 		final Set<Entry<String, Object>> dataCarrier = new HashSet<>(TestDataGenerator.generateMainCatalogEntities(evita,20).entrySet());
 
 		final CatalogContract catalog = evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
-		final OpenAPI openApi = new CatalogRestBuilder(new RestConfig(true, "localhost:5555", null, "rest", null), evita, catalog).build().openApi();
+		final OpenAPI openApi = new CatalogRestBuilder(null, new RestConfig(true, "localhost:5555", null, null, "rest", null), evita, catalog).build().openApi();
 		dataCarrier.add(new SimpleEntry<>("openApi", openApi));
 
 		return new DataCarrier(dataCarrier);

--- a/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/graphql/artificial/GraphQLArtificialFullDatabaseBenchmarkState.java
+++ b/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/graphql/artificial/GraphQLArtificialFullDatabaseBenchmarkState.java
@@ -86,7 +86,7 @@ public class GraphQLArtificialFullDatabaseBenchmarkState extends GraphQLArtifici
 		// start graphql server
 		server = new ExternalApiServer(
 			this.evita,
-			new ApiOptions(null, new CertificateSettings.Builder().build(), Map.of(GraphQLProvider.CODE, new GraphQLConfig())),
+			new ApiOptions(null, null, new CertificateSettings.Builder().build(), Map.of(GraphQLProvider.CODE, new GraphQLConfig())),
 			Collections.singleton(new GraphQLProviderRegistrar())
 		);
 		server.start();

--- a/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/grpc/artificial/GrpcArtificialFullDatabaseBenchmarkState.java
+++ b/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/grpc/artificial/GrpcArtificialFullDatabaseBenchmarkState.java
@@ -42,7 +42,6 @@ import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.TearDown;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -91,7 +90,8 @@ public class GrpcArtificialFullDatabaseBenchmarkState extends GrpcArtificialBenc
 		// start grpc server
 		server = new ExternalApiServer(
 			this.evita,
-			new ApiOptions(null, new CertificateSettings.Builder().build(), Map.of(
+			new ApiOptions(
+				null, null, new CertificateSettings.Builder().build(), Map.of(
 				SystemProvider.CODE, new SystemConfig(AbstractApiConfiguration.LOCALHOST + ":" + SystemConfig.DEFAULT_SYSTEM_PORT),
 				GrpcProvider.CODE, new GrpcConfig())
 			),

--- a/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/javaDriver/artificial/JavaDriverArtificialFullDatabaseBenchmarkState.java
+++ b/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/javaDriver/artificial/JavaDriverArtificialFullDatabaseBenchmarkState.java
@@ -93,7 +93,8 @@ public class JavaDriverArtificialFullDatabaseBenchmarkState extends JavaDriverAr
 		// start grpc server and system api
 		server = new ExternalApiServer(
 			this.evita,
-			new ApiOptions(null, new CertificateSettings.Builder().build(), Map.of(
+			new ApiOptions(
+				null, null, new CertificateSettings.Builder().build(), Map.of(
 				SystemProvider.CODE, new SystemConfig(AbstractApiConfiguration.LOCALHOST + ":" + SystemConfig.DEFAULT_SYSTEM_PORT),
 				GrpcProvider.CODE, new GrpcConfig())
 			),

--- a/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/rest/artificial/RestArtificialFullDatabaseBenchmarkState.java
+++ b/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/rest/artificial/RestArtificialFullDatabaseBenchmarkState.java
@@ -87,7 +87,7 @@ public class RestArtificialFullDatabaseBenchmarkState extends RestArtificialBenc
 		// start rest server
 		server = new ExternalApiServer(
 			this.evita,
-			new ApiOptions(null, new CertificateSettings.Builder().build(), Map.of(RestProvider.CODE, new RestConfig())),
+			new ApiOptions(null, null, new CertificateSettings.Builder().build(), Map.of(RestProvider.CODE, new RestConfig())),
 			Collections.singleton(new RestProviderRegistrar())
 		);
 		server.start();

--- a/evita_test_support/src/main/java/io/evitadb/test/extension/EvitaParameterResolver.java
+++ b/evita_test_support/src/main/java/io/evitadb/test/extension/EvitaParameterResolver.java
@@ -446,7 +446,7 @@ public class EvitaParameterResolver implements ParameterResolver, BeforeAllCallb
 		Exception lastException = null;
 		int initAttempt = 0;
 		do {
-			for (String baseUrl : cfg.getBaseUrls()) {
+			for (String baseUrl : cfg.getBaseUrls(apiOptions.exposedOn())) {
 				final String testUrl = baseUrl + "server-name";
 				try {
 					final URL website = new URL(testUrl);
@@ -456,7 +456,7 @@ public class EvitaParameterResolver implements ParameterResolver, BeforeAllCallb
 						// try to read server name from the system endpoint
 						final char[] buffer = new char[50];
 						final int read = reader.read(buffer);
-						log.info("Server name available on url `{}`: {}", cfg.getBaseUrls()[0], new String(buffer, 0, read));
+						log.info("Server name available on url `{}`: {}", cfg.getBaseUrls(apiOptions.exposedOn())[0], new String(buffer, 0, read));
 						return evitaServer;
 					}
 				} catch (Exception ex) {
@@ -474,7 +474,7 @@ public class EvitaParameterResolver implements ParameterResolver, BeforeAllCallb
 		} while (initAttempt < 3000);
 
 		throw new IllegalStateException(
-			"Evita server hasn't started on url " + Arrays.stream(cfg.getBaseUrls()).map(it -> "`" + it + "server-name`").collect(Collectors.joining(", ")) + " within 10 minutes!",
+			"Evita server hasn't started on url " + Arrays.stream(cfg.getBaseUrls(apiOptions.exposedOn())).map(it -> "`" + it + "server-name`").collect(Collectors.joining(", ")) + " within 10 minutes!",
 			lastException
 		);
 	}

--- a/evita_test_support/src/main/resources/evita-configuration.yaml
+++ b/evita_test_support/src/main/resources/evita-configuration.yaml
@@ -28,6 +28,7 @@ cache:
   cacheSizeInBytes: ${cache.cacheSizeInBytes:null}
 
 api:
+  exposedOn: ${api.exposedOn:null}
   ioThreads: ${api.ioThreads:4}
   certificate:
     generateAndUseSelfSigned: ${api.certificate.generateAndUseSelfSigned:true}
@@ -40,29 +41,33 @@ api:
     system:
       enabled: ${api.endpoints.system.enabled:true}
       host: ${api.endpoints.system.host:localhost:5557}
+      exposedHost: ${api.endpoints.system.exposedHost:null}
       tlsEnabled: ${api.endpoints.system.tlsEnabled:false}
       allowedOrigins: ${api.endpoints.system.allowedOrigins:null}
     graphQL:
       enabled: ${api.endpoints.graphQL.enabled:true}
       host: ${api.endpoints.graphQL.host:localhost:5555}
+      exposedHost: ${api.endpoints.graphQL.exposedHost:null}
       tlsEnabled: ${api.endpoints.graphQL.tlsEnabled:true}
       allowedOrigins: ${api.endpoints.graphQL.allowedOrigins:null}
       parallelize: ${api.endpoints.graphQL.parallelize:true}
     rest:
       enabled: ${api.endpoints.rest.enabled:true}
       host: ${api.endpoints.rest.host:localhost:5555}
+      exposedHost: ${api.endpoints.rest.exposedHost:null}
       tlsEnabled: ${api.endpoints.rest.tlsEnabled:true}
       allowedOrigins: ${api.endpoints.rest.allowedOrigins:null}
     gRPC:
       enabled: ${api.endpoints.gRPC.enabled:true}
       host: ${api.endpoints.gRPC.host:localhost:5556}
+      exposedHost: ${api.endpoints.gRPC.exposedHost:null}
       mTLS:
         enabled: ${api.endpoints.gRPC.mTLS.enabled:false}
         allowedClientCertificatePaths: ${api.endpoints.gRPC.mTLS.allowedClientCertificatesPaths:[]}
     lab:
       enabled: ${api.endpoints.lab.enabled:true}
-      tlsEnabled: ${api.endpoints.lab.tlsEnabled:true}
       host: ${api.endpoints.lab.host:localhost:5555}
+      tlsEnabled: ${api.endpoints.lab.tlsEnabled:true}
       allowedOrigins: ${api.endpoints.lab.allowedOrigins:null}
       gui:
         enabled: false


### PR DESCRIPTION
The host name for all APIs is by default the host name of the system evitaDB is running on. Unfortunately, when evitaDB starts in a Docker container, the host system is a virtual system of the Docker host and neither the host name (nor the ports) matches the host system the developer is working with (unless the `--net=host` parameter is used, which doesn't work on Windows and Mac OS).

That's why we need an additional configuration property for each API that allows to propagate the name of the external system to the evitaDB instance, so that it could be used for generating links in Open API schemas and evitaLab.