### PR TITLE
fix(#162): add validation for managed entity references

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/CatalogSchemaContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/CatalogSchemaContract.java
@@ -24,8 +24,8 @@
 package io.evitadb.api.requestResponse.schema;
 
 import io.evitadb.api.CatalogContract;
+import io.evitadb.api.exception.CollectionNotFoundException;
 import io.evitadb.api.requestResponse.data.ContentComparator;
-import io.evitadb.exception.EvitaInvalidUsageException;
 
 import javax.annotation.Nonnull;
 import java.util.Optional;
@@ -75,6 +75,6 @@ public interface CatalogSchemaContract
 	@Nonnull
 	default EntitySchemaContract getEntitySchemaOrThrowException(@Nonnull String entityType) {
 		return getEntitySchema(entityType)
-			.orElseThrow(() -> new EvitaInvalidUsageException("Schema for entity with name `" + entityType + "` was not found!"));
+			.orElseThrow(() -> new CollectionNotFoundException("Schema for entity with name `" + entityType + "` was not found!"));
 	}
 }

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/mutation/reference/CreateReferenceSchemaMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/mutation/reference/CreateReferenceSchemaMutation.java
@@ -188,6 +188,14 @@ public class CreateReferenceSchemaMutation implements ReferenceSchemaMutation, C
 	@Override
 	public EntitySchemaContract mutate(@Nonnull CatalogSchemaContract catalogSchema, @Nullable EntitySchemaContract entitySchema) {
 		Assert.isPremiseValid(entitySchema != null, "Entity schema is mandatory!");
+		if (this.referencedEntityTypeManaged) {
+			// check that the referenced entity type exists
+			catalogSchema.getEntitySchemaOrThrowException(this.referencedEntityType);
+		}
+		if (this.referencedGroupTypeManaged) {
+			// check that the referenced group entity type exists
+			catalogSchema.getEntitySchemaOrThrowException(this.referencedGroupType);
+		}
 		final ReferenceSchemaContract newReferenceSchema = this.mutate(entitySchema, null);
 		final Optional<ReferenceSchemaContract> existingReferenceSchema = entitySchema.getReference(name);
 		if (existingReferenceSchema.isEmpty()) {

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/mutation/reference/ModifyReferenceSchemaRelatedEntityGroupMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/mutation/reference/ModifyReferenceSchemaRelatedEntityGroupMutation.java
@@ -107,6 +107,10 @@ public class ModifyReferenceSchemaRelatedEntityGroupMutation
 	@Override
 	public EntitySchemaContract mutate(@Nonnull CatalogSchemaContract catalogSchema, @Nullable EntitySchemaContract entitySchema) {
 		Assert.isPremiseValid(entitySchema != null, "Entity schema is mandatory!");
+		if (this.referencedGroupTypeManaged) {
+			// check that the referenced group entity type exists
+			catalogSchema.getEntitySchemaOrThrowException(this.referencedGroupType);
+		}
 		final Optional<ReferenceSchemaContract> existingReferenceSchema = entitySchema.getReference(name);
 		if (existingReferenceSchema.isEmpty()) {
 			// ups, the associated data is missing

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/mutation/reference/ModifyReferenceSchemaRelatedEntityMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/mutation/reference/ModifyReferenceSchemaRelatedEntityMutation.java
@@ -107,6 +107,10 @@ public class ModifyReferenceSchemaRelatedEntityMutation
 	@Override
 	public EntitySchemaContract mutate(@Nonnull CatalogSchemaContract catalogSchema, @Nullable EntitySchemaContract entitySchema) {
 		Assert.isPremiseValid(entitySchema != null, "Entity schema is mandatory!");
+		if (this.referencedEntityTypeManaged) {
+			// check that the referenced entity type exists
+			catalogSchema.getEntitySchemaOrThrowException(this.referencedEntityType);
+		}
 		final Optional<ReferenceSchemaContract> existingReferenceSchema = entitySchema.getReference(name);
 		if (existingReferenceSchema.isEmpty()) {
 			// ups, the associated data is missing

--- a/evita_functional_tests/src/test/java/io/evitadb/core/EvitaTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/core/EvitaTest.java
@@ -921,6 +921,67 @@ class EvitaTest implements EvitaTestSupport {
 	}
 
 	@Test
+	void shouldFailToDefineReferencesToManagedEntitiesThatDontExist() {
+		assertThrows(
+			CollectionNotFoundException.class,
+			() -> evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema("someEntity")
+						.withReferenceToEntity(
+							"someReference",
+							"nonExistingEntity",
+							Cardinality.ONE_OR_MORE
+						)
+						.updateVia(session);
+				}
+			)
+		);
+	}
+
+	@Test
+	void shouldFailToDefineReferencesToManagedEntityGroupThatDoesntExist() {
+		assertThrows(
+			CollectionNotFoundException.class,
+			() -> evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(
+							"someEntity"
+						)
+						.withReferenceTo(
+							"someReference",
+							"nonExistingEntityNonManagedEntity",
+							Cardinality.ONE_OR_MORE,
+							whichIs -> whichIs.withGroupTypeRelatedToEntity("nonExistingGroup")
+						)
+						.updateVia(session);
+				}
+			)
+		);
+	}
+
+	@Test
+	void shouldCreateReferencesToNonManagedEntityAndGroup() {
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(
+						"someEntity"
+					)
+					.withReferenceTo(
+						"someReference",
+						"nonExistingEntityNonManagedEntity",
+						Cardinality.ONE_OR_MORE,
+						whichIs -> whichIs.withGroupType("nonExistingNonManagedGroup")
+					).updateVia(session);
+
+				assertNotNull(session.getEntitySchema("someEntity"));
+			}
+		);
+	}
+
+	@Test
 	void shouldFailGracefullyWhenRequestingHierarchyOnNonHierarchyEntity() {
 		evita.updateCatalog(
 			TEST_CATALOG,


### PR DESCRIPTION
Former implementation allowed to create reference targeting non-existing evitaDB entity type.