### PR TITLE
fix(#393): Predecessor ordering used in facet statistics doesn't work

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
@@ -381,7 +381,7 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 				new EntityIndex[] {entityIndex},
 				entityType,
 				locale,
-				new AttributeSchemaAccessor(queryContext),
+				new AttributeSchemaAccessor(queryContext.getCatalogSchema(), queryContext.getSchema(entityType)),
 				EntityAttributeExtractor.INSTANCE,
 				() -> {
 					for (OrderConstraint innerConstraint : orderBy.getChildren()) {

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EntityByChainOrderingFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EntityByChainOrderingFunctionalTest.java
@@ -100,7 +100,7 @@ public class EntityByChainOrderingFunctionalTest {
 			);
 
 			final DataGenerator dataGenerator = new DataGenerator();
-			AtomicInteger index = new AtomicInteger();
+			final AtomicInteger index = new AtomicInteger();
 
 			dataGenerator.registerValueGenerator(
 				Entities.PRODUCT, ATTRIBUTE_ORDER,


### PR DESCRIPTION
When attribute of `Predecessor` type is used to sort facet statistics, evitaDB doesn't sort the facet statistics within groups.
```
query(
	collection('Product'),
	filterBy(
		entityLocaleEquals('cs')
	),
	require(
		page(1, 20),
		facetSummaryOfReference(
			'groups',
			COUNTS,
			orderBy(
				attributeNatural('order', ASC)
			),
			entityFetch(
				attributeContent('name', "order"),
				dataInLocales('cs')
			)
		)
	)
)
```
Other string attributes work as expected.