### PR TITLE
fix(#398): Global index of entity Group unexpectedly not found! in Fa…

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryContext.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryContext.java
@@ -813,15 +813,6 @@ public class QueryContext implements AutoCloseable, LocaleProvider {
 	 * Returns {@link EntityIndex} by its key and entity type.
 	 */
 	@Nonnull
-	public GlobalEntityIndex getGlobalEntityIndex(@Nonnull String entityType) {
-		return getGlobalEntityIndexIfExists(entityType)
-			.orElseThrow(() -> new EvitaInternalError("Global index of entity " + entityType + " unexpectedly not found!"));
-	}
-
-	/**
-	 * Returns {@link EntityIndex} by its key and entity type.
-	 */
-	@Nonnull
 	public Optional<GlobalEntityIndex> getGlobalEntityIndexIfExists(@Nonnull String entityType) {
 		return ofNullable(getIndex(entityType, GLOBAL_INDEX_KEY, GlobalEntityIndex.class));
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/ReferencedEntityFetcher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/ReferencedEntityFetcher.java
@@ -30,6 +30,7 @@ import com.carrotsearch.hppc.IntSet;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
 import io.evitadb.api.EntityCollectionContract;
 import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.exception.CollectionNotFoundException;
 import io.evitadb.api.query.FilterConstraint;
 import io.evitadb.api.query.filter.EntityPrimaryKeyInSet;
 import io.evitadb.api.query.filter.FilterBy;
@@ -1105,8 +1106,10 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 
 			// initialize used data structures
 			final String entityType = entityCollection.getEntityType();
-			final GlobalEntityIndex globalIndex = entityCollection instanceof EntityCollection ec ? ec.getGlobalIndex() :
-				queryContext.getGlobalEntityIndex(entityType);
+			final GlobalEntityIndex globalIndex = entityCollection instanceof EntityCollection ec ?
+				ec.getGlobalIndex() :
+				queryContext.getGlobalEntityIndexIfExists(entityType)
+					.orElseThrow(() -> new CollectionNotFoundException(entityType));
 			// scope predicate limits the parent traversal
 			final HierarchyTraversalPredicate scopePredicate = hierarchyContent.getStopAt()
 				.map(stopAt -> stopAtConstraintToPredicate(TraversalDirection.BOTTOM_UP, stopAt, queryContext, globalIndex, null))

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/FacetSummaryOfReferenceTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/FacetSummaryOfReferenceTranslator.java
@@ -52,6 +52,7 @@ import io.evitadb.core.query.extraResult.translator.facet.producer.FacetSummaryP
 import io.evitadb.core.query.extraResult.translator.facet.producer.FilteringFormulaPredicate;
 import io.evitadb.core.query.extraResult.translator.reference.EntityFetchTranslator;
 import io.evitadb.core.query.indexSelection.TargetIndexes;
+import io.evitadb.core.query.sort.NoSorter;
 import io.evitadb.core.query.sort.Sorter;
 import io.evitadb.index.EntityIndex;
 import io.evitadb.index.bitmap.Bitmap;
@@ -83,10 +84,10 @@ public class FacetSummaryOfReferenceTranslator implements RequireConstraintTrans
 	/**
 	 * Creates a predicate for filtering facet groups.
 	 *
-	 * @param filterGroupBy the filter group to apply
+	 * @param filterGroupBy      the filter group to apply
 	 * @param extraResultPlanner the extra result planning visitor
-	 * @param referenceSchema the reference schema contract
-	 * @param required indicates if the facet groups are required
+	 * @param referenceSchema    the reference schema contract
+	 * @param required           indicates if the facet groups are required
 	 * @return the predicate for filtering facet groups, or null if not required
 	 */
 	@Nullable
@@ -116,10 +117,10 @@ public class FacetSummaryOfReferenceTranslator implements RequireConstraintTrans
 	/**
 	 * Creates a predicate for filtering facets.
 	 *
-	 * @param filterBy The filter criteria.
+	 * @param filterBy           The filter criteria.
 	 * @param extraResultPlanner The visitor for planning extra result queries.
-	 * @param referenceSchema The schema of the referenced entity.
-	 * @param required Indicates if the facet is required.
+	 * @param referenceSchema    The schema of the referenced entity.
+	 * @param required           Indicates if the facet is required.
 	 * @return The created facet predicate.
 	 */
 	@Nullable
@@ -150,11 +151,11 @@ public class FacetSummaryOfReferenceTranslator implements RequireConstraintTrans
 	/**
 	 * Creates a facet sorter based on the provided parameters.
 	 *
-	 * @param orderBy the ordering criteria for the facet
-	 * @param locale the locale used for sorting
+	 * @param orderBy            the ordering criteria for the facet
+	 * @param locale             the locale used for sorting
 	 * @param extraResultPlanner the extra result planning visitor
-	 * @param referenceSchema the reference schema contract
-	 * @param required indicates whether sorting is required or optional
+	 * @param referenceSchema    the reference schema contract
+	 * @param required           indicates whether sorting is required or optional
 	 * @return the created facet sorter, or null if the reference schema is not managed and sorting is not required
 	 */
 	@Nullable
@@ -174,22 +175,26 @@ public class FacetSummaryOfReferenceTranslator implements RequireConstraintTrans
 		} else if (!referenceSchema.isReferencedEntityTypeManaged()) {
 			return null;
 		}
-		return extraResultPlanner.createSorter(
-			orderBy,
-			locale, extraResultPlanner.getGlobalEntityIndex(referenceSchema.getReferencedEntityType()),
-			referenceSchema.getReferencedEntityType(),
-			() -> "Facet summary `" + referenceSchema.getName() + "` facet ordering: " + orderBy
-		);
+		return extraResultPlanner.getGlobalEntityIndexIfExists(referenceSchema.getReferencedEntityType())
+			.map(ix -> extraResultPlanner.createSorter(
+					orderBy,
+					locale,
+					ix,
+					referenceSchema.getReferencedEntityType(),
+					() -> "Facet summary `" + referenceSchema.getName() + "` facet ordering: " + orderBy
+				)
+			)
+			.orElse(NoSorter.INSTANCE);
 	}
 
 	/**
 	 * Creates a sorter for facet group ordering.
 	 *
-	 * @param orderBy              The order by criteria for the facet groups.
-	 * @param locale               The locale used for sorting.
-	 * @param extraResultPlanner   The extra result planner used for sorting.
-	 * @param referenceSchema      The reference schema for the facet groups.
-	 * @param required             Indicates if sorting is required.
+	 * @param orderBy            The order by criteria for the facet groups.
+	 * @param locale             The locale used for sorting.
+	 * @param extraResultPlanner The extra result planner used for sorting.
+	 * @param referenceSchema    The reference schema for the facet groups.
+	 * @param required           Indicates if sorting is required.
 	 * @return The created sorter for facet group ordering, or null if not required.
 	 */
 	@Nullable
@@ -210,13 +215,16 @@ public class FacetSummaryOfReferenceTranslator implements RequireConstraintTrans
 			return null;
 		}
 
-		return extraResultPlanner.createSorter(
-			orderBy,
-			locale,
-			extraResultPlanner.getGlobalEntityIndex(referenceSchema.getReferencedGroupType()),
-			referenceSchema.getReferencedGroupType(),
-			() -> "Facet summary `" + referenceSchema.getName() + "` group ordering: " + orderBy
-		);
+		return extraResultPlanner.getGlobalEntityIndexIfExists(referenceSchema.getReferencedGroupType())
+			.map(ix -> extraResultPlanner.createSorter(
+					orderBy,
+					locale,
+					ix,
+					referenceSchema.getReferencedGroupType(),
+					() -> "Facet summary `" + referenceSchema.getName() + "` group ordering: " + orderBy
+				)
+			)
+			.orElse(NoSorter.INSTANCE);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/HierarchyOfReferenceTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/HierarchyOfReferenceTranslator.java
@@ -49,6 +49,7 @@ import io.evitadb.utils.Assert;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
 
@@ -91,57 +92,60 @@ public class HierarchyOfReferenceTranslator
 				() -> new EntityIsNotHierarchicalException(referenceName, entityType));
 
 			final HierarchyFilterConstraint hierarchyWithin = evitaRequest.getHierarchyWithin(referenceName);
-			final GlobalEntityIndex globalIndex = extraResultPlanner.getGlobalEntityIndex(entityType);
-			final Sorter sorter = hierarchyOfReference.getOrderBy()
-				.map(
-					it -> extraResultPlanner.createSorter(
-						it,
-						null,
-						globalIndex,
-						entityType,
-						() -> "Hierarchy statistics of `" + entitySchema.getName() + "`: " + it
+			final Optional<GlobalEntityIndex> targetGlobalIndexRef = extraResultPlanner.getGlobalEntityIndexIfExists(entityType);
+			if (targetGlobalIndexRef.isPresent()) {
+				final GlobalEntityIndex globalIndex = targetGlobalIndexRef.get();
+				final Sorter sorter = hierarchyOfReference.getOrderBy()
+					.map(
+						it -> extraResultPlanner.createSorter(
+							it,
+							null,
+							globalIndex,
+							entityType,
+							() -> "Hierarchy statistics of `" + entitySchema.getName() + "`: " + it
+						)
 					)
-				)
-				.orElse(null);
+					.orElse(null);
 
-			// the request is more complex
-			hierarchyStatisticsProducer.interpret(
-				entitySchema,
-				referenceSchema,
-				extraResultPlanner.getAttributeSchemaAccessor().withReferenceSchemaAccessor(referenceName),
-				hierarchyWithin,
-				globalIndex,
-				null,
-				// we need to access EntityIndexType.REFERENCED_HIERARCHY_NODE of the queried type to access
-				// entity primary keys that are referencing the hierarchy entity
-				(nodeId, statisticsBase) ->
-					ofNullable(extraResultPlanner.getIndex(queriedEntityType, createReferencedHierarchyIndexKey(referenceName, nodeId), ReducedEntityIndex.class))
-						.map(hierarchyIndex -> {
-							final FilterBy filter = statisticsBase == StatisticsBase.COMPLETE_FILTER ?
-								extraResultPlanner.getFilterByWithoutHierarchyFilter(referenceSchema) :
-								extraResultPlanner.getFilterByWithoutHierarchyAndUserFilter(referenceSchema);
-							if (filter == null || !filter.isApplicable()) {
-								return hierarchyIndex.getAllPrimaryKeysFormula();
-							} else {
-								return createFilterFormula(
-									extraResultPlanner.getQueryContext(),
-									filter,
-									ReducedEntityIndex.class,
-									hierarchyIndex,
-									extraResultPlanner.getAttributeSchemaAccessor()
-								);
-							}
-						})
-						.orElse(EmptyFormula.INSTANCE),
-				null,
-				hierarchyOfReference.getEmptyHierarchicalEntityBehaviour(),
-				sorter,
-				() -> {
-					for (RequireConstraint child : hierarchyOfReference) {
-						child.accept(extraResultPlanner);
+				// the request is more complex
+				hierarchyStatisticsProducer.interpret(
+					entitySchema,
+					referenceSchema,
+					extraResultPlanner.getAttributeSchemaAccessor().withReferenceSchemaAccessor(referenceName),
+					hierarchyWithin,
+					globalIndex,
+					null,
+					// we need to access EntityIndexType.REFERENCED_HIERARCHY_NODE of the queried type to access
+					// entity primary keys that are referencing the hierarchy entity
+					(nodeId, statisticsBase) ->
+						ofNullable(extraResultPlanner.getIndex(queriedEntityType, createReferencedHierarchyIndexKey(referenceName, nodeId), ReducedEntityIndex.class))
+							.map(hierarchyIndex -> {
+								final FilterBy filter = statisticsBase == StatisticsBase.COMPLETE_FILTER ?
+									extraResultPlanner.getFilterByWithoutHierarchyFilter(referenceSchema) :
+									extraResultPlanner.getFilterByWithoutHierarchyAndUserFilter(referenceSchema);
+								if (filter == null || !filter.isApplicable()) {
+									return hierarchyIndex.getAllPrimaryKeysFormula();
+								} else {
+									return createFilterFormula(
+										extraResultPlanner.getQueryContext(),
+										filter,
+										ReducedEntityIndex.class,
+										hierarchyIndex,
+										extraResultPlanner.getAttributeSchemaAccessor()
+									);
+								}
+							})
+							.orElse(EmptyFormula.INSTANCE),
+					null,
+					hierarchyOfReference.getEmptyHierarchicalEntityBehaviour(),
+					sorter,
+					() -> {
+						for (RequireConstraint child : hierarchyOfReference) {
+							child.accept(extraResultPlanner);
+						}
 					}
-				}
-			);
+				);
+			}
 		}
 		return hierarchyStatisticsProducer;
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/HierarchyOfSelfTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/HierarchyOfSelfTranslator.java
@@ -49,6 +49,7 @@ import io.evitadb.utils.Assert;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This implementation of {@link RequireConstraintTranslator} converts {@link HierarchyOfSelf} to
@@ -74,18 +75,6 @@ public class HierarchyOfSelfTranslator
 		// prepare shared data from the context
 		final EvitaRequest evitaRequest = extraResultPlanner.getEvitaRequest();
 		final HierarchyFilterConstraint hierarchyWithin = evitaRequest.getHierarchyWithin(null);
-		final GlobalEntityIndex globalIndex = extraResultPlanner.getGlobalEntityIndex(queriedEntityType);
-		final Sorter sorter = hierarchyOfSelf.getOrderBy()
-			.map(
-				it -> extraResultPlanner.createSorter(
-					it,
-					null,
-					globalIndex,
-					queriedEntityType,
-					() -> "Hierarchy statistics of `" + entitySchema.getName() + "`: " + it
-				)
-			)
-			.orElse(null);
 
 		// retrieve existing producer or create new one
 		final HierarchyStatisticsProducer hierarchyStatisticsProducer = getHierarchyStatisticsProducer(
@@ -94,73 +83,89 @@ public class HierarchyOfSelfTranslator
 		// we need to register producer prematurely
 		extraResultPlanner.registerProducer(hierarchyStatisticsProducer);
 
-		// the request is simple - we use global index of current entity
-		hierarchyStatisticsProducer.interpret(
-			entitySchema,
-			null,
-			extraResultPlanner.getAttributeSchemaAccessor(),
-			hierarchyWithin,
-			globalIndex,
-			extraResultPlanner.getPrefetchRequirementCollector(),
-			(nodeId, statisticsBase) -> {
-				final FilterBy filter = statisticsBase == StatisticsBase.COMPLETE_FILTER ?
-					extraResultPlanner.getFilterByWithoutHierarchyFilter(null) :
-					extraResultPlanner.getFilterByWithoutHierarchyAndUserFilter(null);
-				final Formula childrenExceptSelfFormula = FormulaFactory.not(
-					new ConstantFormula(new BaseBitmap(nodeId)),
-					globalIndex.getHierarchyNodesForParentFormula(nodeId)
-				);
-				if (filter == null || !filter.isApplicable()) {
-					return childrenExceptSelfFormula;
-				} else {
-					final Formula baseFormula = extraResultPlanner.computeOnlyOnce(
-						Collections.singletonList(globalIndex),
-						filter,
-						() -> createFilterFormula(
-							extraResultPlanner.getQueryContext(),
+		final Optional<GlobalEntityIndex> targetGlobalIndexRef = extraResultPlanner.getGlobalEntityIndexIfExists(queriedEntityType);
+		if (targetGlobalIndexRef.isPresent()) {
+			final GlobalEntityIndex globalIndex = targetGlobalIndexRef.get();
+			final Sorter sorter = hierarchyOfSelf.getOrderBy()
+				.map(
+					it -> extraResultPlanner.createSorter(
+						it,
+						null,
+						globalIndex,
+						queriedEntityType,
+						() -> "Hierarchy statistics of `" + entitySchema.getName() + "`: " + it
+					)
+				)
+				.orElse(null);
+
+			// the request is simple - we use global index of current entity
+			hierarchyStatisticsProducer.interpret(
+				entitySchema,
+				null,
+				extraResultPlanner.getAttributeSchemaAccessor(),
+				hierarchyWithin,
+				globalIndex,
+				extraResultPlanner.getPrefetchRequirementCollector(),
+				(nodeId, statisticsBase) -> {
+					final FilterBy filter = statisticsBase == StatisticsBase.COMPLETE_FILTER ?
+						extraResultPlanner.getFilterByWithoutHierarchyFilter(null) :
+						extraResultPlanner.getFilterByWithoutHierarchyAndUserFilter(null);
+					final Formula childrenExceptSelfFormula = FormulaFactory.not(
+						new ConstantFormula(new BaseBitmap(nodeId)),
+						globalIndex.getHierarchyNodesForParentFormula(nodeId)
+					);
+					if (filter == null || !filter.isApplicable()) {
+						return childrenExceptSelfFormula;
+					} else {
+						final Formula baseFormula = extraResultPlanner.computeOnlyOnce(
+							Collections.singletonList(globalIndex),
 							filter,
-							GlobalEntityIndex.class,
-							globalIndex,
-							extraResultPlanner.getAttributeSchemaAccessor()
-						)
-					);
-					return FormulaFactory.and(
-						baseFormula,
-						childrenExceptSelfFormula
-					);
-				}
-			},
-			statisticsBase -> {
-				final FilterBy filter = statisticsBase == StatisticsBase.COMPLETE_FILTER ?
-					extraResultPlanner.getFilterByWithoutHierarchyFilter(null) :
-					extraResultPlanner.getFilterByWithoutHierarchyAndUserFilter(null);
-				if (filter == null || !filter.isApplicable()) {
-					return HierarchyFilteringPredicate.ACCEPT_ALL_NODES_PREDICATE;
-				} else {
-					final Formula baseFormula = extraResultPlanner.computeOnlyOnce(
-						Collections.singletonList(globalIndex),
-						filter,
-						() -> createFilterFormula(
-							extraResultPlanner.getQueryContext(),
+							() -> createFilterFormula(
+								extraResultPlanner.getQueryContext(),
+								filter,
+								GlobalEntityIndex.class,
+								globalIndex,
+								extraResultPlanner.getAttributeSchemaAccessor()
+							)
+						);
+						return FormulaFactory.and(
+							baseFormula,
+							childrenExceptSelfFormula
+						);
+					}
+				},
+				statisticsBase -> {
+					final FilterBy filter = statisticsBase == StatisticsBase.COMPLETE_FILTER ?
+						extraResultPlanner.getFilterByWithoutHierarchyFilter(null) :
+						extraResultPlanner.getFilterByWithoutHierarchyAndUserFilter(null);
+					if (filter == null || !filter.isApplicable()) {
+						return HierarchyFilteringPredicate.ACCEPT_ALL_NODES_PREDICATE;
+					} else {
+						final Formula baseFormula = extraResultPlanner.computeOnlyOnce(
+							Collections.singletonList(globalIndex),
 							filter,
-							GlobalEntityIndex.class,
-							globalIndex,
-							extraResultPlanner.getAttributeSchemaAccessor()
-						)
-					);
-					return new FilteringFormulaHierarchyEntityPredicate(
-						filter, baseFormula
-					);
+							() -> createFilterFormula(
+								extraResultPlanner.getQueryContext(),
+								filter,
+								GlobalEntityIndex.class,
+								globalIndex,
+								extraResultPlanner.getAttributeSchemaAccessor()
+							)
+						);
+						return new FilteringFormulaHierarchyEntityPredicate(
+							filter, baseFormula
+						);
+					}
+				},
+				EmptyHierarchicalEntityBehaviour.LEAVE_EMPTY,
+				sorter,
+				() -> {
+					for (RequireConstraint child : hierarchyOfSelf) {
+						child.accept(extraResultPlanner);
+					}
 				}
-			},
-			EmptyHierarchicalEntityBehaviour.LEAVE_EMPTY,
-			sorter,
-			() -> {
-				for (RequireConstraint child : hierarchyOfSelf) {
-					child.accept(extraResultPlanner);
-				}
-			}
-		);
+			);
+		}
 
 		return hierarchyStatisticsProducer;
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/ReferencePropertyTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/ReferencePropertyTranslator.java
@@ -78,8 +78,9 @@ public class ReferencePropertyTranslator implements OrderingConstraintTranslator
 		final Optional<ReferencedTypeEntityIndex> referencedEntityTypeIndex = orderByVisitor.getIndex(entityIndexKey);
 
 		final Comparator<EntityIndex> indexComparator = referencedEntityHierarchical ?
-			getHierarchyComparator(orderByVisitor.getGlobalEntityIndex(referenceSchema.getReferencedEntityType())) :
-			DEFAULT_COMPARATOR;
+			orderByVisitor.getGlobalEntityIndexIfExists(referenceSchema.getReferencedEntityType())
+				.map(ReferencePropertyTranslator::getHierarchyComparator)
+				.orElse(DEFAULT_COMPARATOR) : DEFAULT_COMPARATOR;
 
 		return referencedEntityTypeIndex.map(
 				it -> it.getAllPrimaryKeys()
@@ -116,8 +117,9 @@ public class ReferencePropertyTranslator implements OrderingConstraintTranslator
 		boolean referencedEntityHierarchical
 	) {
 		final Comparator<EntityIndex> indexComparator = referencedEntityHierarchical ?
-			getHierarchyComparator(orderByVisitor.getGlobalEntityIndex(referenceSchema.getReferencedEntityType())) :
-			DEFAULT_COMPARATOR;
+			orderByVisitor.getGlobalEntityIndexIfExists(referenceSchema.getReferencedEntityType())
+				.map(ReferencePropertyTranslator::getHierarchyComparator)
+				.orElse(DEFAULT_COMPARATOR) : DEFAULT_COMPARATOR;
 
 		return orderByVisitor.getTargetIndexes()
 			.stream()


### PR DESCRIPTION
…cetSummary sorting

Error encountered when trying to calculate summary on reference / entity without any data.

```
io.evitadb.exception.EvitaInternalError: Global index of entity Group unexpectedly not found!
	at io.evitadb.core.query.QueryContext.lambda$getGlobalEntityIndex$18(QueryContext.java:818)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at io.evitadb.core.query.QueryContext.getGlobalEntityIndex(QueryContext.java:818)
	at io.evitadb.core.query.extraResult.ExtraResultPlanningVisitor.getGlobalEntityIndex(ExtraResultPlanningVisitor.java:139)
	at io.evitadb.core.query.extraResult.translator.facet.FacetSummaryOfReferenceTranslator.createFacetSorter(FacetSummaryOfReferenceTranslator.java:179)
	at io.evitadb.core.query.extraResult.translator.facet.FacetSummaryOfReferenceTranslator.lambda$apply$20(FacetSummaryOfReferenceTranslator.java:324)
	at java.base/java.util.Optional.map(Optional.java:260)
	at io.evitadb.core.query.extraResult.translator.facet.FacetSummaryOfReferenceTranslator.apply(FacetSummaryOfReferenceTranslator.java:324)
	at io.evitadb.core.query.extraResult.translator.facet.FacetSummaryOfReferenceTranslator.apply(FacetSummaryOfReferenceTranslator.java:81)
```