### PR TITLE
fix(#401): NPE when using attributeBetween for attributeHistogram

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
@@ -234,7 +234,7 @@ public class AndFormula extends AbstractCacheableFormula {
 				() -> {
 					final List<Formula> formulasFromEasiestToHardest = Arrays.stream(getInnerFormulas())
 						.sorted(Comparator.comparingLong(TransactionalDataRelatedStructure::getEstimatedCost))
-						.collect(Collectors.toList());
+						.toList();
 					final RoaringBitmap[] theBitmaps = new RoaringBitmap[formulasFromEasiestToHardest.size()];
 					// go from the cheapest formula to the more expensive and compute one by one
 					for (int i = 0; i < formulasFromEasiestToHardest.size(); i++) {

--- a/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientTest.java
@@ -427,13 +427,13 @@ class EvitaClientTest implements TestConstants, EvitaTestSupport {
 			assertEquals(
 				Arrays.stream(expectedAllPricesForSale)
 					.filter(it -> Objects.equals(currency, it.currency()))
-					.filter(it -> Arrays.stream(priceLists).anyMatch(priceList -> Objects.equals(priceList, it.priceList())))
-					.sorted((o1, o2) -> {
+					.filter(it -> Arrays.stream(priceLists)
+						.anyMatch(priceList -> Objects.equals(priceList, it.priceList())))
+					.min((o1, o2) -> {
 						final int ix1 = ArrayUtils.indexOf(o1.priceList(), priceLists);
 						final int ix2 = ArrayUtils.indexOf(o2.priceList(), priceLists);
 						return Integer.compare(ix1, ix2);
 					})
-					.findFirst()
 					.orElse(null),
 				product.getPriceForSale()
 			);

--- a/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/CatalogRestQueryEntityQueryFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/CatalogRestQueryEntityQueryFunctionalTest.java
@@ -1156,7 +1156,7 @@ class CatalogRestQueryEntityQueryFunctionalTest extends CatalogRestDataEndpointF
 			query(
 				collection(Entities.PRODUCT),
 				filterBy(
-					entityPrimaryKeyInSet(productsWithLotsOfStores.keySet().stream().toArray(Integer[]::new)),
+					entityPrimaryKeyInSet(productsWithLotsOfStores.keySet().toArray(Integer[]::new)),
 					entityLocaleEquals(CZECH_LOCALE)
 				),
 				require(


### PR DESCRIPTION
In demo dataset when `attributeHistogram` is requested with `attributeBetween` in a `userFilter`:
```
query(
  collection("Product"),
  filterBy(
    userFilter(
      attributeBetween("battery-capacity", "3000", "7000")
    )
  ),
  require(
    attributeHistogram(10, "battery-capacity")
  )
)
```
evitaDB returns NPE:
```
Caused by: java.lang.NullPointerException: null
	at java.base/java.util.Comparator.lambda$comparingLong$6043328a$1(Comparator.java:515)
	at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
	at java.base/java.util.TimSort.sort(TimSort.java:220)
	at java.base/java.util.Arrays.sort(Arrays.java:1307)
	at java.base/java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:353)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.query.algebra.base.AndFormula.lambda$getRoaringBitmaps$10(AndFormula.java:237)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.query.algebra.base.AndFormula.getRoaringBitmaps(AndFormula.java:233)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.query.algebra.base.AndFormula.computeInternal(AndFormula.java:211)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.query.algebra.AbstractCacheableFormula.compute(AbstractCacheableFormula.java:62)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.query.extraResult.translator.histogram.producer.AttributeHistogramProducer.hasSenseWithMandatoryFilter(AttributeHistogramProducer.java:439)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.query.extraResult.translator.histogram.producer.AttributeHistogramProducer.lambda$fabricate$5(AttributeHistogramProducer.java:368)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178)
	at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1850)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.query.extraResult.translator.histogram.producer.AttributeHistogramProducer.fabricate(AttributeHistogramProducer.java:391)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.query.QueryPlan.fabricateExtraResults(QueryPlan.java:228)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.query.QueryPlan.execute(QueryPlan.java:200)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.EntityCollection.getEntities(EntityCollection.java:333)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.EvitaSession.query(EvitaSession.java:1073)
	at evita.engine@10.1-SNAPSHOT/io.evitadb.core.EvitaSession.query(EvitaSession.java:439)
	... 24 common frames omitted
```
Only if price constraints needed for `priceForSale` calculation (even though `priceForSale` isn't needed by user) are used as well, evitaDB doesn't throw any error, like so:
```
query(
  collection("Product"),
  filterBy(
    priceInCurrency("EUR"),
    priceInPriceLists("basic"),
    userFilter(
      attributeBetween("battery-capacity", "3000", "7000")
    )
  ),
  require(
    attributeHistogram(10, "battery-capacity")
  )
)
```