### PR TITLE
fix(#410): Failed to reset all prices of the entity

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetPriceMethodClassifier.java
+++ b/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetPriceMethodClassifier.java
@@ -291,14 +291,13 @@ public class SetPriceMethodClassifier extends DirectMethodClassification<Object,
 		final boolean initialBuilder = entityBuilder instanceof InitialEntityBuilder;
 		if (initialBuilder) {
 			entityBuilder.removeAllPrices();
+		} else {
+			entityBuilder.removeAllNonTouchedPrices();
 		}
 		@SuppressWarnings("unchecked")
 		final Collection<? extends PriceContract> thePrices = (Collection<? extends PriceContract>) args[0];
 		for (PriceContract thePrice : thePrices) {
 			entityBuilder.setPrice(thePrice);
-		}
-		if (!initialBuilder) {
-			entityBuilder.removeAllNonTouchedPrices();
 		}
 	}
 

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/ExistingPricesBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/ExistingPricesBuilder.java
@@ -444,7 +444,7 @@ public class ExistingPricesBuilder implements PricesBuilder {
 			.filter(it -> !(priceMutations.get(it.priceKey()) instanceof RemovePriceMutation))
 			.findFirst()
 			.orElse(null);
-		if (conflictingPrice != null) {
+		if (conflictingPrice != null && !removeAllNonModifiedPrices) {
 			throw new AmbiguousPriceException(conflictingPrice, price);
 		}
 		// check whether there is no conflicting update


### PR DESCRIPTION
The scenario is as follows:

1. entity has price A ('basic', 'CZK', id = 1)
2. I call setPrices method with collection of new prices where there is price B ('basic', 'CZK', id = 2) ... the price B should replace price A

I get exception:

```
ERROR Failed to index entity eP_380523CZ-45 in catalog milagro_cz due to: Price `💰 90752 in basic CZK ` with id `90752` cannot be added to the entity. There is already present price `💰 8473 in basic CZK ` with id `8473` that would create conflict with newly added price because their validity spans overlap.
io.evitadb.api.exception.AmbiguousPriceException: Price `💰 90752 in basic CZK ` with id `90752` cannot be added to the entity. There is already present price `💰 8473 in basic CZK ` with id `8473` that would create conflict with newly added price because their validity spans overlap.
	at io.evitadb.api.requestResponse.data.structure.ExistingPricesBuilder.assertPriceNotAmbiguousBeforeAdding(ExistingPricesBuilder.java:448) ~[evita_api-10.1.3.jar:?]
```

The method sets `entityBuilder.removeAllNonTouchedPrices();` but too late and nevertheless it's not taken into an account when doing the ambiguous check.