### PR TITLE
fix(#425): Removing reference by id that returns boolean result ends …

### DIFF
--- a/evita_functional_tests/src/test/java/io/evitadb/api/EntityEditorProxyingFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EntityEditorProxyingFunctionalTest.java
@@ -2231,16 +2231,18 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 				assertEquals(1, store.getId());
 				assertEquals("Delirium-Tremens-1", store.getCode());
 
+				assertTrue(product1.removeStoreByIdAndReturnBoolean(2));
+
 				final Optional<EntityMutation> mutation = product1.toMutation();
 				assertTrue(mutation.isPresent());
-				assertEquals(2, mutation.get().getLocalMutations().size());
+				assertEquals(3, mutation.get().getLocalMutations().size());
 
 				final ProductInterface modifiedInstance = product1.toInstance();
 				assertEquals(1, modifiedInstance.getProductCategories().size());
 				assertNotNull(modifiedInstance.getCategoryById(categoryId1));
 				assertNull(modifiedInstance.getCategoryById(categoryId2));
 
-				assertEquals(2, modifiedInstance.getStores().length);
+				assertEquals(1, modifiedInstance.getStores().length);
 
 				product1.upsertVia(evitaSession);
 
@@ -2250,7 +2252,7 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 
 				assertNull(product8SE.getReference(Entities.CATEGORY, categoryId2).orElse(null));
 				assertNotNull(product8SE.getReference(Entities.CATEGORY, categoryId1).orElse(null));
-				assertEquals(2, product8SE.getReferences(Entities.STORE).size());
+				assertEquals(1, product8SE.getReferences(Entities.STORE).size());
 			}
 		);
 	}

--- a/evita_functional_tests/src/test/java/io/evitadb/api/mock/ProductInterfaceEditor.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/mock/ProductInterfaceEditor.java
@@ -322,4 +322,8 @@ public interface ProductInterfaceEditor extends ProductInterface, WithEntityBuil
 	@ReferenceRef(Entities.STORE)
 	@RemoveWhenExists
 	StoreInterface removeStoreById(int storeId);
+
+	@ReferenceRef(Entities.STORE)
+	@RemoveWhenExists
+	boolean removeStoreByIdAndReturnBoolean(int storeId);
 }


### PR DESCRIPTION
…with exception

Method with signature:

```java
/**
     * Removes the tag reference if it exists.
     * @param tagId tag id to be removed
     * @return true if the tag was removed, false if it did not exist
     */
    @ReferenceRef(WithPublishedTags.REFERENCE_TAG)
    @RemoveWhenExists
    boolean removeTagById(int tagId);
```

Throws exception when invoked:

```
ERROR Failed to index entity eG_cym-group in catalog milagro_cz due to: Failed to wrap `SealedEntity` into class `boolean` due to: Failed to wrap `SealedEntity` into class `boolean` due to: Cannot find any constructor with matching arguments in class: `boolean`
io.evitadb.api.exception.EntityClassInvalidException: Failed to wrap `SealedEntity` into class `boolean` due to: Failed to wrap `SealedEntity` into class `boolean` due to: Cannot find any constructor with matching arguments in class: `boolean`
	at io.evitadb.api.proxy.impl.ProxycianFactory.createReferenceProxy(ProxycianFactory.java:344) ~[evita_api-10.2.0.jar:?]
	at io.evitadb.api.proxy.impl.ProxycianFactory.createEntityReferenceProxy(ProxycianFactory.java:186) ~[evita_api-10.2.0.jar:?]
	at io.evitadb.api.proxy.impl.AbstractEntityProxyState.lambda$getOrCreateEntityReferenceProxy$7(AbstractEntityProxyState.java:401) ~[evita_api-10.2.0.jar:?]
	at io.evitadb.api.proxy.impl.AbstractEntityProxyState.lambda$getOrCreateEntityReferenceProxy$8(AbstractEntityProxyState.java:410) ~[evita_api-10.2.0.jar:?]
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708) ~[?:?]
	at io.evitadb.api.proxy.impl.AbstractEntityProxyState.getOrCreateEntityReferenceProxy(AbstractEntityProxyState.java:408) ~[evita_api-10.2.0.jar:?]
	at io.evitadb.api.proxy.impl.SealedEntityProxyState.getOrCreateEntityReferenceProxy(SealedEntityProxyState.java:67) ~[evita_api-10.2.0.jar:?]
	at io.evitadb.api.proxy.impl.entityBuilder.SetReferenceMethodClassifier.lambda$removeReferencedEntityIdWithReferenceResult$55(SetReferenceMethodClassifier.java:1606) ~[evita_api-10.2.0.jar:?]
	at one.edee.oss.proxycian.bytebuddy.ByteBuddyDispatcherInvocationHandler.interceptMethodCall(ByteBuddyDispatcherInvocationHandler.java:94) ~[proxycian_bytebuddy-1.3.10.jar:?]
	at one.edee.oss.proxycian.bytebuddy.ByteBuddyDispatcherInvocationHandler.interceptMethodCall(ByteBuddyDispatcherInvocationHandler.java:46) ~[proxycian_bytebuddy-1.3.10.jar:?]
	at one.edee.oss.proxycian.bytebuddy.generated.PublishedGroupEditor_365.removeTagById(Unknown Source) ~[proxycian_bytebuddy-1.3.10.jar:?]
```