### PR TITLE
fix(#442): Regression: constraints were not excluded when provided NU…

### DIFF
--- a/evita_functional_tests/src/test/java/io/evitadb/api/query/filter/AttributeInSetTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/query/filter/AttributeInSetTest.java
@@ -42,6 +42,25 @@ class AttributeInSetTest {
 	}
 
 	@Test
+	void shouldCreateViaFactoryClassWorkAsExpectedNullInArray() {
+		final AttributeInSet attributeInSet = attributeInSet("refs", 1, null, 5);
+		assertArrayEquals(new Comparable<?>[] {1, 5}, attributeInSet.getAttributeValues());
+	}
+
+	@Test
+	void shouldCreateViaFactoryClassWorkAsExpectedForNullVariable() {
+		final Integer nullInteger = null;
+		final AttributeInSet attributeInSet = attributeInSet("refs", nullInteger);
+		assertNull(attributeInSet);
+	}
+
+	@Test
+	void shouldCreateViaFactoryClassWorkAsExpectedNullValueInArray() {
+		final AttributeInSet attributeInSet = attributeInSet("refs", new Integer[0]);
+		assertArrayEquals(new Comparable<?>[0], attributeInSet.getAttributeValues());
+	}
+
+	@Test
 	void shouldRecognizeApplicability() {
 		assertFalse(new AttributeInSet(null).isApplicable());
 		assertTrue(new AttributeInSet("refs").isApplicable());

--- a/evita_functional_tests/src/test/java/io/evitadb/api/query/filter/EntityPrimaryKeyInSetTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/query/filter/EntityPrimaryKeyInSetTest.java
@@ -42,6 +42,25 @@ class EntityPrimaryKeyInSetTest {
 	}
 
 	@Test
+	void shouldCreateViaFactoryClassWorkAsExpectedNullInArray() {
+		final EntityPrimaryKeyInSet entityPrimaryKeyInSet = entityPrimaryKeyInSet(1, null, 7);
+		assertArrayEquals(new int[] {1, 7}, entityPrimaryKeyInSet.getPrimaryKeys());
+	}
+
+	@Test
+	void shouldCreateViaFactoryClassWorkAsExpectedForNullVariable() {
+		final Integer nullInteger = null;
+		final EntityPrimaryKeyInSet entityPrimaryKeyInSet = entityPrimaryKeyInSet(nullInteger);
+		assertNull(entityPrimaryKeyInSet);
+	}
+
+	@Test
+	void shouldCreateViaFactoryClassWorkAsExpectedNullValueInArray() {
+		final EntityPrimaryKeyInSet entityPrimaryKeyInSet = entityPrimaryKeyInSet(new Integer[0]);
+		assertArrayEquals(new int[0], entityPrimaryKeyInSet.getPrimaryKeys());
+	}
+
+	@Test
 	void shouldRecognizeApplicability() {
 		assertTrue(new EntityPrimaryKeyInSet().isApplicable());
 		assertTrue(entityPrimaryKeyInSet(1).isApplicable());

--- a/evita_functional_tests/src/test/java/io/evitadb/api/query/filter/PriceInPriceListsTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/query/filter/PriceInPriceListsTest.java
@@ -42,6 +42,25 @@ class PriceInPriceListsTest {
 	}
 
 	@Test
+	void shouldCreateViaFactoryClassWorkAsExpectedNullInArray() {
+		final PriceInPriceLists priceInPriceLists = priceInPriceLists("basic", null, "reference");
+		assertArrayEquals(new String[] {"basic", "reference"}, priceInPriceLists.getPriceLists());
+	}
+
+	@Test
+	void shouldCreateViaFactoryClassWorkAsExpectedForNullVariable() {
+		final String nullString = null;
+		final PriceInPriceLists priceInPriceLists = priceInPriceLists(nullString);
+		assertNull(priceInPriceLists);
+	}
+
+	@Test
+	void shouldCreateViaFactoryClassWorkAsExpectedNullValueInArray() {
+		final PriceInPriceLists priceInPriceLists = priceInPriceLists(new String[0]);
+		assertArrayEquals(new String[0], priceInPriceLists.getPriceLists());
+	}
+
+	@Test
 	void shouldRecognizeApplicability() {
 		assertTrue(new PriceInPriceLists(new String[0]).isApplicable());
 		assertTrue(priceInPriceLists("A").isApplicable());

--- a/evita_query/src/main/java/io/evitadb/api/query/QueryConstraints.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/QueryConstraints.java
@@ -690,7 +690,19 @@ public interface QueryConstraints {
 		if (priceList == null) {
 			return null;
 		}
-		return new PriceInPriceLists(priceList);
+		// if the array is empty - it was deliberate action which needs to produce empty result of the query
+		if (priceList.length == 0) {
+			return new PriceInPriceLists(priceList);
+		}
+		final String[] normalizeNames = Arrays.stream(priceList).filter(Objects::nonNull).filter(it -> !it.isBlank()).toArray(String[]::new);
+		// the array was not empty, but contains only null values - this may not be deliberate action - for example
+		// the initalization was like `priceInPriceLists(nullVariable)` and this should exclude the constraint
+		if (normalizeNames.length == 0) {
+			return null;
+		}
+		// otherwise propagate only non-null values
+		return normalizeNames.length == priceList.length ?
+			new PriceInPriceLists(priceList) : new PriceInPriceLists(normalizeNames);
 	}
 
 	/**
@@ -1537,13 +1549,19 @@ public interface QueryConstraints {
 	@SuppressWarnings("unchecked")
 	@Nullable
 	static <T extends Serializable> AttributeInSet attributeInSet(@Nullable String attributeName, @Nullable T... set) {
+		// if the array is empty - it was deliberate action which needs to produce empty result of the query
 		if (attributeName == null || set == null) {
 			return null;
 		}
 		final List<T> args = Arrays.stream(set).filter(Objects::nonNull).toList();
 		if (args.size() == set.length) {
 			return new AttributeInSet(attributeName, set);
+		} else if (args.isEmpty()) {
+			// the array was not empty, but contains only null values - this may not be deliberate action - for example
+			// the initalization was like `attributeInSet("attrName", nullVariable)` and this should exclude the constraint
+			return null;
 		} else {
+			// otherwise propagate only non-null values
 			final T[] limitedSet = (T[]) Array.newInstance(set.getClass().getComponentType(), args.size());
 			for (int i = 0; i < args.size(); i++) {
 				limitedSet[i] = args.get(i);
@@ -1805,7 +1823,19 @@ public interface QueryConstraints {
 		if (primaryKey == null) {
 			return null;
 		}
-		return new EntityPrimaryKeyInSet(primaryKey);
+		// if the array is empty - it was deliberate action which needs to produce empty result of the query
+		if (primaryKey.length == 0) {
+			return new EntityPrimaryKeyInSet(primaryKey);
+		}
+		final Integer[] normalizedPks = Arrays.stream(primaryKey).filter(Objects::nonNull).toArray(Integer[]::new);
+		// the array was not empty, but contains only null values - this may not be deliberate action - for example
+		// the initalization was like `entityPrimaryKeyInSet(nullVariable)` and this should exclude the constraint
+		if (normalizedPks.length == 0) {
+			return null;
+		}
+		// otherwise propagate only non-null values
+		return normalizedPks.length == primaryKey.length ?
+			new EntityPrimaryKeyInSet(primaryKey) : new EntityPrimaryKeyInSet(normalizedPks);
 	}
 
 	/**


### PR DESCRIPTION
…LL arguments

This issue was connected with changes in https://github.com/FgForrest/evitaDB/issues/413. This introduced problem when null values were possible to inject into the constraint via this declaration:

```java
final Integer nullInteger = null;
final EntityPrimaryKeyInSet entityPrimaryKeyInSet = entityPrimaryKeyInSet(nullInteger);
assertNull(entityPrimaryKeyInSet);
```