### PR TITLE
fix(#445): Reference mutations set via OEM might be incomplete

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/ExistingEntityBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/ExistingEntityBuilder.java
@@ -905,7 +905,9 @@ public class ExistingEntityBuilder implements EntityBuilder {
 	 * @return true if the reference is present in the base entity, false otherwise
 	 */
 	public boolean isPresentInBaseEntity(@Nonnull ReferenceContract reference) {
-		return this.baseEntity.getReference(reference.getReferenceKey()).isPresent();
+		return this.baseEntity.getReference(reference.getReferenceKey())
+			.map(Droppable::exists)
+			.orElse(false);
 	}
 
 	@Nullable


### PR DESCRIPTION
In certain scenarios - namely this signature:

```java
product.addOrUpdateStock(
        stock.getIdCatalogEntity(),
        thatIs -> thatIs.setQuantityOnStock(quantity)
);
```

The resulting mutation may lack `InsertReferenceMutation`. The problem is caused by invalid usage of `ExistingReferenceBuilder` for scenarios where `InitialReferenceBuilder` should be used (because there is no such reference in the `ExistingEntityBuilder` base entity that is being modified).