### PR TITLE
refactor(#): speeding up the algorithm for finding a match at the beg…

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeStartsWithTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeStartsWithTranslator.java
@@ -31,15 +31,12 @@ import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.attribute.AttributeFormula;
-import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
 import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
-import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.core.query.filter.FilterByVisitor;
 import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
 import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
-import io.evitadb.utils.ArrayUtils;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
@@ -72,13 +69,7 @@ public class AttributeStartsWithTranslator implements FilteringConstraintTransla
 				filterByVisitor.applyOnFilterIndexes(
 					attributeDefinition, index -> {
 						/* TOBEDONE JNO naive and slow - use RadixTree */
-						final Formula[] foundRecords = index.getValues()
-							.stream()
-							.filter(it -> ((String)it).startsWith(textToSearch))
-							.map(index::getRecordsEqualToFormula)
-							.toArray(Formula[]::new);
-						return ArrayUtils.isEmpty(foundRecords) ?
-							EmptyFormula.INSTANCE : FormulaFactory.or(foundRecords);
+						return index.getRecordsWhoseValuesStartWith(textToSearch);
 					}
 				)
 			);

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -29,6 +29,7 @@ import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.dataType.Range;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.index.IndexDataStructure;
@@ -55,6 +56,7 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.Map;
 
 import static io.evitadb.core.Transaction.isTransactionAvailable;
@@ -180,19 +182,57 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	}
 
 	/**
-	 * Returns true if this {@link FilterIndex} instance contains range index.
-	 */
-	public boolean hasRangeIndex() {
-		return this.rangeIndex != null;
-	}
-
-	/**
 	 * Returns sorted (ascending, natural) collection of all distinct values present in the filter index.
 	 */
 	@Nonnull
 	public <T extends Comparable<T>> Collection<T> getValues() {
 		//noinspection unchecked
 		return (Collection<T>) getValueIndex().keySet();
+	}
+
+	/**
+	 * Returns sorted (ascending, natural) collection of all distinct values present in the filter index.
+	 */
+	@Nonnull
+	public Formula getRecordsWhoseValuesStartWith(@Nonnull String prefix) {
+		final ValueToRecordBitmap<? extends Comparable<?>>[] buckets = invertedIndex.getValueToRecordBitmap();
+		final int matchIndex = ArrayUtils.binarySearch(
+			buckets,
+			prefix,
+			(valueToRecordBitmap, textToSearch) -> {
+				final String valueA = String.valueOf(valueToRecordBitmap.getValue());
+				final String shortenedA = valueA.substring(0, Math.min(valueA.length(), textToSearch.length()));
+				return shortenedA.compareTo(textToSearch);
+			}
+		);
+		if (matchIndex < 0) {
+			return EmptyFormula.INSTANCE;
+		} else {
+			final LinkedList<Formula> formulas = new LinkedList<>();
+			// find all matching values to the end of the bucket list
+			for (int i = matchIndex; i < buckets.length; i++) {
+				final ValueToRecordBitmap<? extends Comparable<?>> bucket = buckets[i];
+				final String value = String.valueOf(bucket.getValue());
+				if (value.startsWith(prefix)) {
+					formulas.add(new ConstantFormula(bucket.getRecordIds()));
+				} else {
+					// break immediately when the prefix is no longer valid
+					break;
+				}
+			}
+			// find all matching values to the start of the bucket list
+			for (int i = matchIndex - 1; i >= 0; i--) {
+				final ValueToRecordBitmap<? extends Comparable<?>> bucket = buckets[i];
+				final String value = String.valueOf(bucket.getValue());
+				if (value.startsWith(prefix)) {
+					formulas.add(new ConstantFormula(bucket.getRecordIds()));
+				} else {
+					// break immediately when the prefix is no longer valid
+					break;
+				}
+			}
+			return FormulaFactory.or(formulas.toArray(new Formula[0]));
+		}
 	}
 
 	/**

--- a/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
@@ -181,6 +181,29 @@ class FilterIndexTest implements TimeBoundedTestSupport {
 	}
 
 	@Test
+	void shouldReturnRecordsStartingWith() {
+		// generate records to verify starts with function
+		stringAttribute.addRecord(1, "Alfa");
+		stringAttribute.addRecord(2, "AlfaBeta");
+		stringAttribute.addRecord(3, "Alfeta");
+		stringAttribute.addRecord(4, "Ab");
+		stringAttribute.addRecord(5, "Beta");
+		stringAttribute.addRecord(6, "Betaversion");
+		stringAttribute.addRecord(7, "Bet");
+		stringAttribute.addRecord(8, "Betamax");
+		stringAttribute.addRecord(9, "Gamma");
+		stringAttribute.addRecord(10, "GammaAlfa");
+		stringAttribute.addRecord(11, "GammaBeta");
+
+		assertArrayEquals(new int[] {1, 2}, stringAttribute.getRecordsWhoseValuesStartWith("Alfa").compute().getArray());
+		assertArrayEquals(new int[] {4}, stringAttribute.getRecordsWhoseValuesStartWith("Ab").compute().getArray());
+		assertArrayEquals(new int[] {5, 6, 7, 8}, stringAttribute.getRecordsWhoseValuesStartWith("Bet").compute().getArray());
+		assertArrayEquals(new int[] {5, 6, 8}, stringAttribute.getRecordsWhoseValuesStartWith("Beta").compute().getArray());
+		assertArrayEquals(new int[] {9, 10, 11}, stringAttribute.getRecordsWhoseValuesStartWith("Gamma").compute().getArray());
+		assertArrayEquals(new int[] {11}, stringAttribute.getRecordsWhoseValuesStartWith("GammaBeta").compute().getArray());
+	}
+
+	@Test
 	void shouldReturnRecordsGreaterThan() {
 		fillStringAttribute();
 		assertArrayEquals(new int[] {1, 3, 4}, stringAttribute.getRecordsGreaterThan("B").getArray());


### PR DESCRIPTION
…inning of a word

Until we finalize the https://github.com/FgForrest/evitaDB/issues/258 release with full text support, we could at least accelerate the `attributeStartsWith' constraint to use a binary search algorithm instead of an exhaustive search through all attribute values. In the future, this should be replaced by some form of RadixTree, but until then, we could at least use binary search here. This constraint is special in the sense that it's often used for auto-completion functions in web applications.