### PR TITLE
fix(#454): Constraint AttributeInRange doesn't correctly work with su…

### DIFF
--- a/evita_functional_tests/src/test/java/io/evitadb/api/query/descriptor/ConstraintDescriptorProviderTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/query/descriptor/ConstraintDescriptorProviderTest.java
@@ -58,7 +58,7 @@ class ConstraintDescriptorProviderTest {
 
 	@Test
 	void shouldHaveProcessedConstraints() {
-		assertEquals(90, ConstraintDescriptorProvider.getAllConstraints().size());
+		assertEquals(91, ConstraintDescriptorProvider.getAllConstraints().size());
 	}
 
 	@Test
@@ -134,7 +134,7 @@ class ConstraintDescriptorProviderTest {
 
 	@Test
 	void shouldFindAllConstraintsForSpecificType() {
-		assertEquals(36, ConstraintDescriptorProvider.getConstraints(ConstraintType.FILTER).size());
+		assertEquals(37, ConstraintDescriptorProvider.getConstraints(ConstraintType.FILTER).size());
 		assertEquals(13, ConstraintDescriptorProvider.getConstraints(ConstraintType.ORDER).size());
 	}
 

--- a/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintDescriptorProvider.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintDescriptorProvider.java
@@ -46,7 +46,6 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static io.evitadb.utils.CollectionUtils.createHashMap;
-import static io.evitadb.utils.CollectionUtils.createHashSet;
 
 /**
  * Provides access to all registered {@link Constraint}s via {@link ConstraintDescriptor}s which serve as generic
@@ -144,10 +143,12 @@ public class ConstraintDescriptorProvider {
 	                                                 @Nullable String suffix) {
 		return getConstraints(constraintClass)
 			.stream()
-			.filter(it -> it.creator()
-				.suffix()
-				.map(it2 -> it2.equals(suffix))
-				.orElse(suffix == null))
+			.filter(it -> {
+				return it.creator()
+					.suffix()
+					.map(it2 -> it2.equals(suffix))
+					.orElse(suffix == null);
+			})
 			.findFirst()
 			.orElseThrow(() ->
 				new EvitaInternalError("Unknown constraint `" + constraintClass.getName() + "` with suffix `" + suffix + "`. Is it properly registered?"));

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeInRange.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeInRange.java
@@ -72,7 +72,7 @@ import java.util.Optional;
  * inRange("age", 24)
  * inRange("age", 63)
  * </pre>
- * 
+ *
  * <p><a href="https://evitadb.io/documentation/query/filtering/range#attribute-in-range">Visit detailed user documentation</a></p>
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
@@ -96,6 +96,7 @@ import java.util.Optional;
 	)
 )
 public class AttributeInRange extends AbstractAttributeFilterConstraintLeaf implements IndexUsingConstraint, ConstraintWithSuffix {
+	private static final String SUFFIX_NOW = "now";
 	@Serial private static final long serialVersionUID = -6018832750772234247L;
 
 	private AttributeInRange(Serializable... arguments) {
@@ -112,6 +113,7 @@ public class AttributeInRange extends AbstractAttributeFilterConstraintLeaf impl
 		);
 	}
 
+	@Creator(suffix = SUFFIX_NOW)
 	public AttributeInRange(@Nonnull @Classifier String attributeName) {
 		super(attributeName);
 	}
@@ -167,7 +169,7 @@ public class AttributeInRange extends AbstractAttributeFilterConstraintLeaf impl
 	@Nonnull
 	@Override
 	public Optional<String> getSuffixIfApplied() {
-		return getArguments().length == 1 ? Optional.of("Now") : Optional.empty();
+		return getArguments().length == 1 ? Optional.of(SUFFIX_NOW) : Optional.empty();
 	}
 
 	@Nonnull


### PR DESCRIPTION
…ffix Now

The constraint:

```
attributeInRangeNow("validity")
```

Fails to be recognized by our descriptor system:

```
io.evitadb.exception.EvitaInternalError: Unknown constraint `io.evitadb.api.query.filter.AttributeInRange` with suffix `Now`. Is it properly registered?
	at io.evitadb.api.query.descriptor.ConstraintDescriptorProvider.lambda$getConstraint$7(ConstraintDescriptorProvider.java:153)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at io.evitadb.api.query.descriptor.ConstraintDescriptorProvider.getConstraint(ConstraintDescriptorProvider.java:152)
	at io.evitadb.test.client.query.ConstraintDescriptorResolver.resolveDescriptor(ConstraintDescriptorResolver.java:70)
	at io.evitadb.test.client.query.ConstraintDescriptorResolver.resolve(ConstraintDescriptorResolver.java:55)
 ```