### PR TITLE
perf(#464): Slow facet summary formula generation

### DIFF
--- a/evita_common/src/main/java/io/evitadb/dataType/data/ComplexDataObjectConverter.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/data/ComplexDataObjectConverter.java
@@ -1003,16 +1003,16 @@ public class ComplexDataObjectConverter<T extends Serializable> {
 		 * Stack containing name of the lastExtractedProperty allows to reconstruct "property path" for signalling
 		 * complete (deep-wise) name of the not extracted property.
 		 */
-		private final Deque<String> lastExtractedProperty = new LinkedList<>();
+		private final Deque<String> lastExtractedProperty = new ArrayDeque<>(16);
 		/**
 		 * Stack containing "property path" for signalling complete (deep-wise) name of the not extracted property.
 		 */
-		private final Deque<String> propertyPath = new LinkedList<>();
+		private final Deque<String> propertyPath = new ArrayDeque<>(16);
 		/**
 		 * Stack of properties that are expected to be extracted into the result Java object. The stack / set is used
 		 * to check that every data item gets converted into some Java property.
 		 */
-		private final Deque<Set<String>> propertySets = new LinkedList<>();
+		private final Deque<Set<String>> propertySets = new ArrayDeque<>(16);
 		/**
 		 * Contains information about all properties found in the {@link ComplexDataObject} that were not deserialized
 		 * and thus lead to information loss.

--- a/evita_common/src/main/java/io/evitadb/dataType/data/ComplexDataObjectToJsonConverter.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/data/ComplexDataObjectToJsonConverter.java
@@ -38,8 +38,8 @@ import javax.annotation.Nonnull;
 import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.Locale;
 import java.util.TreeMap;
 
@@ -66,11 +66,11 @@ public class ComplexDataObjectToJsonConverter implements DataItemVisitor {
 	/**
 	 * Builds a stack that holds property names visited in {@link ComplexDataObject} {@link DataItem} tree.
 	 */
-	private final Deque<String> propertyNameStack = new LinkedList<>();
+	private final Deque<String> propertyNameStack = new ArrayDeque<>(16);
 	/**
 	 * Builds a stack of output JSON nodes - these nodes are used as parents for newly created nodes within the tree.
 	 */
-	private final Deque<JsonNode> stack = new LinkedList<>();
+	private final Deque<JsonNode> stack = new ArrayDeque<>(16);
 	/**
 	 * Contains reference to the tree node.
 	 */

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryContext.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryContext.java
@@ -289,7 +289,7 @@ public class QueryContext implements AutoCloseable, LocaleProvider {
 		this.entityStorageContainerAccessor = entityStorageContainerAccessor;
 		this.evitaSession = evitaSession;
 		this.evitaRequest = evitaRequest;
-		this.telemetryStack = new LinkedList<>();
+		this.telemetryStack = new ArrayDeque<>(16);
 		ofNullable(telemetry).ifPresent(this.telemetryStack::push);
 		//noinspection unchecked
 		this.indexes = (Map<IndexKey, Index<?>>) indexes;
@@ -1073,7 +1073,7 @@ public class QueryContext implements AutoCloseable, LocaleProvider {
 	@Nonnull
 	public int[] borrowBuffer() {
 		if (this.buffers == null) {
-			this.buffers = new LinkedList<>();
+			this.buffers = new ArrayDeque<>(16);
 		}
 		// return locally cached buffer or obtain new one from shared pool
 		return ofNullable(this.buffers.poll())

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
@@ -230,6 +230,19 @@ public abstract class AbstractFormula implements Formula {
 	}
 
 	/**
+	 * Clears the memoized results and hashes of the formula.
+	 */
+	public void clearMemoizedResult() {
+		this.memoizedResult = null;
+		this.memoizedHash = null;
+		this.memoizedTransactionalIds = null;
+		this.memoizedTransactionalIdHash = null;
+		this.cost = null;
+		this.estimatedCost = null;
+		this.costToPerformance = null;
+	}
+
+	/**
 	 * Returns cost to performance ratio. Default implementation is sums cost to performance ratio of all inner formulas
 	 * and adds ratio of this operation that is computed as ration of its cost to output bitmap size. I.e. when large
 	 * bitmap is greatly reduced to a small one, this ratio gets bigger and thus caching output of this formula saves

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
@@ -29,11 +29,11 @@ import io.evitadb.core.query.algebra.base.NotFormula;
 import lombok.Getter;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -63,11 +63,11 @@ public class FormulaCloner implements FormulaVisitor {
 	/**
 	 * This stack contains list of parents for currently examined formula.
 	 */
-	protected final Deque<Formula> parents = new LinkedList<>();
+	protected final Deque<Formula> parents = new ArrayDeque<>(32);
 	/**
 	 * Stacks serves internally to collect the cloned tree of formulas.
 	 */
-	protected final Deque<SubTree> treeStack = new LinkedList<>();
+	protected final Deque<SubTree> treeStack = new ArrayDeque<>(32);
 	/**
 	 * Result set of the clone operation.
 	 */

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
@@ -192,7 +192,7 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 	/**
 	 * Contemporary stack for auxiliary data resolved for each level of the query.
 	 */
-	private final Deque<ProcessingScope> scope = new LinkedList<>();
+	private final Deque<ProcessingScope> scope = new ArrayDeque<>(32);
 
 	public ExtraResultPlanningVisitor(
 		@Nonnull QueryContext queryContext,

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/AbstractFacetFormulaGenerator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/AbstractFacetFormulaGenerator.java
@@ -30,6 +30,7 @@ import io.evitadb.api.requestResponse.EvitaRequest;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.api.requestResponse.schema.dto.ReferenceSchema;
 import io.evitadb.core.query.QueryPlanner.FutureNotFormula;
+import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.FormulaVisitor;
 import io.evitadb.core.query.algebra.base.AndFormula;
@@ -44,6 +45,7 @@ import io.evitadb.core.query.algebra.facet.UserFilterFormula;
 import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.core.query.algebra.utils.visitor.FormulaCloner;
 import io.evitadb.core.query.filter.translator.facet.FacetHavingTranslator;
+import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.index.array.CompositeObjectArray;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
@@ -57,12 +59,13 @@ import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
+import java.util.function.Supplier;
 
 /**
  * Abstract ancestor for {@link FacetCalculator} and {@link ImpactFormulaGenerator} that captures the shared logic
@@ -93,7 +96,15 @@ public abstract class AbstractFacetFormulaGenerator implements FormulaVisitor {
 	/**
 	 * Stack serves internally to collect the cloned tree of formulas.
 	 */
-	protected final Deque<CompositeObjectArray<Formula>> levelStack = new LinkedList<>();
+	protected final Deque<CompositeObjectArray<Formula>> levelStack = new ArrayDeque<>(16);
+	/**
+	 * Contains true if visitor is currently within the scope of {@link NotFormula}.
+	 */
+	private final Deque<Boolean> insideNotContainer = new ArrayDeque<>(16);
+	/**
+	 * Contains true if visitor is currently within the scope of {@link UserFilterFormula}.
+	 */
+	private final Deque<Boolean> insideUserFilter = new ArrayDeque<>(16);
 	/**
 	 * Contains filtering formula that has been stripped of user-defined filter.
 	 */
@@ -117,14 +128,6 @@ public abstract class AbstractFacetFormulaGenerator implements FormulaVisitor {
 	 */
 	protected Bitmap facetEntityIds;
 	/**
-	 * Contains true if visitor is currently within the scope of {@link NotFormula}.
-	 */
-	private final Deque<Boolean> insideNotContainer = new LinkedList<>();
-	/**
-	 * Contains true if visitor is currently within the scope of {@link UserFilterFormula}.
-	 */
-	private final Deque<Boolean> insideUserFilter = new LinkedList<>();
-	/**
 	 * Contains deferred lambda function that should be applied at the moment {@link NotFormula} processing is finished
 	 * by this visitor. This postponed mutator solves the situation when the facet formula needs to be applied above
 	 * NOT container and not within it. This is related to the internal mechanisms of {@link FutureNotFormula}
@@ -136,6 +139,267 @@ public abstract class AbstractFacetFormulaGenerator implements FormulaVisitor {
 	 */
 	@Getter protected Formula result;
 
+	/**
+	 * Method contains the logic that adds brand new {@link Formula} to the examined formula tree. It has
+	 * to take group relation requested by {@link FacetGroupsDisjunction} and {@link FacetGroupsNegation} into
+	 * an account.
+	 */
+	@Nonnull
+	protected static Formula[] alterFormula(@Nonnull Formula newFormula, boolean disjunction, boolean negation, @Nonnull Formula... children) {
+		// if newly added formula should represent OR join
+		if (disjunction) {
+			return addNewFormulaAsDisjunction(newFormula, children);
+		} else if (negation) {
+			return addNewFormulaAsNegation(newFormula, children);
+		} else {
+			return addNewFormulaAsConjunction(newFormula, children);
+		}
+	}
+
+	/**
+	 * Method returns true if any of the `updateChildren` differs from (not same as) passed `formula` children.
+	 */
+	protected static boolean isAnyChildrenExchanged(@Nonnull Formula formula, @Nonnull Formula[] updatedChildren) {
+		if (updatedChildren.length != formula.getInnerFormulas().length) {
+			return true;
+		} else {
+			for (int i = 0; i < updatedChildren.length; i++) {
+				if (updatedChildren[i] != formula.getInnerFormulas()[i]) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Method adds `newFormula` to existing disjunction or creates new one. The method logic must cope with different
+	 * source formula composition. We know that parent is {@link UserFilterFormula} that represents implicit AND. But
+	 * we need to attach `newFormula` with OR.
+	 *
+	 * There might be following compositions:
+	 *
+	 * 1. no OR container is present
+	 *
+	 * USER FILTER
+	 * FACET PARAMETER OR (zero or multiple formulas)
+	 *
+	 * that will be transformed to:
+	 *
+	 * USER FILTER
+	 * OR
+	 * AND
+	 * FACET PARAMETER OR (zero or multiple original formulas)
+	 * FACET PARAMETER OR (newFormula)
+	 *
+	 * 2. existing OR container is present
+	 *
+	 * USER FILTER
+	 * OR
+	 * FACET PARAMETER OR (zero or multiple formulas)
+	 *
+	 * that will be transformed to:
+	 *
+	 * USER FILTER
+	 * OR
+	 * FACET PARAMETER OR (zero or multiple original formulas)
+	 * FACET PARAMETER OR (newFormula)
+	 *
+	 * 3. user filter wth combined facet relations
+	 *
+	 * USER FILTER
+	 * COMBINED AND+OR
+	 * FACET PARAMETER OR (one or multiple original formulas) - AND relation
+	 * FACET PARAMETER OR (one or multiple original formulas) - OR relation
+	 *
+	 * that will be transformed to:
+	 *
+	 * USER FILTER
+	 * COMBINED AND+OR
+	 * FACET PARAMETER OR (one or multiple original formulas) - AND relation
+	 * FACET PARAMETER OR (one or multiple original formulas) - OR relation + newFormula
+	 *
+	 * This method also needs to cope with complicated compositions in case multiple source indexes are used - in such
+	 * occasion the above-mentioned composition is nested within OR containers that combine results from multiple
+	 * source indexes. That's why we use {@link FormulaCloner} internally that traverses the entire `children` structure.
+	 */
+	@Nonnull
+	private static Formula[] addNewFormulaAsDisjunction(@Nonnull Formula newFormula, @Nonnull Formula[] children) {
+		// iterate over existing children
+		final AtomicBoolean childrenAltered = new AtomicBoolean();
+		for (int i = 0; i < children.length; i++) {
+			final Formula mutatedChild = FormulaCloner.clone(children[i], examinedFormula -> {
+				// and if existing OR formula is found
+				if (examinedFormula instanceof OrFormula) {
+					// simply add new facet group formula to the OR formula
+					return examinedFormula.getCloneWithInnerFormulas(
+						ArrayUtils.insertRecordIntoArray(
+							newFormula, examinedFormula.getInnerFormulas(), examinedFormula.getInnerFormulas().length
+						)
+					);
+				} else if (examinedFormula instanceof final CombinedFacetFormula combinedFacetFormula) {
+					// if combined facet formula is found - we know there is combination of AND and OR formulas inside
+					// take the OR part of the combined formula
+					final Formula orFormula = combinedFacetFormula.getOrFormula();
+					// and replace combined formula with AND part untouched and OR part enriched with new facet formula
+					return examinedFormula.getCloneWithInnerFormulas(
+						combinedFacetFormula.getAndFormula(),
+						FormulaFactory.or(
+							newFormula,
+							orFormula
+						)
+					);
+				} else {
+					return examinedFormula;
+				}
+			});
+
+			if (mutatedChild != children[i]) {
+				children[i] = mutatedChild;
+				childrenAltered.set(true);
+			}
+		}
+		if (childrenAltered.get()) {
+			// return the updated array of children
+			return children;
+		} else {
+			// neither OR or combined formula found in children - create new OR wrapping formula and
+			// combine existing children with new facet formula
+			return new Formula[]{
+				FormulaFactory.or(
+					FormulaFactory.and(children),
+					newFormula
+				)
+			};
+		}
+	}
+
+	/**
+	 * Method adds `newFormula` to existing conjunction or creates new one. The method logic must cope with different
+	 * source formula composition. We know that parent is {@link UserFilterFormula} that represents implicit AND and we
+	 * need to append `newFormula` with the same relation type (but on the proper place).
+	 *
+	 * There might be following compositions:
+	 *
+	 * 1. no AND container is present
+	 *
+	 * USER FILTER
+	 * FACET PARAMETER OR (zero or multiple formulas)
+	 *
+	 * that will be transformed to:
+	 *
+	 * USER FILTER
+	 * AND
+	 * FACET PARAMETER OR (zero or multiple original formulas)
+	 * FACET PARAMETER OR (newFormula)
+	 *
+	 * 2. existing AND container is present
+	 *
+	 * USER FILTER
+	 * AND
+	 * FACET PARAMETER OR (zero or multiple formulas)
+	 *
+	 * that will be transformed to:
+	 *
+	 * USER FILTER
+	 * AND
+	 * FACET PARAMETER OR (zero or multiple original formulas)
+	 * FACET PARAMETER OR (newFormula)
+	 *
+	 * 3. user filter wth combined facet relations
+	 *
+	 * USER FILTER
+	 * COMBINED AND+OR
+	 * FACET PARAMETER OR (one or multiple original formulas) - AND relation
+	 * FACET PARAMETER OR (one or multiple original formulas) - OR relation
+	 *
+	 * that will be transformed to:
+	 *
+	 * USER FILTER
+	 * COMBINED AND+OR
+	 * FACET PARAMETER OR (one or multiple original formulas) - AND relation + newFormula
+	 * FACET PARAMETER OR (one or multiple original formulas) - OR relation
+	 *
+	 * This method also needs to cope with complicated compositions in case multiple source indexes are used - in such
+	 * occasion the above-mentioned composition is nested within OR containers that combine results from multiple
+	 * source indexes. That's why we use {@link FormulaCloner} internally that traverses the entire `children` structure.
+	 */
+	@Nonnull
+	private static Formula[] addNewFormulaAsConjunction(@Nonnull Formula newFormula, @Nonnull Formula[] children) {
+		// if newly added formula should represent AND join
+		// iterate over existing children
+		final AtomicBoolean childrenAltered = new AtomicBoolean();
+		for (int i = 0; i < children.length; i++) {
+			final Formula mutatedChild = FormulaCloner.clone(children[i], examinedFormula -> {
+				// and if existing AND formula is found
+				if (examinedFormula instanceof AndFormula) {
+					// simply add new facet group formula to the AND formula
+					return examinedFormula.getCloneWithInnerFormulas(
+						ArrayUtils.insertRecordIntoArray(
+							newFormula, examinedFormula.getInnerFormulas(), examinedFormula.getInnerFormulas().length
+						)
+					);
+				} else if (examinedFormula instanceof final CombinedFacetFormula combinedFacetFormula) {
+					// if combined facet formula is found - we know there is combination of AND and OR formulas inside
+					// take the AND part of the combined formula
+					final Formula andFormula = combinedFacetFormula.getAndFormula();
+					// and replace combined formula with OR part untouched and AND part enriched with new facet formula
+					return examinedFormula.getCloneWithInnerFormulas(
+						FormulaFactory.and(
+							andFormula,
+							newFormula
+						),
+						combinedFacetFormula.getOrFormula()
+					);
+				} else {
+					return examinedFormula;
+				}
+			});
+
+			if (mutatedChild != children[i]) {
+				children[i] = mutatedChild;
+				childrenAltered.set(true);
+			}
+		}
+		if (childrenAltered.get()) {
+			// return the updated array of children
+			return children;
+		} else {
+			// neither AND or combined formula found in children - we know that parent is UserFilterFormula that
+			// represents AND wrapping formula, so we can just combine existing children with new facet formula
+			return ArrayUtils.insertRecordIntoArray(newFormula, children, children.length);
+		}
+	}
+
+	/**
+	 * Method adds `newFormula` as negated facet query. The implementation is straightforward - it takes existing
+	 * filter and combines it with `newFormula` in NOT composition where `newFormula` represents subracted set.
+	 */
+	@Nonnull
+	private static Formula[] addNewFormulaAsNegation(@Nonnull Formula newFormula, @Nonnull Formula[] children) {
+		// if newly added formula should represent OR join
+		// combine existing children with new facet formula in NOT container - now is not yet created
+		// (otherwise this method would not be called at all)
+		return new Formula[]{
+			FormulaFactory.not(
+				newFormula,
+				FormulaFactory.and(children)
+			)
+		};
+	}
+
+	/**
+	 * Generates a formula based on the given parameters.
+	 *
+	 * @param baseFormula                  The base formula to generate the formula from.
+	 * @param baseFormulaWithoutUserFilter The base formula without the user filter applied.
+	 * @param referenceSchema              The reference schema contract.
+	 * @param facetGroupId                 The facet group ID.
+	 * @param facetId                      The facet ID.
+	 * @param facetEntityIds               The facet entity IDs.
+	 * @return The generated formula.
+	 */
+	@Nonnull
 	public Formula generateFormula(
 		@Nonnull Formula baseFormula,
 		@Nonnull Formula baseFormulaWithoutUserFilter,
@@ -153,19 +417,7 @@ public abstract class AbstractFacetFormulaGenerator implements FormulaVisitor {
 			this.facetGroupId = facetGroupId;
 
 			// facets from multiple indexes are always joined with OR
-			if (facetEntityIds.length == 0) {
-				this.facetEntityIds = EmptyBitmap.INSTANCE;
-			} else if (facetEntityIds.length == 1) {
-				this.facetEntityIds = facetEntityIds[0];
-			} else {
-				this.facetEntityIds = new BaseBitmap(
-					RoaringBitmap.or(
-						Arrays.stream(facetEntityIds)
-							.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-							.toArray(RoaringBitmap[]::new)
-					)
-				);
-			}
+			this.facetEntityIds = getBaseEntityIds(facetEntityIds);
 			// now compute the formula
 			baseFormula.accept(this);
 			// and return computation result
@@ -248,6 +500,29 @@ public abstract class AbstractFacetFormulaGenerator implements FormulaVisitor {
 		} else {
 			// reuse original formula
 			storeFormula(formula);
+		}
+	}
+
+	/**
+	 * This method combines bitmaps of passed facet entity IDs into a single bitmap.
+	 *
+	 * @param facetEntityIds The array of facet entity IDs.
+	 * @return The base entity IDs as a Bitmap.
+	 */
+	@Nonnull
+	protected Bitmap getBaseEntityIds(@Nonnull Bitmap[] facetEntityIds) {
+		if (facetEntityIds.length == 0) {
+			return EmptyBitmap.INSTANCE;
+		} else if (facetEntityIds.length == 1) {
+			return facetEntityIds[0];
+		} else {
+			return new BaseBitmap(
+				RoaringBitmap.or(
+					Arrays.stream(facetEntityIds)
+						.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
+						.toArray(RoaringBitmap[]::new)
+				)
+			);
 		}
 	}
 
@@ -345,7 +620,7 @@ public abstract class AbstractFacetFormulaGenerator implements FormulaVisitor {
 	}
 
 	/**
-	 * Method allows to alter the result before it is returned to the caller.
+	 * Method allows altering the result before it is returned to the caller.
 	 */
 	protected Formula getResult(@Nonnull Formula baseFormula) {
 		// simply return the result
@@ -357,251 +632,12 @@ public abstract class AbstractFacetFormulaGenerator implements FormulaVisitor {
 	 * {@link FacetGroupsConjunction} requirement in input {@link EvitaRequest}.
 	 */
 	@Nonnull
-	protected FacetGroupFormula createNewFacetGroupFormula() {
-		return isFacetGroupConjunction.test(referenceSchema, facetGroupId) ?
-			new FacetGroupAndFormula(referenceSchema.getName(), facetGroupId, new BaseBitmap(facetId), facetEntityIds) :
-			new FacetGroupOrFormula(referenceSchema.getName(), facetGroupId, new BaseBitmap(facetId), facetEntityIds);
-	}
-
-	/**
-	 * Method contains the logic that adds brand new {@link Formula} to the examined formula tree. It has
-	 * to take group relation requested by {@link FacetGroupsDisjunction} and {@link FacetGroupsNegation} into
-	 * an account.
-	 */
-	@Nonnull
-	protected static Formula[] alterFormula(@Nonnull Formula newFormula, boolean disjunction, boolean negation, @Nonnull Formula... children) {
-		// if newly added formula should represent OR join
-		if (disjunction) {
-			return addNewFormulaAsDisjunction(newFormula, children);
-		} else if (negation) {
-			return addNewFormulaAsNegation(newFormula, children);
-		} else {
-			return addNewFormulaAsConjunction(newFormula, children);
-		}
-	}
-
-	/**
-	 * Method adds `newFormula` to existing disjunction or creates new one. The method logic must cope with different
-	 * source formula composition. We know that parent is {@link UserFilterFormula} that represents implicit AND. But
-	 * we need to attach `newFormula` with OR.
-	 *
-	 * There might be following compositions:
-	 *
-	 * 1. no OR container is present
-	 *
-	 * USER FILTER
-	 *   FACET PARAMETER OR (zero or multiple formulas)
-	 *
-	 * that will be transformed to:
-	 *
-	 * USER FILTER
-	 *   OR
-	 * 	    AND
-	 * 	       FACET PARAMETER OR (zero or multiple original formulas)
-	 * 	    FACET PARAMETER OR (newFormula)
-	 *
-	 * 2. existing OR container is present
-	 *
-	 * USER FILTER
-	 *   OR
-	 *      FACET PARAMETER OR (zero or multiple formulas)
-	 *
-	 * that will be transformed to:
-	 *
-	 * USER FILTER
-	 *   OR
-	 * 	    FACET PARAMETER OR (zero or multiple original formulas)
-	 * 	    FACET PARAMETER OR (newFormula)
-	 *
-	 * 3. user filter wth combined facet relations
-	 *
-	 * USER FILTER
-	 *    COMBINED AND+OR
-	 *       FACET PARAMETER OR (one or multiple original formulas) - AND relation
-	 *       FACET PARAMETER OR (one or multiple original formulas) - OR relation
-	 *
-	 * that will be transformed to:
-	 *
-	 * USER FILTER
-	 *    COMBINED AND+OR
-	 *       FACET PARAMETER OR (one or multiple original formulas) - AND relation
-	 *       FACET PARAMETER OR (one or multiple original formulas) - OR relation + newFormula
-	 *
-	 * This method also needs to cope with complicated compositions in case multiple source indexes are used - in such
-	 * occasion the above-mentioned composition is nested within OR containers that combine results from multiple
-	 * source indexes. That's why we use {@link FormulaCloner} internally that traverses the entire `children` structure.
-	 */
-	@Nonnull
-	private static Formula[] addNewFormulaAsDisjunction(@Nonnull Formula newFormula, @Nonnull Formula[] children) {
-		// iterate over existing children
-		final AtomicBoolean childrenAltered = new AtomicBoolean();
-		for (int i = 0; i < children.length; i++) {
-			final Formula mutatedChild = FormulaCloner.clone(children[i], examinedFormula -> {
-				// and if existing OR formula is found
-				if (examinedFormula instanceof OrFormula) {
-					// simply add new facet group formula to the OR formula
-					return examinedFormula.getCloneWithInnerFormulas(
-						ArrayUtils.insertRecordIntoArray(
-							newFormula, examinedFormula.getInnerFormulas(), examinedFormula.getInnerFormulas().length
-						)
-					);
-				} else if (examinedFormula instanceof final CombinedFacetFormula combinedFacetFormula) {
-					// if combined facet formula is found - we know there is combination of AND and OR formulas inside
-					// take the OR part of the combined formula
-					final Formula orFormula = combinedFacetFormula.getOrFormula();
-					// and replace combined formula with AND part untouched and OR part enriched with new facet formula
-					return examinedFormula.getCloneWithInnerFormulas(
-						combinedFacetFormula.getAndFormula(),
-						FormulaFactory.or(
-							newFormula,
-							orFormula
-						)
-					);
-				} else {
-					return examinedFormula;
-				}
-			});
-
-			if (mutatedChild != children[i]) {
-				children[i] = mutatedChild;
-				childrenAltered.set(true);
-			}
-		}
-		if (childrenAltered.get()) {
-			// return the updated array of children
-			return children;
-		} else {
-			// neither OR or combined formula found in children - create new OR wrapping formula and
-			// combine existing children with new facet formula
-			return new Formula[]{
-				FormulaFactory.or(
-					FormulaFactory.and(children),
-					newFormula
-				)
-			};
-		}
-	}
-
-	/**
-	 * Method adds `newFormula` to existing conjunction or creates new one. The method logic must cope with different
-	 * source formula composition. We know that parent is {@link UserFilterFormula} that represents implicit AND and we
-	 * need to append `newFormula` with the same relation type (but on the proper place).
-	 *
-	 * There might be following compositions:
-	 *
-	 * 1. no AND container is present
-	 *
-	 * USER FILTER
-	 *   FACET PARAMETER OR (zero or multiple formulas)
-	 *
-	 * that will be transformed to:
-	 *
-	 * USER FILTER
-	 * 	 AND
-	 * 	    FACET PARAMETER OR (zero or multiple original formulas)
-	 * 	    FACET PARAMETER OR (newFormula)
-	 *
-	 * 2. existing AND container is present
-	 *
-	 * USER FILTER
-	 *   AND
-	 *      FACET PARAMETER OR (zero or multiple formulas)
-	 *
-	 * that will be transformed to:
-	 *
-	 * USER FILTER
-	 *   AND
-	 * 	    FACET PARAMETER OR (zero or multiple original formulas)
-	 * 	    FACET PARAMETER OR (newFormula)
-	 *
-	 * 3. user filter wth combined facet relations
-	 *
-	 * USER FILTER
-	 *    COMBINED AND+OR
-	 *       FACET PARAMETER OR (one or multiple original formulas) - AND relation
-	 *       FACET PARAMETER OR (one or multiple original formulas) - OR relation
-	 *
-	 * that will be transformed to:
-	 *
-	 * USER FILTER
-	 *    COMBINED AND+OR
-	 *       FACET PARAMETER OR (one or multiple original formulas) - AND relation + newFormula
-	 *       FACET PARAMETER OR (one or multiple original formulas) - OR relation
-	 *
-	 * This method also needs to cope with complicated compositions in case multiple source indexes are used - in such
-	 * occasion the above-mentioned composition is nested within OR containers that combine results from multiple
-	 * source indexes. That's why we use {@link FormulaCloner} internally that traverses the entire `children` structure.
-	 */
-	@Nonnull
-	private static Formula[] addNewFormulaAsConjunction(@Nonnull Formula newFormula, @Nonnull Formula[] children) {
-		// if newly added formula should represent AND join
-		// iterate over existing children
-		final AtomicBoolean childrenAltered = new AtomicBoolean();
-		for (int i = 0; i < children.length; i++) {
-			final Formula mutatedChild = FormulaCloner.clone(children[i], examinedFormula -> {
-				// and if existing AND formula is found
-				if (examinedFormula instanceof AndFormula) {
-					// simply add new facet group formula to the AND formula
-					return examinedFormula.getCloneWithInnerFormulas(
-						ArrayUtils.insertRecordIntoArray(
-							newFormula, examinedFormula.getInnerFormulas(), examinedFormula.getInnerFormulas().length
-						)
-					);
-				} else if (examinedFormula instanceof final CombinedFacetFormula combinedFacetFormula) {
-					// if combined facet formula is found - we know there is combination of AND and OR formulas inside
-					// take the AND part of the combined formula
-					final Formula andFormula = combinedFacetFormula.getAndFormula();
-					// and replace combined formula with OR part untouched and AND part enriched with new facet formula
-					return examinedFormula.getCloneWithInnerFormulas(
-						FormulaFactory.and(
-							andFormula,
-							newFormula
-						),
-						combinedFacetFormula.getOrFormula()
-					);
-				} else {
-					return examinedFormula;
-				}
-			});
-
-			if (mutatedChild != children[i]) {
-				children[i] = mutatedChild;
-				childrenAltered.set(true);
-			}
-		}
-		if (childrenAltered.get()) {
-			// return the updated array of children
-			return children;
-		} else {
-			// neither AND or combined formula found in children - we know that parent is UserFilterFormula that
-			// represents AND wrapping formula, so we can just combine existing children with new facet formula
-			return ArrayUtils.insertRecordIntoArray(newFormula, children, children.length);
-		}
-	}
-
-	/**
-	 * Method adds `newFormula` as negated facet query. The implementation is straightforward - it takes existing
-	 * filter and combines it with `newFormula` in NOT composition where `newFormula` represents subracted set.
-	 */
-	@Nonnull
-	private static Formula[] addNewFormulaAsNegation(@Nonnull Formula newFormula, @Nonnull Formula[] children) {
-		// if newly added formula should represent OR join
-		// combine existing children with new facet formula in NOT container - now is not yet created
-		// (otherwise this method would not be called at all)
-		return new Formula[]{
-			FormulaFactory.not(
-				newFormula,
-				FormulaFactory.and(children)
-			)
-		};
-	}
-
-	/**
-	 * Method returns true if any of the `updateChildren` differs from (not same as) passed `formula` children.
-	 */
-	protected static boolean isAnyChildrenExchanged(@Nonnull Formula formula, @Nonnull Formula[] updatedChildren) {
-		return updatedChildren.length != formula.getInnerFormulas().length ||
-			Arrays.stream(formula.getInnerFormulas()).anyMatch(examinedFormula -> !ArrayUtils.contains(updatedChildren, examinedFormula));
+	protected MutableFormula createNewFacetGroupFormula() {
+		return new MutableFormula(
+			isFacetGroupConjunction.test(referenceSchema, facetGroupId) ?
+				new FacetGroupAndFormula(referenceSchema.getName(), facetGroupId, new BaseBitmap(facetId), facetEntityIds) :
+				new FacetGroupOrFormula(referenceSchema.getName(), facetGroupId, new BaseBitmap(facetId), facetEntityIds)
+		);
 	}
 
 	/**
@@ -614,6 +650,54 @@ public abstract class AbstractFacetFormulaGenerator implements FormulaVisitor {
 		} else {
 			levelStack.peek().add(formula);
 		}
+	}
+
+	/**
+	 * This implementation of {@link FormulaVisitor} traverses the formula tree and replaces the first found
+	 * {@link MutableFormula} with the formula provided by the supplier (there should be only one such formula).
+	 * The replacement is done in-place and the memoized results of all the parent formulas are cleared so that
+	 * the new formula has chance to alter the computation result.
+	 */
+	@RequiredArgsConstructor
+	protected static class MutableFormulaFinderAndReplacer implements FormulaVisitor {
+		/**
+		 * The supplier of the formula that should replace the first found {@link MutableFormula}.
+		 */
+		private final Supplier<FacetGroupFormula> formulaToReplaceSupplier;
+		/**
+		 * The stack of parent formulas of the currently visited formula tree.
+		 */
+		private final Deque<Formula> formulaStack = new ArrayDeque<>(16);
+		/**
+		 * Flag that is set to true if the visitor found the target {@link MutableFormula}.
+		 */
+		@Getter private boolean targetFound;
+
+		@Override
+		public void visit(@Nonnull Formula formula) {
+			if (!targetFound) {
+				if (formula instanceof MutableFormula mutableFormula) {
+					if (targetFound) {
+						throw new EvitaInternalError("Expected single MutableFormula in the formula tree!");
+					} else {
+						targetFound = true;
+						mutableFormula.setDelegate(formulaToReplaceSupplier.get());
+						for (Formula parentFormula : formulaStack) {
+							if (parentFormula instanceof AbstractFormula abstractFormula) {
+								abstractFormula.clearMemoizedResult();
+							}
+						}
+					}
+				} else {
+					formulaStack.push(formula);
+					for (Formula innerFormula : formula.getInnerFormulas()) {
+						innerFormula.accept(this);
+					}
+					formulaStack.pop();
+				}
+			}
+		}
+
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/ImpactFormulaGenerator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/ImpactFormulaGenerator.java
@@ -23,18 +23,28 @@
 
 package io.evitadb.core.query.extraResult.translator.facet.producer;
 
+import com.carrotsearch.hppc.IntHashSet;
+import com.carrotsearch.hppc.IntSet;
 import io.evitadb.api.requestResponse.EvitaRequest;
 import io.evitadb.api.requestResponse.extraResult.FacetSummary.RequestImpact;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.facet.FacetGroupAndFormula;
 import io.evitadb.core.query.algebra.facet.FacetGroupFormula;
+import io.evitadb.core.query.algebra.facet.FacetGroupOrFormula;
+import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.utils.Assert;
+import io.evitadb.utils.CollectionUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiPredicate;
+
+import static java.util.Optional.ofNullable;
 
 /**
  * This implementation contains the heavy part of {@link ImpactCalculator} interface implementation. It computes
@@ -47,10 +57,16 @@ import java.util.function.BiPredicate;
 @NotThreadSafe
 public class ImpactFormulaGenerator extends AbstractFacetFormulaGenerator {
 	/**
-	 * Contains true if visitor found {@link FacetGroupFormula} in the existing formula that matches the same facet
-	 * `entityType` and `facetGroupId`.
+	 * Contains cache for already generated formulas indexed by a {@link CacheKey} that distinguishes the key situations
+	 * where the formulas have to have different shape and structure.
 	 */
-	private boolean foundTargetInUserFilter;
+	private final Map<CacheKey, Formula> cache = CollectionUtils.createHashMap(64);
+	/**
+	 * This map stores the primary keys of all facet groups that were found in the existing formula by the visitor.
+	 * The keys of the map are the `referenceName` of the facet groups, and the values are sets of `facetGroupId` that were found.
+	 * The `UserFilterFormula` is used to find these facet groups in the existing formula.
+	 */
+	private final Map<String, IntSet> facetGroupsInUserFilter = CollectionUtils.createHashMap(16);
 
 	public ImpactFormulaGenerator(
 		@Nonnull BiPredicate<ReferenceSchemaContract, Integer> isFacetGroupConjunction,
@@ -60,6 +76,7 @@ public class ImpactFormulaGenerator extends AbstractFacetFormulaGenerator {
 		super(isFacetGroupConjunction, isFacetGroupDisjunction, isFacetGroupNegation);
 	}
 
+	@Nonnull
 	@Override
 	public Formula generateFormula(
 		@Nonnull Formula baseFormula,
@@ -69,32 +86,72 @@ public class ImpactFormulaGenerator extends AbstractFacetFormulaGenerator {
 		int facetId,
 		@Nonnull Bitmap[] facetEntityIds
 	) {
-		try {
-			return super.generateFormula(
+		final boolean negation = this.isFacetGroupNegation.test(referenceSchema, facetGroupId);
+		final boolean disjunction = this.isFacetGroupDisjunction.test(referenceSchema, facetGroupId);
+		final boolean conjunction = this.isFacetGroupConjunction.test(referenceSchema, facetGroupId);
+
+		final String referenceName = referenceSchema.getName();
+		// when facetGroupId is null, we use Integer.MIN_VALUE as a placeholder because IntSet can't work with nulls
+		// we're risking that someone will have facet group with such id, but it's very unlikely
+		final Integer normalizedFacetGroupId = ofNullable(facetGroupId).orElse(Integer.MIN_VALUE);
+		boolean found = ofNullable(this.facetGroupsInUserFilter.get(referenceName))
+			.map(it -> it.contains(normalizedFacetGroupId))
+			.orElse(false);
+
+		// if we didn't find the facet group in the user filter, we can use the generic formula
+		final CacheKey key = found ?
+			new CacheKey(referenceName, negation, disjunction, conjunction, normalizedFacetGroupId) :
+			new CacheKey(null, negation, disjunction, conjunction, null);
+
+		final Formula formula = cache.get(key);
+		if (formula != null) {
+			final Bitmap facetEntityIdsBitmap = getBaseEntityIds(facetEntityIds);
+			final MutableFormulaFinderAndReplacer mutableFormulaFinderAndReplacer = new MutableFormulaFinderAndReplacer(
+				() -> conjunction ?
+					new FacetGroupAndFormula(referenceName, facetGroupId, new BaseBitmap(facetId), facetEntityIdsBitmap) :
+					new FacetGroupOrFormula(referenceName, facetGroupId, new BaseBitmap(facetId), facetEntityIdsBitmap)
+			);
+			formula.accept(mutableFormulaFinderAndReplacer);
+			Assert.isPremiseValid(mutableFormulaFinderAndReplacer.isTargetFound(), "Expected single MutableFormula in the formula tree!");
+			return formula;
+		} else {
+			final Formula result = super.generateFormula(
 				baseFormula, baseFormulaWithoutUserFilter, referenceSchema, facetGroupId, facetId, facetEntityIds
 			);
-		} finally {
-			// clear the flag upon leaving this method in a safe manner
-			this.foundTargetInUserFilter = false;
+			// the generation may have been the first time we've seen the formula, so the facetGroupsInUserFilter
+			// may not contain the referenceName yet and we have to repeat the look-up
+			boolean foundAtLast = ofNullable(this.facetGroupsInUserFilter.get(referenceName))
+				.map(it -> it.contains(normalizedFacetGroupId))
+				.orElse(false);
+			final CacheKey cacheKey = new CacheKey(
+				foundAtLast ? referenceName : null, negation, disjunction, conjunction, foundAtLast ? facetGroupId : null
+			);
+			this.cache.put(cacheKey, result);
+			return result;
 		}
 	}
 
 	@Override
 	protected boolean handleFormula(@Nonnull Formula formula) {
 		// if the examined formula is facet group formula matching the same facet `entityType` and `facetGroupId`
-		if (isInsideUserFilter() && formula instanceof FacetGroupFormula oldFacetGroupFormula &&
-			Objects.equals(referenceSchema.getName(), oldFacetGroupFormula.getReferenceName()) &&
-			Objects.equals(facetGroupId, oldFacetGroupFormula.getFacetGroupId())
-		) {
-			final FacetGroupFormula newFacetGroupFormula = createNewFacetGroupFormula();
-			// we found the facet group formula - we need to enrich it with new facet
-			storeFormula(
-				newFacetGroupFormula.mergeWith(oldFacetGroupFormula)
-			);
-			// switch the signalization flag
-			foundTargetInUserFilter = true;
-			// we've stored the formula - instruct super method to skip it's handling
-			return true;
+		if (isInsideUserFilter() && formula instanceof FacetGroupFormula oldFacetGroupFormula) {
+			// register the facet group formula in the index
+			this.facetGroupsInUserFilter.computeIfAbsent(
+				oldFacetGroupFormula.getReferenceName(),
+				s -> new IntHashSet(16)
+			).add(ofNullable(oldFacetGroupFormula.getFacetGroupId()).orElse(Integer.MIN_VALUE));
+
+			// now process it for current facet as well
+			if (Objects.equals(referenceSchema.getName(), oldFacetGroupFormula.getReferenceName()) &&
+				Objects.equals(facetGroupId, oldFacetGroupFormula.getFacetGroupId())
+			) {
+				final MutableFormula newFacetGroupFormula = createNewFacetGroupFormula();
+				// we found the facet group formula - we need to enrich it with new facet
+				newFacetGroupFormula.setPivot(oldFacetGroupFormula);
+				storeFormula(newFacetGroupFormula);
+				// we've stored the formula - instruct super method to skip it's handling
+				return true;
+			}
 		}
 		// let the upper implementation handle the formula
 		return false;
@@ -102,13 +159,55 @@ public class ImpactFormulaGenerator extends AbstractFacetFormulaGenerator {
 
 	@Override
 	protected boolean handleUserFilter(@Nonnull Formula formula, @Nonnull Formula[] updatedChildren) {
-		if (!foundTargetInUserFilter) {
-			// there was no FacetGroupFormula inside - we have to create brand new one and add it before leaving user filter
-			return super.handleUserFilter(formula, updatedChildren);
-		} else {
+		final Boolean wasFoundInTheUserFilter = ofNullable(this.facetGroupsInUserFilter.get(referenceSchema.getName()))
+			.map(it -> it.contains(ofNullable(facetGroupId).orElse(Integer.MIN_VALUE)))
+			.orElse(false);
+
+		if (wasFoundInTheUserFilter) {
 			// we've already enriched existing formula with new formula - let the logic continue without modification
 			return false;
+		} else {
+			// there was no FacetGroupFormula inside - we have to create a brand new one and add it before leaving user filter
+			return super.handleUserFilter(formula, updatedChildren);
 		}
+	}
+
+	/**
+	 * Represents a cache key used for caching formula generation results. The cache key contains all key information
+	 * needed to distinguish the situation when we need to analyze and create new formula composition and we can reuse
+	 * the existing one and just replace one formula with another.
+	 *
+	 * The reference name and the facet group id are set only for cache keys that represents existing facet group
+	 * formulas in original formula tree inside user filter container. If such formula is not found, we may reuse
+	 * the generic formula, because new formula is added always at the same place with behavior driven only by
+	 * negation / disjunction / conjunction combination.
+	 *
+	 * @param referenceName the reference name of the facet group
+	 * @param isConjunction true if the facet group is conjunction
+	 * @param isDisjunction true if the facet group is disjunction
+	 * @param isNegation    true if the facet group is negation
+	 * @param facetGroupId  the facet group id - non-null only if the formula for particular facet group is found in
+	 *                      the main formula
+	 */
+	private record CacheKey(
+		@Nullable String referenceName,
+		boolean isNegation,
+		boolean isDisjunction,
+		boolean isConjunction,
+		@Nullable Integer facetGroupId
+	) {
+
+		@Override
+		public String toString() {
+			return "CacheKey{" +
+				"referenceName='" + referenceName + '\'' +
+				", isNegation=" + isNegation +
+				", isDisjunction=" + isDisjunction +
+				", isConjunction=" + isConjunction +
+				", facetGroupId=" + facetGroupId +
+				'}';
+		}
+
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/MutableFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/MutableFormula.java
@@ -1,0 +1,149 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/main/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.extraResult.translator.facet.producer;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.FormulaVisitor;
+import io.evitadb.core.query.algebra.facet.FacetGroupFormula;
+import io.evitadb.index.bitmap.Bitmap;
+import lombok.Getter;
+import net.openhft.hashing.LongHashFunction;
+
+import javax.annotation.Nonnull;
+
+/**
+ * This formula is a HACK and don't use it!!!
+ *
+ * Ok, now let's talk about why is this a hack, why you shouldn't use it and why it's here. Formulas are meant to be
+ * IMMUTABLE, and this one is mutable - thus breaking the law. It was introduced only because of the performance
+ * reasons (see <a href="https://github.com/FgForrest/evitaDB/issues/464">issue 464</a>). This formula is used only
+ * in facet summary computation logic where we need to generate specific formulas for each facet. The problem is that
+ * there are usually a LOT of facets and generating a new formula for each of them is very expensive. So we use this
+ * hack to generate a formula for the first facet of a specific kind, and then we just change the inner formula to
+ * the next one. This way we avoid unnecessary objects allocation and repeated formula analysis, which (as proven by
+ * profiling) is a significant performance improvement.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+class MutableFormula implements Formula {
+	private FacetGroupFormula pivot;
+	@Getter private FacetGroupFormula delegate;
+
+	public MutableFormula(@Nonnull FacetGroupFormula delegate) {
+		this.delegate = delegate;
+	}
+
+	/**
+	 * The pivot represents a formula found in original formula tree which cannot be ignored and must always be respected
+	 * when the {@link #delegate} is set or exchanged.
+	 *
+	 * @param pivot the pivot formula
+	 */
+	public void setPivot(@Nonnull FacetGroupFormula pivot) {
+		this.pivot = pivot;
+		// if the delegate is already present, merge it with the pivot
+		this.delegate = this.pivot.mergeWith(this.delegate);
+	}
+
+	/**
+	 * The delegate is exchanged with different formula group delegate for each computation. This allows us to fully
+	 * reuse original formula tree and yet calculate different result using an exchanged delegate in this formula.
+	 * This approach is a HACK and should not be used in any other place than the facet summary computation logic.
+	 *
+	 * @param delegate the new delegate formula
+	 */
+	public void setDelegate(@Nonnull FacetGroupFormula delegate) {
+		this.delegate = this.pivot == null ? delegate : this.pivot.mergeWith(delegate);
+	}
+
+	@Override
+	@Nonnull
+	public String prettyPrint() {
+		return delegate.prettyPrint();
+	}
+
+	@Override
+	public void accept(@Nonnull FormulaVisitor visitor) {
+		visitor.visit(this);
+	}
+
+	@Override
+	@Nonnull
+	public Bitmap compute() {
+		return delegate.compute();
+	}
+
+	@Override
+	@Nonnull
+	public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {
+		throw new UnsupportedOperationException("Clone cannot be performed on mutable formula!");
+	}
+
+	@Override
+	@Nonnull
+	public Formula[] getInnerFormulas() {
+		return delegate.getInnerFormulas();
+	}
+
+	@Override
+	public int getEstimatedCardinality() {
+		return delegate.getEstimatedCardinality();
+	}
+
+	@Override
+	public long computeHash(@Nonnull LongHashFunction hashFunction) {
+		return delegate.computeHash(hashFunction);
+	}
+
+	@Override
+	public long computeTransactionalIdHash(@Nonnull LongHashFunction hashFunction) {
+		return delegate.computeTransactionalIdHash(hashFunction);
+	}
+
+	@Override
+	@Nonnull
+	public long[] gatherTransactionalIds() {
+		return delegate.gatherTransactionalIds();
+	}
+
+	@Override
+	public long getEstimatedCost() {
+		return delegate.getEstimatedCost();
+	}
+
+	@Override
+	public long getCost() {
+		return delegate.getCost();
+	}
+
+	@Override
+	public long getOperationCost() {
+		return delegate.getOperationCost();
+	}
+
+	@Override
+	public long getCostToPerformanceRatio() {
+		return delegate.getCostToPerformanceRatio();
+	}
+}

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/visitor/ChildrenStatisticsHierarchyVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/visitor/ChildrenStatisticsHierarchyVisitor.java
@@ -40,9 +40,9 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.EnumSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.IntFunction;
@@ -118,7 +118,7 @@ public class ChildrenStatisticsHierarchyVisitor implements HierarchyVisitor {
 		this.requestedPredicate = requestedPredicate;
 		this.scopePredicate = scopePredicate;
 		this.filterPredicate = filterPredicate;
-		this.accumulator = new LinkedList<>();
+		this.accumulator = new ArrayDeque<>(16);
 
 		// accumulator is used to gather information about its children gradually
 		this.rootAccumulator = new Accumulator(false, null, () -> EmptyFormula.INSTANCE);

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/visitor/ParentStatisticsHierarchyVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/visitor/ParentStatisticsHierarchyVisitor.java
@@ -39,11 +39,11 @@ import lombok.RequiredArgsConstructor;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.IntFunction;
 import java.util.function.IntPredicate;
@@ -75,7 +75,7 @@ public class ParentStatisticsHierarchyVisitor implements HierarchyVisitor {
 	/**
 	 * Deque of accumulators allow to compose a tree of results
 	 */
-	@Nonnull private final Deque<Accumulator> accumulator = new LinkedList<>();
+	@Nonnull private final Deque<Accumulator> accumulator = new ArrayDeque<>(16);
 	/**
 	 * Function that allows to fetch {@link SealedEntity} for `entityType` + `primaryKey` combination. SealedEntity
 	 * is fetched to the depth specified by {@link RequireConstraint[]}.

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/utils/AbstractFormulaStructureOptimizeVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/utils/AbstractFormulaStructureOptimizeVisitor.java
@@ -35,9 +35,9 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.function.Predicate;
 
 /**
@@ -72,15 +72,15 @@ public abstract class AbstractFormulaStructureOptimizeVisitor implements Formula
 	/**
 	 * Stack serves internally to collect the cloned tree of formulas.
 	 */
-	private final Deque<CompositeObjectArray<Formula>> levelStack = new LinkedList<>();
+	private final Deque<CompositeObjectArray<Formula>> levelStack = new ArrayDeque<>(16);
 	/**
 	 * Stack contains parent path that is valid for currently examined formula.
 	 */
-	private final Deque<Formula> parentStack = new LinkedList<>();
+	private final Deque<Formula> parentStack = new ArrayDeque<>(16);
 	/**
 	 * Set contains all formula container, that should be optimized.
 	 */
-	private final Deque<Formula> optimizationSet = new LinkedList<>();
+	private final Deque<Formula> optimizationSet = new ArrayDeque<>(16);
 	/**
 	 * Result optimized form of formula.
 	 */

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/FilterByVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/FilterByVisitor.java
@@ -180,12 +180,12 @@ public class FilterByVisitor implements ConstraintVisitor {
 	/**
 	 * Contemporary stack for keeping results resolved for each level of the query.
 	 */
-	private final Deque<List<Formula>> stack = new LinkedList<>();
+	private final Deque<List<Formula>> stack = new ArrayDeque<>(16);
 	/**
 	 * Contemporary stack for keeping results resolved for each level of the query.
 	 */
 	@Getter(AccessLevel.PROTECTED)
-	private final Deque<ProcessingScope<? extends Index<?>>> scope = new LinkedList<>();
+	private final Deque<ProcessingScope<? extends Index<?>>> scope = new ArrayDeque<>(16);
 	/**
 	 * Contains list of registered post processors. Formula post processor is used to transform final {@link Formula}
 	 * tree constructed in {@link FilterByVisitor} before computing the result. Post processors should analyze created
@@ -1023,7 +1023,7 @@ public class FilterByVisitor implements ConstraintVisitor {
 		 * This stack contains parent chain of the current query.
 		 */
 		@Nonnull
-		private final Deque<FilterConstraint> processedConstraints = new LinkedList<>();
+		private final Deque<FilterConstraint> processedConstraints = new ArrayDeque<>(16);
 		/**
 		 * Contains requirements to be passed for entity prefetch (if available).
 		 */

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/price/PriceListCompositionTerminationVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/price/PriceListCompositionTerminationVisitor.java
@@ -49,6 +49,7 @@ import lombok.RequiredArgsConstructor;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashSet;
@@ -83,7 +84,7 @@ class PriceListCompositionTerminationVisitor implements FormulaVisitor {
 	 * used to recognizing whether the container formula needs to be reconstructed with new children or old formula can
 	 * be reused (nothing has changed in its children).
 	 */
-	private final Deque<List<Formula>> stack = new LinkedList<>();
+	private final Deque<List<Formula>> stack = new ArrayDeque<>(16);
 	/**
 	 * Price filter is used to filter out entities which price doesn't match the predicate.
 	 */

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/OrderByVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/OrderByVisitor.java
@@ -64,9 +64,9 @@ import lombok.experimental.Delegate;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -127,11 +127,11 @@ public class OrderByVisitor implements ConstraintVisitor, LocaleProvider {
 	/**
 	 * Contemporary stack for auxiliary data resolved for each level of the query.
 	 */
-	private final Deque<ProcessingScope> scope = new LinkedList<>();
+	private final Deque<ProcessingScope> scope = new ArrayDeque<>(16);
 	/**
 	 * Contains the created sorter from the ordering query source tree.
 	 */
-	private final LinkedList<Sorter> sorters = new LinkedList<>();
+	private final Deque<Sorter> sorters = new ArrayDeque<>(16);
 
 	public OrderByVisitor(
 		@Nonnull QueryContext queryContext,

--- a/evita_engine/src/main/java/io/evitadb/index/transactionalMemory/TransactionalMemory.java
+++ b/evita_engine/src/main/java/io/evitadb/index/transactionalMemory/TransactionalMemory.java
@@ -30,10 +30,10 @@ import lombok.Getter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -72,7 +72,7 @@ import java.util.function.Function;
 public class TransactionalMemory {
 	@Getter private final long transactionId;
 	private final TransactionalLayerMaintainer transactionalLayer;
-	private final Deque<ObjectIdentityHashSet<TransactionalLayerCreator<?>>> suppressedCreatorStack = new LinkedList<>();
+	private final Deque<ObjectIdentityHashSet<TransactionalLayerCreator<?>>> suppressedCreatorStack = new ArrayDeque<>(64);
 
 	/**
 	 * Propagates changes in states made in transactional layer down to real "state" in {@link TransactionalLayerCreator}

--- a/evita_performance_tests/src/main/java/io/evitadb/performance/client/state/ClientSyntheticTestState.java
+++ b/evita_performance_tests/src/main/java/io/evitadb/performance/client/state/ClientSyntheticTestState.java
@@ -46,6 +46,7 @@ import org.openjdk.jmh.annotations.TearDown;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.LinkedList;
 
@@ -63,7 +64,7 @@ public abstract class ClientSyntheticTestState extends ClientDataFullDatabaseSta
 	private static final int PRELOADED_QUERY_COUNT = 100_000;
 	private final Object monitor = new Object();
 
-	private Deque<Query> preloadedQueries = new LinkedList<>();
+	private Deque<Query> preloadedQueries = new ArrayDeque<>(64);
 	private Path inputFolder;
 	private Kryo kryo;
 	private Input input;

--- a/evita_query/src/main/java/io/evitadb/api/query/visitor/ConstraintCloneVisitor.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/visitor/ConstraintCloneVisitor.java
@@ -32,9 +32,9 @@ import io.evitadb.exception.EvitaInternalError;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.reflect.Array;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.BiFunction;
 
@@ -46,7 +46,7 @@ import static java.util.Optional.ofNullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class ConstraintCloneVisitor implements ConstraintVisitor {
-	private final Deque<List<Constraint<?>>> levelConstraints = new LinkedList<>();
+	private final Deque<List<Constraint<?>>> levelConstraints = new ArrayDeque<>(16);
 	private final BiFunction<ConstraintCloneVisitor, Constraint<?>, Constraint<?>> constraintTranslator;
 	private Constraint<?> result = null;
 

--- a/evita_query/src/main/java/io/evitadb/api/query/visitor/QueryPurifierVisitor.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/visitor/QueryPurifierVisitor.java
@@ -32,9 +32,9 @@ import io.evitadb.exception.EvitaInternalError;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.reflect.Array;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
@@ -49,7 +49,7 @@ import static java.util.Optional.ofNullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class QueryPurifierVisitor implements ConstraintVisitor {
-	private final Deque<List<Constraint<?>>> levelConstraints = new LinkedList<>();
+	private final Deque<List<Constraint<?>>> levelConstraints = new ArrayDeque<>(16);
 	private final UnaryOperator<Constraint<?>> constraintTranslator;
 	private Constraint<?> result = null;
 


### PR DESCRIPTION
The optimization is done by compromising our approach to formula immutability. In this case, I introduce a new special `MutableFormula` that delegates calls to inner formulas that can be swapped. This way we can fully reuse the formula tree for multiple invocations and only replace bitmaps with primary keys referencing specific facets, thus avoiding an awful lot of repeated formula reconstructions.