### PR TITLE
perf(#461): formula deduplication

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/EvitaRequest.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/EvitaRequest.java
@@ -669,7 +669,7 @@ public class EvitaRequest {
 		if (this.priceValidInTimeSet == null) {
 			final List<OffsetDateTime> validitySpan = QueryUtils.findFilters(query, PriceValidIn.class)
 				.stream()
-				.map(it -> ofNullable(it.getTheMoment()).orElse(alignedNow))
+				.map(it -> it.getTheMoment(this::getAlignedNow))
 				.distinct()
 				.toList();
 			Assert.isTrue(

--- a/evita_engine/src/main/java/io/evitadb/core/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/EntityCollection.java
@@ -81,6 +81,7 @@ import io.evitadb.core.query.QueryPlan;
 import io.evitadb.core.query.QueryPlanner;
 import io.evitadb.core.query.ReferencedEntityFetcher;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.response.TransactionalDataRelatedStructure.CalculationContext;
 import io.evitadb.core.sequence.SequenceService;
 import io.evitadb.core.sequence.SequenceType;
 import io.evitadb.exception.EvitaInternalError;
@@ -338,6 +339,7 @@ public final class EntityCollection implements TransactionalLayerProducer<DataSo
 	public Optional<BinaryEntity> getBinaryEntity(int primaryKey, @Nonnull EvitaRequest evitaRequest, @Nonnull EvitaSessionContract session) {
 		final Optional<BinaryEntity> entity = cacheSupervisor.analyse(
 			session,
+			CalculationContext.NO_CACHING_INSTANCE,
 			primaryKey,
 			getSchema().getName(),
 			evitaRequest.getEntityRequirement(),
@@ -715,6 +717,7 @@ public final class EntityCollection implements TransactionalLayerProducer<DataSo
 	public Optional<EntityDecorator> getEntityDecorator(int primaryKey, @Nonnull EvitaRequest evitaRequest, @Nonnull EvitaSessionContract session) {
 		return cacheSupervisor.analyse(
 			session,
+			CalculationContext.NO_CACHING_INSTANCE,
 			primaryKey,
 			getSchema().getName(),
 			evitaRequest.getAlignedNow(),

--- a/evita_engine/src/main/java/io/evitadb/core/cache/CacheSupervisor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cache/CacheSupervisor.java
@@ -33,6 +33,7 @@ import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.extraResult.CacheableEvitaResponseExtraResultComputer;
 import io.evitadb.core.query.extraResult.EvitaResponseExtraResultComputer;
 import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
+import io.evitadb.core.query.response.TransactionalDataRelatedStructure.CalculationContext;
 import io.evitadb.core.query.sort.CacheableSorter;
 import io.evitadb.core.query.sort.Sorter;
 import net.openhft.hashing.LongHashFunction;
@@ -82,12 +83,13 @@ public interface CacheSupervisor {
 	 * Method traverses {@link Formula} tree and for each "expensive" formula it computes hash and checks whether
 	 * the formula has cached counterpart. If so the formula is exchanged with the {@link CachedRecord} that
 	 * has the result already memoized. The cost (expensiveness) of the formula are based on
-	 * {@link TransactionalDataRelatedStructure#getEstimatedCost()} that is the only way how to guess the cost without
+	 * {@link TransactionalDataRelatedStructure#getEstimatedCost(CalculationContext)}  that is the only way how to guess the cost without
 	 * really computing the result.
 	 */
 	@Nonnull
 	<T extends Formula> T analyse(
 		@Nonnull EvitaSessionContract evitaSession,
+		@Nonnull CalculationContext calculationContext,
 		@Nonnull String entityType,
 		@Nonnull T filterFormula
 	);
@@ -96,12 +98,13 @@ public interface CacheSupervisor {
 	 * Method examines whether `extraResultComputer` is "expensive" enough and when it is, it computes hash and checks
 	 * whether the extraResultComputer has cached counterpart. If so the computer is exchanged with
 	 * the {@link CachedRecord} that has the result already memoized. The cost (expensiveness) of the computer are based
-	 * on {@link TransactionalDataRelatedStructure#getEstimatedCost()} that is the only way how to guess the cost
+	 * on {@link TransactionalDataRelatedStructure#getEstimatedCost(CalculationContext)}  that is the only way how to guess the cost
 	 * without really computing the result.
 	 */
 	@Nonnull
 	<U, T extends CacheableEvitaResponseExtraResultComputer<U>> EvitaResponseExtraResultComputer<U> analyse(
 		@Nonnull EvitaSessionContract evitaSession,
+		@Nonnull CalculationContext calculationContext,
 		@Nonnull String entityType,
 		@Nonnull T extraResultComputer
 	);
@@ -110,12 +113,13 @@ public interface CacheSupervisor {
 	 * Method examines whether `sortedRecordsProvider` is "expensive" enough and when it is, it computes hash and checks
 	 * whether the sortedRecordsProvider has cached counterpart. If so the computer is exchanged with
 	 * the {@link CachedRecord} that has the result already memoized. The cost (expensiveness) of the computer are based
-	 * on {@link TransactionalDataRelatedStructure#getEstimatedCost()} that is the only way how to guess the cost
+	 * on {@link TransactionalDataRelatedStructure#getEstimatedCost(CalculationContext)}  that is the only way how to guess the cost
 	 * without really computing the result.
 	 */
 	@Nonnull
 	Sorter analyse(
 		@Nonnull EvitaSessionContract evitaSession,
+		@Nonnull CalculationContext calculationContext,
 		@Nonnull String entityType,
 		@Nonnull CacheableSorter sortedRecordsProvider
 	);
@@ -131,6 +135,7 @@ public interface CacheSupervisor {
 	@Nonnull
 	Optional<EntityDecorator> analyse(
 		@Nonnull EvitaSessionContract evitaSession,
+		@Nonnull CalculationContext calculationContext,
 		int primaryKey,
 		@Nonnull String entityType,
 		@Nonnull OffsetDateTime offsetDateTime,
@@ -147,7 +152,7 @@ public interface CacheSupervisor {
 	 * is created for it. If there are enough requests targeting this entity, the entity will eventually propagate to
 	 * the cache.
 	 *
-	 * This method is analogous to {@link #analyse(EvitaSessionContract, int, String, OffsetDateTime, EntityFetch, Supplier, UnaryOperator)}
+	 * This method is analogous to {@link #analyse(EvitaSessionContract, CalculationContext, int, String, OffsetDateTime, EntityFetch, Supplier, UnaryOperator)}
 	 * but it handles and returns {@link BinaryEntity} instead.
 	 *
 	 * @see io.evitadb.api.requestResponse.EvitaBinaryEntityResponse
@@ -155,6 +160,7 @@ public interface CacheSupervisor {
 	@Nonnull
 	Optional<BinaryEntity> analyse(
 		@Nonnull EvitaSessionContract evitaSession,
+		@Nonnull CalculationContext calculationContext,
 		int primaryKey,
 		@Nonnull String entityType,
 		@Nullable EntityFetch entityRequirement,

--- a/evita_engine/src/main/java/io/evitadb/core/cache/FormulaCacheVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cache/FormulaCacheVisitor.java
@@ -27,6 +27,7 @@ import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.NonCacheableFormula;
 import io.evitadb.core.query.algebra.utils.visitor.FormulaCloner;
+import io.evitadb.core.query.response.TransactionalDataRelatedStructure.CalculationContext;
 import lombok.Getter;
 
 import javax.annotation.Nonnull;
@@ -42,7 +43,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * usage is being tracked and evaluated.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
- * @see CacheAnteroom#register(EvitaSessionContract, String, Formula, FormulaCacheVisitor)  for more details
+ * @see CacheAnteroom#register(EvitaSessionContract, CalculationContext, String, Formula, FormulaCacheVisitor)  for more details
  */
 public class FormulaCacheVisitor extends FormulaCloner {
 
@@ -50,17 +51,19 @@ public class FormulaCacheVisitor extends FormulaCloner {
 	 * Preferred way of invoking this visitor. Accepts formula (tree) and produces clone that may contain already
 	 * cached results.
 	 *
-	 * @see CacheAnteroom#register(EvitaSessionContract, String, Formula, FormulaCacheVisitor)  for more details
+	 * @see CacheAnteroom#register(EvitaSessionContract, CalculationContext, String, Formula, FormulaCacheVisitor)  for more details
 	 */
 	@Nonnull
 	public static Formula analyse(
 		@Nonnull EvitaSessionContract evitaSession,
+		@Nonnull CalculationContext calculationContext,
 		@Nonnull String entityType,
 		@Nonnull Formula formulaToAnalyse,
 		@Nonnull CacheAnteroom cacheAnteroom
 	) {
 		final FormulaCacheVisitor visitor = new FormulaCacheVisitor(
 			evitaSession,
+			calculationContext,
 			entityType,
 			cacheAnteroom
 		);
@@ -70,10 +73,11 @@ public class FormulaCacheVisitor extends FormulaCloner {
 
 	private FormulaCacheVisitor(
 		@Nonnull EvitaSessionContract session,
+		@Nonnull CalculationContext calculationContext,
 		@Nonnull String entityType,
 		@Nonnull CacheAnteroom cacheAnteroom
 	) {
-		super((self, formula) -> cacheAnteroom.register(session, entityType, formula, (FormulaCacheVisitor) self));
+		super((self, formula) -> cacheAnteroom.register(session, calculationContext, entityType, formula, (FormulaCacheVisitor) self));
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/cache/NoCacheSupervisor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cache/NoCacheSupervisor.java
@@ -30,6 +30,7 @@ import io.evitadb.api.requestResponse.data.structure.EntityDecorator;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.extraResult.CacheableEvitaResponseExtraResultComputer;
 import io.evitadb.core.query.extraResult.EvitaResponseExtraResultComputer;
+import io.evitadb.core.query.response.TransactionalDataRelatedStructure.CalculationContext;
 import io.evitadb.core.query.sort.CacheableSorter;
 import io.evitadb.core.query.sort.Sorter;
 import lombok.AccessLevel;
@@ -58,6 +59,7 @@ public class NoCacheSupervisor implements CacheSupervisor {
 	@Override
 	public <T extends Formula> T analyse(
 		@Nullable EvitaSessionContract evitaSession,
+		@Nonnull CalculationContext calculationContext,
 		@Nonnull String entityType,
 		@Nonnull T filterFormula
 	) {
@@ -70,6 +72,7 @@ public class NoCacheSupervisor implements CacheSupervisor {
 	@Override
 	public <U, T extends CacheableEvitaResponseExtraResultComputer<U>> EvitaResponseExtraResultComputer<U> analyse(
 		@Nullable EvitaSessionContract evitaSession,
+		@Nonnull CalculationContext calculationContext,
 		@Nonnull String entityType,
 		@Nonnull T extraResultComputer
 	) {
@@ -81,6 +84,7 @@ public class NoCacheSupervisor implements CacheSupervisor {
 	@Override
 	public Sorter analyse(
 		@Nonnull EvitaSessionContract evitaSession,
+		@Nonnull CalculationContext calculationContext,
 		@Nonnull String entityType,
 		@Nonnull CacheableSorter sortedRecordsProvider
 	) {
@@ -92,6 +96,7 @@ public class NoCacheSupervisor implements CacheSupervisor {
 	@Override
 	public Optional<EntityDecorator> analyse(
 		@Nonnull EvitaSessionContract evitaSession,
+		@Nonnull CalculationContext calculationContext,
 		int primaryKey,
 		@Nonnull String entityType,
 		@Nonnull OffsetDateTime offsetDateTime,
@@ -106,6 +111,7 @@ public class NoCacheSupervisor implements CacheSupervisor {
 	@Override
 	public Optional<BinaryEntity> analyse(
 		@Nonnull EvitaSessionContract evitaSession,
+		@Nonnull CalculationContext calculationContext,
 		int primaryKey,
 		@Nonnull String entityType,
 		@Nullable EntityFetch entityRequirement,

--- a/evita_engine/src/main/java/io/evitadb/core/cache/payload/BinaryEntityComputationalObjectAdapter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cache/payload/BinaryEntityComputationalObjectAdapter.java
@@ -63,7 +63,7 @@ public class BinaryEntityComputationalObjectAdapter implements TransactionalData
 	 */
 	private final int requirementCount;
 	/**
-	 * Contains minimal threshold of the {@link Formula#getEstimatedCost()} that formula needs to exceed in order to
+	 * Contains minimal threshold of the {@link Formula#getEstimatedCost(CalculationContext)}  that formula needs to exceed in order to
 	 * become a cache adept, that may be potentially moved to {@link CacheEden}.
 	 */
 	private final long minimalComplexityThreshold;
@@ -85,13 +85,21 @@ public class BinaryEntityComputationalObjectAdapter implements TransactionalData
 	}
 
 	@Override
-	public long getEstimatedCost() {
-		return Math.max(minimalComplexityThreshold, requirementCount * getOperationCost());
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.ESTIMATED_COST, this)) {
+			return Math.max(minimalComplexityThreshold, requirementCount * getOperationCost());
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
-	public long getCost() {
-		return Math.max(minimalComplexityThreshold, requirementCount * getOperationCost());
+	public long getCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.COST, this)) {
+			return Math.max(minimalComplexityThreshold, requirementCount * getOperationCost());
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
@@ -100,8 +108,8 @@ public class BinaryEntityComputationalObjectAdapter implements TransactionalData
 	}
 
 	@Override
-	public long getCostToPerformanceRatio() {
-		return getCost();
+	public long getCostToPerformanceRatio(@Nonnull CalculationContext calculationContext) {
+		return getCost(calculationContext);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/cache/payload/EntityComputationalObjectAdapter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cache/payload/EntityComputationalObjectAdapter.java
@@ -83,7 +83,7 @@ public class EntityComputationalObjectAdapter implements TransactionalDataRelate
 	 */
 	private final int requirementCount;
 	/**
-	 * Contains minimal threshold of the {@link Formula#getEstimatedCost()} that formula needs to exceed in order to
+	 * Contains minimal threshold of the {@link Formula#getEstimatedCost(CalculationContext)}  that formula needs to exceed in order to
 	 * become a cache adept, that may be potentially moved to {@link CacheEden}.
 	 */
 	private final long minimalComplexityThreshold;
@@ -105,13 +105,21 @@ public class EntityComputationalObjectAdapter implements TransactionalDataRelate
 	}
 
 	@Override
-	public long getEstimatedCost() {
-		return Math.max(minimalComplexityThreshold, requirementCount * getOperationCost());
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.ESTIMATED_COST, this)) {
+			return Math.max(minimalComplexityThreshold, requirementCount * getOperationCost());
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
-	public long getCost() {
-		return Math.max(minimalComplexityThreshold, requirementCount * getOperationCost());
+	public long getCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.COST, this)) {
+			return Math.max(minimalComplexityThreshold, requirementCount * getOperationCost());
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
@@ -120,8 +128,8 @@ public class EntityComputationalObjectAdapter implements TransactionalDataRelate
 	}
 
 	@Override
-	public long getCostToPerformanceRatio() {
-		return getCost();
+	public long getCostToPerformanceRatio(@Nonnull CalculationContext calculationContext) {
+		return getCost(calculationContext);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormula.java
@@ -83,12 +83,12 @@ public class FlattenedFormula extends CachePayloadHeader implements Formula {
 	}
 
 	@Override
-	public long getEstimatedCost() {
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
 		return 0;
 	}
 
 	@Override
-	public long getCost() {
+	public long getCost(@Nonnull CalculationContext calculationContext) {
 		return 0;
 	}
 
@@ -98,7 +98,7 @@ public class FlattenedFormula extends CachePayloadHeader implements Formula {
 	}
 
 	@Override
-	public long getCostToPerformanceRatio() {
+	public long getCostToPerformanceRatio(@Nonnull CalculationContext calculationContext) {
 		return Integer.MAX_VALUE;
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryContext.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryContext.java
@@ -65,6 +65,7 @@ import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
 import io.evitadb.core.query.extraResult.CacheSupervisorExtraResultAccessor;
 import io.evitadb.core.query.extraResult.ExtraResultCacheAccessor;
 import io.evitadb.core.query.extraResult.translator.facet.producer.FilteringFormulaPredicate;
+import io.evitadb.core.query.response.TransactionalDataRelatedStructure.CalculationContext;
 import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.function.TriFunction;
 import io.evitadb.index.CatalogIndexKey;
@@ -182,6 +183,10 @@ public class QueryContext implements AutoCloseable, LocaleProvider {
 	 */
 	@Nonnull @Getter
 	private final ExtraResultCacheAccessor extraResultCacheAccessor = new CacheSupervisorExtraResultAccessor(this);
+	/**
+	 * Context used for calculation of estimated costs.
+	 */
+	@Nonnull @Getter private final CalculationContext calculationContext = new CalculationContext();
 	/**
 	 * Contains list of prefetched entities if they were considered worthwhile to prefetch -
 	 * see {@link SelectionFormula} for more information.
@@ -824,7 +829,7 @@ public class QueryContext implements AutoCloseable, LocaleProvider {
 	@Nonnull
 	public Formula analyse(@Nonnull Formula formula) {
 		return ofNullable(evitaRequest.getEntityType())
-			.map(it -> cacheSupervisor.analyse(evitaSession, it, formula))
+			.map(it -> cacheSupervisor.analyse(evitaSession, calculationContext, it, formula))
 			.orElse(formula);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlan.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlan.java
@@ -109,7 +109,10 @@ public class QueryPlan {
 	@Nonnull
 	public <S extends Serializable, T extends EvitaResponse<S>> T execute() {
 		queryContext.pushStep(QueryPhase.EXECUTION);
-		new QueryPlanStepExecutedEvent(QueryPhase.EXECUTION.name(), this.filter.getEstimatedCost()).commit();
+		new QueryPlanStepExecutedEvent(
+			QueryPhase.EXECUTION.name(),
+			this.filter.getEstimatedCost(queryContext.getCalculationContext())
+		).commit();
 
 		try {
 			// prefetch the entities to allow using them in filtering / sorting in next step

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanBuilder.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanBuilder.java
@@ -29,6 +29,7 @@ import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.prefetch.PrefetchFormulaVisitor;
 import io.evitadb.core.query.extraResult.ExtraResultProducer;
 import io.evitadb.core.query.indexSelection.TargetIndexes;
+import io.evitadb.core.query.response.TransactionalDataRelatedStructure.CalculationContext;
 import io.evitadb.core.query.sort.NoSorter;
 import io.evitadb.core.query.sort.Sorter;
 import lombok.Getter;
@@ -140,16 +141,16 @@ public class QueryPlanBuilder implements PrefetchRequirementCollector {
 	 */
 	@Nonnull
 	public String getDescriptionWithCosts() {
-		return targetIndexes.toStringWithCosts(getEstimatedCost());
+		return targetIndexes.toStringWithCosts(getEstimatedCost(queryContext.getCalculationContext()));
 	}
 
 	/**
 	 * Returns estimated costs for computing filtered result.
 	 *
-	 * @see Formula#getEstimatedCost()
+	 * @see Formula#getEstimatedCost(CalculationContext)
 	 */
-	public long getEstimatedCost() {
-		return filterFormula.getEstimatedCost();
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
+		return filterFormula.getEstimatedCost(calculationContext);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/ConstantFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/ConstantFormula.java
@@ -58,7 +58,7 @@ public class ConstantFormula extends AbstractFormula {
 	}
 
 	@Override
-	public long getEstimatedCostInternal() {
+	public long getEstimatedCostInternal(@Nonnull CalculationContext calculationContext) {
 		return delegate.size();
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
@@ -121,7 +121,7 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 	}
 
 	@Override
-	public long getEstimatedCostInternal() {
+	public long getEstimatedCostInternal(@Nonnull CalculationContext calculationContext) {
 		if (mainBitmap != null && controlBitmap != null) {
 			try {
 				long costs = mainBitmap.size();
@@ -131,7 +131,7 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 				return Long.MAX_VALUE;
 			}
 		} else {
-			return super.getEstimatedCostInternal();
+			return super.getEstimatedCostInternal(calculationContext);
 		}
 	}
 
@@ -178,11 +178,11 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 	}
 
 	@Override
-	protected long getCostInternal() {
+	protected long getCostInternal(@Nonnull CalculationContext calculationContext) {
 		if (mainBitmap != null && controlBitmap != null) {
 			return Stream.of(mainBitmap, controlBitmap).mapToLong(Bitmap::size).sum();
 		} else {
-			return super.getCostInternal();
+			return super.getCostInternal(calculationContext);
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
@@ -210,7 +210,7 @@ public class JoinFormula extends AbstractFormula {
 	}
 
 	@Override
-	public long getEstimatedCostInternal() {
+	public long getEstimatedCostInternal(@Nonnull CalculationContext calculationContext) {
 		try {
 			long costs = 0L;
 			for (Bitmap bitmap : bitmaps) {
@@ -255,10 +255,10 @@ public class JoinFormula extends AbstractFormula {
 	}
 
 	@Override
-	protected long getCostInternal() {
+	protected long getCostInternal(@Nonnull CalculationContext calculationContext) {
 		return ofNullable(this.bitmaps)
 			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).sum())
-			.orElseGet(super::getCostInternal);
+			.orElseGet(() -> super.getCostInternal(calculationContext));
 	}
 
 	/*

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
@@ -31,7 +31,6 @@ import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import io.evitadb.index.transactionalMemory.TransactionalLayerProducer;
-import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 import lombok.Data;
 import net.openhft.hashing.LongHashFunction;
@@ -69,7 +68,7 @@ public class JoinFormula extends AbstractFormula {
 	/**
 	 * Computes next integer to be included in result map.
 	 */
-	private static int computeNextInt(PriorityQueue<IntIteratorPointer> priorityQueue) {
+	private static int computeNext(@Nonnull PriorityQueue<IntIteratorPointer> priorityQueue) {
 		// finish when priority queue is empty
 		if (!priorityQueue.isEmpty()) {
 			// poll pointer with the lowest number from the queue
@@ -100,16 +99,101 @@ public class JoinFormula extends AbstractFormula {
 		return priorityQueue;
 	}
 
+	/**
+	 * Use more performant way when merging two bitmaps.
+	 *
+	 * @param iterators array of two iterators
+	 * @param intArray  array to store merged numbers
+	 */
+	private static void joinTwoBitmaps(@Nonnull IntIterator[] iterators, @Nonnull CompositeIntArray intArray) {
+		boolean leftAdded = true;
+		boolean rightAdded = true;
+		int leftValue = Integer.MIN_VALUE;
+		int rightValue = Integer.MIN_VALUE;
+		while (iterators[0].hasNext() && iterators[1].hasNext()) {
+			leftValue = leftAdded ? iterators[0].next() : leftValue;
+			rightValue = rightAdded ? iterators[1].next() : rightValue;
+			if (leftValue < rightValue) {
+				intArray.add(leftValue);
+				leftAdded = true;
+				rightAdded = false;
+			} else if (leftValue > rightValue) {
+				intArray.add(rightValue);
+				rightAdded = true;
+				leftAdded = false;
+			} else {
+				intArray.add(leftValue);
+				intArray.add(rightValue);
+				leftAdded = true;
+				rightAdded = true;
+			}
+		}
+		// quickly add remaining numbers from one non-empty iterator left
+		if (!leftAdded) {
+			intArray.add(leftValue);
+		}
+		if (!rightAdded) {
+			intArray.add(rightValue);
+		}
+		while (iterators[0].hasNext()) {
+			intArray.add(iterators[0].next());
+		}
+		while (iterators[1].hasNext()) {
+			intArray.add(iterators[1].next());
+		}
+	}
+
+	@Nonnull
+	private static IntIterator[] getImmutableRoaringBitmapIterators(@Nonnull Bitmap[] bitmaps) {
+		return Arrays.stream(bitmaps)
+			.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
+			.map(it -> it.getBatchIterator().asIntIterator(new int[256]))
+			.toArray(IntIterator[]::new);
+	}
+
 	public JoinFormula(long indexTransactionId, @Nonnull Bitmap... bitmaps) {
 		super();
-		Assert.isTrue(bitmaps.length > 0, "Join formula has to have at least one bitmap - otherwise use EmptyFormula.INSTANCE.");
-		this.bitmaps = bitmaps;
+		this.bitmaps = Arrays.stream(bitmaps)
+			.filter(it -> !(it instanceof EmptyBitmap))
+			.toArray(Bitmap[]::new);
+		Assert.isTrue(this.bitmaps.length > 1, "Join formula has to have at least two bitmaps - otherwise use EmptyFormula.INSTANCE or just the bitmap itself.");
 		this.indexTransactionId = new long[]{indexTransactionId};
+	}
+
+	/**
+	 * Returns a new OrFormula object using the indexTransactionId and bitmaps of this JoinFormula.
+	 *
+	 * @return a Formula object representing the logical OR operation on the indexTransactionId and bitmaps
+	 */
+	@Nonnull
+	public Formula getAsOrFormula() {
+		return new OrFormula(this.indexTransactionId, this.bitmaps);
 	}
 
 	@Override
 	public String toString() {
 		return "JOIN: " + Arrays.stream(bitmaps).map(Bitmap::toString).collect(Collectors.joining(", "));
+	}
+
+	@Nonnull
+	@Override
+	public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {
+		throw new UnsupportedOperationException("Join formula doesn't support inner formulas, just bitmaps.");
+	}
+
+	@Override
+	public int getEstimatedCardinality() {
+		return Arrays.stream(this.bitmaps).mapToInt(Bitmap::size).sum();
+	}
+
+	@Override
+	public long getOperationCost() {
+		return 2560;
+	}
+
+	@Override
+	protected boolean isFormulaOrderSignificant() {
+		return true;
 	}
 
 	@Nonnull
@@ -144,11 +228,6 @@ public class JoinFormula extends AbstractFormula {
 	}
 
 	@Override
-	public int getEstimatedCardinality() {
-		return Arrays.stream(this.bitmaps).mapToInt(Bitmap::size).sum();
-	}
-
-	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
 		if (bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
 			return hashFunction.hashLongs(indexTransactionId);
@@ -171,11 +250,6 @@ public class JoinFormula extends AbstractFormula {
 	}
 
 	@Override
-	protected boolean isFormulaOrderSignificant() {
-		return true;
-	}
-
-	@Override
 	protected long getClassId() {
 		return CLASS_ID;
 	}
@@ -187,47 +261,30 @@ public class JoinFormula extends AbstractFormula {
 			.orElseGet(super::getCostInternal);
 	}
 
-	@Nonnull
-	@Override
-	public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {
-		throw new UnsupportedOperationException("Join formula doesn't support inner formulas, just bitmaps.");
-	}
-
-	@Override
-	public long getOperationCost() {
-		return 2560;
-	}
+	/*
+		PRIVATE METHODS
+	 */
 
 	@Nonnull
 	@Override
 	protected Bitmap computeInternal() {
 		// init priority queue that will produce numbers from all bitmaps from lowest to highest keeping duplicates
-		final IntIterator[] iterators = getImmutableRoaringBitmapIterators();
-		if (ArrayUtils.isEmpty(iterators)) {
-			return EmptyBitmap.INSTANCE;
-		}
-		final PriorityQueue<IntIteratorPointer> priorityQueue = initIntPriorityQueue(iterators);
-		// init array that can extend itself
+		final IntIterator[] iterators = getImmutableRoaringBitmapIterators(bitmaps);
 		final CompositeIntArray intArray = new CompositeIntArray();
-		// iterate number by number until priority queue is exhausted.
-		int number;
-		while ((number = computeNextInt(priorityQueue)) != END_OF_STREAM) {
-			intArray.add(number);
+		if (iterators.length == 2) {
+			// if there are two iterators, just merge them into one bitmap
+			joinTwoBitmaps(iterators, intArray);
+		} else {
+			final PriorityQueue<IntIteratorPointer> priorityQueue = initIntPriorityQueue(iterators);
+			// init array that can extend itself
+			// iterate number by number until priority queue is exhausted.
+			int number;
+			while ((number = computeNext(priorityQueue)) != END_OF_STREAM) {
+				intArray.add(number);
+			}
 		}
 		// now just wrap array into a bitmap
 		return new ArrayBitmap(intArray);
-	}
-
-	/*
-		PRIVATE METHODS
-	 */
-
-	private IntIterator[] getImmutableRoaringBitmapIterators() {
-		return Arrays.stream(bitmaps)
-				.filter(it -> !(it instanceof EmptyBitmap))
-				.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-				.map(it -> it.getBatchIterator().asIntIterator(new int[256]))
-				.toArray(IntIterator[]::new);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
@@ -92,7 +92,7 @@ public class NotFormula extends AbstractCacheableFormula {
 	}
 
 	@Override
-	public long getEstimatedCostInternal() {
+	public long getEstimatedCostInternal(@Nonnull CalculationContext calculationContext) {
 		if (subtractedBitmap != null && supersetBitmap != null) {
 			try {
 				long costs = subtractedBitmap.size();
@@ -102,7 +102,7 @@ public class NotFormula extends AbstractCacheableFormula {
 				return Long.MAX_VALUE;
 			}
 		} else {
-			return super.getEstimatedCostInternal();
+			return super.getEstimatedCostInternal(calculationContext);
 		}
 	}
 
@@ -153,11 +153,11 @@ public class NotFormula extends AbstractCacheableFormula {
 	}
 
 	@Override
-	protected long getCostInternal() {
+	protected long getCostInternal(@Nonnull CalculationContext calculationContext) {
 		if (supersetBitmap != null && subtractedBitmap != null) {
 			return Stream.of(supersetBitmap, subtractedBitmap).mapToLong(Bitmap::size).sum();
 		} else {
-			return super.getCostInternal();
+			return super.getCostInternal(calculationContext);
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/OrFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/OrFormula.java
@@ -184,10 +184,10 @@ public class OrFormula extends AbstractCacheableFormula {
 	}
 
 	@Override
-	protected long getCostInternal() {
+	protected long getCostInternal(@Nonnull CalculationContext calculationContext) {
 		return ofNullable(this.bitmaps)
 			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).sum())
-			.orElseGet(super::getCostInternal);
+			.orElseGet(() -> super.getCostInternal(calculationContext));
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/deferred/BitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/deferred/BitmapSupplier.java
@@ -39,7 +39,7 @@ public interface BitmapSupplier extends TransactionalDataRelatedStructure, Suppl
 
 	/**
 	 * Returns the cardinality estimate of {@link #get()} method without really computing the result. The estimate
-	 * will not be precise but differs between AND/OR relations and helps us to compute {@link #getEstimatedCost()}.
+	 * will not be precise but differs between AND/OR relations and helps us to compute {@link #getEstimatedCost(CalculationContext)}.
 	 */
 	int getEstimatedCardinality();
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/deferred/DeferredFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/deferred/DeferredFormula.java
@@ -54,18 +54,18 @@ public class DeferredFormula extends AbstractFormula {
 	}
 
 	@Override
-	protected long getEstimatedCostInternal() {
-		return retrieveLambda.getEstimatedCost();
+	protected long getEstimatedCostInternal(@Nonnull CalculationContext calculationContext) {
+		return retrieveLambda.getEstimatedCost(calculationContext);
 	}
 
 	@Override
-	protected long getCostInternal() {
-		return retrieveLambda.getCost();
+	protected long getCostInternal(@Nonnull CalculationContext calculationContext) {
+		return retrieveLambda.getCost(calculationContext);
 	}
 
 	@Override
-	protected long getCostToPerformanceInternal() {
-		return retrieveLambda.getCost() / Math.max(1, retrieveLambda.get().size());
+	protected long getCostToPerformanceInternal(@Nonnull CalculationContext calculationContext) {
+		return retrieveLambda.getCost(calculationContext) / Math.max(1, retrieveLambda.get().size());
 	}
 
 	@Override
@@ -105,4 +105,8 @@ public class DeferredFormula extends AbstractFormula {
 		return CLASS_ID;
 	}
 
+	@Override
+	public String toString() {
+		return "DEFERRED CALCULATION: " + retrieveLambda.toString();
+	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/deferred/FormulaWrapper.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/deferred/FormulaWrapper.java
@@ -66,13 +66,13 @@ public class FormulaWrapper implements BitmapSupplier {
 	}
 
 	@Override
-	public long getEstimatedCost() {
-		return formula.getEstimatedCost();
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
+		return formula.getEstimatedCost(calculationContext);
 	}
 
 	@Override
-	public long getCost() {
-		return formula.getCost();
+	public long getCost(@Nonnull CalculationContext calculationContext) {
+		return formula.getCost(calculationContext);
 	}
 
 	@Override
@@ -81,8 +81,8 @@ public class FormulaWrapper implements BitmapSupplier {
 	}
 
 	@Override
-	public long getCostToPerformanceRatio() {
-		return formula.getCostToPerformanceRatio();
+	public long getCostToPerformanceRatio(@Nonnull CalculationContext calculationContext) {
+		return formula.getCostToPerformanceRatio(calculationContext);
 	}
 
 	@Override
@@ -91,5 +91,10 @@ public class FormulaWrapper implements BitmapSupplier {
 			computed = firstInvocation.apply(formula);
 		}
 		return computed;
+	}
+
+	@Override
+	public String toString() {
+		return formula.toString();
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
@@ -166,9 +166,9 @@ public class FacetGroupAndFormula extends AbstractFormula implements FacetGroupF
 	}
 
 	@Override
-	protected long getCostInternal() {
+	protected long getCostInternal(@Nonnull CalculationContext calculationContext) {
 		return ofNullable(this.bitmaps)
 			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).sum())
-			.orElseGet(super::getCostInternal);
+			.orElseGet(() -> super.getCostInternal(calculationContext));
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
@@ -176,9 +176,9 @@ public class FacetGroupOrFormula extends AbstractFormula implements FacetGroupFo
 	}
 
 	@Override
-	protected long getCostInternal() {
+	protected long getCostInternal(@Nonnull CalculationContext calculationContext) {
 		return ofNullable(this.bitmaps)
 			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).sum())
-			.orElseGet(super::getCostInternal);
+			.orElseGet(() -> super.getCostInternal(calculationContext));
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/EntityFilteringFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/EntityFilteringFormula.java
@@ -120,7 +120,7 @@ public class EntityFilteringFormula extends AbstractFormula implements Requireme
 	}
 
 	@Override
-	protected long getEstimatedCostInternal() {
+	protected long getEstimatedCostInternal(@Nonnull CalculationContext calculationContext) {
 		if (alternative.getEntityRequire() == null) {
 			return 0;
 		}
@@ -128,7 +128,7 @@ public class EntityFilteringFormula extends AbstractFormula implements Requireme
 	}
 
 	@Override
-	protected long getCostInternal() {
+	protected long getCostInternal(@Nonnull CalculationContext calculationContext) {
 		if (alternative.getEntityRequire() == null) {
 			return 0;
 		}
@@ -136,8 +136,8 @@ public class EntityFilteringFormula extends AbstractFormula implements Requireme
 	}
 
 	@Override
-	protected long getCostToPerformanceInternal() {
-		return getCost() / Math.max(1, compute().size());
+	protected long getCostToPerformanceInternal(@Nonnull CalculationContext calculationContext) {
+		return getCost(calculationContext) / Math.max(1, compute().size());
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/MultipleEntityFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/MultipleEntityFormula.java
@@ -30,7 +30,6 @@ import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.index.bitmap.Bitmap;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import net.openhft.hashing.LongHashFunction;
 
 import javax.annotation.Nonnull;
@@ -46,10 +45,15 @@ import javax.annotation.Nonnull;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
-@RequiredArgsConstructor
 public class MultipleEntityFormula extends AbstractFormula {
 	private static final long CLASS_ID = 7381005856920907843L;
 	@Getter private final Bitmap directEntityReferences;
+	private final long[] transactionalIds;
+
+	public MultipleEntityFormula(@Nonnull long[] transactionalIds, @Nonnull Bitmap directEntityReferences) {
+		this.transactionalIds = transactionalIds;
+		this.directEntityReferences = directEntityReferences;
+	}
 
 	@Override
 	protected long getClassId() {
@@ -58,7 +62,7 @@ public class MultipleEntityFormula extends AbstractFormula {
 
 	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
-		return 0;
+		return hashFunction.hashInts(directEntityReferences.getArray());
 	}
 
 	@Nonnull
@@ -82,4 +86,16 @@ public class MultipleEntityFormula extends AbstractFormula {
 	public long getOperationCost() {
 		return 0;
 	}
+
+	@Nonnull
+	@Override
+	protected long[] gatherBitmapIdsInternal() {
+		return transactionalIds;
+	}
+
+	@Override
+	public String toString() {
+		return "PREFEFETCH: " + directEntityReferences;
+	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/PrefetchFormulaVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/PrefetchFormulaVisitor.java
@@ -77,6 +77,10 @@ public class PrefetchFormulaVisitor implements FormulaVisitor, FormulaPostProces
 	 */
 	@Nonnull private final Bitmap entityReferences = new BaseBitmap();
 	/**
+	 * The query context that will be used to prefetch entities.
+	 */
+	@Nonnull private final QueryContext queryContext;
+	/**
 	 * Flag that signalizes {@link #visit(Formula)} happens in conjunctive scope.
 	 */
 	protected boolean conjunctiveScope = true;
@@ -128,6 +132,10 @@ public class PrefetchFormulaVisitor implements FormulaVisitor, FormulaPostProces
 	 */
 	private static long estimatePrefetchCost(int prefetchedEntityCount, @Nonnull EntityFetchRequire requirements) {
 		return PREFETCH_COST_ESTIMATOR.apply(prefetchedEntityCount, requirements.getRequirements().length);
+	}
+
+	public PrefetchFormulaVisitor(@Nonnull QueryContext queryContext) {
+		this.queryContext = queryContext;
 	}
 
 	/**
@@ -205,7 +213,7 @@ public class PrefetchFormulaVisitor implements FormulaVisitor, FormulaPostProces
 			this.outputFormula = formula;
 		}
 		if (formula instanceof final SelectionFormula selectionFormula) {
-			expectedComputationalCosts += selectionFormula.getDelegate().getEstimatedCost();
+			expectedComputationalCosts += selectionFormula.getDelegate().getEstimatedCost(queryContext.getCalculationContext());
 		}
 		if (formula instanceof final RequirementsDefiner requirementsDefiner) {
 			final EntityRequire entityRequire = requirementsDefiner.getEntityRequire();

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/SelectionFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/SelectionFormula.java
@@ -209,7 +209,7 @@ public class SelectionFormula extends AbstractFormula implements FilteredPriceRe
 	}
 
 	@Override
-	protected long getEstimatedCostInternal() {
+	protected long getEstimatedCostInternal(@Nonnull CalculationContext calculationContext) {
 		return Optional.ofNullable(filterByVisitor.getPrefetchedEntities())
 			.map(it -> {
 				if (alternative.getEntityRequire() == null) {
@@ -217,7 +217,7 @@ public class SelectionFormula extends AbstractFormula implements FilteredPriceRe
 				}
 				return (1 + alternative.getEntityRequire().getRequirements().length) * 148L;
 			})
-			.orElseGet(getDelegate()::getEstimatedCost);
+			.orElseGet(() -> getDelegate().getEstimatedCost(calculationContext));
 	}
 
 	@Override
@@ -237,7 +237,7 @@ public class SelectionFormula extends AbstractFormula implements FilteredPriceRe
 	 */
 
 	@Override
-	protected long getCostInternal() {
+	protected long getCostInternal(@Nonnull CalculationContext calculationContext) {
 		return Optional.ofNullable(filterByVisitor.getPrefetchedEntities())
 			.map(it -> {
 				if (alternative.getEntityRequire() == null) {
@@ -246,14 +246,14 @@ public class SelectionFormula extends AbstractFormula implements FilteredPriceRe
 
 				return (1 + alternative.getEntityRequire().getRequirements().length) * 148L;
 			})
-			.orElseGet(getDelegate()::getCost);
+			.orElseGet(() -> getDelegate().getCost(calculationContext));
 	}
 
 	@Override
-	protected long getCostToPerformanceInternal() {
+	protected long getCostToPerformanceInternal(@Nonnull CalculationContext calculationContext) {
 		return Optional.ofNullable(filterByVisitor.getPrefetchedEntities())
-			.map(it -> getCost() / Math.max(1, compute().size()))
-			.orElseGet(getDelegate()::getCostToPerformanceRatio);
+			.map(it -> getCost(calculationContext) / Math.max(1, compute().size()))
+			.orElseGet(() -> getDelegate().getCostToPerformanceRatio(calculationContext));
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/CacheSupervisorExtraResultAccessor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/CacheSupervisorExtraResultAccessor.java
@@ -41,7 +41,9 @@ public class CacheSupervisorExtraResultAccessor implements ExtraResultCacheAcces
 	@Nonnull
 	@Override
 	public <U, T extends CacheableEvitaResponseExtraResultComputer<U>> EvitaResponseExtraResultComputer<U> analyse(@Nonnull String entityType, @Nonnull T computer) {
-		return queryContext.getCacheSupervisor().analyse(queryContext.getEvitaSession(), entityType, computer);
+		return queryContext.getCacheSupervisor().analyse(
+			queryContext.getEvitaSession(), queryContext.getCalculationContext(), entityType, computer
+		);
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/MutableFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/MutableFormula.java
@@ -129,13 +129,13 @@ class MutableFormula implements Formula {
 	}
 
 	@Override
-	public long getEstimatedCost() {
-		return delegate.getEstimatedCost();
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
+		return delegate.getEstimatedCost(calculationContext);
 	}
 
 	@Override
-	public long getCost() {
-		return delegate.getCost();
+	public long getCost(@Nonnull CalculationContext calculationContext) {
+		return delegate.getCost(calculationContext);
 	}
 
 	@Override
@@ -144,8 +144,8 @@ class MutableFormula implements Formula {
 	}
 
 	@Override
-	public long getCostToPerformanceRatio() {
-		return delegate.getCostToPerformanceRatio();
+	public long getCostToPerformanceRatio(@Nonnull CalculationContext calculationContext) {
+		return delegate.getCostToPerformanceRatio(calculationContext);
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/cache/FlattenedHistogramComputer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/cache/FlattenedHistogramComputer.java
@@ -81,12 +81,12 @@ public class FlattenedHistogramComputer extends CachePayloadHeader implements Tr
 	}
 
 	@Override
-	public long getEstimatedCost() {
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
 		return 0;
 	}
 
 	@Override
-	public long getCost() {
+	public long getCost(@Nonnull CalculationContext calculationContext) {
 		return 0;
 	}
 
@@ -96,7 +96,7 @@ public class FlattenedHistogramComputer extends CachePayloadHeader implements Tr
 	}
 
 	@Override
-	public long getCostToPerformanceRatio() {
+	public long getCostToPerformanceRatio(@Nonnull CalculationContext calculationContext) {
 		return Long.MAX_VALUE;
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/PriceHistogramComputer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/PriceHistogramComputer.java
@@ -187,15 +187,23 @@ public class PriceHistogramComputer implements CacheableEvitaResponseExtraResult
 	}
 
 	@Override
-	public long getEstimatedCost() {
-		return filteringFormula.compute().size() *
-			(filteredPriceRecordAccessors.size() / 2) *
-			getOperationCost();
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.ESTIMATED_COST, this)) {
+			return filteringFormula.compute().size() *
+				(filteredPriceRecordAccessors.size() / 2) *
+				getOperationCost();
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
-	public long getCost() {
-		return getPriceRecords().length * getOperationCost();
+	public long getCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.COST, this)) {
+			return getPriceRecords().length * getOperationCost();
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
@@ -205,8 +213,8 @@ public class PriceHistogramComputer implements CacheableEvitaResponseExtraResult
 	}
 
 	@Override
-	public long getCostToPerformanceRatio() {
-		return getCost() / (getOperationCost() * bucketCount);
+	public long getCostToPerformanceRatio(@Nonnull CalculationContext calculationContext) {
+		return getCost(calculationContext) / (getOperationCost() * bucketCount);
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/FormulaDeduplicator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/FormulaDeduplicator.java
@@ -1,0 +1,100 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/main/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.filter;
+
+import io.evitadb.core.cache.CacheSupervisor;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.FormulaPostProcessor;
+import io.evitadb.core.query.algebra.utils.visitor.FormulaCloner;
+import io.evitadb.utils.CollectionUtils;
+import net.openhft.hashing.LongHashFunction;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+/**
+ * TODO JNO - document me
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+public class FormulaDeduplicator extends FormulaCloner implements FormulaPostProcessor {
+	/**
+	 * Hash function used to compute hash of formulas.
+	 */
+	private static final LongHashFunction HASH_FUNCTION = CacheSupervisor.createHashFunction();
+	/**
+	 * Reference to the original unchanged {@link Formula}.
+	 */
+	private Formula originalFormula;
+	/**
+	 * Flag indicating that at least one formula was deduplicated.
+	 */
+	private boolean deduplicationHappened = false;
+
+	/* TODO JNO - tady spočítat celkovou složitost root formuly, protože se musí započítat deduplikace */
+	public FormulaDeduplicator(@Nonnull Formula originalFormula) {
+		super(new Deduplicator());
+		this.originalFormula = originalFormula;
+	}
+
+	@Nonnull
+	@Override
+	public Formula getPostProcessedFormula() {
+		final Formula result = this.deduplicationHappened ?
+			getResultClone() : this.originalFormula;
+		((Deduplicator)this.mutator).clear();
+		this.deduplicationHappened = false;
+		this.originalFormula = null;
+		return result;
+	}
+
+	private static class Deduplicator implements BiFunction<FormulaCloner, Formula, Formula> {
+		/**
+		 * Cache of formulas.
+		 */
+		private final Map<Long, Formula> formulaCache = CollectionUtils.createHashMap(64);
+
+		@Override
+		public Formula apply(FormulaCloner formulaCloner, Formula formula) {
+			final FormulaDeduplicator clonerInstance = (FormulaDeduplicator) formulaCloner;
+			if (clonerInstance.originalFormula == null) {
+				clonerInstance.originalFormula = formula;
+			}
+			final Formula existingFormula = formulaCache.putIfAbsent(formula.computeHash(HASH_FUNCTION), formula);
+			if (existingFormula != null) {
+				clonerInstance.deduplicationHappened = true;
+				return existingFormula;
+			} else {
+				// include the original formula
+				return formula;
+			}
+		}
+
+		void clear() {
+			this.formulaCache.clear();
+		}
+
+	}
+}

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeEqualsTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeEqualsTranslator.java
@@ -78,6 +78,7 @@ public class AttributeEqualsTranslator implements FilteringConstraintTranslator<
 						return entityReference == null ?
 							EmptyFormula.INSTANCE :
 							new MultipleEntityFormula(
+								new long[] { index.getId() },
 								filterByVisitor.translateEntityReference(entityReference)
 							);
 					}

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeInSetTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeInSetTranslator.java
@@ -92,6 +92,7 @@ public class AttributeInSetTranslator implements FilteringConstraintTranslator<A
 						return ArrayUtils.isEmpty(filteredEntityMaskedIds) ?
 							EmptyFormula.INSTANCE :
 							new MultipleEntityFormula(
+								new long[] { index.getId() },
 								new BaseBitmap(
 									filterByVisitor.translateEntityReference(filteredEntityMaskedIds)
 								)

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/price/PriceBetweenTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/price/PriceBetweenTranslator.java
@@ -73,7 +73,7 @@ public class PriceBetweenTranslator extends AbstractPriceRelatedConstraintTransl
 		final QueryPriceMode queryPriceMode = filterByVisitor.getQueryPriceMode();
 
 		final OffsetDateTime theMoment = ofNullable(filterByVisitor.findInConjunctionTree(PriceValidIn.class))
-			.map(PriceValidIn::getTheMoment)
+			.map(it -> it.getTheMoment(filterByVisitor::getNow))
 			.orElse(null);
 		final String[] priceLists = ofNullable(filterByVisitor.findInConjunctionTree(PriceInPriceLists.class))
 			.map(PriceInPriceLists::getPriceLists)

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/price/PriceValidInTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/price/PriceValidInTranslator.java
@@ -75,7 +75,7 @@ public class PriceValidInTranslator extends AbstractPriceRelatedConstraintTransl
 		if (filterByVisitor.isAnyConstraintPresentInConjunctionScopeExcludingUserFilter(PriceBetween.class)) {
 			return SkipFormula.INSTANCE;
 		} else {
-			final OffsetDateTime theMoment = ofNullable(priceValidIn.getTheMoment()).orElseGet(filterByVisitor::getNow);
+			final OffsetDateTime theMoment = priceValidIn.getTheMoment(filterByVisitor::getNow);
 			final String[] priceLists = ofNullable(filterByVisitor.findInConjunctionTree(PriceInPriceLists.class))
 				.map(PriceInPriceLists::getPriceLists)
 				.orElse(null);

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/OrderByVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/OrderByVisitor.java
@@ -188,6 +188,7 @@ public class OrderByVisitor implements ConstraintVisitor, LocaleProvider {
 				final Sorter possiblyCachedSorter = canUseCache && nextSorter instanceof CacheableSorter cacheableSorter ?
 					cacheSupervisor.analyse(
 						queryContext.getEvitaSession(),
+						queryContext.getCalculationContext(),
 						queryContext.getSchema().getName(),
 						cacheableSorter
 					) : nextSorter;

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/PreSortedRecordsSorter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/PreSortedRecordsSorter.java
@@ -184,15 +184,23 @@ public class PreSortedRecordsSorter extends AbstractRecordsSorter implements Cac
 	}
 
 	@Override
-	public long getEstimatedCost() {
-		return Arrays.stream(getSortedRecordsProviders())
-			.mapToInt(SortedRecordsProvider::getRecordCount)
-			.sum() * getOperationCost();
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.ESTIMATED_COST, this)) {
+			return Arrays.stream(getSortedRecordsProviders())
+				.mapToInt(SortedRecordsProvider::getRecordCount)
+				.sum() * getOperationCost();
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
-	public long getCost() {
-		return getEstimatedCost();
+	public long getCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.COST, this)) {
+			return getEstimatedCost(calculationContext);
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
@@ -201,8 +209,8 @@ public class PreSortedRecordsSorter extends AbstractRecordsSorter implements Cac
 	}
 
 	@Override
-	public long getCostToPerformanceRatio() {
-		return getEstimatedCost();
+	public long getCostToPerformanceRatio(@Nonnull CalculationContext calculationContext) {
+		return getEstimatedCost(calculationContext);
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/cache/FlattenedMergedSortedRecordsProvider.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/cache/FlattenedMergedSortedRecordsProvider.java
@@ -89,12 +89,12 @@ public class FlattenedMergedSortedRecordsProvider extends CachePayloadHeader imp
 	}
 
 	@Override
-	public long getEstimatedCost() {
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
 		return 0;
 	}
 
 	@Override
-	public long getCost() {
+	public long getCost(@Nonnull CalculationContext calculationContext) {
 		return 0;
 	}
 
@@ -104,7 +104,7 @@ public class FlattenedMergedSortedRecordsProvider extends CachePayloadHeader imp
 	}
 
 	@Override
-	public long getCostToPerformanceRatio() {
+	public long getCostToPerformanceRatio(@Nonnull CalculationContext calculationContext) {
 		return Long.MAX_VALUE;
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/bitmap/BaseBitmap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bitmap/BaseBitmap.java
@@ -27,6 +27,7 @@ import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Serial;
 import java.util.NoSuchElementException;
@@ -50,7 +51,7 @@ public class BaseBitmap implements RoaringBitmapBackedBitmap {
 		this.memoizedCardinality = 0;
 	}
 
-	public BaseBitmap(int... recordIds) {
+	public BaseBitmap(@Nullable int... recordIds) {
 		final RoaringBitmap theRoaringBitmap = new RoaringBitmap();
 		theRoaringBitmap.add(recordIds);
 		this.roaringBitmap = theRoaringBitmap;

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/FilteringFormulaHierarchyEntityPredicate.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/FilteringFormulaHierarchyEntityPredicate.java
@@ -284,4 +284,12 @@ public class FilteringFormulaHierarchyEntityPredicate implements HierarchyFilter
 		return filteringFormula.compute().contains(hierarchyNodeId);
 	}
 
+	@Override
+	public String toString() {
+		return "HIERARCHY (" +
+			"parent=" + parent +
+			", filterBy=" + filterBy +
+			", filteringFormula=" + filteringFormula +
+			')';
+	}
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/HierarchyFilteringPredicate.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/HierarchyFilteringPredicate.java
@@ -68,6 +68,7 @@ public interface HierarchyFilteringPredicate extends IntPredicate {
 	 */
 	long computeHash(@Nonnull LongHashFunction hashFunction);
 
+	@Nonnull
 	@Override
 	default HierarchyFilteringPredicate negate() {
 		return this instanceof NegatedHierarchyFilteringPredicate negatedHierarchyFilteringPredicate ?
@@ -95,6 +96,12 @@ public interface HierarchyFilteringPredicate extends IntPredicate {
 		public boolean test(int hierarchyNodeId) {
 			return first.test(hierarchyNodeId) && second.test(hierarchyNodeId);
 		}
+
+		@Override
+		public String toString() {
+			return  first + " AND " + second;
+		}
+
 	}
 
 	/**
@@ -116,6 +123,11 @@ public interface HierarchyFilteringPredicate extends IntPredicate {
 		public boolean test(int hierarchyNodeId) {
 			return first.test(hierarchyNodeId) || second.test(hierarchyNodeId);
 		}
+
+		@Override
+		public String toString() {
+			return  first + " OR " + second;
+		}
 	}
 
 	class HierarchyFilteringRejectAllPredicate implements HierarchyFilteringPredicate, Serializable {
@@ -130,6 +142,11 @@ public interface HierarchyFilteringPredicate extends IntPredicate {
 		public boolean test(int value) {
 			return false;
 		}
+
+		@Override
+		public String toString() {
+			return "REJECT ALL";
+		}
 	}
 
 	class HierarchyFilteringAcceptAllPredicate implements HierarchyFilteringPredicate, Serializable {
@@ -143,6 +160,11 @@ public interface HierarchyFilteringPredicate extends IntPredicate {
 		@Override
 		public boolean test(int value) {
 			return true;
+		}
+
+		@Override
+		public String toString() {
+			return "ACCEPT ALL";
 		}
 	}
 
@@ -159,5 +181,11 @@ public interface HierarchyFilteringPredicate extends IntPredicate {
 		public boolean test(int value) {
 			return !predicate.test(value);
 		}
+
+		@Override
+		public String toString() {
+			return "NOT(" + predicate + ")";
+		}
+
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/LocaleHierarchyEntityPredicate.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/LocaleHierarchyEntityPredicate.java
@@ -53,4 +53,8 @@ public class LocaleHierarchyEntityPredicate implements HierarchyFilteringPredica
 		return filteringFormula.compute().contains(hierarchyNodeId);
 	}
 
+	@Override
+	public String toString() {
+		return "BASED ON LOCALE: " + filteringFormula;
+	}
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/MatchNodeIdHierarchyFilteringPredicate.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/MatchNodeIdHierarchyFilteringPredicate.java
@@ -54,4 +54,9 @@ public class MatchNodeIdHierarchyFilteringPredicate implements HierarchyFilterin
 	public boolean test(int nodeId) {
 		return nodeId == matchNodeId;
 	}
+
+	@Override
+	public String toString() {
+		return "MATCH NODE " + matchNodeId;
+	}
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/AbstractHierarchyBitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/AbstractHierarchyBitmapSupplier.java
@@ -67,13 +67,21 @@ public abstract class AbstractHierarchyBitmapSupplier implements BitmapSupplier 
 	}
 
 	@Override
-	public long getEstimatedCost() {
-		return getEstimatedCardinality() * 12L;
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.ESTIMATED_COST, this)) {
+			return getEstimatedCardinality() * 12L;
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
-	public long getCost() {
-		return hierarchyIndex.getHierarchySize() * getOperationCost();
+	public long getCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.COST, this)) {
+			return hierarchyIndex.getHierarchySize() * getOperationCost();
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
@@ -82,8 +90,8 @@ public abstract class AbstractHierarchyBitmapSupplier implements BitmapSupplier 
 	}
 
 	@Override
-	public long getCostToPerformanceRatio() {
-		return getCost() / (get().size() * getOperationCost());
+	public long getCostToPerformanceRatio(@Nonnull CalculationContext calculationContext) {
+		return getCost(calculationContext) / (get().size() * getOperationCost());
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyByParentBitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyByParentBitmapSupplier.java
@@ -75,4 +75,9 @@ public class HierarchyByParentBitmapSupplier extends AbstractHierarchyBitmapSupp
 	public int getEstimatedCardinality() {
 		return hierarchyIndex.getHierarchyNodeCountFromParent(parentNode, excludedNodeTrees);
 	}
+
+	@Override
+	public String toString() {
+		return "HIERARCHY FROM PARENT: " + parentNode + " " + excludedNodeTrees;
+	}
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyByParentDownToLevelBitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyByParentDownToLevelBitmapSupplier.java
@@ -80,4 +80,10 @@ public class HierarchyByParentDownToLevelBitmapSupplier extends AbstractHierarch
 	public int getEstimatedCardinality() {
 		return hierarchyIndex.getHierarchyNodeCountFromParentDownTo(parentNode, levels, excludedNodeTrees);
 	}
+
+	@Override
+	public String toString() {
+		return "HIERARCHY FROM PARENT: " + parentNode + " " + excludedNodeTrees + " DOWN TO " + levels;
+	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyByParentDownToLevelIncludingSelfBitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyByParentDownToLevelIncludingSelfBitmapSupplier.java
@@ -80,4 +80,9 @@ public class HierarchyByParentDownToLevelIncludingSelfBitmapSupplier extends Abs
 	public int getEstimatedCardinality() {
 		return hierarchyIndex.getHierarchyNodeCountFromParentDownTo(parentNode, levels, excludedNodeTrees) + 1;
 	}
+
+	@Override
+	public String toString() {
+		return "HIERARCHY FROM PARENT: " + parentNode + " " + excludedNodeTrees + " DOWN TO " + levels + " AND SELF";
+	}
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyByParentIncludingSelfBitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyByParentIncludingSelfBitmapSupplier.java
@@ -76,4 +76,9 @@ public class HierarchyByParentIncludingSelfBitmapSupplier extends AbstractHierar
 		return hierarchyIndex.getHierarchyNodeCountFromParent(parentNode, excludedNodeTrees) + 1;
 	}
 
+	@Override
+	public String toString() {
+		return "HIERARCHY FROM PARENT: " + parentNode + " " + excludedNodeTrees + " AND SELF";
+	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyForParentBitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyForParentBitmapSupplier.java
@@ -75,4 +75,10 @@ public class HierarchyForParentBitmapSupplier extends AbstractHierarchyBitmapSup
 	public int getEstimatedCardinality() {
 		return hierarchyIndex.getHierarchyNodeCountForParent(parentNode, excludedNodeTrees);
 	}
+
+	@Override
+	public String toString() {
+		return "HIERARCHY FOR PARENT: " + parentNode + " " + excludedNodeTrees;
+	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyRootsBitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyRootsBitmapSupplier.java
@@ -67,4 +67,10 @@ public class HierarchyRootsBitmapSupplier extends AbstractHierarchyBitmapSupplie
 	public int getEstimatedCardinality() {
 		return hierarchyIndex.getRootHierarchyNodeCount(excludedNodeTrees);
 	}
+
+	@Override
+	public String toString() {
+		return "HIERARCHY FOR ROOTS " + excludedNodeTrees;
+	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyRootsDownBitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyRootsDownBitmapSupplier.java
@@ -67,4 +67,10 @@ public class HierarchyRootsDownBitmapSupplier extends AbstractHierarchyBitmapSup
 	public int getEstimatedCardinality() {
 		return hierarchyIndex.getHierarchyNodeCountFromRootDownTo(Integer.MAX_VALUE, excludedNodeTrees);
 	}
+
+	@Override
+	public String toString() {
+		return "HIERARCHY FOR ROOTS " + excludedNodeTrees + " DOWN";
+	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyRootsDownToLevelBitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/suppliers/HierarchyRootsDownToLevelBitmapSupplier.java
@@ -76,4 +76,9 @@ public class HierarchyRootsDownToLevelBitmapSupplier extends AbstractHierarchyBi
 		return hierarchyIndex.getHierarchyNodeCountFromRootDownTo(levels, excludedNodeTrees);
 	}
 
+	@Override
+	public String toString() {
+		return "HIERARCHY FOR ROOTS " + excludedNodeTrees + " DOWN TO " + levels;
+	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/index/invertedIndex/suppliers/HistogramBitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/invertedIndex/suppliers/HistogramBitmapSupplier.java
@@ -51,13 +51,21 @@ public class HistogramBitmapSupplier<T extends Comparable<T>> implements BitmapS
 	private final ValueToRecordBitmap<T>[] histogramBuckets;
 
 	@Override
-	public long getEstimatedCost() {
-		return getEstimatedCardinality() * getOperationCost();
+	public long getEstimatedCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.ESTIMATED_COST, this)) {
+			return getEstimatedCardinality() * getOperationCost();
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
-	public long getCost() {
-		return getEstimatedCost();
+	public long getCost(@Nonnull CalculationContext calculationContext) {
+		if (calculationContext.visit(CalculationType.COST, this)) {
+			return getEstimatedCost(calculationContext);
+		} else {
+			return 0L;
+		}
 	}
 
 	@Override
@@ -73,8 +81,8 @@ public class HistogramBitmapSupplier<T extends Comparable<T>> implements BitmapS
 	}
 
 	@Override
-	public long getCostToPerformanceRatio() {
-		return getCost() / (get().size() * getOperationCost());
+	public long getCostToPerformanceRatio(@Nonnull CalculationContext calculationContext) {
+		return getCost(calculationContext) / (get().size() * getOperationCost());
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/index/range/RangeIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/range/RangeIndex.java
@@ -32,6 +32,7 @@ import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.base.JoinFormula;
 import io.evitadb.core.query.algebra.base.OrFormula;
 import io.evitadb.core.query.algebra.utils.FormulaFactory;
+import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.index.array.TransactionalComplexObjArray;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
@@ -254,9 +255,9 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 		final int startIndex = index >= 0 ? index : -1 * (index) - 1;
 
 		final StartsEndsDTO startsEndsDTO = collectsStartsAndEnds(startIndex, ranges.getLength() - 1, ranges);
-		return new DisentangleFormula(
-			new JoinFormula(getId(), startsEndsDTO.getRangeEndsAsBitmapArray()),
-			new JoinFormula(getId(), startsEndsDTO.getRangeStartsAsBitmapArray())
+		return createDisentangleFormulaIfNecessary(
+			getId(), startsEndsDTO.getRangeEndsAsBitmapArray(),
+			startsEndsDTO.getRangeStartsAsBitmapArray()
 		);
 	}
 
@@ -277,10 +278,7 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 		final int startIndex = index >= 0 ? index : -1 * (index) - 2;
 
 		final StartsEndsDTO startsEndsDTO = collectsStartsAndEnds(0, startIndex, ranges);
-		return new DisentangleFormula(
-			new JoinFormula(getId(), startsEndsDTO.getRangeStartsAsBitmapArray()),
-			new JoinFormula(getId(), startsEndsDTO.getRangeEndsAsBitmapArray())
-		);
+		return createDisentangleFormulaIfNecessary(getId(), startsEndsDTO.getRangeStartsAsBitmapArray(), startsEndsDTO.getRangeEndsAsBitmapArray());
 	}
 
 	/**
@@ -304,14 +302,8 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 			collectsStartsAndEnds(endIndex, ranges.getLength() - 1, ranges) : new StartsEndsDTO();
 
 		final AndFormula envelopeFormula = new AndFormula(
-			new DisentangleFormula(
-				new JoinFormula(getId(), before.getRangeStartsAsBitmapArray()),
-				new JoinFormula(getId(), before.getRangeEndsAsBitmapArray())
-			),
-			new DisentangleFormula(
-				new JoinFormula(getId(), after.getRangeEndsAsBitmapArray()),
-				new JoinFormula(getId(), after.getRangeStartsAsBitmapArray())
-			)
+			createDisentangleFormulaIfNecessary(getId(), before.getRangeStartsAsBitmapArray(), before.getRangeEndsAsBitmapArray()),
+			createDisentangleFormulaIfNecessary(getId(), after.getRangeEndsAsBitmapArray(), after.getRangeStartsAsBitmapArray())
 		);
 
 		// both should be true or false since we have same threshold
@@ -338,6 +330,59 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 	}
 
 	/**
+	 * Creates a DisentangleFormula if necessary based on the given id and bitmap arrays.
+	 * If the left or right bitmap array produces effectively empty bitmap, DisentangleFormula is not created and
+	 * more optimized result is returned.
+	 *
+	 * @param id     the id for the DisentangleFormula
+	 * @param left   the left bitmap array to be used for the DisentangleFormula
+	 * @param right  the right bitmap array to be used for the DisentangleFormula
+	 * @return a Formula object representing the DisentangleFormula if necessary
+	 */
+	@Nonnull
+	private static Formula createDisentangleFormulaIfNecessary(long id, @Nonnull Bitmap[] left, @Nonnull Bitmap[] right) {
+		final Formula leftFormula = createJoinFormulaIfNecessary(id, left);
+		final Formula rightFormula = createJoinFormulaIfNecessary(id, right);
+		if (leftFormula instanceof EmptyFormula) {
+			return EmptyFormula.INSTANCE;
+		} else if (rightFormula instanceof EmptyFormula) {
+			if (leftFormula instanceof ConstantFormula) {
+				return leftFormula;
+			} else if (leftFormula instanceof JoinFormula joinFormula) {
+				return joinFormula.getAsOrFormula();
+			} else {
+				throw new EvitaInternalError("Unexpected formula type: " + leftFormula.getClass().getSimpleName() + "!");
+			}
+		} else {
+			return new DisentangleFormula(leftFormula, rightFormula);
+		}
+	}
+
+	/**
+	 * Creates a join formula if necessary based on the given id and bitmap array.
+	 * If the bitmap array contains only one bitmap, a ConstantFormula is created with that bitmap.
+	 * If the bitmap array is empty, an EmptyFormula is returned.
+	 * Otherwise, a JoinFormula is created with the given id and filtered bitmaps.
+	 *
+	 * @param id     the id for the JoinFormula
+	 * @param bitmaps the bitmap array to be filtered and used for the JoinFormula
+	 * @return a Formula object representing the join formula if necessary
+	 */
+	@Nonnull
+	private static Formula createJoinFormulaIfNecessary(long id, @Nonnull Bitmap[] bitmaps) {
+		final Bitmap[] filteredBitmaps = Arrays.stream(bitmaps)
+			.filter(it -> !(it instanceof EmptyBitmap))
+			.toArray(Bitmap[]::new);
+		if (filteredBitmaps.length == 0) {
+			return EmptyFormula.INSTANCE;
+		} else if (filteredBitmaps.length == 1) {
+			return new ConstantFormula(filteredBitmaps[0]);
+		} else {
+			return new JoinFormula(id, filteredBitmaps);
+		}
+	}
+
+	/**
 	 * Method returns formula that computes all records which range overlap (have points in common)	passed range with
 	 * `from` and `to` bounds.
 	 *
@@ -355,14 +400,8 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 			between.getRangeStarts(),
 			between.getRangeEnds(),
 			new AndFormula(
-				new DisentangleFormula(
-					new JoinFormula(getId(), before.getRangeStartsAsBitmapArray()),
-					new JoinFormula(getId(), before.getRangeEndsAsBitmapArray())
-				),
-				new DisentangleFormula(
-					new JoinFormula(getId(), after.getRangeEndsAsBitmapArray()),
-					new JoinFormula(getId(), after.getRangeStartsAsBitmapArray())
-				)
+				createDisentangleFormulaIfNecessary(getId(), before.getRangeStartsAsBitmapArray(), before.getRangeEndsAsBitmapArray()),
+				createDisentangleFormulaIfNecessary(getId(), after.getRangeEndsAsBitmapArray(), after.getRangeStartsAsBitmapArray())
 			)
 		);
 	}

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/dataFetcher/ListEntitiesDataFetcher.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/dataFetcher/ListEntitiesDataFetcher.java
@@ -195,11 +195,8 @@ public class ListEntitiesDataFetcher implements DataFetcher<DataFetcherResult<Li
 
         final Optional<PriceValidIn> priceValidInConstraint = Optional.ofNullable(QueryUtils.findFilter(query, PriceValidIn.class));
         final OffsetDateTime desiredPriceValidIn = priceValidInConstraint
-            .map(PriceValidIn::getTheMoment)
+            .map(it -> it.getTheMoment(() -> OffsetDateTime.MIN))
             .orElse(null);
-        final boolean desiredpriceValidInNow = priceValidInConstraint
-            .map(it -> it.getTheMoment() == null)
-            .orElse(false);
 
         final String[] desiredPriceInPriceLists = Optional.ofNullable(QueryUtils.findFilter(query, PriceInPriceLists.class))
             .map(PriceInPriceLists::getPriceLists)
@@ -209,8 +206,8 @@ public class ListEntitiesDataFetcher implements DataFetcher<DataFetcherResult<Li
             desiredLocale,
             desiredPriceInCurrency,
             desiredPriceInPriceLists,
-            desiredPriceValidIn,
-            desiredpriceValidInNow
+            desiredPriceValidIn == OffsetDateTime.MIN ? null : desiredPriceValidIn,
+            desiredPriceValidIn == OffsetDateTime.MIN
         );
     }
 

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/dataFetcher/QueryEntitiesDataFetcher.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/dataFetcher/QueryEntitiesDataFetcher.java
@@ -279,7 +279,7 @@ public class QueryEntitiesDataFetcher implements DataFetcher<DataFetcherResult<E
 	}
 
 	@Nonnull
-	private EntityQueryContext buildResultContext(@Nonnull Query query) {
+	private static EntityQueryContext buildResultContext(@Nonnull Query query) {
 		final Locale desiredLocale = Optional.ofNullable(QueryUtils.findFilter(query, EntityLocaleEquals.class))
 			.map(EntityLocaleEquals::getLocale)
 			.orElse(null);
@@ -290,11 +290,8 @@ public class QueryEntitiesDataFetcher implements DataFetcher<DataFetcherResult<E
 
 		final Optional<PriceValidIn> priceValidInConstraint = Optional.ofNullable(QueryUtils.findFilter(query, PriceValidIn.class));
 		final OffsetDateTime desiredPriceValidIn = priceValidInConstraint
-			.map(PriceValidIn::getTheMoment)
+			.map(it -> it.getTheMoment(() -> OffsetDateTime.MIN))
 			.orElse(null);
-		final boolean desiredpriceValidInNow = priceValidInConstraint
-			.map(it -> it.getTheMoment() == null)
-			.orElse(false);
 
 		final String[] desiredPriceInPriceLists = Optional.ofNullable(QueryUtils.findFilter(query, PriceInPriceLists.class))
 			.map(PriceInPriceLists::getPriceLists)
@@ -304,8 +301,8 @@ public class QueryEntitiesDataFetcher implements DataFetcher<DataFetcherResult<E
 			desiredLocale,
 			desiredPriceInCurrency,
 			desiredPriceInPriceLists,
-			desiredPriceValidIn,
-			desiredpriceValidInNow
+			desiredPriceValidIn == OffsetDateTime.MIN ? null : desiredPriceValidIn,
+			desiredPriceValidIn == OffsetDateTime.MIN
 		);
 	}
 

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils/QueryUtil.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/utils/QueryUtil.java
@@ -56,6 +56,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
@@ -265,9 +266,9 @@ public class QueryUtil {
 	 * @return priceValidIn if found, null otherwise
 	 */
 	@Nullable
-	public static OffsetDateTime getPriceValidIn(@Nonnull Query query) {
+	public static OffsetDateTime getPriceValidIn(@Nonnull Query query, @Nonnull Supplier<OffsetDateTime> currentDateAndTime) {
 		return ofNullable(QueryUtils.findFilter(query, PriceValidIn.class))
-			.map(PriceValidIn::getTheMoment)
+			.map(it -> it.getTheMoment(currentDateAndTime))
 			.orElse(null);
 	}
 }

--- a/evita_functional_tests/src/test/java/io/evitadb/api/CombinedPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/CombinedPriceEntityByPriceFilteringFunctionalTest.java
@@ -271,4 +271,28 @@ public class CombinedPriceEntityByPriceFilteringFunctionalTest extends EntityByP
 	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilter(Evita evita, List<SealedEntity> originalProductEntities) {
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilter(evita, originalProductEntities);
 	}
+
+	@DisplayName("Should return price histogram for returned products excluding price between query (and validity)")
+	@UseDataSet(HUNDRED_PRODUCTS_WITH_COMBINED_PRICES)
+	@Test
+	@Override
+	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterAndValidity(Evita evita, List<SealedEntity> originalProductEntities) {
+		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterAndValidity(evita, originalProductEntities);
+	}
+
+	@DisplayName("Should return price histogram for returned products excluding price between query")
+	@UseDataSet(HUNDRED_PRODUCTS_WITH_COMBINED_PRICES)
+	@Test
+	@Override
+	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
+		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterUsingPrefetch(evita, originalProductEntities);
+	}
+
+	@DisplayName("Should return products with price in price list and currency within interval (with tax) ordered by price asc without explicit AND")
+	@UseDataSet(HUNDRED_PRODUCTS_WITH_COMBINED_PRICES)
+	@Test
+	@Override
+	void shouldReturnProductsHavingPriceInCurrencyAndPriceListInIntervalWithTaxOrderByPriceAscendingWithoutExplicitAnd(Evita evita, List<SealedEntity> originalProductEntities) {
+		super.shouldReturnProductsHavingPriceInCurrencyAndPriceListInIntervalWithTaxOrderByPriceAscendingWithoutExplicitAnd(evita, originalProductEntities);
+	}
 }

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EntityByAttributeFilteringFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EntityByAttributeFilteringFunctionalTest.java
@@ -1359,15 +1359,16 @@ public class EntityByAttributeFilteringFunctionalTest {
 							)
 						),
 						require(
-							page(1, Integer.MAX_VALUE),
-							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+							page(1, Integer.MAX_VALUE)
+							/* TODO JNO - uncomment me */
+							//debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
 						)
 					),
 					EntityReference.class
 				);
 				assertResultIs(
 					originalProductEntities,
-					sealedEntity -> ofNullable(sealedEntity.getAttribute(ATTRIBUTE_CODE))
+					sealedEntity -> ofNullable(sealedEntity.getAttribute(ATTRIBUTE_CODE, String.class))
 						.map(randomCodes::contains)
 						.orElse(false),
 					result.getRecordData()

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EntityByAttributeFilteringFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EntityByAttributeFilteringFunctionalTest.java
@@ -1359,9 +1359,8 @@ public class EntityByAttributeFilteringFunctionalTest {
 							)
 						),
 						require(
-							page(1, Integer.MAX_VALUE)
-							/* TODO JNO - uncomment me */
-							//debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
 						)
 					),
 					EntityReference.class

--- a/evita_functional_tests/src/test/java/io/evitadb/api/FindFirstPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/FindFirstPriceEntityByPriceFilteringFunctionalTest.java
@@ -272,6 +272,14 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilter(evita, originalProductEntities);
 	}
 
+	@DisplayName("Should return price histogram for returned products excluding price between query (and validity)")
+	@UseDataSet(HUNDRED_PRODUCTS_WITH_FIND_FIRST_PRICES)
+	@Test
+	@Override
+	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterAndValidity(Evita evita, List<SealedEntity> originalProductEntities) {
+		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterAndValidity(evita, originalProductEntities);
+	}
+
 	@DisplayName("Should return price histogram for returned products excluding price between query")
 	@UseDataSet(HUNDRED_PRODUCTS_WITH_FIND_FIRST_PRICES)
 	@Override

--- a/evita_functional_tests/src/test/java/io/evitadb/api/SumPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/SumPriceEntityByPriceFilteringFunctionalTest.java
@@ -280,6 +280,14 @@ public class SumPriceEntityByPriceFilteringFunctionalTest extends EntityByPriceF
 		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilter(evita, originalProductEntities);
 	}
 
+	@DisplayName("Should return price histogram for returned products excluding price between query (and validity)")
+	@UseDataSet(HUNDRED_PRODUCTS_WITH_SUM_PRICES)
+	@Test
+	@Override
+	void shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterAndValidity(Evita evita, List<SealedEntity> originalProductEntities) {
+		super.shouldReturnPriceHistogramWithoutBeingAffectedByPriceFilterAndValidity(evita, originalProductEntities);
+	}
+
 	@DisplayName("Should return price histogram for returned products excluding price between query")
 	@UseDataSet(HUNDRED_PRODUCTS_WITH_SUM_PRICES)
 	@Override

--- a/evita_functional_tests/src/test/java/io/evitadb/api/query/filter/PriceValidInTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/query/filter/PriceValidInTest.java
@@ -43,10 +43,10 @@ class PriceValidInTest {
 	void shouldCreateMomentViaFactoryClassWorkAsExpected() {
 		final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
 		final PriceValidIn priceValidIn = priceValidIn(now);
-		assertEquals(now, priceValidIn.getTheMoment());
+		assertEquals(now, priceValidIn.getTheMoment(() -> null));
 
 		final PriceValidIn priceValidInNow = priceValidInNow();
-		assertNull(priceValidInNow.getTheMoment());
+		assertNull(priceValidInNow.getTheMoment(() -> null));
 	}
 
 	@Test

--- a/evita_functional_tests/src/test/java/io/evitadb/core/cache/CacheAnteroomTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/core/cache/CacheAnteroomTest.java
@@ -28,6 +28,7 @@ import io.evitadb.core.cache.payload.FlattenedFormula;
 import io.evitadb.core.query.algebra.CacheableFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.AndFormula;
+import io.evitadb.core.query.response.TransactionalDataRelatedStructure.CalculationContext;
 import io.evitadb.core.scheduling.Scheduler;
 import io.evitadb.test.TestConstants;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,7 @@ import java.util.stream.IntStream;
 import static io.evitadb.core.cache.CacheEden.COOL_ENOUGH;
 import static io.evitadb.core.cache.FormulaCacheVisitorTest.toConstantFormula;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -100,7 +102,7 @@ class CacheAnteroomTest {
 		for (int i = 0; i < 1000; i++) {
 			final int formulaIndex = RANDOM.nextInt(inputFormulas.length);
 			final CacheableFormula inputFormula = inputFormulas[formulaIndex];
-			final Formula theFormula = FormulaCacheVisitor.analyse(evitaSession, SOME_ENTITY, inputFormula, cacheAnteroom);
+			final Formula theFormula = FormulaCacheVisitor.analyse(evitaSession, CalculationContext.NO_CACHING_INSTANCE, SOME_ENTITY, inputFormula, cacheAnteroom);
 			assertEquals(inputFormula.compute(), theFormula.compute());
 			if (theFormula instanceof FlattenedFormula) {
 				cacheHits.merge(formulaIndex, 1, Integer::sum);
@@ -111,14 +113,14 @@ class CacheAnteroomTest {
 		assertEquals(12, cacheEden.getCacheRecordCount());
 		final long firstFullCacheSize = cacheEden.getByteSizeUsedByCache();
 		assertTrue(firstFullCacheSize > 2200);
-		assertTrue(cacheHits.size() > 0);
+		assertFalse(cacheHits.isEmpty());
 		cacheHits.clear();
 
 		for (int j = 0; j < COOL_ENOUGH; j++) {
 			for (int i = 0; i < 1000; i++) {
 				final int formulaIndex = RANDOM.nextInt(inputFormulas.length / 2);
 				final CacheableFormula inputFormula = inputFormulas[formulaIndex];
-				final Formula theFormula = FormulaCacheVisitor.analyse(evitaSession, SOME_ENTITY, inputFormula, cacheAnteroom);
+				final Formula theFormula = FormulaCacheVisitor.analyse(evitaSession, CalculationContext.NO_CACHING_INSTANCE, SOME_ENTITY, inputFormula, cacheAnteroom);
 				assertEquals(inputFormula.compute(), theFormula.compute());
 				if (theFormula instanceof FlattenedFormula) {
 					cacheHits.merge(formulaIndex, 1, Integer::sum);
@@ -128,7 +130,7 @@ class CacheAnteroomTest {
 			cacheAnteroom.evaluateAssociatesSynchronously();
 
 			assertEquals(12, cacheEden.getCacheRecordCount());
-			assertTrue(cacheHits.size() > 0);
+			assertFalse(cacheHits.isEmpty());
 			cacheHits.clear();
 		}
 

--- a/evita_functional_tests/src/test/java/io/evitadb/core/cache/FormulaCacheVisitorTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/core/cache/FormulaCacheVisitorTest.java
@@ -30,6 +30,7 @@ import io.evitadb.core.query.algebra.base.AndFormula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.OrFormula;
 import io.evitadb.core.query.algebra.facet.UserFilterFormula;
+import io.evitadb.core.query.response.TransactionalDataRelatedStructure.CalculationContext;
 import io.evitadb.core.scheduling.Scheduler;
 import io.evitadb.index.bitmap.TransactionalBitmap;
 import net.openhft.hashing.LongHashFunction;
@@ -76,6 +77,7 @@ class FormulaCacheVisitorTest {
 
 		final Formula possiblyUpdatedFormula = FormulaCacheVisitor.analyse(
 			Mockito.mock(EvitaSession.class),
+			CalculationContext.NO_CACHING_INSTANCE,
 			SOME_ENTITY,
 			inputFormula,
 			cacheAnteroom
@@ -99,6 +101,7 @@ class FormulaCacheVisitorTest {
 		Mockito.when(evitaSession.getCatalogName()).thenReturn(TEST_CATALOG);
 		final Formula possiblyUpdatedFormula = FormulaCacheVisitor.analyse(
 			evitaSession,
+			CalculationContext.NO_CACHING_INSTANCE,
 			SOME_ENTITY,
 			inputFormula,
 			cacheAnteroom
@@ -142,6 +145,7 @@ class FormulaCacheVisitorTest {
 		Mockito.when(evitaSession.getCatalogName()).thenReturn(TEST_CATALOG);
 		final Formula possiblyUpdatedFormula = FormulaCacheVisitor.analyse(
 			evitaSession,
+			CalculationContext.NO_CACHING_INSTANCE,
 			SOME_ENTITY,
 			inputFormula,
 			cacheAnteroom
@@ -182,6 +186,7 @@ class FormulaCacheVisitorTest {
 		Mockito.when(evitaSession.getCatalogName()).thenReturn(TEST_CATALOG);
 		final Formula possiblyUpdatedFormula = FormulaCacheVisitor.analyse(
 			evitaSession,
+			CalculationContext.NO_CACHING_INSTANCE,
 			SOME_ENTITY,
 			inputFormula,
 			cacheAnteroom
@@ -208,13 +213,13 @@ class FormulaCacheVisitorTest {
 		final EvitaSession evitaSession = Mockito.mock(EvitaSession.class);
 		Mockito.when(evitaSession.getCatalogName()).thenReturn(TEST_CATALOG);
 
-		final Formula possiblyUpdatedFormula = FormulaCacheVisitor.analyse(evitaSession, SOME_ENTITY, inputFormula, cacheAnteroom);
+		final Formula possiblyUpdatedFormula = FormulaCacheVisitor.analyse(evitaSession, CalculationContext.NO_CACHING_INSTANCE, SOME_ENTITY, inputFormula, cacheAnteroom);
 
 		// compute the instrumented formula
 		possiblyUpdatedFormula.compute();
 
 		for (int i = 0; i < MINIMAL_USAGE_THRESHOLD + 10; i++) {
-			FormulaCacheVisitor.analyse(evitaSession, SOME_ENTITY, inputFormula, cacheAnteroom);
+			FormulaCacheVisitor.analyse(evitaSession, CalculationContext.NO_CACHING_INSTANCE, SOME_ENTITY, inputFormula, cacheAnteroom);
 		}
 
 		final CacheRecordAdept cacheAdept = cacheAnteroom.getCacheAdept(TEST_CATALOG, SOME_ENTITY, inputFormula);
@@ -222,7 +227,7 @@ class FormulaCacheVisitorTest {
 		assertEquals(3, cacheAdept.getSpaceToPerformanceRatio(MINIMAL_USAGE_THRESHOLD));
 
 		for (int i = 0; i < 100; i++) {
-			FormulaCacheVisitor.analyse(evitaSession, SOME_ENTITY, inputFormula, cacheAnteroom);
+			FormulaCacheVisitor.analyse(evitaSession, CalculationContext.NO_CACHING_INSTANCE, SOME_ENTITY, inputFormula, cacheAnteroom);
 		}
 
 		assertEquals(32, cacheAdept.getSpaceToPerformanceRatio(MINIMAL_USAGE_THRESHOLD));

--- a/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/JoinFormulaTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/JoinFormulaTest.java
@@ -92,4 +92,82 @@ class JoinFormulaTest {
 		);
 	}
 
+	@Test
+	void shouldHandleOneBitmapBeingSubsetOfOther() {
+		assertArrayEquals(
+			new int[]{1, 1, 2, 2, 3, 3, 4, 5, 5},
+			new JoinFormula(
+				1L,
+				new BaseBitmap(1, 2, 3, 4, 5),
+				new BaseBitmap(1, 2, 3, 5)
+			)
+				.compute().getArray()
+		);
+	}
+
+	@Test
+	void shouldHandleOverlappingBitmaps() {
+		assertArrayEquals(
+			new int[]{1, 1, 2, 3, 4, 5, 5, 7, 8, 8},
+			new JoinFormula(
+				1L,
+				new BaseBitmap(1, 2, 5, 7, 8),
+				new BaseBitmap(1, 3, 4, 5, 8)
+			)
+				.compute().getArray()
+		);
+	}
+
+	@Test
+	void shouldHandleFirstBitmapConsiderablySmaller() {
+		assertArrayEquals(
+			new int[]{1, 2, 2, 3, 4, 5},
+			new JoinFormula(
+				1L,
+				new BaseBitmap(2),
+				new BaseBitmap(1, 2, 3, 4, 5)
+			)
+				.compute().getArray()
+		);
+	}
+
+	@Test
+	void shouldHandleSecondBitmapConsiderablySmaller() {
+		assertArrayEquals(
+			new int[]{1, 2, 2, 3, 4, 5},
+			new JoinFormula(
+				1L,
+				new BaseBitmap(1, 2, 3, 4, 5),
+				new BaseBitmap(2)
+			)
+				.compute().getArray()
+		);
+	}
+
+	@Test
+	void shouldHandleBitmapsHavingNoCommonElements() {
+		assertArrayEquals(
+			new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			new JoinFormula(
+				1L,
+				new BaseBitmap(1, 2, 3, 4, 5),
+				new BaseBitmap(6, 7, 8, 9, 10)
+			)
+				.compute().getArray()
+		);
+	}
+
+	@Test
+	void shouldHandleOneBitmapBeingEmpty() {
+		assertArrayEquals(
+			new int[]{1, 2, 3, 4, 5},
+			new JoinFormula(
+				1L,
+				new BaseBitmap(1, 2, 3, 4, 5),
+				new BaseBitmap()
+			)
+				.compute().getArray()
+		);
+	}
+
 }

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/PriceValidIn.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/PriceValidIn.java
@@ -36,6 +36,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -53,7 +54,7 @@ import static java.util.Optional.of;
  * Warning: Only a single occurrence of any of this constraint is allowed in the filter part of the query.
  * Currently, there is no way to switch context between different parts of the filter and build queries such as find
  * a product whose price is either in "CZK" or "EUR" currency at this or that time using this constraint.
- * 
+ *
  * <p><a href="https://evitadb.io/documentation/filtering/price#price-valid-in">Visit detailed user documentation</a></p>
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
@@ -87,8 +88,8 @@ public class PriceValidIn extends AbstractFilterConstraintLeaf
 	 * Returns {@link OffsetDateTime} that should be verified whether is within the range (inclusive) of price validity.
 	 */
 	@Nullable
-	public OffsetDateTime getTheMoment() {
-		return getArguments().length == 0 ? null : (OffsetDateTime) getArguments()[0];
+	public OffsetDateTime getTheMoment(@Nonnull Supplier<OffsetDateTime> currentDateAndTime) {
+		return getArguments().length == 0 ? currentDateAndTime.get() : (OffsetDateTime) getArguments()[0];
 	}
 
 	@Nonnull

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/query/serializer/filter/PriceValidInSerializer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/query/serializer/filter/PriceValidInSerializer.java
@@ -42,13 +42,13 @@ public class PriceValidInSerializer extends Serializer<PriceValidIn> {
 
 	@Override
 	public void write(Kryo kryo, Output output, PriceValidIn object) {
-		kryo.writeObject(output, object.getTheMoment());
+		kryo.writeObjectOrNull(output, object.getTheMoment(() -> null), OffsetDateTime.class);
 	}
 
 	@Override
 	public PriceValidIn read(Kryo kryo, Input input, Class<? extends PriceValidIn> type) {
-		final OffsetDateTime theMoment = kryo.readObject(input, OffsetDateTime.class);
-		return new PriceValidIn(theMoment);
+		final OffsetDateTime theMoment = kryo.readObjectOrNull(input, OffsetDateTime.class);
+		return theMoment == null ? new PriceValidIn() : new PriceValidIn(theMoment);
 	}
 
 }


### PR DESCRIPTION
Duplicate formulas in calculation tree are replaced with same instance and thus reusing the same memoized result. This mechanism is called deduplication.

When `priceValidInNow` was used in the query the formulas were not deduplicated because they were composed differently (and incorrectly).