### PR TITLE
fix(#471): Extra results sorter does not carry the correct query context

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/SessionRegistry.java
+++ b/evita_engine/src/main/java/io/evitadb/core/SessionRegistry.java
@@ -178,15 +178,13 @@ final class SessionRegistry {
 							throw evitaInvalidUsageException;
 						} else if (targetException instanceof EvitaInternalError evitaInternalError) {
 							log.error(
-								"Internal Evita error occurred in {}: {}",
-								evitaInternalError.getErrorCode(),
-								evitaInternalError.getPrivateMessage(),
+								"Internal Evita error occurred in " + evitaInternalError.getErrorCode() + ": " + evitaInternalError.getPrivateMessage(),
 								targetException
 							);
 							// unwrap and rethrow
 							throw evitaInternalError;
 						} else {
-							log.error("Unexpected internal Evita error occurred: {}", ex.getCause().getMessage(), targetException);
+							log.error("Unexpected internal Evita error occurred: " + ex.getCause().getMessage(), targetException);
 							throw new EvitaInternalError(
 								"Unexpected internal Evita error occurred: " + ex.getCause().getMessage(),
 								"Unexpected internal Evita error occurred.",
@@ -194,7 +192,7 @@ final class SessionRegistry {
 							);
 						}
 					} catch (Throwable ex) {
-						log.error("Unexpected system error occurred: {}", ex.getMessage(), ex);
+						log.error("Unexpected system error occurred: " + ex.getMessage(), ex);
 						throw new EvitaInternalError(
 							"Unexpected system error occurred: " + ex.getMessage(),
 							"Unexpected system error occurred.",

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryContext.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryContext.java
@@ -909,6 +909,22 @@ public class QueryContext implements AutoCloseable, LocaleProvider {
 	 */
 
 	/**
+	 * Method returns appropriate {@link EntityCollection} for the {@link #evitaRequest} or empty value.
+	 */
+	@Nonnull
+	public Optional<EntityCollection> getEntityCollection(@Nullable String entityType) {
+		if (entityType == null) {
+			return Optional.empty();
+		} else if (Objects.equals(entityType, this.entityType) && entityCollection != null) {
+			return Optional.of(entityCollection);
+		} else {
+			return Optional.ofNullable(
+				(EntityCollection) catalog.getCollectionForEntity(entityType).orElse(null)
+			);
+		}
+	}
+
+	/**
 	 * Method returns appropriate {@link EntityCollection} for the {@link #evitaRequest} or throws comprehensible
 	 * exception. In order exception to be comprehensible you need to provide sensible `reason` for accessing
 	 * the collection in the input parameter.

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanner.java
@@ -413,7 +413,7 @@ public class QueryPlanner {
 		@Nonnull QueryContext queryContext
 	) {
 		if (targetIndex.isGlobalIndex() || targetIndex.isCatalogIndex()) {
-			return new PrefetchFormulaVisitor(queryContext);
+			return new PrefetchFormulaVisitor();
 		} else {
 			return null;
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/PrefetchFormulaVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/PrefetchFormulaVisitor.java
@@ -77,10 +77,6 @@ public class PrefetchFormulaVisitor implements FormulaVisitor, FormulaPostProces
 	 */
 	@Nonnull private final Bitmap entityReferences = new BaseBitmap();
 	/**
-	 * The query context that will be used to prefetch entities.
-	 */
-	@Nonnull private final QueryContext queryContext;
-	/**
 	 * Flag that signalizes {@link #visit(Formula)} happens in conjunctive scope.
 	 */
 	protected boolean conjunctiveScope = true;
@@ -134,8 +130,7 @@ public class PrefetchFormulaVisitor implements FormulaVisitor, FormulaPostProces
 		return PREFETCH_COST_ESTIMATOR.apply(prefetchedEntityCount, requirements.getRequirements().length);
 	}
 
-	public PrefetchFormulaVisitor(@Nonnull QueryContext queryContext) {
-		this.queryContext = queryContext;
+	public PrefetchFormulaVisitor() {
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/FacetSummaryProducer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/FacetSummaryProducer.java
@@ -44,7 +44,7 @@ import io.evitadb.core.query.algebra.base.AndFormula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.OrFormula;
 import io.evitadb.core.query.extraResult.ExtraResultProducer;
-import io.evitadb.core.query.sort.Sorter;
+import io.evitadb.core.query.sort.NestedContextSorter;
 import io.evitadb.core.query.sort.utils.SortUtils;
 import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.index.bitmap.BaseBitmap;
@@ -160,14 +160,14 @@ public class FacetSummaryProducer implements ExtraResultProducer {
 	/**
 	 * Registers default settings for facet summary in terms of entity richness (both group and facet) and also
 	 * a default type of statistics depth. These settings will be used for all facet references that are not explicitly
-	 * configured by {@link #requireReferenceFacetSummary(ReferenceSchemaContract, FacetStatisticsDepth, IntPredicate, IntPredicate, Sorter, Sorter, EntityFetch, EntityGroupFetch)}.
+	 * configured by {@link #requireReferenceFacetSummary(ReferenceSchemaContract, FacetStatisticsDepth, IntPredicate, IntPredicate, NestedContextSorter, NestedContextSorter, EntityFetch, EntityGroupFetch)}.
 	 */
 	public void requireDefaultFacetSummary(
 		@Nonnull FacetStatisticsDepth facetStatisticsDepth,
 		@Nullable Function<ReferenceSchemaContract, IntPredicate> facetPredicate,
 		@Nullable Function<ReferenceSchemaContract, IntPredicate> groupPredicate,
-		@Nullable Function<ReferenceSchemaContract, Sorter> facetSorter,
-		@Nullable Function<ReferenceSchemaContract, Sorter> groupSorter,
+		@Nullable Function<ReferenceSchemaContract, NestedContextSorter> facetSorter,
+		@Nullable Function<ReferenceSchemaContract, NestedContextSorter> groupSorter,
 		@Nullable EntityFetch facetEntityRequirement,
 		@Nullable EntityGroupFetch groupEntityRequirement
 	) {
@@ -191,8 +191,8 @@ public class FacetSummaryProducer implements ExtraResultProducer {
 		@Nonnull FacetStatisticsDepth facetStatisticsDepth,
 		@Nullable IntPredicate facetPredicate,
 		@Nullable IntPredicate groupPredicate,
-		@Nullable Sorter facetSorter,
-		@Nullable Sorter groupSorter,
+		@Nullable NestedContextSorter facetSorter,
+		@Nullable NestedContextSorter groupSorter,
 		@Nullable EntityFetch facetEntityRequirement,
 		@Nullable EntityGroupFetch groupEntityRequirement
 	) {
@@ -235,7 +235,6 @@ public class FacetSummaryProducer implements ExtraResultProducer {
 						Collectors.mapping(
 							Function.identity(),
 							new FacetGroupStatisticsCollector(
-								queryContext,
 								// translates Facet#type to EntitySchema#reference#groupType
 								referenceName -> queryContext.getSchema().getReferenceOrThrowException(referenceName),
 								referenceSchema -> ofNullable(facetSummaryRequests.get(referenceSchema.getName()))
@@ -313,10 +312,6 @@ public class FacetSummaryProducer implements ExtraResultProducer {
 	 */
 	@RequiredArgsConstructor
 	private static class FacetGroupStatisticsCollector implements Collector<FacetReferenceIndex, LinkedHashMap<Integer, GroupAccumulator>, Collection<FacetGroupStatistics>> {
-		/**
-		 * The query context used for querying the entities.
-		 */
-		private final QueryContext queryContext;
 		/**
 		 * Translates {@link FacetHaving#getReferenceName()} to {@link EntitySchema#getReference(String)}.
 		 */
@@ -494,6 +489,80 @@ public class FacetSummaryProducer implements ExtraResultProducer {
 		}
 
 		/**
+		 * This method takes a map of facet statistics and a nested context sorter, and returns an array of sorted facet primary keys.
+		 *
+		 * @param theFacetStatistics map of facet statistics, where the key is the facet primary key and the value is the facet accumulator
+		 * @param sorter             nested context sorter used for sorting the facets
+		 * @return array of sorted facet primary keys
+		 */
+		@Nonnull
+		private static int[] getSortedFacets(@Nonnull Map<Integer, FacetAccumulator> theFacetStatistics, @Nonnull NestedContextSorter sorter) {
+			// if the sorter is defined, sort them
+			final RoaringBitmapWriter<RoaringBitmap> writer = RoaringBitmapBackedBitmap.buildWriter();
+			// collect all entity primary keys
+			theFacetStatistics.keySet().forEach(writer::add);
+			// create sorted array using the sorter
+			final ConstantFormula unsortedIds = new ConstantFormula(new BaseBitmap(writer.get()));
+			final Bitmap recordsToSort = unsortedIds.compute();
+			final int count = recordsToSort.size();
+			final int[] result = new int[count];
+			final int peak = sorter.sortAndSlice(unsortedIds, 0, count, result, 0);
+			return SortUtils.asResult(result, peak);
+		}
+
+		/**
+		 * Compares two {@link GroupAccumulator} objects based on their facet group summaries.
+		 * The comparison logic is as follows:
+		 * 1. If the reference schema of o1 and o2 are different, compare based on the order of their facet summary requests.
+		 * 2. If the facet summary request of o1 has a group sorter defined, the facet group summaries are sorted using the sorter.
+		 * The sorted group summaries are then used to determine the order of o1 and o2 based on their group ids.
+		 * 3. If the facet summary request of o2 has a group sorter defined, the facet group summaries are sorted using the sorter.
+		 * The sorted group summaries are then used to determine the order of o1 and o2 based on their group ids.
+		 * 4. If neither o1 or o2 have a group sorter defined and o1's group id is null, o1 is considered greater than o2.
+		 * 5. If neither o1 or o2 have a group sorter defined and o2's group id is null, o1 is considered less than o2.
+		 * 6. If neither o1 or o2 have a group sorter defined and both o1 and o2 have group ids, compare based on their group ids.
+		 *
+		 * @param groupIdIndex   the index of facet groups by reference name
+		 * @param sortedGroupIds the sorted group ids by reference name
+		 * @param o1             the first GroupAccumulator object to compare
+		 * @param o2             the second GroupAccumulator object to compare
+		 * @return a negative integer, zero, or a positive integer as o1 is less than, equal to, or greater than o2
+		 */
+		private static int compareFacetGroupSummaries(@Nonnull Map<String, Bitmap> groupIdIndex, @Nonnull Map<String, int[]> sortedGroupIds, @Nonnull GroupAccumulator o1, @Nonnull GroupAccumulator o2) {
+			if (o1.getReferenceSchema() != o2.getReferenceSchema()) {
+				return Integer.compare(o1.getFacetSummaryRequest().order(), o2.getFacetSummaryRequest().order());
+			} else if (o1.getFacetSummaryRequest().groupSorter() != null) {
+				final NestedContextSorter sorter = o1.getFacetSummaryRequest().groupSorter();
+				// create sorted array using the sorter
+				final String referenceName = o1.getFacetSummaryRequest().referenceSchema().getName();
+				final int[] sortedEntities = sortedGroupIds.computeIfAbsent(
+					referenceName,
+					theReferenceName -> {
+						final ConstantFormula unsortedIds = new ConstantFormula(groupIdIndex.get(theReferenceName));
+						final Bitmap unsortedIdsBitmap = unsortedIds.compute();
+						final int[] result = new int[unsortedIdsBitmap.size()];
+						final int peak = sorter.sortAndSlice(
+							unsortedIds, 0, unsortedIdsBitmap.size(), result, 0
+						);
+						return SortUtils.asResult(result, peak);
+					}
+				);
+				return Integer.compare(
+					ArrayUtils.indexOf(o1.getGroupId(), sortedEntities),
+					ArrayUtils.indexOf(o2.getGroupId(), sortedEntities)
+				);
+			} else {
+				if (o1.getGroupId() == null) {
+					return 1;
+				} else if (o2.getGroupId() == null) {
+					return -1;
+				} else {
+					return Integer.compare(o1.getGroupId(), o2.getGroupId());
+				}
+			}
+		}
+
+		/**
 		 * Returns TRUE if facet with `facetId` of specified `referenceName` was requested by the user.
 		 */
 		public boolean isRequested(@Nonnull String referenceName, int facetId) {
@@ -656,58 +725,6 @@ public class FacetSummaryProducer implements ExtraResultProducer {
 		public Set<Characteristics> characteristics() {
 			return Set.of(Characteristics.UNORDERED);
 		}
-
-		@Nonnull
-		private int[] getSortedFacets(Map<Integer, FacetAccumulator> theFacetStatistics, Sorter sorter) {
-			// if the sorter is defined, sort them
-			final RoaringBitmapWriter<RoaringBitmap> writer = RoaringBitmapBackedBitmap.buildWriter();
-			// collect all entity primary keys
-			theFacetStatistics.keySet().forEach(writer::add);
-			// create sorted array using the sorter
-			final ConstantFormula unsortedIds = new ConstantFormula(new BaseBitmap(writer.get()));
-			final Bitmap recordsToSort = unsortedIds.compute();
-			final int count = recordsToSort.size();
-			final int[] result = new int[count];
-			final int peak = sorter.sortAndSlice(
-				queryContext, unsortedIds, 0, count, result, 0
-			);
-			return SortUtils.asResult(result, peak);
-		}
-
-		private int compareFacetGroupSummaries(Map<String, Bitmap> groupIdIndex, Map<String, int[]> sortedGroupIds, GroupAccumulator o1, GroupAccumulator o2) {
-			if (o1.getReferenceSchema() != o2.getReferenceSchema()) {
-				return Integer.compare(o1.getFacetSummaryRequest().order(), o2.getFacetSummaryRequest().order());
-			} else if (o1.getFacetSummaryRequest().groupSorter() != null) {
-				final Sorter sorter = o1.getFacetSummaryRequest().groupSorter();
-				// create sorted array using the sorter
-				final String referenceName = o1.getFacetSummaryRequest().referenceSchema().getName();
-				final int[] sortedEntities = sortedGroupIds.computeIfAbsent(
-					referenceName,
-					theReferenceName -> {
-						final ConstantFormula unsortedIds = new ConstantFormula(groupIdIndex.get(theReferenceName));
-						final Bitmap unsortedIdsBitmap = unsortedIds.compute();
-						final int[] result = new int[unsortedIdsBitmap.size()];
-						final int peak = sorter.sortAndSlice(
-							queryContext, unsortedIds, 0, unsortedIdsBitmap.size(), result, 0
-						);
-						return SortUtils.asResult(result, peak);
-					}
-				);
-				return Integer.compare(
-					ArrayUtils.indexOf(o1.getGroupId(), sortedEntities),
-					ArrayUtils.indexOf(o2.getGroupId(), sortedEntities)
-				);
-			} else {
-				if (o1.getGroupId() == null) {
-					return 1;
-				} else if (o2.getGroupId() == null) {
-					return -1;
-				} else {
-					return Integer.compare(o1.getGroupId(), o2.getGroupId());
-				}
-			}
-		}
-
 	}
 
 	/**
@@ -917,8 +934,8 @@ public class FacetSummaryProducer implements ExtraResultProducer {
 		@Nonnull ReferenceSchemaContract referenceSchema,
 		@Nullable IntPredicate facetPredicate,
 		@Nullable IntPredicate groupPredicate,
-		@Nullable Sorter facetSorter,
-		@Nullable Sorter groupSorter,
+		@Nullable NestedContextSorter facetSorter,
+		@Nullable NestedContextSorter groupSorter,
 		@Nullable EntityFetch facetEntityRequirement,
 		@Nullable EntityGroupFetch groupEntityRequirement,
 		@Nonnull BiFunction<String, int[], EntityClassifier[]> facetEntityFetcher,
@@ -954,8 +971,8 @@ public class FacetSummaryProducer implements ExtraResultProducer {
 	private record DefaultFacetSummaryRequest(
 		@Nullable Function<ReferenceSchemaContract, IntPredicate> facetPredicate,
 		@Nullable Function<ReferenceSchemaContract, IntPredicate> groupPredicate,
-		@Nullable Function<ReferenceSchemaContract, Sorter> facetSorter,
-		@Nullable Function<ReferenceSchemaContract, Sorter> groupSorter,
+		@Nullable Function<ReferenceSchemaContract, NestedContextSorter> facetSorter,
+		@Nullable Function<ReferenceSchemaContract, NestedContextSorter> groupSorter,
 		@Nullable EntityFetch facetEntityRequirement,
 		@Nullable EntityGroupFetch groupEntityRequirement,
 		@Nonnull FacetStatisticsDepth facetStatisticsDepth

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/producer/HierarchySet.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/producer/HierarchySet.java
@@ -24,11 +24,10 @@
 package io.evitadb.core.query.extraResult.translator.hierarchyStatistics.producer;
 
 import io.evitadb.api.requestResponse.extraResult.Hierarchy.LevelInfo;
-import io.evitadb.core.query.QueryContext;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
-import io.evitadb.core.query.sort.Sorter;
+import io.evitadb.core.query.sort.NestedContextSorter;
 import io.evitadb.core.query.sort.utils.SortUtils;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
@@ -57,10 +56,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class HierarchySet {
 	/**
-	 * Reference to the query context that allows to access entity bodies.
-	 */
-	private final QueryContext queryContext;
-	/**
 	 * The list contains all registered hierarchy computers along with the string key their output will be indexed.
 	 */
 	private final List<NamedComputer> computers = new LinkedList<>();
@@ -69,7 +64,7 @@ public class HierarchySet {
 	 * by its primary key in ascending order.
 	 */
 	@Nullable
-	private Sorter sorter;
+	private NestedContextSorter sorter;
 
 	/**
 	 * Adds all {@link LevelInfo#entity()} primary keys to the `writer` traversing them recursively so that all entities
@@ -114,7 +109,7 @@ public class HierarchySet {
 	/**
 	 * Initializes the {@link #sorter} field.
 	 */
-	public void setSorter(@Nullable Sorter sorter) {
+	public void setSorter(@Nullable NestedContextSorter sorter) {
 		this.sorter = sorter;
 	}
 
@@ -150,7 +145,7 @@ public class HierarchySet {
 			final Formula levelIdFormula = bitmap.isEmpty() ? EmptyFormula.INSTANCE : new ConstantFormula(new BaseBitmap(bitmap));
 			final int[] sortedEntities = new int[levelIdFormula.compute().size()];
 			final int sortedEntitiesPeak = sorter.sortAndSlice(
-				queryContext, levelIdFormula, 0, levelIdFormula.compute().size(), sortedEntities, 0
+				levelIdFormula, 0, levelIdFormula.compute().size(), sortedEntities, 0
 			);
 			// replace the output with the sorted one
 			final int[] normalizedSortedResult = SortUtils.asResult(sortedEntities, sortedEntitiesPeak);

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/producer/HierarchyStatisticsProducer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/producer/HierarchyStatisticsProducer.java
@@ -42,7 +42,7 @@ import io.evitadb.core.query.PrefetchRequirementCollector;
 import io.evitadb.core.query.QueryContext;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.extraResult.ExtraResultProducer;
-import io.evitadb.core.query.sort.Sorter;
+import io.evitadb.core.query.sort.NestedContextSorter;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.function.IntBiFunction;
 import io.evitadb.index.GlobalEntityIndex;
@@ -153,7 +153,7 @@ public class HierarchyStatisticsProducer implements ExtraResultProducer {
 		@Nonnull IntBiFunction<StatisticsBase, Formula> directlyQueriedEntitiesFormulaProducer,
 		@Nullable Function<StatisticsBase, HierarchyFilteringPredicate> hierarchyFilterPredicateProducer,
 		@Nonnull EmptyHierarchicalEntityBehaviour behaviour,
-		@Nullable Sorter sorter,
+		@Nullable NestedContextSorter sorter,
 		@Nonnull Runnable interpretationLambda
 	) {
 		Assert.isTrue(context.get() == null, "HierarchyOfSelf / HierarchyOfReference cannot be nested inside each other!");
@@ -196,13 +196,13 @@ public class HierarchyStatisticsProducer implements ExtraResultProducer {
 		final HierarchyProducerContext ctx = getContext(constraintName);
 		if (ctx.referenceSchema() == null) {
 			if (this.selfHierarchyRequest == null) {
-				this.selfHierarchyRequest = new HierarchySet(queryContext);
+				this.selfHierarchyRequest = new HierarchySet();
 			}
 			this.selfHierarchyRequest.addComputer(outputName, computer);
 		} else {
 			this.hierarchyRequests.computeIfAbsent(
 					ctx.referenceSchema().getName(),
-					s -> new HierarchySet(queryContext)
+					s -> new HierarchySet()
 				)
 				.addComputer(outputName, computer);
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/NestedContextSorter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/NestedContextSorter.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,35 +24,35 @@
 package io.evitadb.core.query.sort;
 
 import io.evitadb.core.query.QueryContext;
+import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
+import lombok.RequiredArgsConstructor;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
- * This interface should be implemented by {@link Sorter} implementations that can be used or omitted based on
- * the condition.
+ * This class is a wrapper for {@link Sorter} along with correct nested {@link QueryContext} initialized for proper
+ * query and entity type.
  *
- * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2023
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
-public interface ConditionalSorter extends Sorter {
+@RequiredArgsConstructor
+public class NestedContextSorter {
+	private final QueryContext context;
+	private final Sorter sorter;
 
 	/**
-	 * Method returns first applicable (either non-conditional, or conditional with satisfied condition) sorter from
-	 * the chain of sorters.
+	 * Method sorts output of the {@link AbstractFormula} input and extracts slice of the result data between `startIndex` (inclusive)
+	 * and `endIndex` (exclusive).
 	 */
-	@Nullable
-	static Sorter getFirstApplicableSorter(@Nullable Sorter sorter, @Nonnull QueryContext queryContext) {
-		while (sorter instanceof ConditionalSorter conditionalSorter && !conditionalSorter.shouldApply(queryContext)) {
-			sorter = conditionalSorter.getNextSorter();
-		}
-		return sorter;
+	public int sortAndSlice(
+		@Nonnull Formula input,
+		int startIndex,
+		int endIndex,
+		@Nonnull int[] result,
+		int peak
+	) {
+		return sorter.sortAndSlice(context, input, startIndex, endIndex, result, peak);
 	}
-
-	/**
-	 * Method must return TRUE in case the sorter {@link #sortAndSlice(QueryContext, Formula, int, int, int[], int)}  should be
-	 * applied on the query result.
-	 */
-	boolean shouldApply(@Nonnull QueryContext queryContext);
 
 }

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiExceptionHandler.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiExceptionHandler.java
@@ -72,9 +72,7 @@ public abstract class ExternalApiExceptionHandler implements HttpHandler {
             if (evitaError instanceof final ExternalApiInternalError externalApiInternalError) {
                 // log any API internal errors that Evita cannot handle because they are outside of Evita execution
                 log.error(
-                    "Internal Evita " + getExternalApiCode() + " API error occurred in {}: {}",
-                    externalApiInternalError.getErrorCode(),
-                    externalApiInternalError.getPrivateMessage(),
+                    "Internal Evita " + getExternalApiCode() + " API error occurred in " + externalApiInternalError.getErrorCode() + ": " + externalApiInternalError.getPrivateMessage(),
                     externalApiInternalError
                 );
             }


### PR DESCRIPTION
Query that used prefetch evaluation logic revealed that sorters in extra result producers - namely facet summary and hierarchy summary stick to the original query context. This resulted in incorrect sorting implementation which tried to locate entities of invalid type in original queried entity query context, which provided unexpected NULL value.