### PR TITLE
fix(#480): GraphQL returns errors when fetching referenced entities in a locale they don't have

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/EntityCollection.java
@@ -723,6 +723,12 @@ public final class EntityCollection implements TransactionalLayerProducer<DataSo
 				final Entity internalEntity = getEntityById(primaryKey, evitaRequest);
 				if (internalEntity == null) {
 					return null;
+				} else if (
+					!ofNullable(evitaRequest.getRequiredOrImplicitLocale())
+					.map(it -> internalEntity.getLocales().contains(it))
+					.orElse(true)
+				) {
+					return null;
 				} else {
 					return wrapToDecorator(evitaRequest, internalEntity, ReferenceFetcher.NO_IMPLEMENTATION);
 				}


### PR DESCRIPTION
The code was updated to add a condition that checks if the requested locale is contained within the entity's locales while fetching the entity by its primary key. If the locale is not present, the function will now return null.