### PR TITLE
fix(#482): Facet group conjunction is ignored

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/ImpactFormulaGenerator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/ImpactFormulaGenerator.java
@@ -121,9 +121,9 @@ public class ImpactFormulaGenerator extends AbstractFacetFormulaGenerator {
 			boolean foundAtLast = ofNullable(this.facetGroupsInUserFilter.get(referenceName))
 				.map(it -> it.contains(normalizedFacetGroupId))
 				.orElse(false);
-			final CacheKey cacheKey = new CacheKey(
-				foundAtLast ? referenceName : null, negation, disjunction, conjunction, foundAtLast ? facetGroupId : null
-			);
+			final CacheKey cacheKey = foundAtLast ?
+				new CacheKey(referenceName, negation, disjunction, conjunction, normalizedFacetGroupId) :
+				new CacheKey(null, negation, disjunction, conjunction, null);
 			this.cache.put(cacheKey, result);
 			return result;
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/facet/FacetHavingTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/facet/FacetHavingTranslator.java
@@ -85,7 +85,7 @@ public class FacetHavingTranslator implements FilteringConstraintTranslator<Face
 				return entityIndex.getFacetReferencingEntityIdsFormula(
 					facetHaving.getReferenceName(),
 					(groupId, theFacetIds, recordIdBitmaps) -> {
-						if (referenceSchema.isReferencedGroupTypeManaged() && filterByVisitor.isFacetGroupConjunction(referenceSchema, groupId)) {
+						if ((referenceSchema.isReferencedGroupTypeManaged() || groupId == null) && filterByVisitor.isFacetGroupConjunction(referenceSchema, groupId)) {
 							// AND relation is requested for facet of this group
 							return new FacetGroupAndFormula(
 								facetHaving.getReferenceName(), groupId, theFacetIds, recordIdBitmaps


### PR DESCRIPTION
This bug was introduced by https://github.com/FgForrest/evitaDB/issues/464

For this query the facet group conjunction the query:

```
query(
    collection("Product"),
    filterBy(
        userFilter(
          facetHaving(
            "groups",
            entityHaving(
              attributeInSet("code", "sale")
            )
          )
        )
    ),
    require(
        facetSummaryOfReference(
            "groups",
            IMPACT,
            entityFetch(attributeContent("code"))
        ),
        facetGroupsConjunction("groups")
    )
)
```

Is not properly recognized and default disjunction logic is used instead.