### PR TITLE
fix(#495): NPE in AttributeBitmap calculation

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/FilterByVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/FilterByVisitor.java
@@ -398,14 +398,6 @@ public class FilterByVisitor implements ConstraintVisitor {
 	}
 
 	/**
-	 * Returns attribute values from current scope.
-	 */
-	@Nonnull
-	public Stream<Optional<AttributeValue>> getAttributeValueStream(@Nonnull EntityContract entity, @Nonnull String attributeName, @Nonnull Locale locale) {
-		return getProcessingScope().getAttributeValueStream(entity, attributeName, locale);
-	}
-
-	/**
 	 * Method returns true if any of the siblings of the currently examined query matches any of the passed types.
 	 */
 	@SuppressWarnings("unchecked")

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/alternative/AttributeBitmapFilter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/alternative/AttributeBitmapFilter.java
@@ -131,8 +131,11 @@ public class AttributeBitmapFilter implements EntityToBitmapFilter {
 					filter = filterFactory.apply(attributeSchema);
 				}
 				// and filter by predicate
-				if (filter != null && filter.test(attributeValueAccessor.apply(entity, attributeName))) {
-					result.add(filterByVisitor.translateEntity(entity));
+				if (filter != null) {
+					final Stream<Optional<AttributeValue>> valueStream = attributeValueAccessor.apply(entity, attributeName);
+					if (valueStream != null && filter.test(valueStream)) {
+						result.add(filterByVisitor.translateEntity(entity));
+					}
 				}
 			}
 			return result;


### PR DESCRIPTION
NullpointerException leaked into the code - obviously the `TriFunction` may return null.

```
2024-03-19T14:04:07.121221777Z 14:04:07.120 ERROR i.e.c.SessionRegistry CID: RID: - Unexpected internal Evita error occurred: Cannot invoke "java.util.stream.Stream.anyMatch(java.util.function.Predicate)" because "attrStream" is null
2024-03-19T14:04:07.121255657Z java.lang.NullPointerException: Cannot invoke "java.util.stream.Stream.anyMatch(java.util.function.Predicate)" because "attrStream" is null
2024-03-19T14:04:07.121261277Z 	at io.evitadb.core.query.filter.translator.attribute.AttributeInRangeTranslator.lambda$getDateTimeRangePredicate$4(AttributeInRangeTranslator.java:152)
2024-03-19T14:04:07.121265897Z 	at io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter.filter(AttributeBitmapFilter.java:134)
2024-03-19T14:04:07.121269137Z 	at io.evitadb.core.query.algebra.prefetch.SelectionFormula.lambda$computeInternal$13(SelectionFormula.java:264)
2024-03-19T14:04:07.121271617Z 	at java.base/java.util.Optional.map(Optional.java:260)
2024-03-19T14:04:07.121274057Z 	at io.evitadb.core.query.algebra.prefetch.SelectionFormula.computeInternal(SelectionFormula.java:264)
2024-03-19T14:04:07.121276367Z 	at io.evitadb.core.query.algebra.AbstractFormula.compute(AbstractFormula.java:150)
2024-03-19T14:04:07.121278677Z 	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
2024-03-19T14:04:07.121281017Z 	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
2024-03-19T14:04:07.121283376Z 	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
2024-03-19T14:04:07.121285696Z 	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
2024-03-19T14:04:07.121288046Z 	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
2024-03-19T14:04:07.121290446Z 	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
```