### PR TITLE
feat(#498): don't allow attributeIs constraint for nonnull attributes

### DIFF
--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/builder/constraint/ConstraintSchemaBuilder.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/builder/constraint/ConstraintSchemaBuilder.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -407,7 +407,8 @@ public abstract class ConstraintSchemaBuilder<CTX extends ConstraintSchemaBuildi
 							ConstraintPropertyType.ATTRIBUTE,
 							buildContext.dataLocator().targetDomain(),
 							attributeSchema.getPlainType(),
-							attributeSchema.getType().isArray()
+							attributeSchema.getType().isArray(),
+							attributeSchema.isNullable()
 						)
 						.stream()
 						.filter(cd -> cd.creator().hasClassifierParameter())

--- a/evita_functional_tests/src/test/java/io/evitadb/api/query/descriptor/ConstraintDescriptorProviderTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/query/descriptor/ConstraintDescriptorProviderTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -157,7 +157,8 @@ class ConstraintDescriptorProviderTest {
 			ConstraintPropertyType.ATTRIBUTE,
 			ConstraintDomain.ENTITY,
 			String.class,
-			false
+			false,
+			true
 		);
 		assertEquals(
 			List.of(
@@ -185,6 +186,7 @@ class ConstraintDescriptorProviderTest {
 				ConstraintPropertyType.ATTRIBUTE,
 				ConstraintDomain.HIERARCHY,
 				String.class,
+				false,
 				false
 			).isEmpty()
 		);
@@ -194,6 +196,7 @@ class ConstraintDescriptorProviderTest {
 			ConstraintPropertyType.ATTRIBUTE,
 			ConstraintDomain.ENTITY,
 			String.class,
+			false,
 			false
 		);
 		assertEquals(
@@ -214,7 +217,8 @@ class ConstraintDescriptorProviderTest {
 				ConstraintPropertyType.ATTRIBUTE,
 				ConstraintDomain.ENTITY,
 				String.class,
-				true
+				true,
+				false
 			).isEmpty()
 		);
 	}

--- a/evita_functional_tests/src/test/java/io/evitadb/api/query/descriptor/ConstraintProcessorTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/query/descriptor/ConstraintProcessorTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -231,7 +231,8 @@ class ConstraintProcessorTest {
 			Set.of(ConstraintDomain.ENTITY, ConstraintDomain.REFERENCE),
 			new SupportedValues(
 				Set.of(String.class),
-				true
+				true,
+				ConstraintNullabilitySupport.NULLABLE_AND_NONNULL
 			),
 			new ConstraintCreator(
 				AttributeStartsWith.class.getConstructor(String.class, String.class),

--- a/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLQueryEntityQueryFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLQueryEntityQueryFunctionalTest.java
@@ -2768,11 +2768,7 @@ public class CatalogGraphQLQueryEntityQueryFunctionalTest extends CatalogGraphQL
 			.document(
 				"""
 		            query {
-		                queryProduct(
-		                    filterBy: {
-		                        attributeAliasIs: NOT_NULL
-		                    }
-		                ) {
+		                queryProduct {
 		                    recordPage(size: %d) {
 		                        data {
 		                            primaryKey
@@ -2847,11 +2843,7 @@ public class CatalogGraphQLQueryEntityQueryFunctionalTest extends CatalogGraphQL
 			.document(
 				"""
 		            query {
-		                queryProduct(
-		                    filterBy: {
-		                        attributeAliasIs: NOT_NULL
-		                    }
-		                ) {
+		                queryProduct {
 		                    recordPage(size: %d) {
 		                        data {
 		                            primaryKey
@@ -2931,7 +2923,6 @@ public class CatalogGraphQLQueryEntityQueryFunctionalTest extends CatalogGraphQL
 		            query {
 		                queryProduct(
 		                    filterBy: {
-		                        attributeAliasIs: NOT_NULL,
 		                        userFilter: {
 		                            attributeQuantityBetween: ["100", "900"]
 	                            }
@@ -3012,11 +3003,7 @@ public class CatalogGraphQLQueryEntityQueryFunctionalTest extends CatalogGraphQL
 			.document(
 				"""
 		            query {
-		                queryProduct(
-		                    filterBy: {
-		                        attributeAliasIs: NOT_NULL
-		                    }
-		                ) {
+		                queryProduct {
 		                    recordPage(size: %d) {
 		                        data {
 		                            primaryKey
@@ -3082,9 +3069,6 @@ public class CatalogGraphQLQueryEntityQueryFunctionalTest extends CatalogGraphQL
 				return session.query(
 					query(
 						collection(Entities.PRODUCT),
-						filterBy(
-							attributeIsNotNull(ATTRIBUTE_ALIAS)
-						),
 						require(
 							page(1, Integer.MAX_VALUE),
 							attributeHistogram(20, ATTRIBUTE_QUANTITY)
@@ -3101,11 +3085,7 @@ public class CatalogGraphQLQueryEntityQueryFunctionalTest extends CatalogGraphQL
 			.document(
 				"""
 		            query {
-		                queryProduct(
-		                    filterBy: {
-		                        attributeAliasIs: NOT_NULL
-		                    }
-		                ) {
+		                queryProduct {
 		                    recordPage(size: %d) {
 		                        data {
 		                            primaryKey

--- a/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/CatalogRestQueryEntityQueryFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/CatalogRestQueryEntityQueryFunctionalTest.java
@@ -1578,9 +1578,6 @@ class CatalogRestQueryEntityQueryFunctionalTest extends CatalogRestDataEndpointF
 			.httpMethod(Request.METHOD_POST)
 			.requestBody("""
 					{
-						"filterBy": {
-							"attributeAliasIs": "NOT_NULL"
-						},
 						"require": {
 							"page": {
 								"number": 1,
@@ -1626,9 +1623,6 @@ class CatalogRestQueryEntityQueryFunctionalTest extends CatalogRestDataEndpointF
 			.httpMethod(Request.METHOD_POST)
 			.requestBody("""
 					{
-						"filterBy": {
-							"attributeAliasIs": "NOT_NULL"
-						},
 						"require": {
 							"page": {
 								"number": 1,
@@ -1679,7 +1673,6 @@ class CatalogRestQueryEntityQueryFunctionalTest extends CatalogRestDataEndpointF
 			.requestBody("""
 					{
 						"filterBy": {
-							"attributeAliasIs": "NOT_NULL",
 							"userFilter": [{
 								"attributeQuantityBetween": ["100", "900"]
 							}]
@@ -1715,9 +1708,6 @@ class CatalogRestQueryEntityQueryFunctionalTest extends CatalogRestDataEndpointF
 			.httpMethod(Request.METHOD_POST)
 			.requestBody("""
 					{
-						"filterBy": {
-							"attributeAliasIs": "NOT_NULL"
-						},
 						"require": {
 							"page": {
 								"number": 1,

--- a/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintDescriptor.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintDescriptor.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -239,8 +239,10 @@ public class ConstraintDescriptor implements Comparable<ConstraintDescriptor> {
 	 *
 	 * @param dataTypes set of value data types of target data this query can operate on
 	 * @param supportsArrays if target data can be an array of supported data types
+	 * @param nullability whether the constraint supports only nullable data or only nonnull data or both and so on.
 	 */
 	public record SupportedValues(@Nonnull Set<Class<?>> dataTypes,
-	                              boolean supportsArrays) {}
+	                              boolean supportsArrays,
+	                              @Nonnull ConstraintNullabilitySupport nullability) {}
 
 }

--- a/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintDescriptorProvider.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintDescriptorProvider.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -196,15 +196,30 @@ public class ConstraintDescriptorProvider {
 	                                                       @Nonnull ConstraintPropertyType requiredPropertyType,
 														   @Nonnull ConstraintDomain requiredSupportedDomain,
                                                            @Nonnull Class<?> requiredSupportedValueType,
-                                                           boolean arraySupportRequired) {
+                                                           boolean arraySupportRequired,
+	                                                       boolean nullableData) {
 		return CONSTRAINT_DESCRIPTORS.stream()
 			.filter(cd -> cd.type().equals(requiredType) &&
 				cd.propertyType().equals(requiredPropertyType) &&
 				cd.supportedIn().contains(requiredSupportedDomain) &&
 				cd.supportedValues() != null &&
 				cd.supportedValues().dataTypes().contains(requiredSupportedValueType.isPrimitive() ? EvitaDataTypes.getWrappingPrimitiveClass(requiredSupportedValueType) : requiredSupportedValueType) &&
+				verifyNullabilitySupport(cd.supportedValues().nullability(), nullableData) &&
 				(!arraySupportRequired || cd.supportedValues().supportsArrays()))
 			.collect(Collectors.toUnmodifiableSet());
+	}
+
+	/**
+	 * Verifies if nullability support of constraint matches nullability setting of data.
+	 */
+	private static boolean verifyNullabilitySupport(@Nonnull ConstraintNullabilitySupport nullabilitySupport, boolean nullableData) {
+		if (nullabilitySupport.equals(ConstraintNullabilitySupport.ONLY_NULLABLE)) {
+			return nullableData;
+		} else if (nullabilitySupport.equals(ConstraintNullabilitySupport.ONLY_NONNULL)) {
+			return !nullableData;
+		} else {
+			return true;
+		}
 	}
 
 	/**

--- a/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintNullabilitySupport.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintNullabilitySupport.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/main/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.query.descriptor;
+
+/**
+ * Whether the constraint supports only nullable data or only nonnull data or both and so on.
+ *
+ * @author Lukáš Hornych, FG Forrest a.s. (c) 2024
+ */
+public enum ConstraintNullabilitySupport {
+
+	/**
+	 * Constraint can operate with nullable and nonnull data.
+	 */
+	NULLABLE_AND_NONNULL,
+	/**
+	 * Constraint can operate only on nullable data.
+	 */
+	ONLY_NULLABLE,
+	/**
+	 * Constraint can operate only on nonnull data.
+	 */
+	ONLY_NONNULL
+}

--- a/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintProcessor.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintProcessor.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -163,7 +163,8 @@ class ConstraintProcessor {
 				constraintSupportedValues.supportedTypes().length > 0 ?
 					Set.of(constraintSupportedValues.supportedTypes()) :
 					EvitaDataTypes.getSupportedDataTypes(),
-				constraintDefinition.supportedValues().arraysSupported()
+				constraintDefinition.supportedValues().arraysSupported(),
+				constraintDefinition.supportedValues().nullability()
 			);
 		}
 		return supportedValues;

--- a/evita_query/src/main/java/io/evitadb/api/query/descriptor/annotation/ConstraintSupportedValues.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/descriptor/annotation/ConstraintSupportedValues.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 
 package io.evitadb.api.query.descriptor.annotation;
 
+import io.evitadb.api.query.descriptor.ConstraintNullabilitySupport;
 import io.evitadb.dataType.EvitaDataTypes;
 
 import java.lang.annotation.ElementType;
@@ -31,7 +32,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines value data types of target data this query can operate on.
+ * Defines value data types of target data this constraint can operate on.
  * One can specify either specific array of classes through {@link #supportedTypes()} or specify that
  * all data types are supported through {@link #allTypesSupported()} (all supported by {@link EvitaDataTypes}.
  * Also, target data may be arrays, thus query can specify if it supports target arrays through {@link #arraysSupported()}.
@@ -57,4 +58,9 @@ public @interface ConstraintSupportedValues {
 	 * Flag stating that those {@link #supportedTypes()} can be in arrays in queried data.
 	 */
 	boolean arraysSupported() default false;
+
+	/**
+	 * Whether the constraint supports only nullable data or only nonnull data or both and so on.
+	 */
+	ConstraintNullabilitySupport nullability() default ConstraintNullabilitySupport.NULLABLE_AND_NONNULL;
 }

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeIs.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeIs.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import io.evitadb.api.query.descriptor.ConstraintDomain;
 import io.evitadb.api.query.descriptor.annotation.Classifier;
 import io.evitadb.api.query.descriptor.annotation.ConstraintDefinition;
 import io.evitadb.api.query.descriptor.annotation.ConstraintSupportedValues;
+import io.evitadb.api.query.descriptor.ConstraintNullabilitySupport;
 import io.evitadb.api.query.descriptor.annotation.Creator;
 
 import javax.annotation.Nonnull;
@@ -51,7 +52,7 @@ import java.io.Serializable;
  * </pre>
  *
  * Function supports attribute arrays in the same way as plain values.
- * 
+ *
  * <p><a href="https://evitadb.io/documentation/query/filtering/comparable#attribute-is">Visit detailed user documentation</a></p>
  *
  * @see AttributeSpecialValue
@@ -62,7 +63,11 @@ import java.io.Serializable;
 	shortDescription = "The constraint if value of the attribute is same as passed special value.",
 	userDocsLink = "/documentation/query/filtering/comparable#attribute-is",
 	supportedIn = { ConstraintDomain.ENTITY, ConstraintDomain.REFERENCE },
-	supportedValues = @ConstraintSupportedValues(allTypesSupported = true, arraysSupported = true)
+	supportedValues = @ConstraintSupportedValues(
+		allTypesSupported = true,
+		arraysSupported = true,
+		nullability = ConstraintNullabilitySupport.ONLY_NULLABLE
+	)
 )
 public class AttributeIs extends AbstractAttributeFilterConstraintLeaf implements IndexUsingConstraint {
 	@Serial private static final long serialVersionUID = 6615086027607982158L;


### PR DESCRIPTION
To support this new tooling was created for handling nullability support in constraints in general.