### PR TITLE
fix(#520): Non-first page of entities empty when ordering by price

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/price/FilteredPricesSorter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/price/FilteredPricesSorter.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -154,13 +154,13 @@ public class FilteredPricesSorter implements Sorter {
 		// slice the output and cut appropriate page from it
 		final int pageSize = Math.min(endIndex - startIndex, translatedResult.length - startIndex);
 		int written = 0;
-		for (int i = startIndex; i < pageSize; i++) {
+		for (int i = startIndex; i < startIndex + pageSize; i++) {
 			result[peak + written++] = translatedResult[i].entityPrimaryKey();
 		}
 
 		// if the output is not complete, and we have not found entity PKs
 		final int[] notFoundEntities = priceRecordsLookupResult.getNotFoundEntities();
-		if (translatedResult.length < endIndex && (notFoundEntities == null || notFoundEntities.length > 0)) {
+		if (translatedResult.length < endIndex && (notFoundEntities != null && notFoundEntities.length > 0)) {
 			// pass them to another sorter
 			final int recomputedStartIndex = Math.max(0, startIndex - written);
 			final int recomputedEndIndex = Math.max(0, endIndex - written);

--- a/evita_functional_tests/src/test/java/io/evitadb/api/CombinedPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/CombinedPriceEntityByPriceFilteringFunctionalTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -294,5 +294,13 @@ public class CombinedPriceEntityByPriceFilteringFunctionalTest extends EntityByP
 	@Override
 	void shouldReturnProductsHavingPriceInCurrencyAndPriceListInIntervalWithTaxOrderByPriceAscendingWithoutExplicitAnd(Evita evita, List<SealedEntity> originalProductEntities) {
 		super.shouldReturnProductsHavingPriceInCurrencyAndPriceListInIntervalWithTaxOrderByPriceAscendingWithoutExplicitAnd(evita, originalProductEntities);
+	}
+
+	@DisplayName("Should correctly traverse through all pages or results")
+	@UseDataSet(HUNDRED_PRODUCTS_WITH_COMBINED_PRICES)
+	@Test
+	@Override
+	void shouldReturnCorrectlyTraverseThroughAllPagesOfResults(Evita evita, List<SealedEntity> originalProductEntities) {
+		super.shouldReturnCorrectlyTraverseThroughAllPagesOfResults(evita, originalProductEntities);
 	}
 }

--- a/evita_functional_tests/src/test/java/io/evitadb/api/FindFirstPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/FindFirstPriceEntityByPriceFilteringFunctionalTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -294,4 +294,11 @@ public class FindFirstPriceEntityByPriceFilteringFunctionalTest extends EntityBy
 		super.shouldReturnProductsHavingPriceInCurrencyAndPriceListInIntervalWithTaxOrderByPriceAscendingWithoutExplicitAnd(evita, originalProductEntities);
 	}
 
+	@DisplayName("Should correctly traverse through all pages or results")
+	@UseDataSet(HUNDRED_PRODUCTS_WITH_FIND_FIRST_PRICES)
+	@Test
+	@Override
+	void shouldReturnCorrectlyTraverseThroughAllPagesOfResults(Evita evita, List<SealedEntity> originalProductEntities) {
+		super.shouldReturnCorrectlyTraverseThroughAllPagesOfResults(evita, originalProductEntities);
+	}
 }

--- a/evita_functional_tests/src/test/java/io/evitadb/api/SumPriceEntityByPriceFilteringFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/SumPriceEntityByPriceFilteringFunctionalTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -300,6 +300,14 @@ public class SumPriceEntityByPriceFilteringFunctionalTest extends EntityByPriceF
 	@Override
 	void shouldReturnProductsHavingPriceInCurrencyAndPriceListInIntervalWithTaxOrderByPriceAscendingWithoutExplicitAnd(Evita evita, List<SealedEntity> originalProductEntities) {
 		super.shouldReturnProductsHavingPriceInCurrencyAndPriceListInIntervalWithTaxOrderByPriceAscendingWithoutExplicitAnd(evita, originalProductEntities);
+	}
+
+	@DisplayName("Should correctly traverse through all pages or results")
+	@UseDataSet(HUNDRED_PRODUCTS_WITH_SUM_PRICES)
+	@Test
+	@Override
+	void shouldReturnCorrectlyTraverseThroughAllPagesOfResults(Evita evita, List<SealedEntity> originalProductEntities) {
+		super.shouldReturnCorrectlyTraverseThroughAllPagesOfResults(evita, originalProductEntities);
 	}
 
 	@Override


### PR DESCRIPTION
Added tests proving the reported issue and corrected error in end index computation and unsorted result appending.