### PR TITLE
fix(#522): Mismatches in query language when sorting by PK of referen…

### DIFF
--- a/evita_common/src/main/java/io/evitadb/comparator/IntComparator.java
+++ b/evita_common/src/main/java/io/evitadb/comparator/IntComparator.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/main/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.comparator;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Interface allowing to compare two primitive integers. Interface follows all the rules of {@link java.util.Comparator},
+ * but allows to compare primitive integers without boxing them into {@link Integer} objects.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+public interface IntComparator {
+
+	/**
+	 * Compares two primitive integers.
+	 * @param o1 first integer
+	 * @param o2 second integer
+	 * @return a negative integer, zero, or a positive integer as the first argument is less than, equal to, or greater
+	 * than the second
+	 */
+	int compare(int o1, int o2);
+
+	/**
+	 * Comparator for sorting integers in ascending order.
+	 */
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	class IntAscendingComparator implements IntComparator {
+		public static final IntAscendingComparator INSTANCE = new IntAscendingComparator();
+
+		@Override
+		public int compare(int o1, int o2) {
+			return Integer.compare(o1, o2);
+		}
+	}
+
+	/**
+	 * Comparator for sorting integers in descending order.
+	 */
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	class IntDescendingComparator implements IntComparator {
+		public static final IntDescendingComparator INSTANCE = new IntDescendingComparator();
+
+		@Override
+		public int compare(int o1, int o2) {
+			return Integer.compare(o2, o1);
+		}
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/PreSortedRecordsSorter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/PreSortedRecordsSorter.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -64,10 +64,6 @@ public class PreSortedRecordsSorter extends AbstractRecordsSorter implements Cac
 	 */
 	private final Consumer<CacheableSorter> computationCallback;
 	/**
-	 * This is the type of entity that is being sorted.
-	 */
-	private final String entityType;
-	/**
 	 * This instance will be used by this sorter to access pre sorted arrays of entities.
 	 */
 	private final Supplier<SortedRecordsProvider[]> sortedRecordsSupplier;
@@ -101,11 +97,9 @@ public class PreSortedRecordsSorter extends AbstractRecordsSorter implements Cac
 	private MergedSortedRecordsSupplier memoizedResult;
 
 	public PreSortedRecordsSorter(
-		@Nonnull String entityType,
 		@Nonnull Supplier<SortedRecordsProvider[]> sortedRecordsSupplier
 	) {
 		this.computationCallback = null;
-		this.entityType = entityType;
 		this.sortedRecordsSupplier = sortedRecordsSupplier;
 		this.unknownRecordIdsSorter = null;
 	}
@@ -115,7 +109,6 @@ public class PreSortedRecordsSorter extends AbstractRecordsSorter implements Cac
 	public Sorter cloneInstance() {
 		return new PreSortedRecordsSorter(
 			computationCallback,
-			entityType,
 			sortedRecordsSupplier,
 			null
 		);
@@ -126,7 +119,6 @@ public class PreSortedRecordsSorter extends AbstractRecordsSorter implements Cac
 	public Sorter andThen(Sorter sorterForUnknownRecords) {
 		return new PreSortedRecordsSorter(
 			computationCallback,
-			entityType,
 			sortedRecordsSupplier,
 			sorterForUnknownRecords
 		);
@@ -257,7 +249,6 @@ public class PreSortedRecordsSorter extends AbstractRecordsSorter implements Cac
 	public CacheableSorter getCloneWithComputationCallback(@Nonnull Consumer<CacheableSorter> selfOperator) {
 		return new PreSortedRecordsSorter(
 			selfOperator,
-			entityType,
 			sortedRecordsSupplier,
 			unknownRecordIdsSorter
 		);

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/AttributeNaturalTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/AttributeNaturalTranslator.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -132,14 +132,10 @@ public class AttributeNaturalTranslator
 		// if prefetch happens we need to prefetch attributes so that the attribute comparator can work
 		orderByVisitor.addRequirementToPrefetch(attributeSchemaEntityAccessor.getRequirements());
 
-		final PreSortedRecordsSorter preSortedRecordsSorter = new PreSortedRecordsSorter(
-			processingScope.entityType(), sortedRecordsSupplier
-		);
-
 		return Stream.of(
-				new PrefetchedRecordsSorter(entityComparator),
-				preSortedRecordsSorter
-			);
+			new PrefetchedRecordsSorter(entityComparator),
+			new PreSortedRecordsSorter(sortedRecordsSupplier)
+		);
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/primaryKey/translator/EntityPrimaryKeyNaturalTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/primaryKey/translator/EntityPrimaryKeyNaturalTranslator.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -25,16 +25,43 @@ package io.evitadb.core.query.sort.primaryKey.translator;
 
 import io.evitadb.api.query.order.EntityPrimaryKeyNatural;
 import io.evitadb.api.query.order.OrderDirection;
+import io.evitadb.api.requestResponse.data.EntityContract;
+import io.evitadb.api.requestResponse.data.ReferenceContract;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
+import io.evitadb.comparator.IntComparator;
+import io.evitadb.comparator.IntComparator.IntAscendingComparator;
+import io.evitadb.comparator.IntComparator.IntDescendingComparator;
+import io.evitadb.core.query.sort.EntityComparator;
 import io.evitadb.core.query.sort.OrderByVisitor;
+import io.evitadb.core.query.sort.OrderByVisitor.ProcessingScope;
 import io.evitadb.core.query.sort.Sorter;
+import io.evitadb.core.query.sort.attribute.PreSortedRecordsSorter;
+import io.evitadb.core.query.sort.attribute.PrefetchedRecordsSorter;
 import io.evitadb.core.query.sort.primaryKey.ReversedSorter;
 import io.evitadb.core.query.sort.translator.OrderingConstraintTranslator;
+import io.evitadb.dataType.array.CompositeObjectArray;
+import io.evitadb.exception.EvitaInternalError;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.attribute.SortedRecordsSupplier;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.bitmap.EmptyBitmap;
+import io.evitadb.index.bitmap.TransactionalBitmap;
+import lombok.RequiredArgsConstructor;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
 import java.util.stream.Stream;
 
+import static java.util.Optional.ofNullable;
+
 /**
- * This implementation of {@link OrderingConstraintTranslator} converts {@link io.evitadb.api.query.order.EntityPrimaryKeyNatural} to {@link Sorter}.
+ * This implementation of {@link OrderingConstraintTranslator} converts {@link EntityPrimaryKeyNatural} to {@link Sorter}.
+ * It allows to sort entities based on their primary key or primary key of referenced entity.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2023
  */
@@ -43,7 +70,131 @@ public class EntityPrimaryKeyNaturalTranslator implements OrderingConstraintTran
 	@Nonnull
 	@Override
 	public Stream<Sorter> createSorter(@Nonnull EntityPrimaryKeyNatural entityPrimaryKeyNatural, @Nonnull OrderByVisitor orderByVisitor) {
-		return entityPrimaryKeyNatural.getOrderDirection() == OrderDirection.DESC ? Stream.of(ReversedSorter.INSTANCE) : Stream.empty();
+		final OrderDirection orderDirection = entityPrimaryKeyNatural.getOrderDirection();
+		final ProcessingScope processingScope = orderByVisitor.getProcessingScope();
+		final ReferenceSchemaContract referenceSchema = processingScope.referenceSchema();
+		if (referenceSchema == null) {
+			return orderDirection == OrderDirection.DESC ? Stream.of(ReversedSorter.INSTANCE) : Stream.empty();
+		} else {
+			final EntityIndex[] entityIndices = processingScope.entityIndex();
+			final TransactionalBitmap[] pkBitmaps = new TransactionalBitmap[entityIndices.length];
+			if (orderDirection == OrderDirection.DESC) {
+				for (int i = 0; i < entityIndices.length; i++) {
+					pkBitmaps[i] = getAsTransactionalBitmap(
+						entityIndices[entityIndices.length - i - 1].getAllPrimaryKeys()
+					);
+				}
+			} else {
+				for (int i = 0; i < entityIndices.length; i++) {
+					pkBitmaps[i] = getAsTransactionalBitmap(
+						entityIndices[i].getAllPrimaryKeys()
+					);
+				}
+			}
+
+			final String referenceSchemaName = referenceSchema.getName();
+			return Stream.of(
+				new PreSortedRecordsSorter(
+					() -> Arrays.stream(pkBitmaps)
+						.filter(Objects::nonNull)
+						.map(
+							bitmap -> new SortedRecordsSupplier(
+								bitmap.getId(), bitmap.getArray(), createPositionArray(bitmap.size()), bitmap
+							)
+						)
+						.toArray(SortedRecordsSupplier[]::new)
+				),
+				new PrefetchedRecordsSorter(
+					new ReferencePrimaryKeyEntityComparator(
+						referenceSchemaName,
+						orderDirection == OrderDirection.DESC ?
+							IntDescendingComparator.INSTANCE : IntAscendingComparator.INSTANCE
+					)
+				)
+			);
+		}
+	}
+
+	/**
+	 * Returns the given bitmap as a {@link TransactionalBitmap} or null if the bitmap is empty.
+	 *
+	 * @param bitmap the bitmap to be converted
+	 * @return the given bitmap as a {@link TransactionalBitmap} or null if the bitmap is empty
+	 */
+	@Nullable
+	private static TransactionalBitmap getAsTransactionalBitmap(@Nonnull Bitmap bitmap) {
+		if (bitmap instanceof TransactionalBitmap txBitmap) {
+			return txBitmap;
+		} else if (bitmap instanceof EmptyBitmap) {
+			return null;
+		} else {
+			throw new EvitaInternalError(
+				"Unexpected bitmap type: " + bitmap.getClass().getName(),
+				"Unexpected bitmap type!"
+			);
+		}
+	}
+
+	/**
+	 * Creates an array of positions from 0 to size - 1.
+	 *
+	 * @param size the size of the array
+	 * @return an array of positions from 0 to size - 1
+	 */
+	private static int[] createPositionArray(int size) {
+		final int[] result = new int[size];
+		for (int i = 0; i < size; i++) {
+			result[i] = i;
+		}
+		return result;
+	}
+
+	/**
+	 * A comparator that compares entities based on the primary key of the referenced entity.
+	 */
+	@RequiredArgsConstructor
+	private static class ReferencePrimaryKeyEntityComparator implements EntityComparator, Serializable {
+		@Serial private static final long serialVersionUID = -7648386897749667944L;
+		@Nonnull private final String referenceSchemaName;
+		@Nonnull private final IntComparator comparator;
+		private CompositeObjectArray<EntityContract> nonSortedEntities;
+
+		@Nonnull
+		@Override
+		public Iterable<EntityContract> getNonSortedEntities() {
+			return nonSortedEntities;
+		}
+
+		@Override
+		public int compare(EntityContract o1, EntityContract o2) {
+			final Collection<ReferenceContract> o1References = o1.getReferences(referenceSchemaName);
+			final Collection<ReferenceContract> o2References = o2.getReferences(referenceSchemaName);
+			if (o1References.isEmpty() && o2References.isEmpty()) {
+				this.nonSortedEntities = getOrCreatedNonSortedEntitiesCollector();
+				this.nonSortedEntities.add(o1);
+				this.nonSortedEntities.add(o2);
+				return 0;
+			} else if (o1References.isEmpty()) {
+				this.nonSortedEntities = getOrCreatedNonSortedEntitiesCollector();
+				this.nonSortedEntities.add(o1);
+				return 1;
+			} else if (o2References.isEmpty()) {
+				this.nonSortedEntities = getOrCreatedNonSortedEntitiesCollector();
+				this.nonSortedEntities.add(o2);
+				return -1;
+			} else {
+				return comparator.compare(
+					o1References.iterator().next().getReferencedPrimaryKey(),
+					o2References.iterator().next().getReferencedPrimaryKey()
+				);
+			}
+		}
+
+		@Nonnull
+		private CompositeObjectArray<EntityContract> getOrCreatedNonSortedEntitiesCollector() {
+			return ofNullable(this.nonSortedEntities)
+				.orElseGet(() -> new CompositeObjectArray<>(EntityContract.class));
+		}
 	}
 
 }

--- a/evita_functional_tests/src/test/java/io/evitadb/core/query/sort/PreSortedRecordsSorterTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/core/query/sort/PreSortedRecordsSorterTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -120,7 +120,6 @@ class PreSortedRecordsSorterTest {
 		Mockito.doNothing().when(bitmapQueryContext).returnBuffer(any());
 		bitmapSorter = new PreSortedRecordsSorterWithContext(
 			new PreSortedRecordsSorter(
-				ENTITY_TYPE,
 				() -> new SortedRecordsProvider[]{new MockSortedRecordsSupplier(7, 2, 4, 1, 3, 8, 5, 9, 6)}
 			),
 			bitmapQueryContext
@@ -156,7 +155,6 @@ class PreSortedRecordsSorterTest {
 	void shouldReturnSortedResultEvenForMissingDataWithAdditionalSorter() {
 		final Sorter updatedSorter = bitmapSorter.sorter().andThen(
 			new PreSortedRecordsSorter(
-				ENTITY_TYPE,
 				() -> new SortedRecordsProvider[]{new MockSortedRecordsSupplier(13, 0, 12)}
 			)
 		);
@@ -179,7 +177,6 @@ class PreSortedRecordsSorterTest {
 		);
 
 		final PreSortedRecordsSorter sorter = new PreSortedRecordsSorter(
-			ENTITY_TYPE,
 			() -> new SortedRecordsProvider[]{sortedRecordsSupplier}
 		);
 		final QueryContext queryContext = Mockito.mock(QueryContext.class);


### PR DESCRIPTION
…ced entity

There are several issues in current query language with sorting by PK of referenced entity on different places in query.

### Cannot sort by `entityPrimaryKeyNatural` in `orderBy` of reference There is not translator for `entityPrimaryKeyNatural` in reference fetcher like it is in `referenceProperty` container in root `orderBy`. Also, we support this syntax in filtering where one can filter by PKs of reference directly on reference.

```
query(
  collection("Product"),
  filterBy(
    attributeEquals("code", "macbook-pro-13-2022")
  ),
  require(
    entityFetch(
      referenceContent(
        "parameterValues",
        filterBy(
          attributeEquals("variant", true)
        ),
        orderBy(
          entityPrimaryKeyNatural(DESC)
        ),
        entityFetch(
          attributeContent("code")
        )
      )
    )
  )
)
```

### `entityPrimaryKeyInSet` in `referenceProperty` doesn`t work properly If an `entityPrimaryKeyNatural` is used within `referenceProperty`, it sorts by PKs of root entities, not by referenced ones. Example query:

```
query(
  collection("Product"),
  filterBy(
    referenceHaving(
      "master",
      entityHaving(
        attributeEquals("code", "macbook-pro-13-2022")
      )
    )
  ),
  orderBy(
    referenceProperty(
      "parameterValues",
      entityPrimaryKeyNatural(DESC)
    )
  ),
  require(
    entityFetch(
      referenceContent(
        "parameterValues",
        filterBy(
          attributeEquals("variant", true)
        )
      )
    )
  )
)
```