### PR TITLE
fix (#536): Invalid OffsetDateTime comparison taking offset difference into an account

### DIFF
--- a/.idea/runConfigurations/All_functional_tests.xml
+++ b/.idea/runConfigurations/All_functional_tests.xml
@@ -21,7 +21,7 @@
     <patterns>
       <pattern testClass=".*" />
     </patterns>
-    <tag value="!documentation" />
+    <tag value="!documentation&amp;!longRunning" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/evita_common/src/main/java/io/evitadb/comparator/LocalizedStringComparator.java
+++ b/evita_common/src/main/java/io/evitadb/comparator/LocalizedStringComparator.java
@@ -30,6 +30,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.text.Collator;
 import java.util.Comparator;
+import java.util.Locale;
 
 /**
  * This comparator compares two string with respect to a national characters.
@@ -40,6 +41,10 @@ import java.util.Comparator;
 public class LocalizedStringComparator implements Comparator<String>, Serializable {
 	@Serial private static final long serialVersionUID = 8102561596057708303L;
 	@Nonnull private final Collator collator;
+
+	public LocalizedStringComparator(@Nonnull Locale locale) {
+		this.collator = Collator.getInstance(locale);
+	}
 
 	@Override
 	public int compare(String o1, String o2) {

--- a/evita_common/src/main/java/io/evitadb/dataType/ByteNumberRange.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/ByteNumberRange.java
@@ -128,6 +128,7 @@ public final class ByteNumberRange extends NumberRange<Byte> {
 		assertNotFloatingPointType(to, "to");
 	}
 
+	@Nonnull
 	@Override
 	public Range<Byte> cloneWithDifferentBounds(@Nullable Byte from, @Nullable Byte to) {
 		return new ByteNumberRange(from, to);

--- a/evita_common/src/main/java/io/evitadb/dataType/IntegerNumberRange.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/IntegerNumberRange.java
@@ -128,6 +128,7 @@ public final class IntegerNumberRange extends NumberRange<Integer> {
 		assertNotFloatingPointType(to, "to");
 	}
 
+	@Nonnull
 	@Override
 	public Range<Integer> cloneWithDifferentBounds(@Nullable Integer from, @Nullable Integer to) {
 		return new IntegerNumberRange(from, to);

--- a/evita_common/src/main/java/io/evitadb/dataType/LongNumberRange.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/LongNumberRange.java
@@ -128,6 +128,7 @@ public final class LongNumberRange extends NumberRange<Long> {
 		assertNotFloatingPointType(to, "to");
 	}
 
+	@Nonnull
 	@Override
 	public Range<Long> cloneWithDifferentBounds(@Nullable Long from, @Nullable Long to) {
 		return new LongNumberRange(from, to);

--- a/evita_common/src/main/java/io/evitadb/dataType/Range.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/Range.java
@@ -26,6 +26,8 @@ package io.evitadb.dataType;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,8 +60,9 @@ public sealed interface Range<T> permits DateTimeRange, NumberRange {
 	 *
 	 * Because other ranges overlap one another.
 	 */
+	@Nonnull
 	@SuppressWarnings("unchecked")
-	static <S, T extends Range<S>> T[] consolidateRange(T[] ranges) {
+	static <S, T extends Range<S>> T[] consolidateRange(@Nonnull T[] ranges) {
 		if (ArrayUtils.isEmpty(ranges)) {
 			return ranges;
 		}
@@ -100,30 +103,33 @@ public sealed interface Range<T> permits DateTimeRange, NumberRange {
 	/**
 	 * Returns original from value used when range was created without any loss of precision.
 	 */
+	@Nullable
 	T getPreciseFrom();
 
 	/**
 	 * Returns original to value used when range was created without any loss of precision.
 	 */
+	@Nullable
 	T getPreciseTo();
 
 	/**
 	 * Returns TRUE when value to check is withing the current range (inclusive).
 	 */
-	boolean isWithin(T valueToCheck);
+	boolean isWithin(@Nonnull T valueToCheck);
 
 	/**
 	 * Creates new range of the same type with changed from and to boundaries.
 	 * This method is used from {@link #consolidateRange(Range[])}
 	 */
-	Range<T> cloneWithDifferentBounds(T from, T to);
+	@Nonnull
+	Range<T> cloneWithDifferentBounds(@Nonnull T from, @Nonnull T to);
 
 	/**
 	 * Returns true if two ranges overlap one another (using inclusive boundaries).
 	 *
 	 * @throws IllegalArgumentException when ranges are not of the same type
 	 */
-	default boolean overlaps(Range<T> otherRange) {
+	default boolean overlaps(@Nonnull Range<T> otherRange) {
 		Assert.isTrue(
 			this.getClass().equals(otherRange.getClass()),
 			"Ranges `" + this.getClass().getName() + "` and `" + otherRange.getClass().getName() + "` are not comparable!"

--- a/evita_common/src/main/java/io/evitadb/dataType/ShortNumberRange.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/ShortNumberRange.java
@@ -128,6 +128,7 @@ public final class ShortNumberRange extends NumberRange<Short> {
 		assertNotFloatingPointType(to, "to");
 	}
 
+	@Nonnull
 	@Override
 	public Range<Short> cloneWithDifferentBounds(@Nullable Short from, @Nullable Short to) {
 		return new ShortNumberRange(from, to);

--- a/evita_common/src/main/java/io/evitadb/utils/ArrayUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/ArrayUtils.java
@@ -870,6 +870,15 @@ public class ArrayUtils {
 	}
 
 	/**
+	 * Sorts array by the Comparator passed in first argument. Contents of the array are changed.
+	 */
+	public static <T> void sortArray(@Nonnull Comparator<T> comparator, @Nonnull T[] array) {
+		// now sort positions according to recordId value - this will change ordered positions to unordered ones
+		final ArrayWrapper<T> wrapper = new ArrayWrapper<>(array);
+		wrapper.sort(comparator);
+	}
+
+	/**
 	 * This method will merge all passed arrays into one. All values from all arrays will be combined one after another.
 	 * Result array is not sorted.
 	 */
@@ -1148,6 +1157,51 @@ public class ArrayUtils {
 			if (!super.equals(o)) return false;
 			IntArrayWrapper integers = (IntArrayWrapper) o;
 			return Arrays.equals(elements, integers.elements);
+		}
+
+		@Override
+		public int hashCode() {
+			int result = super.hashCode();
+			result = 31 * result + Arrays.hashCode(elements);
+			return result;
+		}
+
+		@Override
+		public int size() {
+			return elements.length;
+		}
+
+	}
+
+	/**
+	 * Internal helper class that is used to sort array A by comparator that uses array B. This cannot be easily done
+	 * by other way than mimicking list to get advantage of {@link java.util.AbstractList#sort(Comparator)} function
+	 * that accepts external comparator.
+	 */
+	@RequiredArgsConstructor
+	private static class ArrayWrapper<T> extends AbstractList<T> {
+		@Getter private final T[] elements;
+
+		@Override
+		public T get(int index) {
+			return elements[index];
+		}
+
+		@Override
+		public T set(int index, T element) {
+			T v = elements[index];
+			elements[index] = element;
+			return v;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			if (!super.equals(o)) return false;
+			//noinspection unchecked
+			ArrayWrapper<T> otherElements = (ArrayWrapper<T>) o;
+			return Arrays.equals(elements, otherElements.elements);
 		}
 
 		@Override

--- a/evita_engine/src/main/java/io/evitadb/core/Evita.java
+++ b/evita_engine/src/main/java/io/evitadb/core/Evita.java
@@ -261,7 +261,7 @@ public final class Evita implements EvitaContract {
 						updatedCatalog -> this.catalogs.put(catalogName, updatedCatalog)
 					);
 				} catch (Throwable ex) {
-					log.error("Catalog {} is corrupted!", catalogName);
+					log.error("Catalog {} is corrupted!", catalogName, ex);
 					this.catalogs.put(catalogName, new CorruptedCatalog(catalogName, directory, ex));
 				} finally {
 					startUpLatch.countDown();

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeContainsTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeContainsTranslator.java
@@ -31,15 +31,12 @@ import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.attribute.AttributeFormula;
-import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
 import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
-import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.core.query.filter.FilterByVisitor;
 import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
 import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
-import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 
 import javax.annotation.Nonnull;
@@ -70,16 +67,7 @@ public class AttributeContainsTranslator implements FilteringConstraintTranslato
 				attributeDefinition.isLocalized() ?
 					new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
 				filterByVisitor.applyOnFilterIndexes(
-					attributeDefinition, index -> {
-						/* TOBEDONE JNO naive and slow - use RadixTree */
-						final Formula[] foundRecords = index.getValues()
-							.stream()
-							.filter(it -> ((String)it).contains(textToSearch))
-							.map(index::getRecordsEqualToFormula)
-							.toArray(Formula[]::new);
-						return ArrayUtils.isEmpty(foundRecords) ?
-							EmptyFormula.INSTANCE : FormulaFactory.or(foundRecords);
-					}
+					attributeDefinition, index -> index.getRecordsWhoseValuesContains(textToSearch)
 				)
 			);
 			if (filterByVisitor.isPrefetchPossible()) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeEndsWithTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeEndsWithTranslator.java
@@ -31,15 +31,12 @@ import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.attribute.AttributeFormula;
-import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
 import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
-import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.core.query.filter.FilterByVisitor;
 import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
 import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
-import io.evitadb.utils.ArrayUtils;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
@@ -67,16 +64,7 @@ public class AttributeEndsWithTranslator implements FilteringConstraintTranslato
 			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
 			assertStringType(attributeDefinition);
 			final Formula filteringFormula = filterByVisitor.applyOnFilterIndexes(
-				attributeDefinition, index -> {
-					/* TOBEDONE JNO naive and slow - use RadixTree */
-					final Formula[] foundRecords = index.getValues()
-						.stream()
-						.filter(it -> ((String)it).endsWith(textToSearch))
-						.map(index::getRecordsEqualToFormula)
-						.toArray(Formula[]::new);
-					return ArrayUtils.isEmpty(foundRecords) ?
-						EmptyFormula.INSTANCE : FormulaFactory.or(foundRecords);
-				}
+				attributeDefinition, index -> index.getRecordsWhoseValuesEndsWith(textToSearch)
 			);
 			if (filterByVisitor.isPrefetchPossible()) {
 				return new SelectionFormula(

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -24,14 +24,15 @@
 package io.evitadb.index.attribute;
 
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.comparator.LocalizedStringComparator;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer;
-import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.dataType.Range;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.index.IndexDataStructure;
@@ -53,10 +54,12 @@ import javax.annotation.Nullable;
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Array;
+import java.time.OffsetDateTime;
 import java.util.BitSet;
-import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.function.Function;
 
 import static io.evitadb.core.Transaction.isTransactionAvailable;
 import static io.evitadb.utils.Assert.isTrue;
@@ -74,6 +77,8 @@ import static java.util.Optional.ofNullable;
 public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, IndexDataStructure, Serializable {
 	public static final String ERROR_RANGE_TYPE_NOT_SUPPORTED = "This filter index doesn't handle Range type!";
 	@Serial private static final long serialVersionUID = -6813305126746774103L;
+	private static final Function<Comparable, Comparable> NO_NORMALIZATION = Function.identity();
+	public static final Comparator<Comparable> DEFAULT_COMPARATOR = Comparator.naturalOrder();
 	@Getter private final long id = TransactionalObjectVersion.SEQUENCE.nextId();
 	/**
 	 * Contains key identifying the attribute.
@@ -95,6 +100,19 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * - what records are valid after certain moment
 	 */
 	@Nullable @Getter private final RangeIndex rangeIndex;
+	/**
+	 * Contains information about the type of the value held in this filter index (the type of {@link #attributeKey} values).
+	 */
+	private final Class<?> attributeType;
+	/**
+	 * Instance of conversion function that converts the value before it's placed into internal index or looked up
+	 * in it by {@link Comparator} interface.
+	 */
+	@Nonnull private final Function<Comparable, Comparable> normalizer;
+	/**
+	 * Instance of comparator that should be used for sorting values in this filter index.
+	 */
+	@Nonnull private final Comparator<? extends Comparable> comparator;
 	/**
 	 * Value index is auxiliary data structure that allows fast O(1) access to the records of specified value.
 	 * It is created on demand on first use.
@@ -159,18 +177,97 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 		return remainingRanges;
 	}
 
-	public FilterIndex(@Nonnull AttributeKey attributeKey, @Nonnull Class<?> attributeType) {
-		this.attributeKey = attributeKey;
-		this.dirty = new TransactionalBoolean();
-		this.invertedIndex = new InvertedIndex<>();
-		this.rangeIndex = Range.class.isAssignableFrom(attributeType) ? new RangeIndex() : null;
+	/**
+	 * Returns the appropriate normalizer function for particular attribute type and key.
+	 *
+	 * @param attributeType type of the attribute
+	 * @return appropriate comparator
+	 */
+	@Nonnull
+	private static Function<Comparable, Comparable> getNormalizer(@Nonnull Class<?> attributeType) {
+		if (OffsetDateTime.class.isAssignableFrom(attributeType)) {
+			return comparable -> ((OffsetDateTime) comparable).toInstant();
+		} else {
+			return NO_NORMALIZATION;
+		}
 	}
 
-	public <T extends Comparable<T>> FilterIndex(@Nonnull AttributeKey attributeKey, @Nonnull InvertedIndex<T> invertedIndex, @Nullable RangeIndex rangeIndex) {
+	/**
+	 * Returns the appropriate comparator for particular attribute type and key.
+	 *
+	 * @param attributeKey  key containing information about used locale
+	 * @param attributeType type of the attribute
+	 * @return appropriate comparator
+	 */
+	@Nonnull
+	private static Comparator<? extends Comparable> getComparator(@Nonnull AttributeKey attributeKey, @Nonnull Class<?> attributeType) {
+		if (String.class.isAssignableFrom(attributeType) && attributeKey.localized()) {
+			return new LocalizedStringComparator(attributeKey.locale());
+		} else {
+			return DEFAULT_COMPARATOR;
+		}
+	}
+
+	public FilterIndex(@Nonnull AttributeKey attributeKey, @Nonnull Class<?> attributeType) {
 		this.attributeKey = attributeKey;
+		this.attributeType = attributeType;
+		this.dirty = new TransactionalBoolean();
+		this.rangeIndex = Range.class.isAssignableFrom(attributeType) ? new RangeIndex() : null;
+		this.comparator = getComparator(attributeKey, attributeType);
+		this.normalizer = getNormalizer(attributeType);
+		this.invertedIndex = new InvertedIndex<>(this.comparator);
+	}
+
+	public <T extends Comparable<T>> FilterIndex(
+		@Nonnull AttributeKey attributeKey,
+		@Nonnull ValueToRecordBitmap<T>[] valueToRecords,
+		@Nullable RangeIndex rangeIndex,
+		@Nonnull Class<?> attributeType
+	) {
+		this.attributeKey = attributeKey;
+		this.attributeType = attributeType;
+		this.dirty = new TransactionalBoolean();
+		this.rangeIndex = rangeIndex;
+		this.comparator = getComparator(attributeKey, attributeType);
+		this.normalizer = getNormalizer(attributeType);
+		this.invertedIndex = new InvertedIndex<>(valueToRecords, (Comparator<T>) this.comparator);
+	}
+
+	//	TOBEDONE #538 - remove unnecessary constructor
+	public <T extends Comparable<T>> FilterIndex(
+		@Nonnull AttributeKey attributeKey,
+		@Nonnull ValueToRecordBitmap<T>[] valueToRecords,
+		@Nullable RangeIndex rangeIndex,
+		@Nonnull Class<?> attributeType,
+		boolean updateSortedValues
+	) {
+		this.attributeKey = attributeKey;
+		this.attributeType = attributeType;
+		this.dirty = new TransactionalBoolean();
+		this.rangeIndex = rangeIndex;
+		this.comparator = getComparator(attributeKey, attributeType);
+		this.normalizer = getNormalizer(attributeType);
+		if (updateSortedValues && this.comparator != DEFAULT_COMPARATOR) {
+			ArrayUtils.sortArray((o1, o2) -> ((Comparator<T>)this.comparator).compare(o1.getValue(), o2.getValue()), valueToRecords);
+		}
+		this.invertedIndex = new InvertedIndex<>(valueToRecords, (Comparator<T>) this.comparator);
+	}
+
+	private <T extends Comparable<T>> FilterIndex(
+		@Nonnull AttributeKey attributeKey,
+		@Nonnull Class<?> attributeType,
+		@Nonnull InvertedIndex<T> invertedIndex,
+		@Nullable RangeIndex rangeIndex,
+		@Nonnull Comparator<? extends Comparable> comparator,
+		@Nonnull Function<Comparable, Comparable> normalizer
+	) {
+		this.attributeKey = attributeKey;
+		this.attributeType = attributeType;
 		this.dirty = new TransactionalBoolean();
 		this.invertedIndex = invertedIndex;
 		this.rangeIndex = rangeIndex;
+		this.comparator = comparator;
+		this.normalizer = normalizer;
 	}
 
 	/**
@@ -181,16 +278,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	}
 
 	/**
-	 * Returns sorted (ascending, natural) collection of all distinct values present in the filter index.
-	 */
-	@Nonnull
-	public <T extends Comparable<T>> Collection<T> getValues() {
-		//noinspection unchecked
-		return (Collection<T>) getValueIndex().keySet();
-	}
-
-	/**
-	 * Returns sorted (ascending, natural) collection of all distinct values present in the filter index.
+	 * Returns formula of record ids whose String attribute starts with particular prefix.
 	 */
 	@Nonnull
 	public Formula getRecordsWhoseValuesStartWith(@Nonnull String prefix) {
@@ -201,7 +289,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 			(valueToRecordBitmap, textToSearch) -> {
 				final String valueA = String.valueOf(valueToRecordBitmap.getValue());
 				final String shortenedA = valueA.substring(0, Math.min(valueA.length(), textToSearch.length()));
-				return shortenedA.compareTo(textToSearch);
+				return ((Comparator<String>)this.comparator).compare(shortenedA, textToSearch);
 			}
 		);
 		if (matchIndex < 0) {
@@ -232,6 +320,38 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 			}
 			return FormulaFactory.or(formulas.toArray(new Formula[0]));
 		}
+	}
+
+	/**
+	 * Returns formula of record ids whose String attribute ends with particular prefix.
+	 */
+	@Nonnull
+	public Formula getRecordsWhoseValuesEndsWith(@Nonnull String suffix) {
+		/* TOBEDONE JNO naive and slow - use RadixTree */
+		final Formula[] foundRecords = getValueIndex().keySet()
+			.stream()
+			.map(String.class::cast)
+			.filter(it -> it.endsWith(suffix))
+			.map(this::getRecordsEqualToFormula)
+			.toArray(Formula[]::new);
+		return ArrayUtils.isEmpty(foundRecords) ?
+			EmptyFormula.INSTANCE : FormulaFactory.or(foundRecords);
+	}
+
+	/**
+	 * Returns formula of record ids whose String attribute contains particular text.
+	 */
+	@Nonnull
+	public Formula getRecordsWhoseValuesContains(@Nonnull String text) {
+		/* TOBEDONE JNO naive and slow - use RadixTree */
+		final Formula[] foundRecords = getValueIndex().keySet()
+			.stream()
+			.map(String.class::cast)
+			.filter(it -> it.contains(text))
+			.map(this::getRecordsEqualToFormula)
+			.toArray(Formula[]::new);
+		return ArrayUtils.isEmpty(foundRecords) ?
+			EmptyFormula.INSTANCE : FormulaFactory.or(foundRecords);
 	}
 
 	/**
@@ -400,7 +520,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 */
 	@Nonnull
 	public <T extends Comparable<T>> Bitmap getRecordsEqualTo(@Nonnull T attributeValue) {
-		return ofNullable(getValueIndex().get(attributeValue))
+		return ofNullable(getValueIndex().get(this.normalizer.apply(attributeValue)))
 			.map(invertedIndex::getRecordsAtIndex)
 			.orElse(EmptyBitmap.INSTANCE);
 	}
@@ -410,7 +530,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 */
 	@Nonnull
 	public <T extends Comparable<T>> Formula getRecordsEqualToFormula(@Nonnull T attributeValue) {
-		return ofNullable(getValueIndex().get(attributeValue))
+		return ofNullable(getValueIndex().get(this.normalizer.apply(attributeValue)))
 			.map(it -> (Formula) new ConstantFormula(invertedIndex.getRecordsAtIndex(it)))
 			.orElse(EmptyFormula.INSTANCE);
 	}
@@ -448,93 +568,93 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	/**
 	 * Returns all records lesser than or equals attribute value passed in the argument in the form of {@link InvertedIndexSubSet}.
 	 */
-	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsLesserThanEq(@Nonnull T comparable) {
-		return ((InvertedIndex) this.invertedIndex).getSortedRecords(null, comparable);
+	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsLesserThanEq(@Nonnull T to) {
+		return ((InvertedIndex) this.invertedIndex).getSortedRecords(null, this.normalizer.apply(to));
 	}
 
 	/**
 	 * Returns all records lesser than or equals attribute value passed in the argument in the form of {@link Bitmap}.
 	 */
 	@Nonnull
-	public <T extends Comparable<T>> Bitmap getRecordsLesserThanEq(@Nonnull T comparable) {
-		final Formula recordsLesserThanEqFormula = getRecordsLesserThanEqFormula(comparable);
+	public <T extends Comparable<T>> Bitmap getRecordsLesserThanEq(@Nonnull T to) {
+		final Formula recordsLesserThanEqFormula = getRecordsLesserThanEqFormula(to);
 		return recordsLesserThanEqFormula.compute();
 	}
 
 	/**
 	 * Returns all records lesser than or equals attribute value passed in the argument in the form of {@link Bitmap}.
 	 */
-	public <T extends Comparable<T>> Formula getRecordsLesserThanEqFormula(@Nonnull T comparable) {
-		return getHistogramOfRecordsLesserThanEq(comparable).getFormula();
+	public <T extends Comparable<T>> Formula getRecordsLesserThanEqFormula(@Nonnull T to) {
+		return getHistogramOfRecordsLesserThanEq(to).getFormula();
 	}
 
 	/**
 	 * Returns all records greater than or equals attribute value passed in the argument in the form of {@link InvertedIndexSubSet}.
 	 */
-	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsGreaterThanEq(@Nonnull T comparable) {
-		return ((InvertedIndex) this.invertedIndex).getSortedRecords(comparable, null);
+	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsGreaterThanEq(@Nonnull T from) {
+		return ((InvertedIndex) this.invertedIndex).getSortedRecords(this.normalizer.apply(from), null);
 	}
 
 	/**
 	 * Returns all records greater than or equals attribute value passed in the argument in the form of {@link Bitmap}.
 	 */
 	@Nonnull
-	public <T extends Comparable<T>> Bitmap getRecordsGreaterThanEq(@Nonnull T comparable) {
-		final Formula recordsGreaterThanEqFormula = getRecordsGreaterThanEqFormula(comparable);
+	public <T extends Comparable<T>> Bitmap getRecordsGreaterThanEq(@Nonnull T from) {
+		final Formula recordsGreaterThanEqFormula = getRecordsGreaterThanEqFormula(from);
 		return recordsGreaterThanEqFormula.compute();
 	}
 
 	/**
 	 * Returns all records greater than or equals attribute value passed in the argument in the form of {@link AbstractFormula}.
 	 */
-	public <T extends Comparable<T>> Formula getRecordsGreaterThanEqFormula(@Nonnull T comparable) {
-		return getHistogramOfRecordsGreaterThanEq(comparable).getFormula();
+	public <T extends Comparable<T>> Formula getRecordsGreaterThanEqFormula(@Nonnull T to) {
+		return getHistogramOfRecordsGreaterThanEq(to).getFormula();
 	}
 
 	/**
 	 * Returns all records lesser than attribute value passed in the argument in the form of {@link InvertedIndexSubSet}.
 	 */
-	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsLesserThan(@Nonnull T comparable) {
-		return ((InvertedIndex) this.invertedIndex).getSortedRecordsExclusive(null, comparable);
+	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsLesserThan(@Nonnull T to) {
+		return ((InvertedIndex) this.invertedIndex).getSortedRecordsExclusive(null, this.normalizer.apply(to));
 	}
 
 	/**
 	 * Returns all records lesser than attribute value passed in the argument in the form of {@link Bitmap}.
 	 */
 	@Nonnull
-	public <T extends Comparable<T>> Bitmap getRecordsLesserThan(@Nonnull T comparable) {
-		final Formula recordsLesserThanFormula = getRecordsLesserThanFormula(comparable);
+	public <T extends Comparable<T>> Bitmap getRecordsLesserThan(@Nonnull T to) {
+		final Formula recordsLesserThanFormula = getRecordsLesserThanFormula(to);
 		return recordsLesserThanFormula.compute();
 	}
 
 	/**
 	 * Returns all records lesser than attribute value passed in the argument in the form of {@link AbstractFormula}.
 	 */
-	public <T extends Comparable<T>> Formula getRecordsLesserThanFormula(@Nonnull T comparable) {
-		return getHistogramOfRecordsLesserThan(comparable).getFormula();
+	public <T extends Comparable<T>> Formula getRecordsLesserThanFormula(@Nonnull T from) {
+		return getHistogramOfRecordsLesserThan(from).getFormula();
 	}
 
 	/**
 	 * Returns all records greater than attribute value passed in the argument in the form of {@link InvertedIndexSubSet}.
 	 */
-	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsGreaterThan(@Nonnull T comparable) {
-		return ((InvertedIndex) this.invertedIndex).getSortedRecordsExclusive(comparable, null);
+	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsGreaterThan(@Nonnull T from) {
+		return ((InvertedIndex) this.invertedIndex).getSortedRecordsExclusive(this.normalizer.apply(from), null);
 	}
 
 	/**
 	 * Returns all records greater than attribute value passed in the argument in the form of {@link Bitmap}.
 	 */
 	@Nonnull
-	public <T extends Comparable<T>> Bitmap getRecordsGreaterThan(@Nonnull T comparable) {
-		final Formula recordsGreaterThanFormula = getRecordsGreaterThanFormula(comparable);
+	public <T extends Comparable<T>> Bitmap getRecordsGreaterThan(@Nonnull T from) {
+		final Formula recordsGreaterThanFormula = getRecordsGreaterThanFormula(from);
 		return recordsGreaterThanFormula.compute();
 	}
 
 	/**
 	 * Returns all records greater than attribute value passed in the argument in the form of {@link AbstractFormula}.
 	 */
-	public <T extends Comparable<T>> Formula getRecordsGreaterThanFormula(@Nonnull T comparable) {
-		return getHistogramOfRecordsGreaterThan(comparable).getFormula();
+	public <T extends Comparable<T>> Formula getRecordsGreaterThanFormula(@Nonnull T from) {
+		return getHistogramOfRecordsGreaterThan(this.normalizer.apply(from)).getFormula();
 	}
 
 	/**
@@ -542,7 +662,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * in the form of {@link InvertedIndexSubSet}.
 	 */
 	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsBetween(@Nonnull T from, @Nonnull T to) {
-		return ((InvertedIndex) this.invertedIndex).getSortedRecords(from, to);
+		return ((InvertedIndex) this.invertedIndex).getSortedRecords(this.normalizer.apply(from), this.normalizer.apply(to));
 	}
 
 	/**
@@ -612,7 +732,11 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	@Nullable
 	public StoragePart createStoragePart(int entityIndexPrimaryKey) {
 		if (this.dirty.isTrue()) {
-			return new FilterIndexStoragePart(entityIndexPrimaryKey, attributeKey, invertedIndex, rangeIndex);
+			return new FilterIndexStoragePart(
+				entityIndexPrimaryKey, this.attributeKey, this.attributeType,
+				this.invertedIndex.getValueToRecordBitmap(),
+				this.rangeIndex
+			);
 		} else {
 			return null;
 		}
@@ -630,8 +754,11 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 		transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
 		return new FilterIndex(
 			this.attributeKey,
+			this.attributeType,
 			transactionalLayer.getStateCopyWithCommittedChanges(this.invertedIndex),
-			this.rangeIndex == null ? null : transactionalLayer.getStateCopyWithCommittedChanges(this.rangeIndex)
+			this.rangeIndex == null ? null : transactionalLayer.getStateCopyWithCommittedChanges(this.rangeIndex),
+			this.comparator,
+			this.normalizer
 		);
 	}
 
@@ -692,12 +819,12 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	}
 
 	private <T extends Comparable<T>> void addRecordToHistogramAndValueIndex(int recordId, @Nonnull T value) {
-		((InvertedIndex) this.invertedIndex).addRecord(value, recordId);
+		((InvertedIndex) this.invertedIndex).addRecord(this.normalizer.apply(value), recordId);
 		this.valueIndex = null;
 	}
 
 	private <T extends Comparable<T>> void removeRecordFromHistogramAndValueIndex(int recordId, @Nonnull T value) {
-		final int removalIndex = ((InvertedIndex) this.invertedIndex).removeRecord(value, recordId);
+		final int removalIndex = ((InvertedIndex) this.invertedIndex).removeRecord(this.normalizer.apply(value), recordId);
 		isTrue(removalIndex >= 0, "Sanity check - record not found!");
 		this.valueIndex = null;
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndex.java
@@ -57,7 +57,6 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Array;
-import java.text.Collator;
 import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -188,10 +187,7 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 	private static Comparator createComparatorFor(@Nullable Locale locale, @Nonnull ComparatorSource comparatorSource) {
 		final Comparator nextComparator = String.class.isAssignableFrom(comparatorSource.type()) ?
 			ofNullable(locale)
-				.map(it -> {
-					final Collator collator = Collator.getInstance(it);
-					return (Comparator) new LocalizedStringComparator(collator);
-				})
+				.map(it -> (Comparator) new LocalizedStringComparator(it))
 				.orElse(Comparator.naturalOrder()) :
 			Comparator.naturalOrder();
 

--- a/evita_engine/src/main/java/io/evitadb/index/invertedIndex/InvertedIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/invertedIndex/InvertedIndex.java
@@ -47,6 +47,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.function.BiFunction;
 
@@ -82,6 +83,10 @@ public class InvertedIndex<T extends Comparable<T>> implements VoidTransactionMe
 	 * The buckets contain ordered comparable values with bitmaps of all records with such value.
 	 */
 	private final TransactionalComplexObjArray<ValueToRecordBitmap<T>> valueToRecordBitmap;
+	/**
+	 * Instance of comparator that should be used for values in {@link #valueToRecordBitmap}
+	 */
+	@Nonnull @Getter private final Comparator<T> comparator;
 
 	/**
 	 * This lambda lay out records by {@link ValueToRecordBitmap#getValue()} one after another.
@@ -113,38 +118,42 @@ public class InvertedIndex<T extends Comparable<T>> implements VoidTransactionMe
 	 * Method verifies that {@link ValueToRecordBitmap#getValue()}s in passed set are monotonically increasing and contain
 	 * no duplicities.
 	 */
-	private static <T extends Comparable<T>> void assertValueIsMonotonic(@Nonnull ValueToRecordBitmap<T>[] points) {
+	private static <T extends Comparable<T>> void assertValueIsMonotonic(@Nonnull ValueToRecordBitmap<T>[] points, @Nonnull Comparator<T> comparator) {
 		T previous = null;
 		for (ValueToRecordBitmap<T> bucket : points) {
 			Assert.isTrue(
-				previous == null || previous.compareTo(bucket.getValue()) < 0,
+				previous == null || comparator.compare(previous, bucket.getValue()) < 0,
 				"Histogram values are not monotonic - conflicting values: " + previous + ", " + bucket.getValue()
 			);
 			previous = bucket.getValue();
 		}
 	}
 
-	public InvertedIndex() {
+	public InvertedIndex(@Nonnull Comparator<T> comparator) {
 		//noinspection unchecked, rawtypes
-		valueToRecordBitmap = new TransactionalComplexObjArray<>(
+		this.valueToRecordBitmap = new TransactionalComplexObjArray<>(
 			new ValueToRecordBitmap[0],
 			ValueToRecordBitmap::add,
 			ValueToRecordBitmap::remove,
 			ValueToRecordBitmap::isEmpty,
+			(Comparator<ValueToRecordBitmap<T>>) (o1, o2) -> comparator.compare(o1.getValue(), o2.getValue()),
 			ValueToRecordBitmap::deepEquals
 		);
+		this.comparator = comparator;
 	}
 
-	public InvertedIndex(@Nonnull ValueToRecordBitmap<T>[] buckets) {
+	public InvertedIndex(@Nonnull ValueToRecordBitmap<T>[] buckets, @Nonnull Comparator<T> comparator) {
 		// contract check
-		assertValueIsMonotonic(buckets);
+		assertValueIsMonotonic(buckets, comparator);
 		this.valueToRecordBitmap = new TransactionalComplexObjArray<>(
 			buckets,
 			ValueToRecordBitmap::add,
 			ValueToRecordBitmap::remove,
 			ValueToRecordBitmap::isEmpty,
+			(o1, o2) -> comparator.compare(o1.getValue(), o2.getValue()),
 			ValueToRecordBitmap::deepEquals
 		);
+		this.comparator = comparator;
 	}
 
 	/**
@@ -350,7 +359,10 @@ public class InvertedIndex<T extends Comparable<T>> implements VoidTransactionMe
 	@Nonnull
 	@Override
 	public InvertedIndex<T> createCopyWithMergedTransactionalMemory(Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		return new InvertedIndex<>(transactionalLayer.getStateCopyWithCommittedChanges(this.valueToRecordBitmap));
+		return new InvertedIndex<>(
+			transactionalLayer.getStateCopyWithCommittedChanges(this.valueToRecordBitmap),
+			this.comparator
+		);
 	}
 
 	@Override
@@ -396,10 +408,10 @@ public class InvertedIndex<T extends Comparable<T>> implements VoidTransactionMe
 	 */
 	@Nonnull
 	private ValueToRecordBitmap<T>[] getRecordsInternal(@Nullable T moreThanEq, @Nullable T lessThanEq, @Nonnull BoundsHandling boundsHandling) {
-		final HistogramBounds<T> histogramBounds = new HistogramBounds<>(valueToRecordBitmap.getArray(), moreThanEq, lessThanEq, boundsHandling);
+		final HistogramBounds<T> histogramBounds = new HistogramBounds<>(this.valueToRecordBitmap.getArray(), moreThanEq, lessThanEq, boundsHandling, this.comparator);
 		@SuppressWarnings("unchecked") final ValueToRecordBitmap<T>[] result = new ValueToRecordBitmap[histogramBounds.getNormalizedEndIndex() - histogramBounds.getNormalizedStartIndex()];
 		int index = -1;
-		final Iterator<ValueToRecordBitmap<T>> it = valueToRecordBitmap.iterator();
+		final Iterator<ValueToRecordBitmap<T>> it = this.valueToRecordBitmap.iterator();
 		while (it.hasNext()) {
 			final ValueToRecordBitmap<T> bucket = it.next();
 			index++;
@@ -435,14 +447,14 @@ public class InvertedIndex<T extends Comparable<T>> implements VoidTransactionMe
 		 */
 		@Getter private final int normalizedEndIndex;
 
-		HistogramBounds(@Nonnull ValueToRecordBitmap<T>[] points, @Nullable T moreThanEq, @Nullable T lessThanEq, @Nonnull BoundsHandling boundsHandling) {
+		HistogramBounds(@Nonnull ValueToRecordBitmap<T>[] points, @Nullable T moreThanEq, @Nullable T lessThanEq, @Nonnull BoundsHandling boundsHandling, @Nonnull Comparator<T> comparator) {
 			Assert.isTrue(
-				moreThanEq == null || lessThanEq == null || moreThanEq.compareTo(lessThanEq) <= 0,
+				moreThanEq == null || lessThanEq == null || comparator.compare(moreThanEq, lessThanEq) <= 0,
 				"From must be lower than to: " + moreThanEq + " vs. " + lessThanEq
 			);
 
 			if (moreThanEq != null) {
-				final int startIndex = Arrays.binarySearch(points, new ValueToRecordBitmap<>(moreThanEq));
+				final int startIndex = ArrayUtils.binarySearch(points, new ValueToRecordBitmap<>(moreThanEq), (b1, b2) -> comparator.compare(b1.getValue(), b2.getValue()));
 				if (boundsHandling == BoundsHandling.EXCLUSIVE) {
 					normalizedStartIndex = startIndex >= 0 ? startIndex + 1 : -1 * (startIndex) - 1;
 				} else {
@@ -453,7 +465,7 @@ public class InvertedIndex<T extends Comparable<T>> implements VoidTransactionMe
 			}
 
 			if (lessThanEq != null) {
-				final int endIndex = Arrays.binarySearch(points, new ValueToRecordBitmap<>(lessThanEq));
+				final int endIndex = ArrayUtils.binarySearch(points, new ValueToRecordBitmap<>(lessThanEq), (b1, b2) -> comparator.compare(b1.getValue(), b2.getValue()));
 				if (boundsHandling == BoundsHandling.EXCLUSIVE) {
 					normalizedEndIndex = endIndex >= 0 ? endIndex : (-1 * (endIndex) - 1);
 				} else {

--- a/evita_engine/src/main/java/io/evitadb/store/spi/model/storageParts/index/FilterIndexStoragePart.java
+++ b/evita_engine/src/main/java/io/evitadb/store/spi/model/storageParts/index/FilterIndexStoragePart.java
@@ -27,7 +27,7 @@ import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.api.requestResponse.schema.dto.AttributeSchema;
 import io.evitadb.api.requestResponse.schema.dto.EntitySchema;
 import io.evitadb.dataType.Range;
-import io.evitadb.index.invertedIndex.InvertedIndex;
+import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
 import io.evitadb.index.range.RangeIndex;
 import io.evitadb.store.model.RecordWithCompressedId;
 import lombok.AllArgsConstructor;
@@ -52,7 +52,7 @@ import java.io.Serial;
 @AllArgsConstructor
 @ToString(of = {"attributeKey", "entityIndexPrimaryKey"})
 public class FilterIndexStoragePart implements AttributeIndexStoragePart, RecordWithCompressedId<AttributeKey> {
-	@Serial private static final long serialVersionUID = 6163295675316818632L;
+	@Serial private static final long serialVersionUID = -3363238752052021735L;
 
 	/**
 	 * Unique id that identifies {@link io.evitadb.index.EntityIndex}.
@@ -63,9 +63,14 @@ public class FilterIndexStoragePart implements AttributeIndexStoragePart, Record
 	 */
 	@Getter private final AttributeKey attributeKey;
 	/**
+	 * Contains the type of the objects kept as values in this particular filter index.
+	 */
+	@Getter private final Class<?> attributeType;
+	/**
 	 * Histogram is the main data structure that holds the information about value to record ids relation.
 	 */
-	@Nonnull @Getter private final InvertedIndex<? extends Comparable<?>> histogram;
+	@SuppressWarnings("rawtypes")
+	@Nonnull @Getter private final ValueToRecordBitmap[] histogramPoints;
 	/**
 	 * Range index is used only for attribute types that are assignable to {@link Range} and can answer questions like:
 	 * <p>

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EntityByAttributeFilteringFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EntityByAttributeFilteringFunctionalTest.java
@@ -121,6 +121,51 @@ public class EntityByAttributeFilteringFunctionalTest {
 
 	private static final int SEED = 40;
 
+	static void assertSortedAndPagedResultIs(List<SealedEntity> originalProductEntities, List<EntityReference> records, Predicate<SealedEntity> predicate, Comparator<SealedEntity> comparator, int skip, int limit) {
+		assertSortedResultEquals(
+			records.stream().map(EntityReference::getPrimaryKey).collect(Collectors.toList()),
+			originalProductEntities.stream()
+				.filter(predicate)
+				.sorted(comparator)
+				.mapToInt(EntityContract::getPrimaryKey)
+				.skip(Math.max(skip, 0))
+				.limit(skip >= 0 ? limit : limit + skip)
+				.toArray()
+		);
+	}
+
+	static void assertSortedResultIs(List<SealedEntity> originalProductEntities, List<EntityReference> records, Predicate<SealedEntity> predicate, Comparator<SealedEntity> comparator) {
+		assertSortedResultIs(originalProductEntities, records, predicate, new PredicateWithComparatorTuple(predicate, comparator));
+	}
+
+	static void assertSortedResultIs(List<SealedEntity> originalProductEntities, List<EntityReference> records, Predicate<SealedEntity> filteringPredicate, PredicateWithComparatorTuple... sortVector) {
+		final List<Predicate<SealedEntity>> previousPredicateAcc = new ArrayList<>();
+		final List<SealedEntity> expectedSortedRecords = Stream.concat(
+				Arrays.stream(sortVector)
+					.flatMap(it -> {
+						final List<SealedEntity> subResult = originalProductEntities
+							.stream()
+							.filter(filteringPredicate)
+							.filter(entity -> previousPredicateAcc.stream().noneMatch(predicate -> predicate.test(entity)))
+							.filter(it.predicate())
+							.sorted(it.comparator()).toList();
+						previousPredicateAcc.add(it.predicate());
+						return subResult.stream();
+					}),
+				// append entities that don't match any predicate
+				originalProductEntities
+					.stream()
+					.filter(filteringPredicate)
+					.filter(entity -> previousPredicateAcc.stream().noneMatch(predicate -> predicate.test(entity)))
+			)
+			.toList();
+
+		assertSortedResultEquals(
+			records.stream().map(EntityReference::getPrimaryKey).collect(Collectors.toList()),
+			expectedSortedRecords.stream().mapToInt(EntityContract::getPrimaryKey).toArray()
+		);
+	}
+
 	/**
 	 * Verifies histogram integrity against source entities.
 	 */
@@ -171,7 +216,7 @@ public class EntityByAttributeFilteringFunctionalTest {
 				assertTrue(bucket.requested());
 			} else if (
 				(from == null || from.compareTo(bucket.threshold()) <= 0) &&
-				(to == null || to.compareTo(bucket.threshold()) >= 0)) {
+					(to == null || to.compareTo(bucket.threshold()) >= 0)) {
 				assertTrue(bucket.requested());
 			} else {
 				assertFalse(bucket.requested());
@@ -1033,8 +1078,39 @@ public class EntityByAttributeFilteringFunctionalTest {
 				);
 				assertResultIs(
 					originalProductEntities,
-					sealedEntity -> ofNullable(sealedEntity.getAttribute(ATTRIBUTE_CREATED))
-						.map(createdAttribute::equals)
+					sealedEntity -> ofNullable(sealedEntity.getAttribute(ATTRIBUTE_CREATED, OffsetDateTime.class))
+						.map(createdAttribute::isEqual)
+						.orElse(false),
+					result.getRecordData()
+				);
+				return null;
+			}
+		);
+
+		// transform the time to different offset but exact the same moment
+		final OffsetDateTime createdAttributeInDifferentTimeZone = OffsetDateTime.ofInstant(createdAttribute.toInstant(), ZoneOffset.ofHours(3));
+		assertTrue(createdAttribute.isEqual(createdAttributeInDifferentTimeZone));
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeEquals(ATTRIBUTE_CREATED, createdAttributeInDifferentTimeZone)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				assertResultIs(
+					originalProductEntities,
+					sealedEntity -> ofNullable(sealedEntity.getAttribute(ATTRIBUTE_CREATED, OffsetDateTime.class))
+						.map(it -> it.isEqual(createdAttribute))
 						.orElse(false),
 					result.getRecordData()
 				);
@@ -2005,6 +2081,71 @@ public class EntityByAttributeFilteringFunctionalTest {
 		);
 	}
 
+	@DisplayName("Should return entities by offset date time attribute lesserThanOrEquals")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnEntitiesByOffsetDateTimeAttributeLesserThanOrEqualsTo(Evita evita, List<SealedEntity> originalProductEntities) {
+		final OffsetDateTime createdAttribute = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_CREATED);
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeLessThanEquals(ATTRIBUTE_CREATED, createdAttribute)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				assertResultIs(
+					originalProductEntities,
+					sealedEntity -> ofNullable(sealedEntity.getAttribute(ATTRIBUTE_CREATED, OffsetDateTime.class))
+						.map(it -> it.isEqual(createdAttribute) || it.isBefore(createdAttribute))
+						.orElse(false),
+					result.getRecordData()
+				);
+				return null;
+			}
+		);
+
+		// transform the time to different offset but exact the same moment
+		final OffsetDateTime createdAttributeInDifferentTimeZone = OffsetDateTime.ofInstant(createdAttribute.toInstant(), ZoneOffset.ofHours(3));
+		assertTrue(createdAttribute.isEqual(createdAttributeInDifferentTimeZone));
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeLessThanEquals(ATTRIBUTE_CREATED, createdAttributeInDifferentTimeZone)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				assertResultIs(
+					originalProductEntities,
+					sealedEntity -> ofNullable(sealedEntity.getAttribute(ATTRIBUTE_CREATED, OffsetDateTime.class))
+						.map(it -> it.isEqual(createdAttribute) || it.isBefore(createdAttribute))
+						.orElse(false),
+					result.getRecordData()
+				);
+				return null;
+			}
+		);
+	}
+
 	@DisplayName("Should return entities by lesser than attribute (NumberRange) with plain value")
 	@UseDataSet(HUNDRED_PRODUCTS)
 	@Test
@@ -2373,6 +2514,71 @@ public class EntityByAttributeFilteringFunctionalTest {
 					originalProductEntities,
 					sealedEntity -> ofNullable((Long) sealedEntity.getAttribute(ATTRIBUTE_PRIORITY))
 						.map(it -> it >= priorityAttribute)
+						.orElse(false),
+					result.getRecordData()
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities by offset date time attribute greaterThanOrEquals")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnEntitiesByOffsetDateTimeAttributeGreaterThanOrEqualsTo(Evita evita, List<SealedEntity> originalProductEntities) {
+		final OffsetDateTime createdAttribute = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_CREATED);
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeGreaterThanEquals(ATTRIBUTE_CREATED, createdAttribute)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				assertResultIs(
+					originalProductEntities,
+					sealedEntity -> ofNullable(sealedEntity.getAttribute(ATTRIBUTE_CREATED, OffsetDateTime.class))
+						.map(it -> it.isEqual(createdAttribute) || it.isAfter(createdAttribute))
+						.orElse(false),
+					result.getRecordData()
+				);
+				return null;
+			}
+		);
+
+		// transform the time to different offset but exact the same moment
+		final OffsetDateTime createdAttributeInDifferentTimeZone = OffsetDateTime.ofInstant(createdAttribute.toInstant(), ZoneOffset.ofHours(3));
+		assertTrue(createdAttribute.isEqual(createdAttributeInDifferentTimeZone));
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeGreaterThanEquals(ATTRIBUTE_CREATED, createdAttributeInDifferentTimeZone)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				assertResultIs(
+					originalProductEntities,
+					sealedEntity -> ofNullable(sealedEntity.getAttribute(ATTRIBUTE_CREATED, OffsetDateTime.class))
+						.map(it -> it.isEqual(createdAttribute) || it.isAfter(createdAttribute))
 						.orElse(false),
 					result.getRecordData()
 				);
@@ -3699,9 +3905,9 @@ public class EntityByAttributeFilteringFunctionalTest {
 					)
 					.toArray(Integer[]::new);
 
-				final String[] exactCodeOrder = Arrays.copyOfRange(randomCodesStartingWithE, 0, (int)(randomCodesStartingWithE.length * 0.5));
-				final Integer[] exactOrder = Arrays.copyOfRange(randomProductIdsStartingWithE, 0, (int)(randomProductIdsStartingWithE.length * 0.5));
-				final Integer[] theRest = Arrays.copyOfRange(randomProductIdsStartingWithE, (int)(randomProductIdsStartingWithE.length * 0.5), randomProductIdsStartingWithE.length);
+				final String[] exactCodeOrder = Arrays.copyOfRange(randomCodesStartingWithE, 0, (int) (randomCodesStartingWithE.length * 0.5));
+				final Integer[] exactOrder = Arrays.copyOfRange(randomProductIdsStartingWithE, 0, (int) (randomProductIdsStartingWithE.length * 0.5));
+				final Integer[] theRest = Arrays.copyOfRange(randomProductIdsStartingWithE, (int) (randomProductIdsStartingWithE.length * 0.5), randomProductIdsStartingWithE.length);
 				ArrayUtils.reverse(exactOrder);
 				ArrayUtils.reverse(exactCodeOrder);
 
@@ -4206,6 +4412,10 @@ public class EntityByAttributeFilteringFunctionalTest {
 		);
 	}
 
+	/*
+		HELPER METHODS AND ASSERTIONS
+	 */
+
 	@DisplayName("Should return entities by complex OR / NOT query")
 	@UseDataSet(HUNDRED_PRODUCTS)
 	@Test
@@ -4328,10 +4538,6 @@ public class EntityByAttributeFilteringFunctionalTest {
 		);
 	}
 
-	/*
-		HELPER METHODS AND ASSERTIONS
-	 */
-
 	private EvitaResponse<EntityReference> getByAttributeSize(EvitaSessionContract session, int size) {
 		return session.query(
 			query(
@@ -4398,51 +4604,6 @@ public class EntityByAttributeFilteringFunctionalTest {
 			.skip(10)
 			.findFirst()
 			.orElseThrow(() -> new IllegalStateException("Failed to localize `" + attributeName + "` attribute!"));
-	}
-
-	static void assertSortedAndPagedResultIs(List<SealedEntity> originalProductEntities, List<EntityReference> records, Predicate<SealedEntity> predicate, Comparator<SealedEntity> comparator, int skip, int limit) {
-		assertSortedResultEquals(
-			records.stream().map(EntityReference::getPrimaryKey).collect(Collectors.toList()),
-			originalProductEntities.stream()
-				.filter(predicate)
-				.sorted(comparator)
-				.mapToInt(EntityContract::getPrimaryKey)
-				.skip(Math.max(skip, 0))
-				.limit(skip >= 0 ? limit : limit + skip)
-				.toArray()
-		);
-	}
-
-	static void assertSortedResultIs(List<SealedEntity> originalProductEntities, List<EntityReference> records, Predicate<SealedEntity> predicate, Comparator<SealedEntity> comparator) {
-		assertSortedResultIs(originalProductEntities, records, predicate, new PredicateWithComparatorTuple(predicate, comparator));
-	}
-
-	static void assertSortedResultIs(List<SealedEntity> originalProductEntities, List<EntityReference> records, Predicate<SealedEntity> filteringPredicate, PredicateWithComparatorTuple... sortVector) {
-		final List<Predicate<SealedEntity>> previousPredicateAcc = new ArrayList<>();
-		final List<SealedEntity> expectedSortedRecords = Stream.concat(
-				Arrays.stream(sortVector)
-					.flatMap(it -> {
-						final List<SealedEntity> subResult = originalProductEntities
-							.stream()
-							.filter(filteringPredicate)
-							.filter(entity -> previousPredicateAcc.stream().noneMatch(predicate -> predicate.test(entity)))
-							.filter(it.predicate())
-							.sorted(it.comparator()).toList();
-						previousPredicateAcc.add(it.predicate());
-						return subResult.stream();
-					}),
-				// append entities that don't match any predicate
-				originalProductEntities
-					.stream()
-					.filter(filteringPredicate)
-					.filter(entity -> previousPredicateAcc.stream().noneMatch(predicate -> predicate.test(entity)))
-			)
-			.toList();
-
-		assertSortedResultEquals(
-			records.stream().map(EntityReference::getPrimaryKey).collect(Collectors.toList()),
-			expectedSortedRecords.stream().mapToInt(EntityContract::getPrimaryKey).toArray()
-		);
 	}
 
 	public record PredicateWithComparatorTuple(Predicate<SealedEntity> predicate, Comparator<SealedEntity> comparator) {

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EvitaBackwardCompatibilityTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EvitaBackwardCompatibilityTest.java
@@ -1,0 +1,117 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/main/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api;
+
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.requestResponse.system.SystemStatus;
+import io.evitadb.core.Evita;
+import io.evitadb.test.EvitaTestSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This test verifies that data stored in older versions of evitaDB are still readable by the current version.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+public class EvitaBackwardCompatibilityTest implements EvitaTestSupport {
+	private static final String DIRECTORY = "evita-backward-compatibility";
+	private Path mainDirectory;
+
+	@BeforeEach
+	void setUp() throws MalformedURLException {
+		mainDirectory = Path.of(System.getProperty("java.io.tmpdir")).resolve(DIRECTORY);
+		if (!mainDirectory.toFile().exists()) {
+			mainDirectory.toFile().mkdirs();
+		}
+	}
+
+	@DisplayName("Verify backward binary data compatibility to 2024.5")
+	@Tag(LONG_RUNNING_TEST)
+	@Test
+	void verifyBackwardCompatibilityTo_2024_5() throws IOException {
+		final Path directory_2024_5 = mainDirectory.resolve("2024.5");
+		if (!directory_2024_5.toFile().exists()) {
+			directory_2024_5.toFile().mkdirs();
+			// first download the file from https://evitadb.io/test/evita-demo-dataset_2024.5.zip to tmp folder and unzip it
+			try (final InputStream is = new URL("https://evitadb.io/download/test/evita-demo-dataset_2024.5.zip").openStream()) {
+				Files.copy(is, directory_2024_5.resolve("evita-demo-dataset_2024.5.zip"), StandardCopyOption.REPLACE_EXISTING);
+			}
+			// unzip the file
+			try (
+				final InputStream is = Files.newInputStream(directory_2024_5.resolve("evita-demo-dataset_2024.5.zip"));
+				final ZipInputStream zis = new ZipInputStream(is)
+			) {
+				ZipEntry zipEntry = zis.getNextEntry();
+				while (zipEntry != null) {
+					Path newPath = directory_2024_5.resolve(zipEntry.getName());
+					if (zipEntry.isDirectory()) {
+						Files.createDirectories(newPath);
+					} else {
+						// Make sure parent directory exist
+						Files.createDirectories(newPath.getParent());
+						// Write file content
+						Files.copy(zis, newPath, StandardCopyOption.REPLACE_EXISTING);
+					}
+					zipEntry = zis.getNextEntry();
+				}
+			}
+		}
+
+		final Evita evita = new Evita(
+			EvitaConfiguration.builder()
+				.server(
+					ServerOptions.builder()
+						.closeSessionsAfterSecondsOfInactivity(-1)
+						.build()
+				)
+				.storage(
+					StorageOptions.builder()
+						.storageDirectory(directory_2024_5)
+						.build()
+				)
+				.build()
+		);
+
+		final SystemStatus status = evita.getSystemStatus();
+		assertEquals(0, status.catalogsCorrupted());
+		assertEquals(1, status.catalogsOk());
+	}
+}

--- a/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexTest.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -225,6 +226,30 @@ class FilterIndexTest implements TimeBoundedTestSupport {
 	void shouldReturnRecordsLesserThanEq() {
 		fillStringAttribute();
 		assertArrayEquals(new int[] {1, 2}, stringAttribute.getRecordsLesserThanEq("B").getArray());
+	}
+
+	@Test
+	void shouldReturnRecordsLesserThanLocaleSpecific_Czech() {
+		FilterIndex czechStringAttribute = new FilterIndex(new AttributeKey("a", new Locale("cs", "CZ")), String.class);
+		czechStringAttribute.addRecord(1, "CH");
+		czechStringAttribute.addRecord(2, "E");
+		czechStringAttribute.addRecord(3, "K");
+		czechStringAttribute.addRecord(4, "D");
+		czechStringAttribute.addRecord(5, "C");
+		czechStringAttribute.addRecord(6, "B");
+		assertArrayEquals(new int[] {2, 4, 5, 6}, czechStringAttribute.getRecordsLesserThan("CH").getArray());
+	}
+
+	@Test
+	void shouldReturnRecordsLesserThanLocaleSpecific_English() {
+		FilterIndex czechStringAttribute = new FilterIndex(new AttributeKey("a", Locale.ENGLISH), String.class);
+		czechStringAttribute.addRecord(1, "CH");
+		czechStringAttribute.addRecord(2, "E");
+		czechStringAttribute.addRecord(3, "K");
+		czechStringAttribute.addRecord(4, "D");
+		czechStringAttribute.addRecord(5, "C");
+		czechStringAttribute.addRecord(6, "B");
+		assertArrayEquals(new int[] {5, 6}, czechStringAttribute.getRecordsLesserThan("CH").getArray());
 	}
 
 	@Test
@@ -458,8 +483,9 @@ class FilterIndexTest implements TimeBoundedTestSupport {
 						committedResult.set(
 							new FilterIndex(
 								new AttributeKey("a"),
-								committed.getInvertedIndex(),
-								committed.getRangeIndex()
+								committed.getInvertedIndex().getValueToRecordBitmap(),
+								committed.getRangeIndex(),
+								Integer.class
 							)
 						);
 					}

--- a/evita_functional_tests/src/test/java/io/evitadb/index/invertedIndex/InvertedIndexTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/index/invertedIndex/InvertedIndexTest.java
@@ -1,13 +1,13 @@
 /*
  *
- *                         _ _        ____  ____  
- *               _____   _(_) |_ __ _|  _ \| __ ) 
- *              / _ \ \ / / | __/ _` | | | |  _ \ 
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
  *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/ 
- *            
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
  *   Copyright (c) 2023
- *  
+ *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
 class InvertedIndexTest implements TimeBoundedTestSupport {
-	private final InvertedIndex<Integer> tested = new InvertedIndex<>();
+	private final InvertedIndex<Integer> tested = new InvertedIndex<>((Comparator<Integer>) Comparator.naturalOrder());
 
 	@BeforeEach
 	void setUp() {
@@ -243,7 +243,7 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 	@Test
 	void shouldAddAndRemoveItemsInTransaction() {
 		assertStateAfterCommit(
-			new InvertedIndex<Integer>(),
+			new InvertedIndex<Integer>(Comparator.naturalOrder()),
 			original -> {
 				original.addRecord(5, 7);
 				original.addRecord(12, 18);
@@ -447,7 +447,7 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 
 	@Test
 	void shouldGenerationalTestPass() {
-		final InvertedIndex<Long> histogram = new InvertedIndex<>();
+		final InvertedIndex<Long> histogram = new InvertedIndex<>((Comparator<Long>) Comparator.naturalOrder());
 		histogram.addRecord(64L, 36, 47);
 		histogram.addRecord(0L, 10);
 		histogram.addRecord(65L, 90);
@@ -620,7 +620,7 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 					)
 					.append("\nOps:\n");
 
-				final InvertedIndex<Long> histogram = new InvertedIndex<>();
+				final InvertedIndex<Long> histogram = new InvertedIndex<>((Comparator<Long>) Comparator.naturalOrder());
 				for (Entry<Long, List<Integer>> entry : mapToCompare.entrySet()) {
 					histogram.addRecord(
 						entry.getKey(),

--- a/evita_functional_tests/src/test/java/io/evitadb/utils/ArrayUtilsTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/utils/ArrayUtilsTest.java
@@ -188,13 +188,23 @@ class ArrayUtilsTest {
 	}
 
 	@Test
-	void shouldSortedArrayByComparator() {
+	void shouldSortArrayOfIntegersByComparator() {
 		final String[] external = {"F", "B", "D", "A", "E", "I"};
 		final int[] theSortedArray = {0, 1, 2, 3, 4, 5};
 		ArrayUtils.sortArray((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(external[o1], external[o2]), theSortedArray);
 		assertArrayEquals(
 			new int[]{3, 1, 2, 4, 0, 5},
 			theSortedArray
+		);
+	}
+
+	@Test
+	void shouldSortArrayByComparator() {
+		final String[] external = {"F", "B", "D", "A", "E", "I"};
+		ArrayUtils.sortArray(String.CASE_INSENSITIVE_ORDER, external);
+		assertArrayEquals(
+			new String[] {"A", "B", "D", "E", "F", "I"},
+			external
 		);
 	}
 

--- a/evita_performance_tests/src/main/java/io/evitadb/spike/mock/BucketsRecordState.java
+++ b/evita_performance_tests/src/main/java/io/evitadb/spike/mock/BucketsRecordState.java
@@ -32,7 +32,6 @@ import io.evitadb.dataType.array.CompositeIntArray;
 import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.bitmap.ArrayBitmap;
 import io.evitadb.index.bitmap.Bitmap;
-import io.evitadb.index.invertedIndex.InvertedIndex;
 import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
 import io.evitadb.index.range.RangeIndex;
 import lombok.Getter;
@@ -70,11 +69,11 @@ public class BucketsRecordState {
 		request = new AttributeHistogramRequest(
 			AttributeSchema._internalBuild("whatever", Integer.class, false),
 			Arrays.asList(
-				new FilterIndex(new AttributeKey("whatever"), new InvertedIndex<>(generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5)), new RangeIndex()),
-				new FilterIndex(new AttributeKey("whatever"), new InvertedIndex<>(generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5)), new RangeIndex()),
-				new FilterIndex(new AttributeKey("whatever"), new InvertedIndex<>(generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5)), new RangeIndex()),
-				new FilterIndex(new AttributeKey("whatever"), new InvertedIndex<>(generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5)), new RangeIndex()),
-				new FilterIndex(new AttributeKey("whatever"), new InvertedIndex<>(generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5)), new RangeIndex())
+				new FilterIndex(new AttributeKey("whatever"), generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5), new RangeIndex(), Integer.class),
+				new FilterIndex(new AttributeKey("whatever"), generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5), new RangeIndex(), Integer.class),
+				new FilterIndex(new AttributeKey("whatever"), generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5), new RangeIndex(), Integer.class),
+				new FilterIndex(new AttributeKey("whatever"), generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5), new RangeIndex(), Integer.class),
+				new FilterIndex(new AttributeKey("whatever"), generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5), new RangeIndex(), Integer.class)
 			),
 			Collections.emptySet()
 		);

--- a/evita_store/evita_store_common/src/main/java/io/evitadb/store/dataType/serializer/OffsetDateTimeSerializer.java
+++ b/evita_store/evita_store_common/src/main/java/io/evitadb/store/dataType/serializer/OffsetDateTimeSerializer.java
@@ -28,7 +28,6 @@ import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.ImmutableSerializer;
-import io.evitadb.dataType.DateTimeRange;
 
 import javax.annotation.Nonnull;
 import java.time.LocalDate;
@@ -37,7 +36,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
 /**
- * This {@link Serializer} implementation reads/writes {@link DateTimeRange} from/to binary format.
+ * This {@link Serializer} implementation reads/writes {@link OffsetDateTime} from/to binary format.
  * The {@link OffsetDateTime} deserialization logic was taken out from the Kryo library so that we can replace the ZoneId
  * deserialization logic where we cache previously deserialized ZoneOffsets to avoid expensive lookups in Java itself.
  *

--- a/evita_store/evita_store_common/src/main/java/io/evitadb/store/dataType/serializer/SerialVersionBasedSerializer.java
+++ b/evita_store/evita_store_common/src/main/java/io/evitadb/store/dataType/serializer/SerialVersionBasedSerializer.java
@@ -30,6 +30,7 @@ import com.esotericsoftware.kryo.io.Output;
 import io.evitadb.store.dataType.exception.StoredVersionNotSupportedException;
 import io.evitadb.utils.Assert;
 
+import javax.annotation.Nonnull;
 import java.io.ObjectStreamClass;
 import java.util.Collections;
 import java.util.HashMap;
@@ -52,7 +53,7 @@ public class SerialVersionBasedSerializer<T> extends Serializer<T> {
 	private final long currentSerializerUID;
 	private Map<Long, Serializer<T>> backwardCompatibleSerializers;
 
-	public SerialVersionBasedSerializer(Serializer<T> currentVersionSerializer, Class<T> targetClass) {
+	public SerialVersionBasedSerializer(@Nonnull Serializer<T> currentVersionSerializer, @Nonnull Class<T> targetClass) {
 		this.currentSerializerUID = ObjectStreamClass.lookup(targetClass).getSerialVersionUID();;
 		this.currentVersionSerializer = currentVersionSerializer;
 	}
@@ -63,13 +64,15 @@ public class SerialVersionBasedSerializer<T> extends Serializer<T> {
 	 * Java class structures through the time while still be able to deserialize old binary data even if they are
 	 * not fully compatible with the current state.
 	 */
-	public void addBackwardCompatibleSerializer(long serialVersionUID, Serializer<T> backwardCompatibleSerializer) {
+	@Nonnull
+	public SerialVersionBasedSerializer<T> addBackwardCompatibleSerializer(long serialVersionUID, @Nonnull Serializer<T> backwardCompatibleSerializer) {
 		final Map<Long, Serializer<T>> serializerIndex = ofNullable(backwardCompatibleSerializers)
 			.orElseGet(() -> {
 				this.backwardCompatibleSerializers = new HashMap<>(32);
 				return this.backwardCompatibleSerializers;
 			});
 		serializerIndex.put(serialVersionUID, backwardCompatibleSerializer);
+		return this;
 	}
 
 	/**

--- a/evita_store/evita_store_common/src/main/java/io/evitadb/store/service/KryoFactory.java
+++ b/evita_store/evita_store_common/src/main/java/io/evitadb/store/service/KryoFactory.java
@@ -33,6 +33,7 @@ import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.ShortArrayS
 import com.esotericsoftware.kryo.serializers.DefaultArraySerializers.StringArraySerializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.EnumSetSerializer;
 import com.esotericsoftware.kryo.serializers.DefaultSerializers.*;
+import com.esotericsoftware.kryo.serializers.TimeSerializers.InstantSerializer;
 import com.esotericsoftware.kryo.serializers.TimeSerializers.LocalDateSerializer;
 import com.esotericsoftware.kryo.serializers.TimeSerializers.LocalDateTimeSerializer;
 import com.esotericsoftware.kryo.serializers.TimeSerializers.LocalTimeSerializer;
@@ -63,6 +64,7 @@ import io.evitadb.utils.Assert;
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -198,6 +200,7 @@ public class KryoFactory {
 		kryoInstance.register(Collections.unmodifiableMap(Collections.EMPTY_MAP).getClass(), new MapSerializer<>(count -> Collections.unmodifiableMap(new HashMap<>((int) Math.ceil(count / .75f), .75f))), index++);
 		kryoInstance.register(Collections.emptySet().getClass(), new CollectionsEmptySetSerializer(), index++);
 		kryoInstance.register(Collections.unmodifiableSet(Collections.EMPTY_SET).getClass(), new SetSerializer<>(count -> Collections.unmodifiableSet(new HashSet<>((int) Math.ceil(count / .75f), .75f))), index++);
+		kryoInstance.register(Instant.class, new InstantSerializer(), index++);
 		Assert.isPremiseValid(index < 200, "Index count overflow.");
 		return kryoInstance;
 	}

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/IndexStoragePartConfigurer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/IndexStoragePartConfigurer.java
@@ -63,7 +63,12 @@ public class IndexStoragePartConfigurer implements Consumer<Kryo> {
 		kryo.register(CatalogIndexStoragePart.class, new SerialVersionBasedSerializer<>(new CatalogIndexStoragePartSerializer(keyCompressor), CatalogIndexStoragePart.class), index++);
 		kryo.register(EntityIndexStoragePart.class, new SerialVersionBasedSerializer<>(new EntityIndexStoragePartSerializer(keyCompressor), EntityIndexStoragePart.class), index++);
 		kryo.register(UniqueIndexStoragePart.class, new SerialVersionBasedSerializer<>(new UniqueIndexStoragePartSerializer(keyCompressor), UniqueIndexStoragePart.class), index++);
-		kryo.register(FilterIndexStoragePart.class, new SerialVersionBasedSerializer<>(new FilterIndexStoragePartSerializer(keyCompressor), FilterIndexStoragePart.class), index++);
+		kryo.register(
+			FilterIndexStoragePart.class,
+			new SerialVersionBasedSerializer<>(new FilterIndexStoragePartSerializer(keyCompressor), FilterIndexStoragePart.class)
+				.addBackwardCompatibleSerializer(6163295675316818632L, new FilterIndexStoragePartSerializer_2024_5(keyCompressor)),
+			index++
+		);
 		kryo.register(SortIndexStoragePart.class, new SerialVersionBasedSerializer<>(new SortIndexStoragePartSerializer(keyCompressor), SortIndexStoragePart.class), index++);
 		kryo.register(ChainIndexStoragePart.class, new SerialVersionBasedSerializer<>(new ChainIndexStoragePartSerializer(keyCompressor), ChainIndexStoragePart.class), index++);
 		kryo.register(CardinalityIndexStoragePart.class, new SerialVersionBasedSerializer<>(new CardinalityIndexStoragePartSerializer(keyCompressor), CardinalityIndexStoragePart.class), index++);

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/InvertedIndexSerializer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/InvertedIndexSerializer.java
@@ -30,11 +30,14 @@ import com.esotericsoftware.kryo.io.Output;
 import io.evitadb.index.invertedIndex.InvertedIndex;
 import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
 
+import java.util.Comparator;
+
 /**
  * Class handles Kryo (de)serialization of {@link InvertedIndex} instances.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
+@Deprecated
 @SuppressWarnings("rawtypes")
 public class InvertedIndexSerializer extends Serializer<InvertedIndex> {
 
@@ -55,7 +58,7 @@ public class InvertedIndexSerializer extends Serializer<InvertedIndex> {
 			points[i] = kryo.readObject(input, ValueToRecordBitmap.class);
 		}
 		//noinspection unchecked
-		return new InvertedIndex(points);
+		return new InvertedIndex(points, Comparator.naturalOrder());
 	}
 
 }


### PR DESCRIPTION
…es into account

Equal date times:

- `2024-04-24T11:07:11.677467736Z`
- `2024-04-24T13:07:11.677467736+02:00`

were considered different. Also, the filter index didn't take string collations into account, so less than & greater than didn't work properly for strings containing national characters.

The fix changed the format of the stored data, so I had to include a backward compatible deserializer so that existing data is loaded correctly. When the data is saved again, it has the correct new format. The old format should be automatically removed by compaction.