### PR TITLE
refactor(#542): Limit allocations when no changes in indexes occur

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -247,8 +247,16 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 		this.rangeIndex = rangeIndex;
 		this.comparator = getComparator(attributeKey, attributeType);
 		this.normalizer = getNormalizer(attributeType);
-		if (updateSortedValues && this.comparator != DEFAULT_COMPARATOR) {
-			ArrayUtils.sortArray((o1, o2) -> ((Comparator<T>)this.comparator).compare(o1.getValue(), o2.getValue()), valueToRecords);
+		if (updateSortedValues) {
+			if (this.normalizer != NO_NORMALIZATION) {
+				for (int i = 0; i < valueToRecords.length; i++) {
+					final ValueToRecordBitmap<T> valueToRecord = valueToRecords[i];
+					valueToRecords[i] = new ValueToRecordBitmap<>(this.normalizer.apply(valueToRecord.getValue()), valueToRecord.getRecordIds());
+				}
+			}
+			if (this.comparator != DEFAULT_COMPARATOR) {
+				ArrayUtils.sortArray((o1, o2) -> ((Comparator<T>) this.comparator).compare(o1.getValue(), o2.getValue()), valueToRecords);
+			}
 		}
 		this.invertedIndex = new InvertedIndex<>(valueToRecords, (Comparator<T>) this.comparator);
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndex.java
@@ -608,14 +608,18 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 	@Override
 	public SortIndex createCopyWithMergedTransactionalMemory(@Nullable SortIndexChanges layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		// we can safely throw away dirty flag now
-		transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
-		return new SortIndex(
-			this.comparatorBase,
-			this.attributeKey,
-			transactionalLayer.getStateCopyWithCommittedChanges(this.sortedRecords),
-			transactionalLayer.getStateCopyWithCommittedChanges(this.sortedRecordsValues),
-			transactionalLayer.getStateCopyWithCommittedChanges(this.valueCardinalities)
-		);
+		final Boolean isDirty = transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
+		if (isDirty) {
+			return new SortIndex(
+				this.comparatorBase,
+				this.attributeKey,
+				transactionalLayer.getStateCopyWithCommittedChanges(this.sortedRecords),
+				transactionalLayer.getStateCopyWithCommittedChanges(this.sortedRecordsValues),
+				transactionalLayer.getStateCopyWithCommittedChanges(this.valueCardinalities)
+			);
+		} else {
+			return this;
+		}
 	}
 
 	/*

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/UniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/UniqueIndex.java
@@ -235,15 +235,19 @@ public class UniqueIndex implements TransactionalLayerProducer<TransactionalCont
 	@Nonnull
 	@Override
 	public UniqueIndex createCopyWithMergedTransactionalMemory(@Nullable TransactionalContainerChanges<MapChanges<Serializable, Integer>, Map<Serializable, Integer>, TransactionalMap<Serializable, Integer>> layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		final UniqueIndex uniqueKeyIndex = new UniqueIndex(
-			entityType, attributeKey, type,
-			transactionalLayer.getStateCopyWithCommittedChanges(this.uniqueValueToRecordId),
-			transactionalLayer.getStateCopyWithCommittedChanges(this.recordIds)
-		);
-		transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
-		// we can safely throw away dirty flag now
-		ofNullable(layer).ifPresent(it -> it.clean(transactionalLayer));
-		return uniqueKeyIndex;
+		final Boolean isDirty = transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
+		if (isDirty) {
+			final UniqueIndex uniqueKeyIndex = new UniqueIndex(
+				entityType, attributeKey, type,
+				transactionalLayer.getStateCopyWithCommittedChanges(this.uniqueValueToRecordId),
+				transactionalLayer.getStateCopyWithCommittedChanges(this.recordIds)
+			);
+			// we can safely throw away dirty flag now
+			ofNullable(layer).ifPresent(it -> it.clean(transactionalLayer));
+			return uniqueKeyIndex;
+		} else {
+			return this;
+		}
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/index/bitmap/TransactionalBitmap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bitmap/TransactionalBitmap.java
@@ -91,7 +91,7 @@ public class TransactionalBitmap implements RoaringBitmapBackedBitmap, Transacti
 	@Override
 	public RoaringBitmapBackedBitmap createCopyWithMergedTransactionalMemory(@Nullable BitmapChanges layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		if (layer == null) {
-			return new BaseBitmap(roaringBitmap);
+			return this;
 		} else {
 			return new BaseBitmap(layer.getMergedBitmap());
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/cardinality/CardinalityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/cardinality/CardinalityIndex.java
@@ -179,11 +179,15 @@ public class CardinalityIndex implements VoidTransactionMemoryProducer<Cardinali
 	@Override
 	public CardinalityIndex createCopyWithMergedTransactionalMemory(@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		// we can safely throw away dirty flag now
-		transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
-		return new CardinalityIndex(
-			valueType,
-			transactionalLayer.getStateCopyWithCommittedChanges(this.cardinalities)
-		);
+		final Boolean isDirty = transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
+		if (isDirty) {
+			return new CardinalityIndex(
+				valueType,
+				transactionalLayer.getStateCopyWithCommittedChanges(this.cardinalities)
+			);
+		} else {
+			return this;
+		}
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/facet/FacetIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/facet/FacetIndex.java
@@ -269,13 +269,17 @@ public class FacetIndex implements FacetIndexContract, TransactionalLayerProduce
 	@Override
 	public FacetIndex createCopyWithMergedTransactionalMemory(@Nullable FacetIndexChanges layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		// we can safely throw away dirty flag now
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this.dirtyIndexes);
-		final FacetIndex facetIndex = new FacetIndex(
-			// this is a HACK - facetingEntities id indexes produce NonTransactionalCopy instead of type than generics would suggest
-			(Map) transactionalLayer.getStateCopyWithCommittedChanges(this.facetingEntities)
-		);
-		ofNullable(layer).ifPresent(it -> it.clean(transactionalLayer));
-		return facetIndex;
+		final Set<Serializable> setOfDirtyIndexes = transactionalLayer.getStateCopyWithCommittedChanges(this.dirtyIndexes);
+		if (setOfDirtyIndexes.isEmpty()) {
+			return this;
+		} else {
+			final FacetIndex facetIndex = new FacetIndex(
+				// this is a HACK - facetingEntities id indexes produce NonTransactionalCopy instead of type than generics would suggest
+				(Map) transactionalLayer.getStateCopyWithCommittedChanges(this.facetingEntities)
+			);
+			ofNullable(layer).ifPresent(it -> it.clean(transactionalLayer));
+			return facetIndex;
+		}
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
@@ -711,13 +711,17 @@ public class HierarchyIndex implements HierarchyIndexContract, VoidTransactionMe
 	@Override
 	public HierarchyIndex createCopyWithMergedTransactionalMemory(@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		// we can safely throw away dirty flag now
-		transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
-		return new HierarchyIndex(
-			transactionalLayer.getStateCopyWithCommittedChanges(this.roots),
-			transactionalLayer.getStateCopyWithCommittedChanges(this.levelIndex),
-			transactionalLayer.getStateCopyWithCommittedChanges(this.itemIndex),
-			transactionalLayer.getStateCopyWithCommittedChanges(this.orphans)
-		);
+		final Boolean isDirty = transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
+		if (isDirty) {
+			return new HierarchyIndex(
+				transactionalLayer.getStateCopyWithCommittedChanges(this.roots),
+				transactionalLayer.getStateCopyWithCommittedChanges(this.levelIndex),
+				transactionalLayer.getStateCopyWithCommittedChanges(this.itemIndex),
+				transactionalLayer.getStateCopyWithCommittedChanges(this.orphans)
+			);
+		} else {
+			return this;
+		}
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/index/map/TransactionalMap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/TransactionalMap.java
@@ -130,7 +130,7 @@ public class TransactionalMap<K, V> implements Map<K, V>,
 		// iterate over inserted or updated keys
 		if (layer != null) {
 			return layer.createMergedMap(transactionalLayer);
-		} else {
+		} else if (valueType == null || TransactionalLayerProducer.class.isAssignableFrom(valueType)) {
 			// iterate original map and copy all values from it
 			List<Tuple<K, V>> modifiedEntries = null;
 			for (Entry<K, V> entry : mapDelegate.entrySet()) {
@@ -161,6 +161,8 @@ public class TransactionalMap<K, V> implements Map<K, V>,
 				modifiedEntries.forEach(it -> copy.put(it.key(), it.value()));
 				return copy;
 			}
+		} else {
+			return mapDelegate;
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndex.java
@@ -342,15 +342,19 @@ public class PriceListAndCurrencyPriceRefIndex implements VoidTransactionMemoryP
 	@Override
 	public PriceListAndCurrencyPriceRefIndex createCopyWithMergedTransactionalMemory(@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		// we can safely throw away dirty flag now
-		transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this.priceRecords);
-		return new PriceListAndCurrencyPriceRefIndex(
-			priceIndexKey,
-			transactionalLayer.getStateCopyWithCommittedChanges(this.indexedPriceEntityIds),
-			transactionalLayer.getStateCopyWithCommittedChanges(this.indexedPriceIds),
-			transactionalLayer.getStateCopyWithCommittedChanges(this.validityIndex),
-			this.superIndexAccessor
-		);
+		final Boolean isDirty = transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
+		if (isDirty) {
+			transactionalLayer.removeTransactionalMemoryLayerIfExists(this.priceRecords);
+			return new PriceListAndCurrencyPriceRefIndex(
+				priceIndexKey,
+				transactionalLayer.getStateCopyWithCommittedChanges(this.indexedPriceEntityIds),
+				transactionalLayer.getStateCopyWithCommittedChanges(this.indexedPriceIds),
+				transactionalLayer.getStateCopyWithCommittedChanges(this.validityIndex),
+				this.superIndexAccessor
+			);
+		} else {
+			return this;
+		}
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndex.java
@@ -353,16 +353,20 @@ public class PriceListAndCurrencyPriceSuperIndex implements VoidTransactionMemor
 	@Override
 	public PriceListAndCurrencyPriceSuperIndex createCopyWithMergedTransactionalMemory(@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		// we can safely throw away dirty flag now
-		transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
-		final PriceRecordContract[] newTriples = transactionalLayer.getStateCopyWithCommittedChanges(this.priceRecords);
-		return new PriceListAndCurrencyPriceSuperIndex(
-			priceIndexKey,
-			transactionalLayer.getStateCopyWithCommittedChanges(this.indexedPriceEntityIds),
-			transactionalLayer.getStateCopyWithCommittedChanges(this.indexedPriceIds),
-			transactionalLayer.getStateCopyWithCommittedChanges(this.entityPrices),
-			transactionalLayer.getStateCopyWithCommittedChanges(this.validityIndex),
-			newTriples
-		);
+		final Boolean isDirty = transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
+		if (isDirty) {
+			final PriceRecordContract[] newTriples = transactionalLayer.getStateCopyWithCommittedChanges(this.priceRecords);
+			return new PriceListAndCurrencyPriceSuperIndex(
+				priceIndexKey,
+				transactionalLayer.getStateCopyWithCommittedChanges(this.indexedPriceEntityIds),
+				transactionalLayer.getStateCopyWithCommittedChanges(this.indexedPriceIds),
+				transactionalLayer.getStateCopyWithCommittedChanges(this.entityPrices),
+				transactionalLayer.getStateCopyWithCommittedChanges(this.validityIndex),
+				newTriples
+			);
+		} else {
+			return this;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
There's a transactional boolean `dirty` in many places in transactional data structures, but it's not taken into account in the `io.evitadb.core.transaction.memory.TransactionalLayerProducer#createCopyWithMergedTransactionalMemory` method, which is called when a new state is created. If we had taken advantage of this flag and just returned "this" reference in cases where it's not dirty, we could save a lot of memory allocations. If nothing has changed, we can reuse the exact same instance of the object for the next generation.