### PR TITLE
fix(#537): Incorrect facet statistics difference when userFilter is used

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormula.java
@@ -141,6 +141,12 @@ public class FlattenedFormula extends CachePayloadHeader implements Formula {
 
 	@Override
 	public String toString() {
+		return "FLATTENED: " +  memoizedResult.size() + " primary keys";
+	}
+
+	@Nonnull
+	@Override
+	public String toStringVerbose() {
 		return "FLATTENED: " +  memoizedResult.toString();
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanner.java
@@ -277,9 +277,9 @@ public class QueryPlanner {
 						queryContext, adeptFormula, targetIndex, prefetchFormulaVisitor
 					);
 					if (result.isEmpty() || adeptFormula.getEstimatedCost() < result.get(0).getEstimatedCost()) {
-						result.addLast(queryPlanBuilder);
-					} else {
 						result.addFirst(queryPlanBuilder);
+					} else {
+						result.addLast(queryPlanBuilder);
 					}
 				} finally {
 					if (adeptFormula == null) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
@@ -174,6 +174,12 @@ public abstract class AbstractFormula implements Formula {
 		return PrettyPrintingFormulaVisitor.toString(this);
 	}
 
+	@Nonnull
+	@Override
+	public String toStringVerbose() {
+		return toString();
+	}
+
 	/**
 	 * Method signalizes whether the {@link #innerFormulas} order is significant in this formula. Usually the order
 	 * is not significant, and we want to order the hashes by their value to avoid different hashes for formula

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/Formula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/Formula.java
@@ -87,4 +87,11 @@ public interface Formula extends TransactionalDataRelatedStructure, PrettyPrinta
 	 * Clears the memoized results and hashes of the formula.
 	 */
 	void clearMemory();
+
+	/**
+	 * Prints information about the formula in a user-friendly way in verbose mode.
+	 */
+	@Nonnull
+	String toStringVerbose();
+
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/ConstantFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/ConstantFormula.java
@@ -102,7 +102,12 @@ public class ConstantFormula extends AbstractFormula {
 
 	@Override
 	public String toString() {
-		return delegate.toString();
+		return delegate.size() + " primary keys";
 	}
 
+	@Nonnull
+	@Override
+	public String toStringVerbose() {
+		return delegate.toString();
+	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
@@ -210,6 +210,16 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 	@Override
 	public String toString() {
 		if (mainBitmap != null && controlBitmap != null) {
+			return "DISENTANGLE: main" + mainBitmap.size() + ", control: " + controlBitmap.size() + " primary keys";
+		} else {
+			return "DISENTANGLE";
+		}
+	}
+
+	@Nonnull
+	@Override
+	public String toStringVerbose() {
+		if (mainBitmap != null && controlBitmap != null) {
 			return "DISENTANGLE: " + Stream.of(mainBitmap, controlBitmap).map(Bitmap::toString).collect(Collectors.joining(", "));
 		} else {
 			return "DISENTANGLE";
@@ -241,7 +251,7 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 		PRIVATE METHODS
 	 */
 
-	private int computeNextInt(OfInt mainIt, OfInt controlIt, AtomicInteger controlNumberRef) {
+	private static int computeNextInt(OfInt mainIt, OfInt controlIt, AtomicInteger controlNumberRef) {
 		if (mainIt.hasNext()) {
 			do {
 				final int nextNumberAdept = mainIt.next();

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
@@ -172,6 +172,12 @@ public class JoinFormula extends AbstractFormula {
 
 	@Override
 	public String toString() {
+		return "JOIN: " + Arrays.stream(bitmaps).map(it -> String.valueOf(it.size())).collect(Collectors.joining(", ")) + " primary keys";
+	}
+
+	@Nonnull
+	@Override
+	public String toStringVerbose() {
 		return "JOIN: " + Arrays.stream(bitmaps).map(Bitmap::toString).collect(Collectors.joining(", "));
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
@@ -109,6 +109,20 @@ public class FacetGroupAndFormula extends AbstractFormula implements FacetGroupF
 		final StringBuilder sb = new StringBuilder("FACET " + referenceName + " AND (" + ofNullable(facetGroupId).map(Object::toString).orElse("-") + " - " + facetIds.toString() + "): ");
 		for (int i = 0; i < bitmaps.length; i++) {
 			final Bitmap bitmap = bitmaps[i];
+			sb.append(" ↦ ").append(bitmap.size());
+			if (i + 1 < facetIds.size()) {
+				sb.append(", ");
+			}
+		}
+		return sb.append(" primary keys").toString();
+	}
+
+	@Nonnull
+	@Override
+	public String toStringVerbose() {
+		final StringBuilder sb = new StringBuilder("FACET " + referenceName + " AND (" + ofNullable(facetGroupId).map(Object::toString).orElse("-") + " - " + facetIds.toString() + "): ");
+		for (int i = 0; i < bitmaps.length; i++) {
+			final Bitmap bitmap = bitmaps[i];
 			sb.append(" ↦ ").append(bitmap.toString());
 			if (i + 1 < facetIds.size()) {
 				sb.append(", ");

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
@@ -111,6 +111,20 @@ public class FacetGroupOrFormula extends AbstractFormula implements FacetGroupFo
 		final StringBuilder sb = new StringBuilder("FACET " + referenceName + " OR (" + ofNullable(facetGroupId).map(Object::toString).orElse("-") + " - " + facetIds.toString() + "): ");
 		for (int i = 0; i < bitmaps.length; i++) {
 			final Bitmap bitmap = bitmaps[i];
+			sb.append(" ↦ ").append(bitmap.size());
+			if (i + 1 < facetIds.size()) {
+				sb.append(", ");
+			}
+		}
+		return sb.append(" primary keys").toString();
+	}
+
+	@Nonnull
+	@Override
+	public String toStringVerbose() {
+		final StringBuilder sb = new StringBuilder("FACET " + referenceName + " OR (" + ofNullable(facetGroupId).map(Object::toString).orElse("-") + " - " + facetIds.toString() + "): ");
+		for (int i = 0; i < bitmaps.length; i++) {
+			final Bitmap bitmap = bitmaps[i];
 			sb.append(" ↦ ").append(bitmap.toString());
 			if (i + 1 < facetIds.size()) {
 				sb.append(", ");

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/locale/LocaleFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/locale/LocaleFormula.java
@@ -49,4 +49,14 @@ public class LocaleFormula extends ConstantFormula {
 		return CLASS_ID;
 	}
 
+	@Override
+	public String toString() {
+		return "LOCALE: " + super.toString();
+	}
+
+	@Nonnull
+	@Override
+	public String toStringVerbose() {
+		return "LOCALE: " + super.toStringVerbose();
+	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
@@ -117,6 +117,13 @@ public class FormulaCloner implements FormulaVisitor {
 	}
 
 	/**
+	 * Returns true if all parents match the passed predicate.
+	 */
+	public boolean allParentsMatch(@Nonnull Predicate<Formula> formulaTester) {
+		return parents.stream().allMatch(formulaTester);
+	}
+
+	/**
 	 * Returns true if there is at least single parent formula of passed `formulaType` for currently visited formula.
 	 */
 	public boolean isWithin(@Nonnull Class<? extends Formula> formulaType) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/PrettyPrintingFormulaVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/PrettyPrintingFormulaVisitor.java
@@ -46,6 +46,10 @@ public class PrettyPrintingFormulaVisitor implements FormulaVisitor {
 	 */
 	private final int indent;
 	/**
+	 * Contains true if the calculated results should contain precise primary keys.
+	 */
+	private final PrettyPrintStyle style;
+	/**
 	 * This map keeps track of already seen formulas so that we can mark duplicate instances in tree as references
 	 * to them.
 	 */
@@ -57,17 +61,33 @@ public class PrettyPrintingFormulaVisitor implements FormulaVisitor {
 
 	public PrettyPrintingFormulaVisitor() {
 		this.indent = 3;
+		this.style = PrettyPrintStyle.NORMAL;
 	}
 
 	public PrettyPrintingFormulaVisitor(int indent) {
 		this.indent = indent;
+		this.style = PrettyPrintStyle.NORMAL;
+	}
+
+	public PrettyPrintingFormulaVisitor(int indent, @Nonnull PrettyPrintStyle style) {
+		this.indent = indent;
+		this.style = style;
 	}
 
 	/**
 	 * Preferred way of invoking this visitor. Accepts formula (tree) and produces description string.
 	 */
-	public static String toString(Formula formula) {
-		final PrettyPrintingFormulaVisitor visitor = new PrettyPrintingFormulaVisitor();
+	public static String toString(@Nonnull Formula formula) {
+		final PrettyPrintingFormulaVisitor visitor = new PrettyPrintingFormulaVisitor(3);
+		formula.accept(visitor);
+		return visitor.getResult();
+	}
+
+	/**
+	 * Preferred way of invoking this visitor. Accepts formula (tree) and produces description string.
+	 */
+	public static String toStringVerbose(@Nonnull Formula formula) {
+		final PrettyPrintingFormulaVisitor visitor = new PrettyPrintingFormulaVisitor(3, PrettyPrintStyle.VERBOSE);
 		formula.accept(visitor);
 		return visitor.getResult();
 	}
@@ -83,9 +103,14 @@ public class PrettyPrintingFormulaVisitor implements FormulaVisitor {
 			formulasSeen.put(formula, new FormulaInstance(id, formula));
 			result.append("[#").append(id).append("] ");
 		}
-		result.append(formula);
+		if (style == PrettyPrintStyle.VERBOSE) {
+			result.append(formula.toStringVerbose());
+		} else {
+			result.append(formula);
+		}
 		if (formula.getInnerFormulas().length > 0) {
-			result.append(" → ").append(formula.compute());
+			result.append(" → ")
+				.append(style == PrettyPrintStyle.VERBOSE ? formula.compute() : " result count " + formula.compute().size());
 		}
 		result.append("\n");
 		level++;
@@ -106,6 +131,22 @@ public class PrettyPrintingFormulaVisitor implements FormulaVisitor {
 	private static class FormulaInstance {
 		private final int id;
 		private final Formula formula;
+	}
+
+	/**
+	 * Defines the style of pretty-printing.
+	 */
+	public enum PrettyPrintStyle {
+
+		/**
+		 * Output is concise and contains only necessary information.
+		 */
+		NORMAL,
+		/**
+		 * Output is verbose and contains all possible information.
+		 */
+		VERBOSE
+
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/FilterFormulaFacetOptimizeVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/FilterFormulaFacetOptimizeVisitor.java
@@ -77,6 +77,6 @@ public class FilterFormulaFacetOptimizeVisitor extends AbstractFormulaStructureO
 		final FilterFormulaFacetOptimizeVisitor visitor = new FilterFormulaFacetOptimizeVisitor();
 		inputFormula.accept(visitor);
 		return visitor.userFormulaFound ?
-			visitor.getResult() : FormulaFactory.and(inputFormula, new UserFilterFormula());
+			visitor.getResult() : FormulaFactory.and(visitor.getResult(), new UserFilterFormula());
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/MutableFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/MutableFormula.java
@@ -182,6 +182,12 @@ class MutableFormula implements Formula {
 		return getInnerFormula().toString();
 	}
 
+	@Nonnull
+	@Override
+	public String toStringVerbose() {
+		return getInnerFormula().toStringVerbose();
+	}
+
 	/**
 	 * Returns the inner formula. If the pivot is set, the result is merged with the pivot.
 	 * @return the inner formula

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/utils/AbstractFormulaStructureOptimizeVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/utils/AbstractFormulaStructureOptimizeVisitor.java
@@ -108,7 +108,7 @@ public abstract class AbstractFormulaStructureOptimizeVisitor implements Formula
 
 		// we found formula to optimize for - duplicate current container with separate sub container
 		// for all other formulas except the one we optimize for
-		if (optimizationSet.contains(formula) && !(formula instanceof NotFormula)) {
+		if (optimizationSet.contains(formula) && !(formula instanceof NotFormula) && updatedChildren.length > 2) {
 
 			final CompositeObjectArray<Formula> newDivertedFormulas = new CompositeObjectArray<>(Formula.class);
 			final CompositeObjectArray<Formula> matchingFormulas = new CompositeObjectArray<>(Formula.class);
@@ -178,8 +178,8 @@ public abstract class AbstractFormulaStructureOptimizeVisitor implements Formula
 		if (levelStack.isEmpty()) {
 			this.result = formula;
 		} else {
-			levelStack.peek().add(formula);
-			optimizationSet.add(formula);
+			this.levelStack.peek().add(formula);
+			this.optimizationSet.add(formula);
 		}
 	}
 

--- a/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/facet/producer/FilterFormulaFacetOptimizeVisitorTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/facet/producer/FilterFormulaFacetOptimizeVisitorTest.java
@@ -76,7 +76,7 @@ class FilterFormulaFacetOptimizeVisitorTest {
 			         [#10] FACET BRAND OR (1 - [1]):  ↦ [1]
 			         [#11] FACET STORE OR (1 - [1]):  ↦ [2]
 			""",
-			PrettyPrintingFormulaVisitor.toString(optimizedFormula)
+			PrettyPrintingFormulaVisitor.toStringVerbose(optimizedFormula)
 		);
 	}
 
@@ -128,7 +128,7 @@ class FilterFormulaFacetOptimizeVisitorTest {
 			               [#17] FACET BRAND OR (1 - [2]):  ↦ [7]
 			               [#18] FACET STORE OR (1 - [3]):  ↦ [9]
 			""",
-			PrettyPrintingFormulaVisitor.toString(optimizedFormula)
+			PrettyPrintingFormulaVisitor.toStringVerbose(optimizedFormula)
 		);
 	}
 

--- a/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/facet/producer/ImpactFormulaGeneratorTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/facet/producer/ImpactFormulaGeneratorTest.java
@@ -88,7 +88,7 @@ class ImpactFormulaGeneratorTest {
 			   [#2] USER FILTER → [8, 9, 10]
 			      [#3] FACET BRAND OR (5 - [10, 15]):  ↦ [9],  ↦ [8, 9, 10]
 			""",
-			PrettyPrintingFormulaVisitor.toString(updatedFormula)
+			PrettyPrintingFormulaVisitor.toStringVerbose(updatedFormula)
 		);
 	}
 
@@ -115,7 +115,7 @@ class ImpactFormulaGeneratorTest {
 			      [#3] FACET BRAND OR (8 - [10]):  ↦ [9]
 			      [#4] FACET BRAND OR (5 - [15]):  ↦ [8, 9, 10]
 			""",
-			PrettyPrintingFormulaVisitor.toString(updatedFormula)
+			PrettyPrintingFormulaVisitor.toStringVerbose(updatedFormula)
 		);
 	}
 
@@ -144,7 +144,7 @@ class ImpactFormulaGeneratorTest {
 			      [#3] FACET BRAND OR (8 - [10]):  ↦ [9]
 			      [#4] FACET BRAND AND (5 - [15]):  ↦ [8, 9, 10]
 			""",
-			PrettyPrintingFormulaVisitor.toString(updatedFormula)
+			PrettyPrintingFormulaVisitor.toStringVerbose(updatedFormula)
 		);
 	}
 
@@ -177,7 +177,7 @@ class ImpactFormulaGeneratorTest {
 			            [#5] FACET BRAND OR (8 - [10]):  ↦ [9]
 			         [#6] FACET BRAND OR (5 - [15]):  ↦ [8, 9, 10]
 			""",
-			PrettyPrintingFormulaVisitor.toString(updatedFormula)
+			PrettyPrintingFormulaVisitor.toStringVerbose(updatedFormula)
 		);
 	}
 
@@ -210,7 +210,7 @@ class ImpactFormulaGeneratorTest {
 			            [Ref to #1] [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 			            [#6] FACET BRAND OR (8 - [10]):  ↦ [9]
 			""",
-			PrettyPrintingFormulaVisitor.toString(updatedFormula)
+			PrettyPrintingFormulaVisitor.toStringVerbose(updatedFormula)
 		);
 	}
 


### PR DESCRIPTION
When UserFilterFormula was not part of the computational tree, the facet impact computation didn't work well. Also the calculation of the best query plan tree was inverse and that was corrected as well. Finally the pretty printing visitor got split in normal and verbose mode. The normal mode is much more comprehensible when debugging larger trees.