### PR TITLE
perf(#559): Entity fetching optimization

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/ReferencedEntityFetcher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/ReferencedEntityFetcher.java
@@ -323,16 +323,13 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 
 		// enrich and limit entities them appropriately
 		if (!entities.isEmpty()) {
-			referenceFetcher.initReferenceIndex(entities, entityCollection);
-			entities.forEach(
-				// if so, enrich or limit the existing entity for desired scope
-				previouslyFetchedEntity -> {
-					final SealedEntity refEntity = queryContext.enrichOrLimitReferencedEntity(
-						previouslyFetchedEntity, fetchRequest, referenceFetcher
-					);
-					entityIndex.put(refEntity.getPrimaryKey(), refEntity);
-				}
-			);
+			entityCollection.applyReferenceFetcher(
+				entities.stream()
+					.map(it -> entityCollection.enrichEntity(it, fetchRequest))
+					.map(it -> entityCollection.limitEntity(it, fetchRequest, queryContext.getEvitaSession()))
+					.toList(),
+				referenceFetcher
+			).forEach(refEntity -> entityIndex.put(refEntity.getPrimaryKey(), refEntity));
 		}
 		return entityIndex;
 	}


### PR DESCRIPTION
When the entity is fetched from the data store, it's entity body storage part is always fetched twice. This becomes a problem when a large number of entities are fetched from the data store, and when the OS file cache is cold, it can mean twice the latency. This fetching is not entirely necessary if we refactor the `enrichEntity` method into two separate ones and call the second one only conditionally.