### PR TITLE
fix(#531): Random errors and NullPointerExceptions in ChainIndex

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/ConsistencySensitiveDataStructure.java
+++ b/evita_engine/src/main/java/io/evitadb/ConsistencySensitiveDataStructure.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/main/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * All {@link io.evitadb.index.Index} and {@link io.evitadb.index.IndexDataStructure} that are sensitive to data
+ * consistency should implement this interface. The interface provides a method to check the consistency of the index
+ * and return a report about the state of the index.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+public interface ConsistencySensitiveDataStructure {
+
+	/**
+	 * Returns up-to-date consistency report of the index instance.
+	 *
+	 * @return consistency report of the index
+	 */
+	@Nonnull
+	ConsistencyReport getConsistencyReport();
+
+	/**
+	 * Describes the consistency state of the index.
+	 */
+	enum ConsistencyState {
+		/**
+		 * All data in the index are in consistent state.
+		 */
+		CONSISTENT,
+		/**
+		 * Index is operating ok, but some data are not consistent from the user prospective. This state is usually
+		 * temporary and should be eventually corrected by new data arriving to the index.
+		 */
+		INCONSISTENT,
+		/**
+		 * Index internal state is broken. This state may never happen and if it does, it usually means error in
+		 * evitaDB implementation. The only solution is to rebuild the index from scratch.
+		 */
+		BROKEN
+	}
+
+	/**
+	 * Describes the consistency state of the index.
+	 *
+	 * @param state  enum signaling the state of the index
+	 * @param report textual description of the state in English / Markdown format
+	 */
+	record ConsistencyReport(
+		@Nonnull ConsistencyState state,
+		@Nullable String report
+	) {
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/ChainIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/ChainIndex.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.index.attribute;
 
+import io.evitadb.ConsistencySensitiveDataStructure;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.core.Catalog;
 import io.evitadb.core.Transaction;
@@ -31,7 +32,6 @@ import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.dataType.Predecessor;
-import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.index.IndexDataStructure;
 import io.evitadb.index.array.TransactionalUnorderedIntArray;
@@ -40,6 +40,7 @@ import io.evitadb.index.bool.TransactionalBoolean;
 import io.evitadb.index.map.TransactionalMap;
 import io.evitadb.store.model.StoragePart;
 import io.evitadb.store.spi.model.storageParts.index.ChainIndexStoragePart;
+import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 import lombok.Getter;
 
@@ -53,6 +54,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.PrimitiveIterator.OfInt;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -78,7 +80,12 @@ import static java.util.Optional.ofNullable;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2023
  */
-public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLayerProducer<ChainIndexChanges, ChainIndex>, IndexDataStructure, Serializable {
+public class ChainIndex implements
+	IndexDataStructure,
+	ConsistencySensitiveDataStructure,
+	SortedRecordsSupplierFactory,
+	TransactionalLayerProducer<ChainIndexChanges, ChainIndex>,
+	Serializable {
 	@Serial private static final long serialVersionUID = 6633952268102524794L;
 	/**
 	 * Index contains tuples of entity primary key and its predecessor primary key. The conflicting primary key is
@@ -150,8 +157,6 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 		this.dirty = new TransactionalBoolean();
 		this.chains = new TransactionalMap<>(chains, TransactionalUnorderedIntArray.class, TransactionalUnorderedIntArray::new);
 		this.elementStates = new TransactionalMap<>(elementStates);
-		// TOBEDONE #531 - REMOVE WHEN THE ISSUE GETS FIXED
-		checkForCorruption();
 	}
 
 	/**
@@ -213,26 +218,23 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 	 * @param primaryKey  primary key of the element
 	 */
 	public void upsertPredecessor(@Nonnull Predecessor predecessor, int primaryKey) {
-		try {
-			Assert.isTrue(
-				primaryKey != predecessor.predecessorId(),
-				"An entity that is its own predecessor doesn't have sense!"
-			);
-			final ChainElementState existingState = this.elementStates.get(primaryKey);
+		Assert.isTrue(
+			primaryKey != predecessor.predecessorId(),
+			"An entity that is its own predecessor doesn't have sense!"
+		);
+		final ChainElementState existingState = this.elementStates.get(primaryKey);
+		if (existingState == null) {
 			// if existing state is not found - we need to insert new one
-			if (existingState == null) {
-				insertPredecessor(primaryKey, predecessor);
-			} else {
-				updatePredecessor(primaryKey, predecessor, existingState);
-			}
-			this.dirty.setToTrue();
-			getOrCreateChainIndexChanges().reset();
-		} catch (RuntimeException ex) {
-			throw new ChainUpdateFailedException(
-				"State of the index: " + this.toString(),
-				ex
-			);
+			insertPredecessor(primaryKey, predecessor);
+		} else if (existingState.predecessorPrimaryKey() == predecessor.predecessorId()) {
+			// the predecessor is the same - nothing to do
+			return;
+		} else {
+			// otherwise we need to perform update
+			updatePredecessor(primaryKey, predecessor, existingState);
 		}
+		this.dirty.setToTrue();
+		getOrCreateChainIndexChanges().reset();
 	}
 
 	/**
@@ -241,22 +243,15 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 	 * @param primaryKey primary key of the element
 	 */
 	public void removePredecessor(int primaryKey) {
-		try {
-			final ChainElementState existingState = this.elementStates.remove(primaryKey);
-			isTrue(
-				existingState != null,
-				"Value `" + primaryKey + "` is not present in the chain element index!"
-			);
-			// if existing state is not found - we need to insert new one
-			removePredecessorFromChain(primaryKey, existingState);
-			this.dirty.setToTrue();
-			getOrCreateChainIndexChanges().reset();
-		} catch (RuntimeException ex) {
-			throw new ChainUpdateFailedException(
-				"State of the index: " + this.toString(),
-				ex
-			);
-		}
+		final ChainElementState existingState = this.elementStates.remove(primaryKey);
+		isTrue(
+			existingState != null,
+			"Value `" + primaryKey + "` is not present in the chain element index!"
+		);
+		// if existing state is not found - we need to insert new one
+		removePredecessorFromChain(primaryKey, existingState);
+		this.dirty.setToTrue();
+		getOrCreateChainIndexChanges().reset();
 	}
 
 	/**
@@ -264,6 +259,172 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 	 */
 	public boolean isEmpty() {
 		return this.elementStates.isEmpty();
+	}
+
+	@Nonnull
+	@Override
+	public SortedRecordsSupplier getAscendingOrderRecordsSupplier() {
+		return getOrCreateChainIndexChanges().getAscendingOrderRecordsSupplier();
+	}
+
+	@Nonnull
+	@Override
+	public SortedRecordsSupplier getDescendingOrderRecordsSupplier() {
+		return getOrCreateChainIndexChanges().getDescendingOrderRecordsSupplier();
+	}
+
+	/**
+	 * This method verifies internal consistency of the data-structure. It checks whether the chains are correctly
+	 * ordered and whether the element states are correctly set.
+	 */
+	@Nonnull
+	@Override
+	public ConsistencyReport getConsistencyReport() {
+		final StringBuilder errors = new StringBuilder(512);
+
+		int overallCount = 0;
+		for (Entry<Integer, TransactionalUnorderedIntArray> entry : chains.entrySet()) {
+			overallCount += entry.getValue().getLength();
+			final int[] unorderedList = entry.getValue().getArray();
+			if (unorderedList.length <= 0) {
+				errors.append("\nThe chain with head `")
+					.append(entry.getKey())
+					.append("` is empty!");
+			}
+			int headElementId = unorderedList[0];
+			if (headElementId != entry.getKey()) {
+				errors.append("\nThe head of the chain `")
+					.append(headElementId).append("` doesn't match the chain head `")
+					.append(entry.getKey())
+					.append("`!");
+			}
+
+			int previousElementId = headElementId;
+			for (int i = 0; i < unorderedList.length; i++) {
+				int elementId = unorderedList[i];
+				final ChainElementState state = elementStates.get(elementId);
+				if (state == null) {
+					errors.append("\nThe element `")
+						.append(elementId)
+						.append("` is not present in the element states!");
+				}
+				if (i > 0) {
+					if (state.state() == ElementState.HEAD) {
+						errors.append("\nThe element `")
+							.append(elementId)
+							.append("` must not be a head of the chain!");
+					}
+					if (state.inChainOfHeadWithPrimaryKey() != headElementId) {
+						errors.append("\nThe element `")
+							.append(elementId)
+							.append("` is not in the chain with head `")
+							.append(headElementId)
+							.append("`!");
+					}
+					if (state.predecessorPrimaryKey() != previousElementId) {
+						errors.append("\nThe predecessor of the element `")
+							.append(elementId)
+							.append("` doesn't match the previous element!");
+					}
+				}
+				previousElementId = elementId;
+			}
+
+			final Integer headId = entry.getKey();
+			final ChainElementState headState = this.elementStates.get(headId);
+			if (headState.state() == ElementState.CIRCULAR) {
+				// the chain must contain element the head refers to
+				if (Arrays.stream(entry.getValue().getArray()).noneMatch(it -> it == headState.predecessorPrimaryKey())) {
+					errors.append("\nThe chain with CIRCULAR head `")
+						.append(headId)
+						.append("` doesn't contain element `")
+						.append(headState.predecessorPrimaryKey())
+						.append("` the head refers to!");
+				}
+			} else {
+				// the chain must not contain element the head refers to
+				if (Arrays.stream(entry.getValue().getArray()).anyMatch(it -> it == headState.predecessorPrimaryKey())) {
+					errors.append("\nThe chain with head `")
+						.append(headId)
+						.append("` contain element `")
+						.append(headState.predecessorPrimaryKey())
+						.append("` the head refers to and is not marked as CIRCULAR!");
+				}
+			}
+		}
+
+		for (Entry<Integer, ChainElementState> entry : elementStates.entrySet()) {
+			final int chainHeadPk = entry.getValue().inChainOfHeadWithPrimaryKey();
+			if (entry.getValue().state() == ElementState.SUCCESSOR) {
+				final TransactionalUnorderedIntArray chain = this.chains.get(chainHeadPk);
+				if (chain == null) {
+					errors.append("\nThe referenced chain with head `")
+						.append(chainHeadPk)
+						.append("` referenced by ")
+						.append(entry.getValue().state())
+						.append("` element `")
+						.append(entry.getKey())
+						.append("` doesn't exist!");
+				} else if (chain.indexOf(entry.getKey()) < 0) {
+					errors.append("\nThe `")
+						.append(entry.getValue().state())
+						.append("` element `")
+						.append(entry.getKey())
+						.append("` is not in the chain with head `")
+						.append(chainHeadPk)
+						.append("`!");
+				}
+			} else if (chainHeadPk != entry.getKey()) {
+				errors.append("\nThe `")
+					.append(entry.getValue().state())
+					.append("` element `")
+					.append(entry.getKey())
+					.append("` is not in the chain with head `")
+					.append(chainHeadPk)
+					.append("`!");
+			}
+		}
+
+		if (overallCount != elementStates.size()) {
+			errors.append("\nThe number of elements in chains doesn't match " +
+				"the number of elements in element states!");
+		}
+
+		final ConsistencyState state;
+		if (!errors.isEmpty()) {
+			state = ConsistencyState.BROKEN;
+		} else if (isConsistent()) {
+			state = ConsistencyState.CONSISTENT;
+		} else {
+			state = ConsistencyState.INCONSISTENT;
+		}
+
+		final String chainsListing = chains.values()
+			.stream()
+			.map(it -> {
+				final StringBuilder sb = new StringBuilder("\t- ");
+				final OfInt pkIt = it.iterator();
+				int counter = 0;
+				while (pkIt.hasNext() && sb.length() < 80) {
+					if (counter > 0) {
+						sb.append(", ");
+					}
+					sb.append(pkIt.nextInt());
+					counter++;
+				}
+				if (counter < it.getLength()) {
+					sb.append("... (")
+						.append(it.getLength() - counter)
+						.append(" more)");
+				}
+				return sb.toString();
+			})
+			.collect(Collectors.joining("\n"));
+		return new ConsistencyReport(
+			state,
+			"## Chains\n\n" + chainsListing + "\n\n" +
+				(errors.isEmpty() ? "## No errors detected." : "## Errors detected\n\n" + errors)
+		);
 	}
 
 	/**
@@ -293,15 +454,14 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 		this.dirty.reset();
 	}
 
+	/*
+		Implementation of TransactionalLayerProducer
+	 */
+
 	@Override
 	public ChainIndexChanges createLayer() {
 		return new ChainIndexChanges(this);
 	}
-
-
-	/*
-		Implementation of TransactionalLayerProducer
-	 */
 
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
@@ -332,49 +492,9 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 			"   - elementStates:\n" + elementStates.entrySet().stream().map(it -> "      - " + it.getKey() + ": " + it.getValue()).collect(Collectors.joining("\n"));
 	}
 
-	@Nonnull
-	@Override
-	public SortedRecordsSupplier getAscendingOrderRecordsSupplier() {
-		return getOrCreateChainIndexChanges().getAscendingOrderRecordsSupplier();
-	}
-
-	@Nonnull
-	@Override
-	public SortedRecordsSupplier getDescendingOrderRecordsSupplier() {
-		return getOrCreateChainIndexChanges().getDescendingOrderRecordsSupplier();
-	}
-
-	/**
-	 * This method verifies internal consistency of the data-structure. It checks whether the chains are correctly
-	 * ordered and whether the element states are correctly set.
+	/*
+		PRIVATE METHODS
 	 */
-	private void checkForCorruption() {
-		int overallCount = 0;
-		for (Entry<Integer, TransactionalUnorderedIntArray> entry : chains.entrySet()) {
-			overallCount += entry.getValue().getLength();
-			final int[] unorderedList = entry.getValue().getArray();
-			Assert.isPremiseValid(unorderedList.length > 0, () -> new ChainIndexCorruptedException("Corruption detected! The chain with head `" + entry.getKey() + "` is empty!"));
-			int headElementId = unorderedList[0];
-			Assert.isPremiseValid(headElementId == entry.getKey(), () -> new ChainIndexCorruptedException("Corruption detected! The head of the chain `" + headElementId + "` doesn't match the chain head `" + entry.getKey() + "`!"));
-
-			int previousElementId = headElementId;
-			for (int i = 0; i < unorderedList.length; i++) {
-				int elementId = unorderedList[i];
-				final ChainElementState state = elementStates.get(elementId);
-				Assert.isPremiseValid(state != null, () -> new ChainIndexCorruptedException("Corruption detected! The element `" + elementId + "` is not present in the element states!"));
-				if (i > 0) {
-					Assert.isPremiseValid(state.state() != ElementState.HEAD, () -> new ChainIndexCorruptedException("Corruption detected! The element `" + elementId + "` must not be a head of the chain!"));
-					Assert.isPremiseValid(state.inChainOfHeadWithPrimaryKey() == headElementId, () -> new ChainIndexCorruptedException("Corruption detected! The element `" + elementId + "` is not in the chain with head `" + headElementId + "`!"));
-					Assert.isPremiseValid(state.predecessorPrimaryKey() == previousElementId, () -> new ChainIndexCorruptedException("Corruption detected! The predecessor of the element `" + elementId + "` doesn't match the previous element!"));
-				}
-				previousElementId = elementId;
-			}
-		}
-		Assert.isPremiseValid(
-			overallCount == elementStates.size(),
-			() -> new ChainIndexCorruptedException("Corruption detected! The number of elements in chains doesn't match the number of elements in element states!")
-		);
-	}
 
 	/**
 	 * Retrieves or creates temporary data structure. When transaction exists it's created in the transactional memory
@@ -454,6 +574,7 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 		// if the primary key is successor of its chain
 		final TransactionalUnorderedIntArray chain = ofNullable(this.chains.get(chainHeadPk))
 			.orElseThrow(() -> new EvitaInvalidUsageException("Chain with head `" + chainHeadPk + "` is not present in the index!"));
+		final ChainElementState existingStateHeadState = this.elementStates.get(chainHeadPk);
 
 		final int index = chain.indexOf(primaryKey);
 		// sanity check - the primary key must be present in the chain according to the state information
@@ -470,9 +591,19 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 				final int[] subChainWithoutRemovedElement = Arrays.copyOfRange(subChain, 1, subChain.length);
 				this.chains.put(subChainWithoutRemovedElement[0], new TransactionalUnorderedIntArray(subChainWithoutRemovedElement));
 				reclassifyChain(subChainWithoutRemovedElement[0], subChainWithoutRemovedElement);
+
+				// verify whether the head of chain was not in circular conflict and if so
+				verifyIfCircularDependencyExistsAndIsBroken(existingStateHeadState);
 			} else {
 				// just remove it from the chain
 				chain.removeRange(index, chain.getLength());
+				// if the primary key was the perpetrator of the circular dependency, remove the status
+				if (existingStateHeadState.state() == ElementState.CIRCULAR && existingStateHeadState.predecessorPrimaryKey() == primaryKey) {
+					this.elementStates.put(
+						chainHeadPk,
+						new ChainElementState(existingStateHeadState, ElementState.SUCCESSOR)
+					);
+				}
 			}
 			return OptionalInt.of(chainHeadPk);
 		} else {
@@ -507,6 +638,14 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 					// we may safely append the primary key to it
 					predecessorChain.add(predecessor.predecessorId(), primaryKey);
 					this.elementStates.put(primaryKey, new ChainElementState(chainHeadId, predecessor, ElementState.SUCCESSOR));
+					// if the head of the chain refers to the appended primary key - we have circular dependency
+					final ChainElementState chainHeadState = this.elementStates.get(chainHeadId);
+					if (chainHeadState.predecessorPrimaryKey() == primaryKey) {
+						this.elementStates.put(
+							chainHeadId,
+							new ChainElementState(chainHeadState, ElementState.CIRCULAR)
+						);
+					}
 				} else {
 					// we have to create new "split" chain for the primary key
 					introduceNewSuccessorChain(primaryKey, predecessor);
@@ -619,40 +758,56 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 			final int movedChainHeadPk;
 
 			final ChainElementState predecessorState = this.elementStates.get(predecessor.predecessorId());
-			final TransactionalUnorderedIntArray predecessorChain = this.chains.get(predecessorState.inChainOfHeadWithPrimaryKey());
-			// if we append the sub-chain to after the last record of the predecessor chain
-			if (predecessor.predecessorId() == predecessorChain.getLastRecordId()) {
-				// we can merge both chains together
-				movedChainHeadPk = predecessorState.inChainOfHeadWithPrimaryKey();
+			if (predecessorState == null) {
+				// the predecessor doesn't exist in current index
 				if (index > 0) {
-					// the element is in the body of the chain, we need to split the chain
-					movedChain = existingChain.removeRange(index, existingChain.getLength());
-					// append only the sub-chain to the predecessor chain
-					predecessorChain.appendAll(movedChain);
-				} else {
-					// the element is the head of the chain, discard the chain completely
-					final TransactionalUnorderedIntArray removedChain = this.chains.remove(existingState.inChainOfHeadWithPrimaryKey());
-					// and fully merge with predecessor chain
-					movedChain = existingChain.getArray();
-					predecessorChain.appendAll(movedChain);
-					// if there was transactional memory associated with the chain, discard it
-					removedChain.removeLayer();
-				}
-			} else {
-				// if the element is in the body of the chain and is already successor of the predecessor
-				if (index > 0 && predecessor.predecessorId() == existingChain.get(index - 1)) {
-					// do nothing - the update doesn't affect anything
-					return;
-				} else if (index > 0) {
-					// the element is in the body of the chain, we need to split the chain - we have a situation with
-					// multiple successors of the single predecessor
+					// we need to split the chain and make new successor chain
 					movedChain = existingChain.removeRange(index, existingChain.getLength());
 					movedChainHeadPk = primaryKey;
 					this.chains.put(primaryKey, new TransactionalUnorderedIntArray(movedChain));
 				} else {
-					// leave the current chain be - we need to switch the state to SUCCESSOR only
+					// but we tackle the head of the chain - so we don't have to do anything
+					movedChainHeadPk = primaryKey;
 					movedChain = null;
-					movedChainHeadPk = existingState.inChainOfHeadWithPrimaryKey();
+				}
+			} else {
+				final TransactionalUnorderedIntArray predecessorChain = this.chains.get(predecessorState.inChainOfHeadWithPrimaryKey());
+				// if we append the sub-chain to after the last record of the predecessor chain
+				if (predecessor.predecessorId() == predecessorChain.getLastRecordId()) {
+					// we can merge both chains together
+					movedChainHeadPk = predecessorState.inChainOfHeadWithPrimaryKey();
+					if (index > 0) {
+						// the element is in the body of the chain, we need to split the chain
+						movedChain = existingChain.removeRange(index, existingChain.getLength());
+						// append only the sub-chain to the predecessor chain
+						predecessorChain.appendAll(movedChain);
+						// if the appended chain contains primary key the head of predecessor chain refers to - we have circular dependency
+						examineCircularConflictInNewlyAppendedChain(predecessorState.inChainOfHeadWithPrimaryKey(), movedChain);
+					} else {
+						// the element is the head of the chain, discard the chain completely
+						final TransactionalUnorderedIntArray removedChain = this.chains.remove(existingState.inChainOfHeadWithPrimaryKey());
+						// and fully merge with predecessor chain
+						movedChain = existingChain.getArray();
+						predecessorChain.appendAll(movedChain);
+						// if there was transactional memory associated with the chain, discard it
+						removedChain.removeLayer();
+					}
+				} else {
+					// if the element is in the body of the chain and is already successor of the predecessor
+					if (index > 0 && predecessor.predecessorId() == existingChain.get(index - 1)) {
+						// do nothing - the update doesn't affect anything
+						return;
+					} else if (index > 0) {
+						// the element is in the body of the chain, we need to split the chain - we have a situation with
+						// multiple successors of the single predecessor
+						movedChain = existingChain.removeRange(index, existingChain.getLength());
+						movedChainHeadPk = primaryKey;
+						this.chains.put(primaryKey, new TransactionalUnorderedIntArray(movedChain));
+					} else {
+						// leave the current chain be - we need to switch the state to SUCCESSOR only
+						movedChain = null;
+						movedChainHeadPk = existingState.inChainOfHeadWithPrimaryKey();
+					}
 				}
 			}
 
@@ -660,6 +815,9 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 			this.elementStates.put(primaryKey, new ChainElementState(movedChainHeadPk, predecessor, ElementState.SUCCESSOR));
 			// if there was a chain split
 			if (movedChain != null) {
+				// check whether the new head doesn't introduce circular dependency with new chain
+				examineCircularConflictInNewlyAppendedChain(movedChainHeadPk, movedChain);
+
 				// then we need to update the chain head for all other elements in the split chain
 				// (except the element itself which was already updated by previous statement)
 				for (int i = 1; i < movedChain.length; i++) {
@@ -679,6 +837,24 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 
 			// verify whether the head of chain was not in circular conflict and if so
 			verifyIfCircularDependencyExistsAndIsBroken(existingStateHeadState);
+		}
+	}
+
+	/**
+	 * Method check whether there is circular dependency between chain head predecessor and the contents of the appended
+	 * chain. If so, the chain head is marked as circular.
+	 *
+	 * @param chainHeadPrimaryKey primary key of the chain head
+	 * @param appendedChain       chain that was appended to the chain head
+	 */
+	private void examineCircularConflictInNewlyAppendedChain(int chainHeadPrimaryKey, int[] appendedChain) {
+		final ChainElementState predecessorChainHeadState = this.elementStates.get(chainHeadPrimaryKey);
+		final boolean newCircularConflict = ArrayUtils.indexOf(predecessorChainHeadState.predecessorPrimaryKey(), appendedChain) >= 0;
+		if (newCircularConflict) {
+			this.elementStates.put(
+				chainHeadPrimaryKey,
+				new ChainElementState(predecessorChainHeadState, ElementState.CIRCULAR)
+			);
 		}
 	}
 
@@ -728,12 +904,20 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 		// if original chain head is in circular dependency
 		if (originalChainHeadState.state() == ElementState.CIRCULAR) {
 			final TransactionalUnorderedIntArray originalHeadChain = this.chains.get(originalChainHeadState.inChainOfHeadWithPrimaryKey());
-			// verify it is still in circular dependency
-			if (originalHeadChain.indexOf(originalChainHeadState.predecessorPrimaryKey()) < 0) {
-				// the circular dependency was broken
-				this.elementStates.put(
+			if (originalHeadChain != null) {
+				// verify it is still in circular dependency
+				if (originalHeadChain.indexOf(originalChainHeadState.predecessorPrimaryKey()) < 0) {
+					// the circular dependency was broken
+					this.elementStates.put(
+						originalChainHeadState.inChainOfHeadWithPrimaryKey(),
+						new ChainElementState(originalChainHeadState, ElementState.SUCCESSOR)
+					);
+				}
+			} else {
+				// the circular dependency was broken - the chain is now part of another chain
+				this.elementStates.compute(
 					originalChainHeadState.inChainOfHeadWithPrimaryKey(),
-					new ChainElementState(originalChainHeadState, ElementState.SUCCESSOR)
+					(k, newState) -> new ChainElementState(newState, ElementState.SUCCESSOR)
 				);
 			}
 		}
@@ -746,8 +930,10 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 	 */
 	private void reclassifyChain(int inChainOfHeadWithPrimaryKey, @Nonnull int[] primaryKeys) {
 		for (int splitPk : primaryKeys) {
-			final ChainElementState movedPkState = this.elementStates.get(splitPk);
-			this.elementStates.put(splitPk, new ChainElementState(inChainOfHeadWithPrimaryKey, movedPkState));
+			this.elementStates.compute(
+				splitPk,
+				(key, movedPkState) -> new ChainElementState(inChainOfHeadWithPrimaryKey, movedPkState)
+			);
 		}
 	}
 
@@ -810,6 +996,8 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 				removedChain.removeLayer();
 				predecessorChain.appendAll(movedChain);
 				reclassifyChain(predecessorState.inChainOfHeadWithPrimaryKey(), movedChain);
+				// if the moved chain contains primary key the new head refers to - we have circular dependency
+				examineCircularConflictInNewlyAppendedChain(predecessorState.inChainOfHeadWithPrimaryKey(), movedChain);
 				return predecessorState.inChainOfHeadWithPrimaryKey();
 			}
 		}
@@ -831,30 +1019,49 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 		final int lastRecordId = chain.getLastRecordId();
 		final Optional<Integer> collapsableChain = this.chains.keySet()
 			.stream()
-			.filter(pk -> {
-				final ChainElementState theState = this.elementStates.get(pk);
-				return theState.state() == ElementState.SUCCESSOR && theState.predecessorPrimaryKey() == lastRecordId;
-			})
+			.filter(pk -> this.elementStates.get(pk).predecessorPrimaryKey() == lastRecordId)
 			.findFirst();
 		if (collapsableChain.isPresent()) {
-			final ChainElementState headChainState = this.elementStates.get(collapsableChain.get());
-			final TransactionalUnorderedIntArray chainToBeCollapsed = this.chains.get(collapsableChain.get());
-			if (chainToBeCollapsed.indexOf(headChainState.predecessorPrimaryKey()) >= 0) {
+			final Integer collapsableHeadPk = collapsableChain.get();
+			final ChainElementState collapsableHeadChainState = this.elementStates.get(collapsableHeadPk);
+			final TransactionalUnorderedIntArray chainToBeCollapsed = this.chains.get(collapsableHeadPk);
+			if (chainToBeCollapsed.indexOf(collapsableHeadChainState.predecessorPrimaryKey()) >= 0) {
 				// we have circular dependency - we can't collapse the chain
 				this.elementStates.put(
-					collapsableChain.get(),
-					new ChainElementState(headChainState, ElementState.CIRCULAR)
+					collapsableHeadPk,
+					new ChainElementState(collapsableHeadChainState, ElementState.CIRCULAR)
 				);
 				return null;
 			} else {
 				// we may append the chain to the predecessor chain
-				final TransactionalUnorderedIntArray removedChain = this.chains.remove(collapsableChain.get());
+				final TransactionalUnorderedIntArray removedChain = this.chains.remove(collapsableHeadPk);
 				final int[] movedChain = removedChain.getArray();
 				// if there was transactional memory associated with the chain, discard it
 				removedChain.removeLayer();
 				chain.appendAll(movedChain);
 				reclassifyChain(chainHeadElement, movedChain);
-				return collapsableChain.get();
+				// this collapse introduced new circular dependency
+				final ChainElementState chainHeadElementState = this.elementStates.get(chainHeadElement);
+				if (ArrayUtils.indexOf(chainHeadElementState.predecessorPrimaryKey(), movedChain) >= 0) {
+					this.elementStates.put(
+						chainHeadElement,
+						new ChainElementState(
+							chainHeadElement,
+							chainHeadState.predecessorPrimaryKey(),
+							ElementState.CIRCULAR
+						)
+					);
+				} else if (collapsableHeadChainState.state() == ElementState.CIRCULAR) {
+					this.elementStates.put(
+						collapsableHeadPk,
+						new ChainElementState(
+							chainHeadElement,
+							collapsableHeadChainState.predecessorPrimaryKey(),
+							ElementState.SUCCESSOR
+						)
+					);
+				}
+				return collapsableHeadPk;
 			}
 		}
 		return null;
@@ -938,25 +1145,6 @@ public class ChainIndex implements SortedRecordsSupplierFactory, TransactionalLa
 				default -> throw new IllegalStateException("Unexpected value: " + state);
 			}
 		}
-	}
-
-	public static class ChainIndexCorruptedException extends EvitaInternalError {
-		@Serial private static final long serialVersionUID = 8701958569974008862L;
-
-		public ChainIndexCorruptedException(@Nonnull String publicMessage) {
-			super(publicMessage);
-		}
-
-	}
-
-	/* TOBEDONE #531 - remove when fixed */
-	public static class ChainUpdateFailedException extends EvitaInternalError {
-		@Serial private static final long serialVersionUID = 8701958569974008862L;
-
-		public ChainUpdateFailedException(@Nonnull String publicMessage, @Nonnull RuntimeException cause) {
-			super(publicMessage, cause);
-		}
-
 	}
 
 }

--- a/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ChainIndexTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ChainIndexTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 
 package io.evitadb.index.attribute;
 
+import io.evitadb.ConsistencySensitiveDataStructure.ConsistencyState;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.dataType.Predecessor;
 import io.evitadb.test.duration.TimeArgumentProvider;
@@ -40,10 +41,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -51,10 +54,7 @@ import java.util.stream.Stream;
 
 import static io.evitadb.test.TestConstants.LONG_RUNNING_TEST;
 import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This test verifies the contract of {@link ChainIndex} implementation.
@@ -295,6 +295,21 @@ class ChainIndexTest implements TimeBoundedTestSupport {
 		);
 	}
 
+	@Test
+	void shouldGenerateConsistencyReport() {
+		shouldExecuteOperationsInTransactionAndStayConsistent();
+
+		assertEquals(
+			"""
+			## Chains
+
+				- 23, 26, 8, 3, 2, 4, 7, 6, 9, 10, 5, 11
+			
+			## No errors detected.""",
+			index.getConsistencyReport().report()
+		);
+	}
+
 	@ParameterizedTest(name = "ChainIndex should survive generational randomized test applying modifications on it")
 	@Tag(LONG_RUNNING_TEST)
 	@ArgumentsSource(TimeArgumentProvider.class)
@@ -400,6 +415,8 @@ class ChainIndexTest implements TimeBoundedTestSupport {
 							assertArrayEquals(desiredOrder.get(), finalArray);
 							assertTrue(original.isConsistent());
 							assertTrue(committed.isConsistent());
+							assertEquals(ConsistencyState.CONSISTENT, original.getConsistencyReport().state());
+							assertEquals(ConsistencyState.CONSISTENT, committed.getConsistencyReport().state());
 
 							originalOrder.set(finalArray);
 							transactionalIndex.set(committed);
@@ -413,6 +430,159 @@ class ChainIndexTest implements TimeBoundedTestSupport {
 				);
 
 				return new StringBuilder();
+			}
+		);
+	}
+
+	/**
+	 * This test will insert to a and remove from the data chaotically. In the final stage it reorder them in
+	 * a consistent way and checks if the final state is consistent.
+	 *
+	 * @param input input for the test
+	 */
+	@ParameterizedTest(name = "ChainIndex should survive generational randomized test with garbage")
+	@Tag(LONG_RUNNING_TEST)
+	@ArgumentsSource(TimeArgumentProvider.class)
+	void generationalAllTimeBrokenProofTest(GenerationalTestInput input) {
+		final int initialCount = 30;
+		final Random theRandom = new Random(input.randomSeed());
+		final int[] initialState = generateInitialChain(theRandom, initialCount);
+		final AtomicReference<int[]> originalOrder = new AtomicReference<>(new int[0]);
+		final AtomicReference<ChainIndex> transactionalIndex = new AtomicReference<>(this.index);
+
+		runFor(
+			input,
+			100,
+			new StringBuilder(),
+			(random, codeBuffer) -> {
+				final int[] originalState = originalOrder.get();
+
+				final ChainIndex index = transactionalIndex.get();
+				codeBuffer.append("\nSTART: ")
+					.append(
+						"int[] initialState = {" + Arrays.stream(index.getUnorderedLookup().getArray()).mapToObj(String::valueOf).collect(Collectors.joining(", ")) + "};\n" +
+							"\t\tfor (int i = 0; i < initialState.length; i++) {\n" +
+							"\t\t\tint pk = initialState[i];\n" +
+							"\t\t\tfinal Predecessor predecessor = i == 0 ? new Predecessor() : new Predecessor(initialState[i - 1]);\n" +
+							"\t\t\tindex.upsertPredecessor(predecessor, pk);\n" +
+							"\t\t}"
+					)
+					.append("\n");
+
+				assertStateAfterCommit(
+					index,
+					original -> {
+						final Deque<Integer> removedPrimaryKeys = new LinkedList<>();
+						for (int pk : originalState) {
+							if (originalState.length - removedPrimaryKeys.size() > initialCount * 0.8 && random.nextInt(5) == 0) {
+								removedPrimaryKeys.push(pk);
+							}
+						}
+
+						try {
+
+							final Set<Integer> processedPks = new HashSet<>(removedPrimaryKeys);
+							for (int i = 0; i < initialCount * 0.5; i++) {
+								final int randomPreviousIndex = random.nextInt(initialState.length);
+								final int previousPk = initialState[randomPreviousIndex];
+
+								int randomPk;
+								do {
+									randomPk = initialState[random.nextInt(initialState.length)];
+								} while (processedPks.contains(randomPk) || randomPk == previousPk);
+
+								processedPks.add(randomPk);
+								final Predecessor predecessor = randomPreviousIndex == 0 ? Predecessor.HEAD : new Predecessor(previousPk);
+
+								// change order
+								codeBuffer.append("index.upsertPredecessor(")
+									.append("new Predecessor(").append(predecessor.predecessorId()).append("), ")
+									.append(randomPk).append(");\n");
+								original.upsertPredecessor(predecessor, randomPk);
+
+								// remove the element randomly
+								if (!removedPrimaryKeys.isEmpty() && random.nextInt(5) == 0) {
+									final Integer pkToRemove = removedPrimaryKeys.pop();
+									codeBuffer.append("index.removePredecessor(")
+										.append(pkToRemove).append(");\n");
+									original.removePredecessor(pkToRemove);
+								}
+							}
+
+							while (!removedPrimaryKeys.isEmpty()) {
+								final Integer pkToRemove = removedPrimaryKeys.pop();
+								codeBuffer.append("index.removePredecessor(")
+									.append(pkToRemove).append(");\n");
+								original.removePredecessor(pkToRemove);
+							}
+
+							codeBuffer.append("\n");
+
+						} catch (Exception ex) {
+							System.out.println(codeBuffer);
+							throw ex;
+						}
+					},
+					(original, committed) -> {
+						try {
+							final int[] originalArray = original.getUnorderedLookup().getArray();
+							assertArrayEquals(originalOrder.get(), originalArray);
+							final int[] finalArray = committed.getUnorderedLookup().getArray();
+							assertNotEquals(ConsistencyState.BROKEN, committed.getConsistencyReport().state());
+
+							originalOrder.set(finalArray);
+							transactionalIndex.set(committed);
+						} catch (Throwable ex) {
+							System.out.println(codeBuffer);
+							throw ex;
+						}
+					}
+				);
+
+				return new StringBuilder();
+			}
+		);
+
+		final StringBuilder codeBuffer = new StringBuilder();
+		final int[] originalState = originalOrder.get();
+		final AtomicReference<int[]> desiredOrder = new AtomicReference<>(initialState);
+		defineTargetState(theRandom, originalState, initialCount, desiredOrder);
+		assertStateAfterCommit(
+			index,
+			original -> {
+				final int[] targetState = desiredOrder.get();
+				try {
+					for (int i = 0; i < targetState.length; i++) {
+						final int pk = targetState[i];
+						final Predecessor predecessor = i <= 0 ? Predecessor.HEAD : new Predecessor(targetState[i - 1]);
+
+						// change order
+						codeBuffer.append("index.upsertPredecessor(")
+							.append("new Predecessor(").append(predecessor.predecessorId()).append("), ")
+							.append(pk).append(");\n");
+						original.upsertPredecessor(predecessor, pk);
+					}
+
+					codeBuffer.append("\n");
+
+				} catch (Exception ex) {
+					System.out.println(codeBuffer);
+					throw ex;
+				}
+			},
+			(original, committed) -> {
+				try {
+					final int[] finalArray = committed.getUnorderedLookup().getArray();
+					assertArrayEquals(desiredOrder.get(), finalArray);
+					assertTrue(committed.isConsistent());
+					assertEquals(ConsistencyState.CONSISTENT, committed.getConsistencyReport().state());
+
+					originalOrder.set(finalArray);
+					transactionalIndex.set(committed);
+				} catch (Throwable ex) {
+					System.out.println(codeBuffer);
+					throw ex;
+				}
 			}
 		);
 	}
@@ -439,7 +609,7 @@ class ChainIndexTest implements TimeBoundedTestSupport {
 	 * @param initialCount number of elements in the chain
 	 * @return array of primary keys
 	 */
-	private int[] generateInitialChain(@Nonnull Random random, int initialCount) {
+	private static int[] generateInitialChain(@Nonnull Random random, int initialCount) {
 		final int[] initialState = new int[initialCount];
 		for (int i = 0; i < initialCount; i++) {
 			initialState[i] = i + 1;


### PR DESCRIPTION
We need to write better fuzzy tests that would allow us to exterminate the edge cases in the ChainIndex. It seems that the real production systems may behave sometimes chaotically till they return back to consistent state.