### PR TITLE
fix(#556): Add support for comparing OffsetDateTime against DateTimeR…

### DIFF
--- a/evita_common/src/main/java/io/evitadb/dataType/EvitaDataTypes.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/EvitaDataTypes.java
@@ -192,6 +192,15 @@ public class EvitaDataTypes {
 	private static final BiFunction<Class<?>, Serializable, DateTimeRange> DATE_TIME_RANGE_FUNCTION = (requestedType, unknownObject) -> {
 		if (unknownObject instanceof DateTimeRange) {
 			return (DateTimeRange) unknownObject;
+		} else if (unknownObject instanceof OffsetDateTime offsetDateTime) {
+			return DateTimeRange.between(offsetDateTime, offsetDateTime);
+		} else if (unknownObject instanceof LocalDateTime localDateTime) {
+			return DateTimeRange.between(localDateTime.atOffset(ZoneOffset.UTC), localDateTime.atOffset(ZoneOffset.UTC));
+		} else if (unknownObject instanceof LocalDate localDate) {
+			return DateTimeRange.between(
+				localDate.atStartOfDay(ZoneOffset.UTC).toOffsetDateTime(),
+				localDate.atStartOfDay(ZoneOffset.UTC).toOffsetDateTime().plusHours(23).plusMinutes(59).plusSeconds(59).plusNanos(999999999)
+			);
 		} else {
 			final String value = unknownObject.toString();
 			final String[] parsedResult = DateTimeRange.PARSE_FCT.apply(value);


### PR DESCRIPTION
…ange data type

If the client uses `attributeGreaterThan("validity", OffsetDateTime.now())`, the exception of a different type will be thrown. He/she needs to update the constraint to `attributeGreaterThan("validity", DateTimeRange.since(OffsetDateTime.now()))` or `attributeGreaterThan("validity", DateTimeRange.between(OffsetDateTime.now(), OffsetDateTime.now()))`, both of which work fine, but this approach is counterintuitive. We should handle the passing of OffsetDateTime and automatically convert it to a time (i.e. the `between` variant) internally to avoid confusion for developers.