### PR TITLE
fix(#577): Support for layering configuration

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,31 @@
 FROM index.docker.io/azul/zulu-openjdk:17-latest
 
-## not supposed to be overriden in container
+## input arguments for the build
 ARG EVITA_JAR_NAME
 ARG VERSION=not_set
 ARG RELEASE_DATE=not_set
+
+## 1. Environment variables, NOT supposed to be overriden in container ##
 ENV EVITA_HOME="/evita"
 ENV EVITA_JAR_NAME="$EVITA_JAR_NAME"
 ENV SYSTEM_API_PORT="5557"
+
+## 2. Environment variables, MAY BE overriden in container ##
+
+## using volumes:
+
+## folder with configuration files, all of them are applied one on top of another in alphabetical order
+ENV EVITA_BIN_DIR="$EVITA_HOME/bin/"
+ENV EVITA_CONFIG_DIR="$EVITA_HOME/conf/"
+ENV EVITA_STORAGE_DIR="$EVITA_HOME/data/"
+ENV EVITA_CERTIFICATE_DIR="$EVITA_HOME/certificates/"
+ENV EVITA_LOG_FILE="$EVITA_HOME/logback.xml"
+
+## using environment variables
+ENV EVITA_JAVA_OPTS=""
+ENV EVITA_ARGS=""
+
+## 3. Metadata definition part ##
 
 # Labels with dynamic information based on environment variables and current date
 LABEL vendor="FG Forrest, a.s." \
@@ -16,6 +35,8 @@ LABEL vendor="FG Forrest, a.s." \
 HEALTHCHECK --start-period=5m --interval=10s --timeout=2s --retries=3 \
     CMD curl -f http://localhost:$SYSTEM_API_PORT/system/liveness || exit 1
 
+## 4. Image build part
+
 USER root
 
 # Install bash and networking utilities
@@ -23,21 +44,15 @@ RUN apt update && apt install -y netcat-openbsd iproute2 iputils-ping mc tcpdump
 
 # Create necessary folders
 RUN set -ex \
-    && mkdir "$EVITA_HOME" "$EVITA_HOME/bin" "$EVITA_HOME/conf" "$EVITA_HOME/data" "$EVITA_HOME/certificates" \
+    && mkdir "$EVITA_HOME" "$EVITA_BIN_DIR" "$EVITA_CONFIG_DIR" "$EVITA_STORAGE_DIR" "$EVITA_CERTIFICATE_DIR" \
     && : ## end
 
 # Copy files
 COPY "entrypoint.sh" "/"
-COPY "$EVITA_JAR_NAME" "$EVITA_HOME/bin"
-COPY "evita-configuration.yaml" "$EVITA_HOME/conf"
+COPY "$EVITA_JAR_NAME" "$EVITA_BIN_DIR"
+COPY "evita-configuration.yaml" "$EVITA_CONFIG_DIR/evita-configuration.yaml"
 
-## may be to be overriden in container
-ENV EVITA_CONFIG_FILE="$EVITA_HOME/conf/evita-configuration.yaml"
-ENV EVITA_STORAGE_DIR="$EVITA_HOME/data"
-ENV EVITA_CERTIFICATE_DIR="$EVITA_HOME/certificates"
-ENV EVITA_LOG_FILE="$EVITA_HOME/logback.xml"
-ENV EVITA_JAVA_OPTS=""
-ENV EVITA_ARGS=""
+## 5. Startup part ##
 
 WORKDIR "$EVITA_HOME"
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,7 +7,7 @@
 #             |  __/\ V /| | || (_| | |_| | |_) |
 #              \___| \_/ |_|\__\__,_|____/|____/
 #
-#   Copyright (c) 2023
+#   Copyright (c) 2023-2024
 #
 #   Licensed under the Business Source License, Version 1.1 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -27,13 +27,13 @@ set -e
 if [ "$1" = "" ]; then
     set -x
     exec java \
-        -javaagent:${EVITA_HOME}/bin/${EVITA_JAR_NAME} \
+        -javaagent:${EVITA_BIN_DIR}${EVITA_JAR_NAME} \
         $EVITA_JAVA_OPTS \
-        -jar "${EVITA_HOME}/bin/${EVITA_JAR_NAME}" \
-        "-DconfigFile=$EVITA_CONFIG_FILE" \
-        "-Dstorage.storageDirectory=$EVITA_STORAGE_DIR" \
-        "-Dapi.certificate.folderPath=$EVITA_CERTIFICATE_DIR" \
-        "-Dlogback.configurationFile=$EVITA_LOG_FILE" \
+        -jar "${EVITA_BIN_DIR}${EVITA_JAR_NAME}" \
+        "configDir=$EVITA_CONFIG_DIR" \
+        "storage.storageDirectory=$EVITA_STORAGE_DIR" \
+        "api.certificate.folderPath=$EVITA_CERTIFICATE_DIR" \
+        "logback.configurationFile=$EVITA_LOG_FILE" \
         $EVITA_ARGS
 else
     exec "$@"

--- a/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/configuration/GuiConfig.java
+++ b/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/configuration/GuiConfig.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -49,12 +49,6 @@ public class GuiConfig {
 		this.preconfiguredConnections = null;
 	}
 
-	public GuiConfig(boolean enabled) {
-		this.enabled = enabled;
-		this.readOnly = false;
-		this.preconfiguredConnections = null;
-	}
-
 	@JsonCreator
 	public GuiConfig(@Nullable @JsonProperty("enabled") Boolean enabled,
 	                 @Nullable @JsonProperty("readOnly") Boolean readOnly,
@@ -63,4 +57,5 @@ public class GuiConfig {
 		this.readOnly = Optional.ofNullable(readOnly).orElse(false);
 		this.preconfiguredConnections = preconfiguredConnections;
 	}
+
 }

--- a/evita_functional_tests/src/test/resources/testData/evita-configuration-one.yaml
+++ b/evita_functional_tests/src/test/resources/testData/evita-configuration-one.yaml
@@ -1,0 +1,2 @@
+cache:
+  enabled: false

--- a/evita_functional_tests/src/test/resources/testData/evita-configuration-two.yaml
+++ b/evita_functional_tests/src/test/resources/testData/evita-configuration-two.yaml
@@ -1,0 +1,14 @@
+api:
+  endpoints:
+    system:
+      enabled: false
+    graphQL:
+      enabled: false
+    rest:
+      enabled: false
+    gRPC:
+      enabled: false
+    lab:
+      enabled: false
+    observability:
+      enabled: false

--- a/evita_server/src/main/java/io/evitadb/server/EvitaServer.java
+++ b/evita_server/src/main/java/io/evitadb/server/EvitaServer.java
@@ -31,7 +31,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import io.evitadb.api.configuration.CacheOptions;
 import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.TransactionOptions;
 import io.evitadb.core.Evita;
 import io.evitadb.externalApi.configuration.AbstractApiConfiguration;
 import io.evitadb.externalApi.configuration.ApiOptions;
@@ -60,17 +64,23 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Optional.ofNullable;
 
@@ -92,13 +102,9 @@ import static java.util.Optional.ofNullable;
  */
 public class EvitaServer {
 	/**
-	 * Name of the argument for specification of evita configuration file path.
+	 * Name of the argument for specification of evita configuration directory.
 	 */
-	public static final String OPTION_EVITA_CONFIGURATION_FILE = "configFile";
-	/**
-	 * Default name of the evita configuration file relative to the "working directory".
-	 */
-	public static final String DEFAULT_EVITA_CONFIGURATION_FILE = "evita-configuration.yaml";
+	public static final String OPTION_EVITA_CONFIGURATION_DIR = "configDir";
 	/**
 	 * Pattern for matching Java arguments `-Dname=value`
 	 */
@@ -107,6 +113,10 @@ public class EvitaServer {
 	 * Pattern for matching Unix like arguments `--name=value`
 	 */
 	private static final Pattern OPTION_GNU_ARGUMENT = Pattern.compile("--(\\S+)=(\\S+)");
+	/**
+	 * Pattern for matching simple arguments `name=value`
+	 */
+	private static final Pattern OPTION_SIMPLE_ARGUMENT = Pattern.compile("(\\S+)=(\\S+)");
 	/**
 	 * Logger.
 	 */
@@ -145,11 +155,11 @@ public class EvitaServer {
 
 		final String logMsg = initLog();
 
-		final Path configFilePath = ofNullable(options.get(OPTION_EVITA_CONFIGURATION_FILE))
+		final Path configDirPath = ofNullable(options.get(OPTION_EVITA_CONFIGURATION_DIR))
 			.map(it -> Paths.get("").resolve(it))
-			.orElseGet(() -> Paths.get("").resolve(DEFAULT_EVITA_CONFIGURATION_FILE));
+			.orElseGet(() -> Paths.get(""));
 
-		final EvitaServer evitaServer = new EvitaServer(configFilePath, logMsg, options);
+		final EvitaServer evitaServer = new EvitaServer(configDirPath, logMsg, options);
 		final ShutdownSequence shutdownSequence = new ShutdownSequence(evitaServer);
 		Runtime.getRuntime().addShutdownHook(new Thread(shutdownSequence));
 		evitaServer.run();
@@ -186,10 +196,13 @@ public class EvitaServer {
 		for (String arg : args) {
 			final Matcher javaArgMatcher = OPTION_JAVA_ARGUMENT.matcher(arg.trim());
 			final Matcher gnuArgMatcher = OPTION_GNU_ARGUMENT.matcher(arg.trim());
+			final Matcher simpleArgMatcher = OPTION_SIMPLE_ARGUMENT.matcher(arg.trim());
 			if (javaArgMatcher.matches()) {
 				map.put(javaArgMatcher.group(1), javaArgMatcher.group(2));
 			} else if (gnuArgMatcher.matches()) {
 				map.put(gnuArgMatcher.group(1), gnuArgMatcher.group(2));
+			} else if (simpleArgMatcher.matches()) {
+				map.put(simpleArgMatcher.group(1), simpleArgMatcher.group(2));
 			}
 		}
 		return map;
@@ -206,7 +219,7 @@ public class EvitaServer {
 				variable -> ofNullable(arguments.get(variable))
 					.orElseGet(
 						() -> ofNullable(System.getProperty(variable))
-							.orElseGet(() -> System.getenv(variable))
+							.orElseGet(() -> transformEnvironmentVariable(System.getenv(variable)))
 					)
 			)
 		);
@@ -214,6 +227,19 @@ public class EvitaServer {
 		stringSubstitutor.setEnableUndefinedVariableException(false);
 		stringSubstitutor.setValueDelimiter(':');
 		return stringSubstitutor;
+	}
+
+	/**
+	 * Linux operating systems don't allow dots in the environment variable names. Other systems in the industry
+	 * follow mechanism that transform such variables to upper-case, replace dots with underscores and prepend the
+	 * variable with the name of the application in upper-case. This method tries to mimic this behavior.
+	 *
+	 * @param variableName original variable name with dots
+	 * @return transformed variable name
+	 */
+	@Nullable
+	private static String transformEnvironmentVariable(@Nonnull String variableName) {
+		return "EVITADB_" + variableName.toUpperCase().replace('.', '_');
 	}
 
 	/**
@@ -228,6 +254,102 @@ public class EvitaServer {
 	}
 
 	/**
+	 * Method merges multiple YAML files into a single configuration. Values from the last file override the previous
+	 * ones.
+	 *
+	 * @param yamlMapper        YAML mapper to use
+	 * @param stringSubstitutor variable substitutor to use
+	 * @param readerFactory     lambda function that creates a reader from an input stream
+	 * @param configDirLocation location of the configuration directory
+	 * @param files             list of files to merge in the correct order
+	 * @return merged configuration
+	 * @throws IOException if an I/O error occurs
+	 */
+	@Nonnull
+	private static EvitaServerConfiguration mergeYamlFiles(
+		@Nonnull ObjectMapper yamlMapper,
+		@Nonnull StringSubstitutor stringSubstitutor,
+		@Nonnull Function<InputStream, Reader> readerFactory,
+		@Nonnull Path configDirLocation,
+		@Nonnull Path... files
+	) throws IOException {
+		final AtomicReference<Yaml> yamlParser = new AtomicReference<>();
+		yamlParser.set(
+			new Yaml(
+				new EvitaConstructor(
+					yamlParser,
+					stringSubstitutor,
+					configDirLocation
+				)
+			)
+		);
+
+		try {
+			// iterate over all files in the directory and merge them into a single configuration
+			Map<String, Object> finalYaml = null;
+			for (Path file : files) {
+				final Map<String, Object> loadedYaml = yamlParser.get().load(readerFactory.apply(new FileInputStream(file.toFile())));
+				finalYaml = finalYaml == null ? loadedYaml : combine(finalYaml, loadedYaml);
+			}
+
+			// if the final configuration is null, return default configuration, otherwise convert it to the object
+			return finalYaml == null ?
+				new EvitaServerConfiguration(
+					"evitaDB",
+					ServerOptions.builder().build(),
+					StorageOptions.builder().build(),
+					TransactionOptions.builder().build(),
+					CacheOptions.builder().build(),
+					ApiOptions.builder().build()
+				) :
+				yamlMapper.convertValue(finalYaml, EvitaServerConfiguration.class);
+		} catch (IOException e) {
+			throw new ConfigurationParseException(
+				"Failed to parse configuration files in folder `" + configDirLocation + "` due to: " + e.getMessage() + ".",
+				"Failed to parse configuration files.", e
+			);
+		}
+	}
+
+	/**
+	 * Method combines two maps into a single map. If the same key is present in both maps, the value from the second map
+	 * overrides the value from the first map. If the value is a map, the method is called recursively.
+	 *
+	 * @param base  base map
+	 * @param delta map with keys and values that should override the base map
+	 * @return combined map
+	 */
+	@Nonnull
+	private static Map<String, Object> combine(
+		@Nonnull Map<String, Object> base,
+		@Nonnull Map<String, Object> delta
+	) {
+		final Map<String, Object> combined = CollectionUtils.createHashMap(base.size() + delta.size());
+		combined.putAll(base);
+		for (Entry<String, Object> entry : delta.entrySet()) {
+			if (combined.containsKey(entry.getKey())) {
+				final Object existingValue = combined.get(entry.getKey());
+				final Object newValue = entry.getValue();
+				if (existingValue instanceof Map && newValue instanceof Map) {
+					//noinspection unchecked
+					combined.put(
+						entry.getKey(),
+						combine(
+							(Map<String, Object>) combined.get(entry.getKey()),
+							(Map<String, Object>) entry.getValue()
+						)
+					);
+				} else {
+					combined.put(entry.getKey(), entry.getValue());
+				}
+			} else {
+				combined.put(entry.getKey(), entry.getValue());
+			}
+		}
+		return combined;
+	}
+
+	/**
 	 * Constructor that initializes the EvitaServer.
 	 */
 	public EvitaServer(@Nonnull Path configFileLocation, @Nonnull Map<String, String> arguments) {
@@ -237,9 +359,10 @@ public class EvitaServer {
 	/**
 	 * Constructor that initializes the EvitaServer.
 	 */
-	public EvitaServer(@Nonnull Path configFileLocation, @Nullable String logInitializationStatus, @Nonnull Map<String, String> arguments) {
+	public EvitaServer(@Nonnull Path configDirLocation, @Nullable String logInitializationStatus, @Nonnull Map<String, String> arguments) {
 		this.externalApiProviders = ExternalApiServer.gatherExternalApiProviders();
-		final EvitaServerConfiguration evitaServerConfig = parseConfiguration(configFileLocation, arguments);
+		final EvitaServerConfigurationWithLogFilesListing evitaServerConfigurationWithLogFilesListing = parseConfiguration(configDirLocation, arguments);
+		final EvitaServerConfiguration evitaServerConfig = evitaServerConfigurationWithLogFilesListing.configuration();
 		this.evitaConfiguration = new EvitaConfiguration(
 			evitaServerConfig.name(),
 			evitaServerConfig.server(),
@@ -268,10 +391,14 @@ public class EvitaServer {
 		ConsoleWriter.write("https://evitadb.io", ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
 		ConsoleWriter.write("\n\n", ConsoleColor.WHITE);
 		ConsoleWriter.write("Log config used: " + System.getProperty(ContextInitializer.CONFIG_FILE_PROPERTY) + ofNullable(logInitializationStatus).map(it -> " (" + it + ")").orElse("") + "", ConsoleColor.DARK_GRAY);
+		ConsoleWriter.write("Config files used:\n" + Arrays.stream(evitaServerConfigurationWithLogFilesListing.configFilesApplied()).map(it -> "\t" + it.toAbsolutePath()).collect(Collectors.joining("\n")), ConsoleColor.DARK_GRAY);
 		ConsoleWriter.write("\n", ConsoleColor.WHITE);
 
 		ConsoleWriter.write("Server name: ", ConsoleColor.WHITE);
 		ConsoleWriter.write(this.evitaConfiguration.name(), ConsoleColor.BRIGHT_YELLOW);
+		ConsoleWriter.write("\n", ConsoleColor.WHITE);
+
+		ConsoleWriter.write("Actual configuration:\n\n" + evitaServerConfigurationWithLogFilesListing.configAsString(), ConsoleColor.DARK_GRAY);
 		ConsoleWriter.write("\n", ConsoleColor.WHITE);
 	}
 
@@ -309,43 +436,60 @@ public class EvitaServer {
 	}
 
 	/**
-	 * Method parses contents of `configFileLocation` YAML file using `arguments` for variable replacement and returns
-	 * the loaded configuration as a result.
+	 * Method parses contents of `configDirLocation` YAML files in alphabetical order and applies contents of the latter
+	 * files to the former ones. The method allows using `arguments` for variable replacement and returns the loaded
+	 * configuration as a result.
 	 */
 	@Nonnull
-	private EvitaServerConfiguration parseConfiguration(@Nonnull Path configFileLocation, @Nonnull Map<String, String> arguments) throws ConfigurationParseException {
+	private EvitaServerConfigurationWithLogFilesListing parseConfiguration(
+		@Nonnull Path configDirLocation,
+		@Nonnull Map<String, String> arguments
+	) throws ConfigurationParseException {
 		final StringSubstitutor stringSubstitutor = createStringSubstitutor(arguments);
-
-		final AtomicReference<Yaml> yamlParser = new AtomicReference<>();
-		yamlParser.set(new Yaml(new EvitaConstructor(yamlParser, stringSubstitutor, configFileLocation)));
 
 		final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 		yamlMapper.registerModule(createAbstractApiConfigModule());
 		yamlMapper.registerModule(new ParameterNamesModule());
 		yamlMapper.addHandler(new SpecialConfigInputFormatsHandler());
 
+		final Path[] configFiles;
 		final EvitaServerConfiguration evitaServerConfig;
-		try (
-			final Reader reader = new StringSubstitutorReader(
-				new InputStreamReader(
-					new BufferedInputStream(
-						new FileInputStream(
-							configFileLocation.toFile()
-						)
-					), StandardCharsets.UTF_8
+		final String configAsString;
+		try (final Stream<Path> filesInDirectory = Files.list(configDirLocation)) {
+			configFiles = filesInDirectory
+				.filter(Files::isRegularFile)
+				.filter(it -> it.getFileName().toString().endsWith(".yaml"))
+				.sorted()
+				.toArray(Path[]::new);
+			evitaServerConfig = mergeYamlFiles(
+				yamlMapper,
+				stringSubstitutor,
+				stream -> new StringSubstitutorReader(
+					new InputStreamReader(
+						new BufferedInputStream(stream), StandardCharsets.UTF_8
+					),
+					stringSubstitutor
 				),
-				stringSubstitutor
-			)
-		) {
-			final Map<String, Object> parsedYaml = yamlParser.get().load(reader);
-			evitaServerConfig = yamlMapper.convertValue(parsedYaml, EvitaServerConfiguration.class);
+				configDirLocation,
+				// list all files in the directory and filter only the YAML files
+				// then sort them alphabetically and convert them to array
+				// finally pass the array to the `mergeYamlFiles` method
+				// to merge them into a single configuration
+				// (the last file has the highest priority and overrides the previous ones)
+				configFiles
+			);
+			configAsString = yamlMapper.writeValueAsString(evitaServerConfig);
 		} catch (IOException e) {
 			throw new ConfigurationParseException(
-				"Failed to parse configuration file `" + configFileLocation + "` due to: " + e.getMessage() + ".",
-				"Failed to parse configuration file.", e
+				"Failed to parse configuration files from directory `" + configDirLocation + "` due to: " + e.getMessage() + ".",
+				"Failed to parse configuration files.", e
 			);
 		}
-		return evitaServerConfig;
+		return new EvitaServerConfigurationWithLogFilesListing(
+			evitaServerConfig,
+			configFiles,
+			configAsString
+		);
 	}
 
 	/**
@@ -364,6 +508,19 @@ public class EvitaServer {
 		}
 		module.addDeserializer(AbstractApiConfiguration.class, deserializer);
 		return module;
+	}
+
+	/**
+	 * Record contains final configuration and list of configuration files that were applied.
+	 *
+	 * @param configuration      final configuration
+	 * @param configFilesApplied list of configuration files that were applied
+	 */
+	private record EvitaServerConfigurationWithLogFilesListing(
+		@Nonnull EvitaServerConfiguration configuration,
+		@Nonnull Path[] configFilesApplied,
+		@Nonnull String configAsString
+	) {
 	}
 
 	/**

--- a/evita_test_support/src/main/java/io/evitadb/test/EvitaTestSupport.java
+++ b/evita_test_support/src/main/java/io/evitadb/test/EvitaTestSupport.java
@@ -63,18 +63,37 @@ public interface EvitaTestSupport extends TestConstants {
 	 * Method copies `evita-configuration.yaml` from the classpath to the temporary directory on the filesystem so that
 	 * evita server that is going to be started in tests will be able to find it.
 	 *
+	 * @param folderName name of the folder where the configuration file will be stored
 	 * @return path of the exported configuration file
 	 */
 	@Nonnull
 	static Path bootstrapEvitaServerConfigurationFile(@Nonnull String folderName) {
+		return bootstrapEvitaServerConfigurationFileFrom(
+			folderName,
+			"/" + DEFAULT_EVITA_CONFIGURATION_FILE,
+			DEFAULT_EVITA_CONFIGURATION_FILE
+		);
+	}
+
+	/**
+	 * Method copies `evita-configuration.yaml` from the classpath to the temporary directory on the filesystem so that
+	 * evita server that is going to be started in tests will be able to find it.
+	 *
+	 * @param folderName        name of the folder where the configuration file will be stored
+	 * @param classPathLocation classpath location of the source configuration file
+	 * @param targetFileName    name of the target configuration file
+	 * @return path of the exported configuration file
+	 */
+	@Nonnull
+	static Path bootstrapEvitaServerConfigurationFileFrom(@Nonnull String folderName, @Nonnull String classPathLocation, @Nonnull String targetFileName) {
 		final Path dir = Path.of(System.getProperty("java.io.tmpdir"))
 			.resolve("evita")
 			.resolve(folderName);
 		if (!dir.toFile().exists()) {
 			Assert.isTrue(dir.toFile().mkdirs(), "Cannot set up folder: " + dir);
 		}
-		final Path configFilePath = dir.resolve(DEFAULT_EVITA_CONFIGURATION_FILE);
-		try (final InputStream sourceIs = TestConstants.class.getResourceAsStream("/" + DEFAULT_EVITA_CONFIGURATION_FILE)) {
+		final Path configFilePath = dir.resolve(targetFileName);
+		try (final InputStream sourceIs = TestConstants.class.getResourceAsStream(classPathLocation)) {
 			Files.copy(
 				Objects.requireNonNull(sourceIs),
 				configFilePath,
@@ -82,12 +101,12 @@ public interface EvitaTestSupport extends TestConstants {
 			);
 		} catch (IOException e) {
 			throw new RuntimeException(
-				"Failed to copy evita `" + DEFAULT_EVITA_CONFIGURATION_FILE + "` to `" + configFilePath + "` due to: " + e.getMessage(),
+				"Failed to copy evita `" + targetFileName + "` to `" + configFilePath + "` due to: " + e.getMessage(),
 				e
 			);
 		}
 
-		return configFilePath;
+		return dir;
 	}
 
 	/**


### PR DESCRIPTION
In complex build pipelines it's not easy to set up all evitaDB parameters in one shot. It would be helpful if we could layer the `evita-configuration.yml` so that we first load the full configuration with defaults and then apply shorter versions that override only part of those settings. The overriding configurations could be expected to be in the same folder as the default configuration and could be applied in alphabetical order - i.e:

1. evita-configuration.yml
2. evita-configuration-environment.yml
3. evita-configuration-project.yml