### PR TITLE
fix: Formula results haven't been computed!

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
@@ -187,7 +187,12 @@ public class NotFormula extends AbstractCacheableFormula {
 		if (supersetBitmap != null && subtractedBitmap != null) {
 			return Stream.of(supersetBitmap, subtractedBitmap).mapToLong(Bitmap::size).sum();
 		} else {
-			return super.getCostInternal();
+			final Bitmap supersetBitmap = innerFormulas[1].compute();
+			if (supersetBitmap.isEmpty()) {
+				return innerFormulas[1].getCost();
+			} else {
+				return super.getCostInternal();
+			}
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/UserFilterFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/UserFilterFormula.java
@@ -29,13 +29,18 @@ import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.NonCacheableFormula;
 import io.evitadb.core.query.algebra.NonCacheableFormulaScope;
 import io.evitadb.core.query.algebra.base.AndFormula;
+import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
+import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import net.openhft.hashing.LongHashFunction;
 import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * This formula has almost identical implementation as {@link AndFormula} but it accepts only set of
@@ -48,6 +53,7 @@ import java.util.Arrays;
  */
 public class UserFilterFormula extends AbstractFormula implements NonCacheableFormula, NonCacheableFormulaScope {
 	private static final long CLASS_ID = 6890499931556487481L;
+	private List<Formula> sortedFormulasByComplexity;
 
 	public UserFilterFormula(Formula... innerFormulas) {
 		super(innerFormulas);
@@ -64,10 +70,51 @@ public class UserFilterFormula extends AbstractFormula implements NonCacheableFo
 		return 15;
 	}
 
+	@Override
+	protected long getCostInternal() {
+		long cost = 0L;
+		if (this.sortedFormulasByComplexity == null) {
+			initialize(CalculationContext.NO_CACHING_INSTANCE);
+		}
+		for (Formula innerFormula : this.sortedFormulasByComplexity) {
+			final Bitmap innerResult = innerFormula.compute();
+			cost += innerFormula.getCost() + innerResult.size() * getOperationCost();
+			if (innerResult == EmptyBitmap.INSTANCE) {
+				break;
+			}
+		}
+		return cost;
+	}
+
+	@Override
+	protected long getCostToPerformanceInternal() {
+		long costToPerformance = 0L;
+		if (this.sortedFormulasByComplexity == null) {
+			initialize(CalculationContext.NO_CACHING_INSTANCE);
+		}
+		for (Formula innerFormula : this.sortedFormulasByComplexity) {
+			final Bitmap innerResult = innerFormula.compute();
+			if (innerResult == EmptyBitmap.INSTANCE) {
+				break;
+			}
+			costToPerformance += innerFormula.getCostToPerformanceRatio();
+		}
+		return costToPerformance + getCost() / Math.max(1, compute().size());
+	}
+
 	@Nonnull
 	@Override
 	protected Bitmap computeInternal() {
-		return RoaringBitmapBackedBitmap.and(getRoaringBitmaps());
+		final Bitmap theResult;
+		final RoaringBitmap[] theBitmaps = getRoaringBitmaps();
+		if (theBitmaps.length == 0 || Arrays.stream(theBitmaps).anyMatch(RoaringBitmap::isEmpty)) {
+			theResult = EmptyBitmap.INSTANCE;
+		} else if (theBitmaps.length == 1) {
+			theResult = new BaseBitmap(theBitmaps[0]);
+		} else {
+			theResult = RoaringBitmapBackedBitmap.and(theBitmaps);
+		}
+		return theResult.isEmpty() ? EmptyBitmap.INSTANCE : theResult;
 	}
 
 	@Override
@@ -96,9 +143,23 @@ public class UserFilterFormula extends AbstractFormula implements NonCacheableFo
 
 	@Nonnull
 	private RoaringBitmap[] getRoaringBitmaps() {
-		return Arrays.stream(getInnerFormulas())
-			.map(Formula::compute)
-			.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-			.toArray(RoaringBitmap[]::new);
+		if (this.sortedFormulasByComplexity == null) {
+			this.sortedFormulasByComplexity = Arrays.stream(getInnerFormulas())
+				.sorted(Comparator.comparingLong(TransactionalDataRelatedStructure::getEstimatedCost))
+				.toList();
+		}
+		final RoaringBitmap[] theBitmaps = new RoaringBitmap[this.sortedFormulasByComplexity.size()];
+		// go from the cheapest formula to the more expensive and compute one by one
+		for (int i = 0; i < this.sortedFormulasByComplexity.size(); i++) {
+			final Formula formula = this.sortedFormulasByComplexity.get(i);
+			final Bitmap computedBitmap = formula.compute();
+			// if you encounter formula that returns nothing immediately return nothing - hence AND
+			if (computedBitmap.isEmpty()) {
+				return new RoaringBitmap[0];
+			} else {
+				theBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(computedBitmap);
+			}
+		}
+		return theBitmaps;
 	}
 }


### PR DESCRIPTION
Error occurred on our test system:

```
2024-05-30T05:02:40.171480900Z SEVERE: Exception while executing runnable io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed@66e3d4d9
2024-05-30T05:02:40.171486100Z io.evitadb.exception.GenericEvitaInternalError: Formula results haven't been computed!
2024-05-30T05:02:40.171489959Z 	at io.evitadb.utils.Assert.isPremiseValid(Assert.java:89)
2024-05-30T05:02:40.171493839Z 	at io.evitadb.core.query.algebra.AbstractFormula.getCost(AbstractFormula.java:127)
2024-05-30T05:02:40.171497789Z 	at java.base/java.util.stream.ReferencePipeline$5$1.accept(ReferencePipeline.java:231)
2024-05-30T05:02:40.171501369Z 	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
2024-05-30T05:02:40.171517549Z 	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
2024-05-30T05:02:40.171521309Z 	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
2024-05-30T05:02:40.171533709Z 	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
2024-05-30T05:02:40.171537469Z 	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
2024-05-30T05:02:40.171540929Z 	at java.base/java.util.stream.LongPipeline.reduce(LongPipeline.java:498)
2024-05-30T05:02:40.171544379Z 	at java.base/java.util.stream.LongPipeline.sum(LongPipeline.java:456)
2024-05-30T05:02:40.171547899Z 	at io.evitadb.core.query.algebra.AbstractFormula.getCostInternal(AbstractFormula.java:252)
2024-05-30T05:02:40.171551899Z 	at io.evitadb.core.query.algebra.base.NotFormula.getCostInternal(NotFormula.java:190)
2024-05-30T05:02:40.171555719Z 	at io.evitadb.core.query.algebra.AbstractFormula.initializeInternal(AbstractFormula.java:324)
2024-05-30T05:02:40.171559269Z 	at io.evitadb.core.query.algebra.AbstractFormula.initialize(AbstractFormula.java:87)
2024-05-30T05:02:40.171563109Z 	at io.evitadb.core.query.algebra.AbstractFormula.initializeInternal(AbstractFormula.java:290)
2024-05-30T05:02:40.171566459Z 	at io.evitadb.core.query.algebra.AbstractFormula.initialize(AbstractFormula.java:87)
2024-05-30T05:02:40.171570149Z 	at io.evitadb.core.query.algebra.AbstractFormula.initializeInternal(AbstractFormula.java:290)
2024-05-30T05:02:40.171573929Z 	at io.evitadb.core.query.algebra.AbstractFormula.initialize(AbstractFormula.java:87)
2024-05-30T05:02:40.171576869Z 	at io.evitadb.core.query.algebra.AbstractFormula.getCost(AbstractFormula.java:126)
```

This commit also aligns more UserFormula with AndFormula internal logic.