### PR TITLE
fix: Formula results haven't been computed!

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
@@ -196,6 +196,20 @@ public class NotFormula extends AbstractCacheableFormula {
 		}
 	}
 
+	@Override
+	protected long getCostToPerformanceInternal() {
+		if (supersetBitmap != null && subtractedBitmap != null) {
+			return getCost() / Math.max(1, compute().size());
+		} else {
+			final Bitmap supersetBitmap = innerFormulas[1].compute();
+			if (supersetBitmap.isEmpty()) {
+				return getCost() / Math.max(1, compute().size());
+			} else {
+				return super.getCostToPerformanceInternal();
+			}
+		}
+	}
+
 	@Nonnull
 	@Override
 	protected Bitmap computeInternal() {


### PR DESCRIPTION
Error occurred on our test system:

```
2024-05-30T05:02:40.171480900Z SEVERE: Exception while executing runnable io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed@66e3d4d9
2024-05-30T05:02:40.171486100Z io.evitadb.exception.GenericEvitaInternalError: Formula results haven't been computed!
2024-05-30T05:02:40.171489959Z 	at io.evitadb.utils.Assert.isPremiseValid(Assert.java:89)
2024-05-30T05:02:40.171493839Z 	at io.evitadb.core.query.algebra.AbstractFormula.getCost(AbstractFormula.java:127)
2024-05-30T05:02:40.171497789Z 	at java.base/java.util.stream.ReferencePipeline$5$1.accept(ReferencePipeline.java:231)
2024-05-30T05:02:40.171501369Z 	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
2024-05-30T05:02:40.171517549Z 	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
2024-05-30T05:02:40.171521309Z 	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
2024-05-30T05:02:40.171533709Z 	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
2024-05-30T05:02:40.171537469Z 	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
2024-05-30T05:02:40.171540929Z 	at java.base/java.util.stream.LongPipeline.reduce(LongPipeline.java:498)
2024-05-30T05:02:40.171544379Z 	at java.base/java.util.stream.LongPipeline.sum(LongPipeline.java:456)
2024-05-30T05:02:40.171547899Z 	at io.evitadb.core.query.algebra.AbstractFormula.getCostInternal(AbstractFormula.java:252)
2024-05-30T05:02:40.171551899Z 	at io.evitadb.core.query.algebra.base.NotFormula.getCostInternal(NotFormula.java:190)
2024-05-30T05:02:40.171555719Z 	at io.evitadb.core.query.algebra.AbstractFormula.initializeInternal(AbstractFormula.java:324)
2024-05-30T05:02:40.171559269Z 	at io.evitadb.core.query.algebra.AbstractFormula.initialize(AbstractFormula.java:87)
2024-05-30T05:02:40.171563109Z 	at io.evitadb.core.query.algebra.AbstractFormula.initializeInternal(AbstractFormula.java:290)
2024-05-30T05:02:40.171566459Z 	at io.evitadb.core.query.algebra.AbstractFormula.initialize(AbstractFormula.java:87)
2024-05-30T05:02:40.171570149Z 	at io.evitadb.core.query.algebra.AbstractFormula.initializeInternal(AbstractFormula.java:290)
2024-05-30T05:02:40.171573929Z 	at io.evitadb.core.query.algebra.AbstractFormula.initialize(AbstractFormula.java:87)
2024-05-30T05:02:40.171576869Z 	at io.evitadb.core.query.algebra.AbstractFormula.getCost(AbstractFormula.java:126)
```

This commit also aligns more UserFormula with AndFormula internal logic.