### PR TITLE
fix(#588): Avoid certificate generation when no TLS endpoint is confi…

### DIFF
--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/certificate/ServerCertificateManager.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/certificate/ServerCertificateManager.java
@@ -23,10 +23,10 @@
 
 package io.evitadb.externalApi.certificate;
 
-import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.externalApi.configuration.AbstractApiConfiguration;
 import io.evitadb.externalApi.configuration.CertificatePath;
 import io.evitadb.externalApi.configuration.CertificateSettings;
+import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 import io.evitadb.utils.CertificateUtils;
 import lombok.Getter;
@@ -66,8 +66,12 @@ import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.Optional;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -103,31 +107,32 @@ public class ServerCertificateManager {
 	 * @return {@link CertificatePath} object that contains paths to the certificate and private key.
 	 */
 	@Nonnull
-	public static CertificatePath getCertificatePath(@Nonnull CertificateSettings certificateSettings) {
+	public static Optional<CertificatePath> getCertificatePath(@Nonnull CertificateSettings certificateSettings) {
 		final Path certPath;
 		final Path certPrivateKeyPath;
 		final String certPrivateKeyPassword;
+		final CertificatePath customPaths = certificateSettings.custom();
 		if (certificateSettings.generateAndUseSelfSigned()) {
 			certPath = certificateSettings.getFolderPath().resolve(CertificateUtils.getGeneratedServerCertificateFileName());
 			certPrivateKeyPath = certificateSettings.getFolderPath().resolve(CertificateUtils.getGeneratedServerCertificatePrivateKeyFileName());
 			certPrivateKeyPassword = null;
+		} else if (customPaths != null && customPaths.certificate() != null && customPaths.privateKey() != null) {
+			certPath = ofNullable(customPaths.certificate()).map(Path::of).orElse(null);
+			certPrivateKeyPath = ofNullable(customPaths.privateKey()).map(Path::of).orElse(null);
+			certPrivateKeyPassword = customPaths.privateKeyPassword();
 		} else {
-			final CertificatePath certificatePath = certificateSettings.custom();
-			if (certificatePath == null || certificatePath.certificate() == null || certificatePath.privateKey() == null) {
-				throw new GenericEvitaInternalError("Certificate path is not properly set in the configuration file.");
-			}
-			certPath = ofNullable(certificatePath.certificate()).map(Path::of).orElse(null);
-			certPrivateKeyPath = ofNullable(certificatePath.privateKey()).map(Path::of).orElse(null);
-			certPrivateKeyPassword = certificatePath.privateKeyPassword();
+			return empty();
 		}
-		return new CertificatePath(
-			ofNullable(certPath.toAbsolutePath())
-				.map(it -> it.toAbsolutePath().toString())
-				.orElse(null),
-			ofNullable(certPrivateKeyPath)
-				.map(it -> it.toAbsolutePath().toString())
-				.orElse(null),
-			certPrivateKeyPassword
+		return of(
+			new CertificatePath(
+				ofNullable(certPath.toAbsolutePath())
+					.map(it -> it.toAbsolutePath().toString())
+					.orElse(null),
+				ofNullable(certPrivateKeyPath)
+					.map(it -> it.toAbsolutePath().toString())
+					.orElse(null),
+				certPrivateKeyPassword
+			)
 		);
 	}
 
@@ -187,7 +192,11 @@ public class ServerCertificateManager {
 	/**
 	 * Generates a self-signed certificate using the BouncyCastle library.
 	 */
-	public void generateSelfSignedCertificate() throws Exception {
+	public void generateSelfSignedCertificate(@Nonnull CertificateType... type) throws Exception {
+		if (ArrayUtils.isEmpty(type)) {
+			return;
+		}
+
 		final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KEY_ALGORITHM, BC_PROVIDER);
 		keyPairGenerator.initialize(2048, new SecureRandom());
 		final KeyPair keyPair = keyPairGenerator.generateKeyPair();
@@ -223,8 +232,12 @@ public class ServerCertificateManager {
 		}
 
 		// Issue server and client certificates
-		issueCertificate(CertificateUtils.getServerCertName(), keyPairGenerator, keyPair, x500Name, notBefore, notAfter, rootCert);
-		issueCertificate(CertificateUtils.getClientCertName(), keyPairGenerator, keyPair, x500Name, notBefore, notAfter, rootCert);
+		if (Arrays.stream(type).anyMatch(it -> it == CertificateType.SERVER)) {
+			issueCertificate(CertificateUtils.getServerCertName(), keyPairGenerator, keyPair, x500Name, notBefore, notAfter, rootCert);
+		}
+		if (Arrays.stream(type).anyMatch(it -> it == CertificateType.CLIENT)) {
+			issueCertificate(CertificateUtils.getClientCertName(), keyPairGenerator, keyPair, x500Name, notBefore, notAfter, rootCert);
+		}
 	}
 
 	/**
@@ -296,4 +309,13 @@ public class ServerCertificateManager {
 			privateKeyWriter.writeObject(new PemObject("PRIVATE KEY", issuedCertKeyPair.getPrivate().getEncoded()));
 		}
 	}
+
+	/**
+	 * The type of the certificate to generate.
+	 */
+	public enum CertificateType {
+		SERVER,
+		CLIENT
+	}
+
 }

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/configuration/AbstractApiConfiguration.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/configuration/AbstractApiConfiguration.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -158,5 +158,13 @@ public abstract class AbstractApiConfiguration {
 			.map(it -> (isTlsEnabled() ? "https://" : "http://") + it +
 				(this instanceof ApiWithSpecificPrefix withSpecificPrefix ? "/" + withSpecificPrefix.getPrefix() + "/" : "/"))
 			.toArray(String[]::new);
+	}
+
+	/**
+	 * Returns true if particular API has mutual TLS enabled.
+	 * @return true if mutual TLS is enabled
+	 */
+	public boolean isMtlsEnabled() {
+		return false;
 	}
 }

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiServer.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiServer.java
@@ -27,6 +27,7 @@ import io.evitadb.core.Evita;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.externalApi.certificate.ServerCertificateManager;
+import io.evitadb.externalApi.certificate.ServerCertificateManager.CertificateType;
 import io.evitadb.externalApi.configuration.AbstractApiConfiguration;
 import io.evitadb.externalApi.configuration.ApiOptions;
 import io.evitadb.externalApi.configuration.ApiWithSpecificPrefix;
@@ -35,6 +36,7 @@ import io.evitadb.externalApi.configuration.HostDefinition;
 import io.evitadb.externalApi.exception.ExternalApiInternalError;
 import io.evitadb.externalApi.log.NoopAccessLogReceiver;
 import io.evitadb.externalApi.log.Slf4JAccessLogReceiver;
+import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 import io.evitadb.utils.CertificateUtils;
 import io.evitadb.utils.ConsoleWriter;
@@ -87,6 +89,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
@@ -94,6 +97,7 @@ import java.util.ServiceLoader.Provider;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.evitadb.utils.CollectionUtils.createHashMap;
 import static java.util.Optional.empty;
@@ -129,36 +133,53 @@ public class ExternalApiServer implements AutoCloseable {
 	}
 
 	@Nonnull
-	public static CertificatePath initCertificate(final @Nonnull ApiOptions apiOptions, final @Nonnull ServerCertificateManager serverCertificateManager) {
-		final CertificatePath certificatePath = ServerCertificateManager.getCertificatePath(apiOptions.certificate());
-		if (certificatePath.certificate() == null || certificatePath.privateKey() == null) {
-			throw new GenericEvitaInternalError("Either certificate path or its private key path is not set");
-		}
+	public static CertificatePath initCertificate(
+		final @Nonnull ApiOptions apiOptions,
+		final @Nonnull ServerCertificateManager serverCertificateManager
+	) {
+		final CertificatePath certificatePath = ServerCertificateManager.getCertificatePath(apiOptions.certificate())
+			.orElseThrow(() -> new GenericEvitaInternalError("Either certificate path or its private key path is not set"));
 		final File certificateFile = new File(certificatePath.certificate());
 		final File certificateKeyFile = new File(certificatePath.privateKey());
 		if (apiOptions.certificate().generateAndUseSelfSigned()) {
-			final Path certificateFolderPath = serverCertificateManager.getCertificateFolderPath();
-			if (!certificateFolderPath.toFile().exists()) {
-				Assert.isTrue(
-					certificateFolderPath.toFile().mkdirs(),
-					() -> "Cannot create certificate folder path: `" + certificateFolderPath + "`"
-				);
-			}
-			final File rootCaFile = serverCertificateManager.getRootCaCertificatePath().toFile();
-			if (!certificateFile.exists() && !certificateKeyFile.exists() && !rootCaFile.exists()) {
-				try {
-					serverCertificateManager.generateSelfSignedCertificate();
-				} catch (Exception e) {
-					throw new GenericEvitaInternalError(
-						"Failed to generate self-signed certificate: " + e.getMessage(),
-						"Failed to generate self-signed certificate",
-						e
+			final CertificateType[] certificateTypes = apiOptions.endpoints()
+				.values()
+				.stream()
+				.flatMap(it -> Stream.of(
+					it.isTlsEnabled() ? CertificateType.SERVER : null,
+					it.isMtlsEnabled() ? CertificateType.CLIENT : null
+				)
+				.filter(Objects::nonNull))
+				.distinct()
+				.toArray(CertificateType[]::new);
+
+			// if no end-point requires any certificate skip generation
+			if (ArrayUtils.isEmpty(certificateTypes)) {
+				log.info("No end-point is configured to use TLS or mTLS. Skipping certificate generation regardless `generateAndUseSelfSigned` is set to true.");
+			} else {
+				final Path certificateFolderPath = serverCertificateManager.getCertificateFolderPath();
+				if (!certificateFolderPath.toFile().exists()) {
+					Assert.isTrue(
+						certificateFolderPath.toFile().mkdirs(),
+						() -> "Cannot create certificate folder path: `" + certificateFolderPath + "`"
 					);
 				}
-			} else if (!certificateFile.exists() || !certificateKeyFile.exists() || !rootCaFile.exists()) {
-				throw new EvitaInvalidUsageException("One of essential certificate files is missing. Please either " +
-					"provide all of these files or delete all files in the configured certificate folder and try again."
-				);
+				final File rootCaFile = serverCertificateManager.getRootCaCertificatePath().toFile();
+				if (!certificateFile.exists() && !certificateKeyFile.exists() && !rootCaFile.exists()) {
+					try {
+						serverCertificateManager.generateSelfSignedCertificate(certificateTypes);
+					} catch (Exception e) {
+						throw new GenericEvitaInternalError(
+							"Failed to generate self-signed certificate: " + e.getMessage(),
+							"Failed to generate self-signed certificate",
+							e
+						);
+					}
+				} else if (!certificateFile.exists() || !certificateKeyFile.exists() || !rootCaFile.exists()) {
+					throw new EvitaInvalidUsageException("One of the essential certificate files is missing. Please either " +
+						"provide all of these files or delete all files in the configured certificate folder and try again."
+					);
+				}
 			}
 		} else {
 			if (!certificateFile.exists() || !certificateKeyFile.exists()) {
@@ -290,6 +311,7 @@ public class ExternalApiServer implements AutoCloseable {
 		@Nonnull ApiOptions apiOptions,
 		@SuppressWarnings("rawtypes") @Nonnull Collection<ExternalApiProviderRegistrar> externalApiProviders
 	) {
+		//noinspection rawtypes
 		return (Map) externalApiProviders
 			.stream()
 			.sorted(Comparator.comparingInt(ExternalApiProviderRegistrar::getOrder))
@@ -334,7 +356,8 @@ public class ExternalApiServer implements AutoCloseable {
 		final Undertow.Builder rootServerBuilder = Undertow.builder();
 
 		final ServerCertificateManager serverCertificateManager = new ServerCertificateManager(apiOptions.certificate());
-		final CertificatePath certificatePath = initCertificate(apiOptions, serverCertificateManager);
+		final CertificatePath certificatePath = apiOptions.certificate().generateAndUseSelfSigned() ?
+			initCertificate(apiOptions, serverCertificateManager) : null;
 
 		this.registeredApiProviders = registerApiProviders(evita, this, apiOptions, externalApiProviders);
 		if (this.registeredApiProviders.isEmpty()) {
@@ -402,7 +425,7 @@ public class ExternalApiServer implements AutoCloseable {
 	private void configureUndertow(
 		@Nonnull Undertow.Builder undertowBuilder,
 		@Nonnull Evita evita,
-		@Nonnull CertificatePath certificatePath,
+		@Nullable CertificatePath certificatePath,
 		@Nonnull ApiOptions apiOptions,
 		@Nonnull ServerCertificateManager serverCertificateManager
 	) {
@@ -460,83 +483,102 @@ public class ExternalApiServer implements AutoCloseable {
 
 		final AccessLogReceiver accessLogReceiver = apiOptions.accessLog() ? new Slf4JAccessLogReceiver() : new NoopAccessLogReceiver();
 
-		final SSLContext sslContext = configureSSLContext(certificatePath, serverCertificateManager);
+		final Optional<SSLContext> sslContext = certificatePath == null ?
+			empty() : of(configureSSLContext(certificatePath, serverCertificateManager));
 		final Map<HostKey, PathHandler> undertowSetupHosts = createHashMap(10);
-		for (ExternalApiProvider<?> registeredApiProvider : registeredApiProviders.values()) {
-			final AbstractApiConfiguration configuration = apiOptions.endpoints().get(registeredApiProvider.getCode());
-			for (HostDefinition host : configuration.getHost()) {
-				final HostKey hostKey = new HostKey(host, configuration.isTlsEnabled());
-				if (!registeredApiProvider.isManagedByUndertow() || registeredApiProvider.getApiHandler() == null) {
-					continue;
-				}
+		this.registeredApiProviders
+			.entrySet()
+			.stream()
+			.sorted(Entry.comparingByKey())
+			.forEach(
+				entry -> {
+					final String apiCode = entry.getKey();
+					final ExternalApiProvider<?> registeredApiProvider = entry.getValue();
+					final AbstractApiConfiguration configuration = apiOptions.endpoints().get(registeredApiProvider.getCode());
+					for (HostDefinition host : configuration.getHost()) {
+						final HostKey hostKey = new HostKey(host, configuration.isTlsEnabled());
+						if (!registeredApiProvider.isManagedByUndertow() || registeredApiProvider.getApiHandler() == null) {
+							continue;
+						}
 
-				final boolean portCollision = undertowSetupHosts.keySet()
-					.stream()
-					.anyMatch(it -> it.host().port() == hostKey.host().port() &&
-						it.ssl() != hostKey.ssl());
-				if (portCollision) {
-					throw new EvitaInvalidUsageException("There is ports collision in APIs configuration for `" + host + "`.");
-				}
+						final boolean portCollision = undertowSetupHosts.keySet()
+							.stream()
+							.anyMatch(it -> it.host().port() == hostKey.host().port() &&
+								it.ssl() != hostKey.ssl());
+						if (portCollision) {
+							throw new EvitaInvalidUsageException("There is ports collision in APIs configuration for `" + host + "`.");
+						}
 
-				final PathHandler hostRouter;
-				if (undertowSetupHosts.containsKey(hostKey)) {
-					hostRouter = undertowSetupHosts.get(hostKey);
-				} else {
-					hostRouter = Handlers.path();
-					undertowSetupHosts.put(hostKey, hostRouter);
+						final PathHandler hostRouter;
+						if (undertowSetupHosts.containsKey(hostKey)) {
+							hostRouter = undertowSetupHosts.get(hostKey);
+						} else {
+							hostRouter = Handlers.path();
+							undertowSetupHosts.put(hostKey, hostRouter);
 
-					final HttpHandler fallbackHandler = new FallbackExceptionHandler(hostRouter);
+							final HttpHandler fallbackHandler = new FallbackExceptionHandler(hostRouter);
 
-					// we want to support GZIP/deflate compression options for large payloads
-					// source https://stackoverflow.com/questions/28295752/compressing-undertow-server-responses#28329810
-					final EncodingHandler compressionHandler = new EncodingHandler(
-						new ContentEncodingRepository()
-							.addEncodingHandler("gzip", new GzipEncodingProvider(), 50)
-							.addEncodingHandler("deflate", new DeflateEncodingProvider(), 5)
-					)
-						.setNext(fallbackHandler);
+							// we want to support GZIP/deflate compression options for large payloads
+							// source https://stackoverflow.com/questions/28295752/compressing-undertow-server-responses#28329810
+							final EncodingHandler compressionHandler = new EncodingHandler(
+								new ContentEncodingRepository()
+									.addEncodingHandler("gzip", new GzipEncodingProvider(), 50)
+									.addEncodingHandler("deflate", new DeflateEncodingProvider(), 5)
+							)
+								.setNext(fallbackHandler);
 
-					// we want to log all requests coming into the Undertow server
-					final HttpHandler accessLogHandler = new AccessLogHandler(
-						compressionHandler,
-						accessLogReceiver,
-						"combined",
-						ExternalApiServer.class.getClassLoader()
+							// we want to log all requests coming into the Undertow server
+							final HttpHandler accessLogHandler = new AccessLogHandler(
+								compressionHandler,
+								accessLogReceiver,
+								"combined",
+								ExternalApiServer.class.getClassLoader()
+							);
+
+							if (configuration.isTlsEnabled()) {
+								undertowBuilder.addHttpsListener(
+									host.port(), host.host().getHostAddress(),
+									sslContext
+										.orElseThrow(
+											() -> new ExternalApiInternalError(
+												"API `" + apiCode + "` has TLS enabled, but server is not configured" +
+													" to use either provided server certificate nor to generate its own self-signed one."
+											)
+										),
+									accessLogHandler
+								);
+							} else {
+								undertowBuilder.addHttpListener(host.port(), host.host().getHostAddress(), accessLogHandler);
+							}
+						}
+
+						Assert.isPremiseValid(
+							configuration instanceof ApiWithSpecificPrefix,
+							() -> new ExternalApiInternalError("Cannot register path because API `" + apiCode + "` has no prefix specified.")
+						);
+						hostRouter.addPrefixPath(
+							((ApiWithSpecificPrefix) configuration).getPrefix(),
+							registeredApiProvider.getApiHandler()
+						);
+					}
+					ConsoleWriter.write(
+						StringUtils.rightPad("API `" + apiCode + "` listening on ", " ", PADDING_START_UP)
 					);
+					final String[] baseUrls = configuration.getBaseUrls(apiOptions.exposedOn());
+					for (int i = 0; i < baseUrls.length; i++) {
+						final String url = baseUrls[i];
+						if (i > 0) {
+							ConsoleWriter.write(", ", ConsoleColor.WHITE);
+						}
+						ConsoleWriter.write(url, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
+					}
+					ConsoleWriter.write("\n", ConsoleColor.WHITE);
 
-					if (configuration.isTlsEnabled()) {
-						undertowBuilder.addHttpsListener(host.port(), host.host().getHostAddress(), sslContext, accessLogHandler);
-					} else {
-						undertowBuilder.addHttpListener(host.port(), host.host().getHostAddress(), accessLogHandler);
+					if (registeredApiProvider instanceof ExternalApiProviderWithConsoleOutput<?> consoleOutput) {
+						consoleOutput.writeToConsole();
 					}
 				}
-
-				Assert.isPremiseValid(
-					configuration instanceof ApiWithSpecificPrefix,
-					() -> new ExternalApiInternalError("Cannot register path because API has no prefix specified.")
-				);
-				hostRouter.addPrefixPath(
-					((ApiWithSpecificPrefix) configuration).getPrefix(),
-					registeredApiProvider.getApiHandler()
-				);
-			}
-			ConsoleWriter.write(
-				StringUtils.rightPad("API `" + registeredApiProvider.getCode() + "` listening on ", " ", PADDING_START_UP)
 			);
-			final String[] baseUrls = configuration.getBaseUrls(apiOptions.exposedOn());
-			for (int i = 0; i < baseUrls.length; i++) {
-				final String url = baseUrls[i];
-				if (i > 0) {
-					ConsoleWriter.write(", ", ConsoleColor.WHITE);
-				}
-				ConsoleWriter.write(url, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
-			}
-			ConsoleWriter.write("\n", ConsoleColor.WHITE);
-
-			if (registeredApiProvider instanceof ExternalApiProviderWithConsoleOutput consoleOutput) {
-				consoleOutput.writeToConsole();
-			}
-		}
 	}
 
 	private record HostKey(HostDefinition host, boolean ssl) {

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/configuration/GrpcConfig.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/configuration/GrpcConfig.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -70,4 +70,10 @@ public class GrpcConfig extends AbstractApiConfiguration {
 		super(enabled, host, exposedHost, true);
 		this.mtlsConfiguration = mtlsConfiguration;
 	}
+
+	@Override
+	public boolean isMtlsEnabled() {
+		return mtlsConfiguration.enabled();
+	}
+
 }

--- a/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/SystemProvider.java
+++ b/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/SystemProvider.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ package io.evitadb.externalApi.system;
 import io.evitadb.externalApi.http.ExternalApiProviderWithConsoleOutput;
 import io.evitadb.externalApi.http.ExternalApiServer;
 import io.evitadb.externalApi.system.configuration.SystemConfig;
+import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.ConsoleWriter;
 import io.evitadb.utils.ConsoleWriter.ConsoleColor;
 import io.evitadb.utils.ConsoleWriter.ConsoleDecoration;
@@ -97,53 +98,63 @@ public class SystemProvider implements ExternalApiProviderWithConsoleOutput<Syst
 			ConsoleWriter.write(serverNameUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
 		}
 		ConsoleWriter.write("\n", ConsoleColor.WHITE);
-		ConsoleWriter.write(StringUtils.rightPad("   - CA certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
-		for (int i = 0; i < rootCertificateUrls.length; i++) {
-			final String rootCertificateUrl = rootCertificateUrls[i];
-			if (i > 0) {
-				ConsoleWriter.write(", ", ConsoleColor.WHITE);
+		if (!ArrayUtils.isEmpty(rootCertificateUrls)) {
+			ConsoleWriter.write(StringUtils.rightPad("   - CA certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
+			for (int i = 0; i < rootCertificateUrls.length; i++) {
+				final String rootCertificateUrl = rootCertificateUrls[i];
+				if (i > 0) {
+					ConsoleWriter.write(", ", ConsoleColor.WHITE);
+				}
+				ConsoleWriter.write(rootCertificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
 			}
-			ConsoleWriter.write(rootCertificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
+			ConsoleWriter.write("\n", ConsoleColor.WHITE);
 		}
-		ConsoleWriter.write("\n", ConsoleColor.WHITE);
-		ConsoleWriter.write(StringUtils.rightPad("   - server certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
-		for (int i = 0; i < serverCertificateUrls.length; i++) {
-			final String serverCertificateUrl = serverCertificateUrls[i];
-			if (i > 0) {
-				ConsoleWriter.write(", ", ConsoleColor.WHITE);
+		if (!ArrayUtils.isEmpty(serverCertificateUrls)) {
+			ConsoleWriter.write(StringUtils.rightPad("   - server certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
+			for (int i = 0; i < serverCertificateUrls.length; i++) {
+				final String serverCertificateUrl = serverCertificateUrls[i];
+				if (i > 0) {
+					ConsoleWriter.write(", ", ConsoleColor.WHITE);
+				}
+				ConsoleWriter.write(serverCertificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
 			}
-			ConsoleWriter.write(serverCertificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
+			ConsoleWriter.write("\n", ConsoleColor.WHITE);
 		}
-		ConsoleWriter.write("\n", ConsoleColor.WHITE);
-		ConsoleWriter.write(StringUtils.rightPad("   - client certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
-		for (int i = 0; i < clientCertificateUrls.length; i++) {
-			final String clientCertificateUrl = clientCertificateUrls[i];
-			if (i > 0) {
-				ConsoleWriter.write(", ", ConsoleColor.WHITE);
+		if (!ArrayUtils.isEmpty(clientCertificateUrls)) {
+			ConsoleWriter.write(StringUtils.rightPad("   - client certificate served at: ", " ", ExternalApiServer.PADDING_START_UP));
+			for (int i = 0; i < clientCertificateUrls.length; i++) {
+				final String clientCertificateUrl = clientCertificateUrls[i];
+				if (i > 0) {
+					ConsoleWriter.write(", ", ConsoleColor.WHITE);
+				}
+				ConsoleWriter.write(clientCertificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
 			}
-			ConsoleWriter.write(clientCertificateUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
+			ConsoleWriter.write("\n", ConsoleColor.WHITE);
 		}
-		ConsoleWriter.write("\n", ConsoleColor.WHITE);
-		ConsoleWriter.write(StringUtils.rightPad("   - client private key served at: ", " ", ExternalApiServer.PADDING_START_UP));
-		for (int i = 0; i < clientPrivateKeyUrls.length; i++) {
-			final String clientPrivateKeyUrl = clientPrivateKeyUrls[i];
-			if (i > 0) {
-				ConsoleWriter.write(", ", ConsoleColor.WHITE);
+		if (!ArrayUtils.isEmpty(clientPrivateKeyUrls)) {
+			ConsoleWriter.write(StringUtils.rightPad("   - client private key served at: ", " ", ExternalApiServer.PADDING_START_UP));
+			for (int i = 0; i < clientPrivateKeyUrls.length; i++) {
+				final String clientPrivateKeyUrl = clientPrivateKeyUrls[i];
+				if (i > 0) {
+					ConsoleWriter.write(", ", ConsoleColor.WHITE);
+				}
+				ConsoleWriter.write(clientPrivateKeyUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
 			}
-			ConsoleWriter.write(clientPrivateKeyUrl, ConsoleColor.DARK_BLUE, ConsoleDecoration.UNDERLINE);
+			ConsoleWriter.write("\n", ConsoleColor.WHITE);
 		}
-		ConsoleWriter.write("\n", ConsoleColor.WHITE);
-		ConsoleWriter.write("""
-                
-                ************************* WARNING!!! *************************
-                You use mTLS with automatically generated client certificate.
-                This is not safe for production environments!
-                Supply the certificate for production manually and set `useGeneratedCertificate` to false.
-                ************************* WARNING!!! *************************
-                
-                """,
-			ConsoleColor.BRIGHT_RED, ConsoleDecoration.BOLD
-		);
+		if (!ArrayUtils.isEmpty(clientCertificateUrls)) {
+			ConsoleWriter.write("""
+					
+					************************* WARNING!!! *************************
+					You use mTLS with automatically generated client certificate.
+					This is not safe for production environments!
+					Supply the certificate for production manually and set `useGeneratedCertificate` to false.
+					************************* WARNING!!! *************************
+					
+					""",
+				ConsoleColor.BRIGHT_RED, ConsoleDecoration.BOLD
+			);
+		}
 	}
 
 	@Override

--- a/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/SystemProviderRegistrar.java
+++ b/evita_external_api/evita_external_api_system/src/main/java/io/evitadb/externalApi/system/SystemProviderRegistrar.java
@@ -30,6 +30,7 @@ import io.evitadb.externalApi.api.system.ProbesProvider;
 import io.evitadb.externalApi.api.system.ProbesProvider.Readiness;
 import io.evitadb.externalApi.api.system.ProbesProvider.ReadinessState;
 import io.evitadb.externalApi.api.system.model.HealthProblem;
+import io.evitadb.externalApi.configuration.AbstractApiConfiguration;
 import io.evitadb.externalApi.configuration.ApiOptions;
 import io.evitadb.externalApi.configuration.CertificatePath;
 import io.evitadb.externalApi.configuration.CertificateSettings;
@@ -38,6 +39,7 @@ import io.evitadb.externalApi.http.ExternalApiProvider;
 import io.evitadb.externalApi.http.ExternalApiProviderRegistrar;
 import io.evitadb.externalApi.http.ExternalApiServer;
 import io.evitadb.externalApi.system.configuration.SystemConfig;
+import io.evitadb.utils.Assert;
 import io.evitadb.utils.CertificateUtils;
 import io.evitadb.utils.StringUtils;
 import io.undertow.Handlers;
@@ -179,25 +181,6 @@ public class SystemProviderRegistrar implements ExternalApiProviderRegistrar<Sys
 		@Nonnull ApiOptions apiOptions,
 		@Nonnull SystemConfig systemConfig
 	) {
-		final File file;
-		final String fileName;
-		final CertificateSettings certificateSettings = apiOptions.certificate();
-		if (certificateSettings.generateAndUseSelfSigned()) {
-			file = apiOptions.certificate()
-				.getFolderPath()
-				.toFile();
-			fileName = CertificateUtils.getGeneratedRootCaCertificateFileName();
-		} else {
-			final CertificatePath certificatePath = certificateSettings.custom();
-			if (certificatePath == null || certificatePath.certificate() == null || certificatePath.privateKey() == null) {
-				throw new GenericEvitaInternalError("Certificate path is not properly set in the configuration file.");
-			}
-			final String certificate = certificatePath.certificate();
-			final int lastSeparatorIndex = certificatePath.certificate().lastIndexOf(File.separator);
-			file = new File(certificate.substring(0, lastSeparatorIndex));
-			fileName = certificate.substring(lastSeparatorIndex);
-		}
-
 		final PathHandler router = Handlers.path();
 		router.addExactPath(
 			"/" + ENDPOINT_SERVER_NAME,
@@ -281,58 +264,101 @@ public class SystemProviderRegistrar implements ExternalApiProviderRegistrar<Sys
 			}
 		);
 
-		final ResourceHandler fileSystemHandler;
-		try (ResourceManager resourceManager = new FileResourceManager(file, 100)) {
-			fileSystemHandler = new ResourceHandler(
-				(exchange, path) -> {
-					if (("/" + fileName).equals(path)) {
-						return resourceManager.getResource(fileName);
-					} else if (("/" + CertificateUtils.getGeneratedServerCertificateFileName()).equals(path) && certificateSettings.generateAndUseSelfSigned()) {
-						return resourceManager.getResource(CertificateUtils.getGeneratedServerCertificateFileName());
-					} else if (("/" + CertificateUtils.getGeneratedClientCertificateFileName()).equals(path) && certificateSettings.generateAndUseSelfSigned()) {
-						return resourceManager.getResource(CertificateUtils.getGeneratedClientCertificateFileName());
-					} else if (("/" + CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName()).equals(path) && certificateSettings.generateAndUseSelfSigned()) {
-						return resourceManager.getResource(CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName());
-					} else {
-						return null;
-					}
+		final String fileName;
+		final CertificateSettings certificateSettings = apiOptions.certificate();
+		final boolean atLeastOnEndpointRequiresTls = apiOptions.endpoints()
+			.values()
+			.stream()
+			.anyMatch(AbstractApiConfiguration::isTlsEnabled);
+		final boolean atLeastOnEndpointRequiresMtls = apiOptions.endpoints()
+			.values()
+			.stream()
+			.anyMatch(it -> {
+				if (it.isMtlsEnabled()) {
+					Assert.isPremiseValid(
+						it.isTlsEnabled(), "mTLS cannot be enabled without enabled TLS!"
+					);
+					return true;
+				} else {
+					return false;
 				}
-			);
-			router.addPrefixPath("/", fileSystemHandler);
+			});
 
-			return new SystemProvider(
-				systemConfig,
-				new BlockingHandler(
-					new CorsFilter(
-						router,
-						systemConfig.getAllowedOrigins()
-					)
-				),
-				Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
-					.map(it -> it + ENDPOINT_SERVER_NAME)
-					.toArray(String[]::new),
-				Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
+		if (atLeastOnEndpointRequiresTls) {
+			final File file;
+			if (certificateSettings.generateAndUseSelfSigned()) {
+				file = apiOptions.certificate()
+					.getFolderPath()
+					.toFile();
+				fileName = CertificateUtils.getGeneratedRootCaCertificateFileName();
+			} else {
+				final CertificatePath certificatePath = certificateSettings.custom();
+				if (certificatePath == null || certificatePath.certificate() == null || certificatePath.privateKey() == null) {
+					throw new GenericEvitaInternalError(
+						"Certificate path is not properly set in the configuration file and `generateAndUseSelfSigned` is set to false."
+					);
+				}
+				final String certificate = certificatePath.certificate();
+				final int lastSeparatorIndex = certificatePath.certificate().lastIndexOf(File.separator);
+				file = new File(certificate.substring(0, lastSeparatorIndex));
+				fileName = certificate.substring(lastSeparatorIndex);
+			}
+
+			try (ResourceManager resourceManager = new FileResourceManager(file, 100)) {
+				final ResourceHandler fileSystemHandler = new ResourceHandler(
+					(exchange, path) -> {
+						if (("/" + fileName).equals(path)) {
+							return resourceManager.getResource(fileName);
+						} else if (("/" + CertificateUtils.getGeneratedServerCertificateFileName()).equals(path) && certificateSettings.generateAndUseSelfSigned()) {
+							return resourceManager.getResource(CertificateUtils.getGeneratedServerCertificateFileName());
+						} else if (("/" + CertificateUtils.getGeneratedClientCertificateFileName()).equals(path) && certificateSettings.generateAndUseSelfSigned()) {
+							return resourceManager.getResource(CertificateUtils.getGeneratedClientCertificateFileName());
+						} else if (("/" + CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName()).equals(path) && certificateSettings.generateAndUseSelfSigned()) {
+							return resourceManager.getResource(CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName());
+						} else {
+							return null;
+						}
+					}
+				);
+				router.addPrefixPath("/", fileSystemHandler);
+			} catch (IOException e) {
+				throw new GenericEvitaInternalError(e.getMessage(), e);
+			}
+		} else {
+			fileName = null;
+		}
+
+		return new SystemProvider(
+			systemConfig,
+			new BlockingHandler(
+				new CorsFilter(
+					router,
+					systemConfig.getAllowedOrigins()
+				)
+			),
+			Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
+				.map(it -> it + ENDPOINT_SERVER_NAME)
+				.toArray(String[]::new),
+			fileName == null ?
+				new String[0] : Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
 					.map(it -> it + fileName)
 					.toArray(String[]::new),
-				certificateSettings.generateAndUseSelfSigned() ?
-					Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
-						.map(it -> it + CertificateUtils.getGeneratedServerCertificateFileName())
-						.toArray(String[]::new) :
-					new String[0],
-				certificateSettings.generateAndUseSelfSigned() ?
-					Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
-						.map(it -> it + CertificateUtils.getGeneratedClientCertificateFileName())
-						.toArray(String[]::new) :
-					new String[0],
-				certificateSettings.generateAndUseSelfSigned() ?
-					Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
-						.map(it -> it + CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName())
-						.toArray(String[]::new) :
-					new String[0]
-			);
-		} catch (IOException e) {
-			throw new GenericEvitaInternalError(e.getMessage(), e);
-		}
+			certificateSettings.generateAndUseSelfSigned() && atLeastOnEndpointRequiresTls ?
+				Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
+					.map(it -> it + CertificateUtils.getGeneratedServerCertificateFileName())
+					.toArray(String[]::new) :
+				new String[0],
+			certificateSettings.generateAndUseSelfSigned() && atLeastOnEndpointRequiresMtls ?
+				Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
+					.map(it -> it + CertificateUtils.getGeneratedClientCertificateFileName())
+					.toArray(String[]::new) :
+				new String[0],
+			certificateSettings.generateAndUseSelfSigned() && atLeastOnEndpointRequiresMtls ?
+				Arrays.stream(systemConfig.getBaseUrls(apiOptions.exposedOn()))
+					.map(it -> it + CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName())
+					.toArray(String[]::new) :
+				new String[0]
+		);
 	}
 
 }

--- a/evita_server/run-server.sh
+++ b/evita_server/run-server.sh
@@ -26,6 +26,6 @@ java \
         -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8005 \
         -javaagent:target/evita-server.jar \
         -jar "target/evita-server.jar" \
-        "configDir=../docker/" \
+        "configDir=../config/" \
         "storage.storageDirectory=../data " \
         "cache.enabled=false"

--- a/evita_server/src/main/java/io/evitadb/server/EvitaServer.java
+++ b/evita_server/src/main/java/io/evitadb/server/EvitaServer.java
@@ -467,6 +467,7 @@ public class EvitaServer {
 					final String fileName = it.getFileName().toString().toLowerCase();
 					return fileName.endsWith(".yaml") || fileName.endsWith(".yml");
 				})
+				.map(Path::normalize)
 				.sorted()
 				.toArray(Path[]::new);
 			evitaServerConfig = mergeYamlFiles(

--- a/evita_server/src/main/resources/evita-configuration.yaml
+++ b/evita_server/src/main/resources/evita-configuration.yaml
@@ -74,6 +74,7 @@ api:
       enabled: ${api.endpoints.gRPC.enabled:true}
       host: ${api.endpoints.gRPC.host:localhost:5556}
       exposedHost: ${api.endpoints.gRPC.exposedHost:null}
+      tlsEnabled: ${api.endpoints.gRPC.tlsEnabled:true}
       mTLS:
         enabled: ${api.endpoints.gRPC.mTLS.enabled:false}
         allowedClientCertificatePaths: ${api.endpoints.gRPC.mTLS.allowedClientCertificatesPaths:[]}


### PR DESCRIPTION
…gured

Currently server generates or requires access to the certificates even if there is no TLS configured on any endpoint. Also we shouldn't generate and provide client certificates if MTLs is not configured.

Also this patch changes how gRPC readiness probe works. Now Managed channel is used.