### PR TITLE
fix(#590): Catalog data file gets broken after compaction

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/exception/TransactionException.java
+++ b/evita_api/src/main/java/io/evitadb/api/exception/TransactionException.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import java.io.Serial;
 public class TransactionException extends EvitaInternalError {
 	@Serial private static final long serialVersionUID = -4612052525218524619L;
 
-	protected TransactionException(@Nonnull String message) {
+	public TransactionException(@Nonnull String message) {
 		super(message);
 	}
 

--- a/evita_common/src/main/java/io/evitadb/dataType/array/CompositeObjectArray.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/array/CompositeObjectArray.java
@@ -237,7 +237,7 @@ public class CompositeObjectArray<T> implements Iterable<T> {
 			} else if (index * -1 > CHUNK_SIZE) {
 				// continue searching - the index is out of this chunk
 			} else if (index < -1) {
-				return -1 * CHUNK_SIZE + index;
+				return -1 * i * CHUNK_SIZE + index;
 			}
 		}
 		return -1;

--- a/evita_engine/src/main/java/io/evitadb/core/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/Catalog.java
@@ -281,7 +281,7 @@ public final class Catalog implements CatalogContract, CatalogVersionBeyondTheHo
 	) {
 		final SubmissionPublisher<ConflictResolutionTransactionTask> txPublisher = new SubmissionPublisher<>(scheduler, transactionOptions.maxQueueSize());
 		final ConflictResolutionTransactionStage stage1 = new ConflictResolutionTransactionStage(scheduler, transactionOptions.maxQueueSize(), catalog);
-		final WalAppendingTransactionStage stage2 = new WalAppendingTransactionStage(scheduler, transactionOptions.maxQueueSize(), catalog);
+		final WalAppendingTransactionStage stage2 = new WalAppendingTransactionStage(scheduler, transactionOptions.maxQueueSize(), catalog, stage1::notifyCatalogVersionDropped);
 		final TrunkIncorporationTransactionStage stage3 = new TrunkIncorporationTransactionStage(scheduler, transactionOptions.maxQueueSize(), catalog, transactionOptions.flushFrequencyInMillis());
 		final CatalogSnapshotPropagationTransactionStage stage4 = new CatalogSnapshotPropagationTransactionStage(newCatalogVersionConsumer);
 
@@ -1065,7 +1065,7 @@ public final class Catalog implements CatalogContract, CatalogVersionBeyondTheHo
 		@Nonnull CompletableFuture<Long> transactionFinalizationFuture
 	) {
 		try {
-			transactionalPipeline.submit(
+			transactionalPipeline.offer(
 				new ConflictResolutionTransactionTask(
 					getName(),
 					transactionId,
@@ -1074,7 +1074,15 @@ public final class Catalog implements CatalogContract, CatalogVersionBeyondTheHo
 					walPersistenceService.getWalReference(),
 					commitBehaviour,
 					transactionFinalizationFuture
-				)
+				),
+				(subscriber, task) -> {
+					transactionFinalizationFuture.completeExceptionally(
+						new TransactionException(
+							"Conflict resolution transaction queue is full! Transaction cannot be processed at the moment."
+						)
+					);
+					return false;
+				}
 			);
 		} catch (Exception e) {
 			if (e.getCause() instanceof TransactionException txException) {

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTransactionalFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTransactionalFunctionalTest.java
@@ -29,13 +29,16 @@ import com.github.javafaker.Faker;
 import io.evitadb.api.SessionTraits.SessionFlags;
 import io.evitadb.api.TransactionContract.CommitBehavior;
 import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
 import io.evitadb.api.configuration.StorageOptions;
 import io.evitadb.api.configuration.TransactionOptions;
 import io.evitadb.api.exception.RollbackException;
 import io.evitadb.api.query.QueryConstraints;
 import io.evitadb.api.requestResponse.data.EntityContract;
+import io.evitadb.api.requestResponse.data.EntityEditor.EntityBuilder;
 import io.evitadb.api.requestResponse.data.InstanceEditor;
 import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.data.SealedInstance;
 import io.evitadb.api.requestResponse.data.mutation.EntityMutation;
 import io.evitadb.api.requestResponse.data.structure.EntityReference;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
@@ -46,6 +49,7 @@ import io.evitadb.api.requestResponse.system.CatalogVersionDescriptor;
 import io.evitadb.api.requestResponse.system.CatalogVersionDescriptor.TransactionChanges;
 import io.evitadb.api.requestResponse.system.TimeFlow;
 import io.evitadb.api.requestResponse.transaction.TransactionMutation;
+import io.evitadb.core.Catalog;
 import io.evitadb.core.Evita;
 import io.evitadb.core.EvitaSession;
 import io.evitadb.core.Transaction;
@@ -65,9 +69,12 @@ import io.evitadb.test.Entities;
 import io.evitadb.test.EvitaTestSupport;
 import io.evitadb.test.annotation.DataSet;
 import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.duration.TimeArgumentProvider;
+import io.evitadb.test.duration.TimeArgumentProvider.GenerationalTestInput;
 import io.evitadb.test.extension.EvitaParameterResolver;
 import io.evitadb.test.generator.DataGenerator;
 import io.evitadb.utils.CollectionUtils;
+import io.evitadb.utils.StringUtils;
 import io.evitadb.utils.UUIDUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
@@ -75,10 +82,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
+import java.math.BigDecimal;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -86,6 +98,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -101,6 +114,7 @@ import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
 import static io.evitadb.api.query.QueryConstraints.entityFetchAllContent;
 import static io.evitadb.test.TestConstants.FUNCTIONAL_TEST;
 import static io.evitadb.test.generator.DataGenerator.ATTRIBUTE_CODE;
@@ -283,6 +297,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 
 		final Path catalogDirectory = cfg.storage().storageDirectory().resolve(TEST_CATALOG);
 		final CatalogWriteAheadLog wal = new CatalogWriteAheadLog(
+			0L,
 			TEST_CATALOG,
 			catalogDirectory,
 			catalogKryoPool,
@@ -336,6 +351,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 
 		final Path catalogDirectory = cfg.storage().storageDirectory().resolve(TEST_CATALOG);
 		final CatalogWriteAheadLog wal = new CatalogWriteAheadLog(
+			0L,
 			TEST_CATALOG,
 			catalogDirectory,
 			catalogKryoPool,
@@ -799,7 +815,25 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 	@UseDataSet(value = TRANSACTIONAL_DATA_SET, destroyAfterTest = true)
 	@Tag(LONG_RUNNING_TEST)
 	@Test
-	void shouldAutomaticallyGenerateEntitiesInParallel(EvitaContract evita, SealedEntitySchema productSchema) throws Exception {
+	void shouldAutomaticallyGenerateEntitiesInParallel(EvitaContract originalEvita, SealedEntitySchema productSchema) throws Exception {
+		final EvitaConfiguration originalConfiguration = ((Evita) originalEvita).getConfiguration();
+		originalEvita.close();
+
+		// reinitialize evita with a larger queue size
+		final Evita evita = new Evita(
+			EvitaConfiguration.builder()
+				.name(originalConfiguration.name())
+				.storage(originalConfiguration.storage())
+				.transaction(
+					TransactionOptions.builder()
+						.maxQueueSize(16_384)
+						.build()
+				)
+				.server(originalConfiguration.server())
+				.cache(originalConfiguration.cache())
+				.build()
+		);
+
 		final int numberOfThreads = 30;
 		final int iterations = 100;
 		final ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
@@ -903,8 +937,183 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 
 		System.out.println(
 			"Created " + primaryKeysWithTxIds.size() + " entities in " + (numberOfThreads * iterations) +
-				" transactions and " + (System.currentTimeMillis() - initialStart) + " ms."
+				" transactions in " + StringUtils.formatDuration(Duration.ofMillis(System.currentTimeMillis() - initialStart)) + "."
 		);
+	}
+
+	@UseDataSet(value = TRANSACTIONAL_DATA_SET, destroyAfterTest = true)
+	@Tag(LONG_RUNNING_TEST)
+	@ParameterizedTest(name = "This test verifies, that all data files are correctly rotated and compacted.")
+	@ArgumentsSource(TimeArgumentProvider.class)
+	void shouldCorrectlyRotateAllFiles(GenerationalTestInput input) throws Exception {
+		final Path testDirectory = getTestDirectory().resolve("shouldCorrectlyRotateAllFiles");
+		cleanTestSubDirectory("shouldCorrectlyRotateAllFiles");
+		final Evita evita = new Evita(
+			EvitaConfiguration.builder()
+				.storage(
+					StorageOptions.builder()
+						.storageDirectory(testDirectory)
+						.minimalActiveRecordShare(0.9)
+						.fileSizeCompactionThresholdBytes(16_384)
+						.build()
+				)
+				.transaction(
+					TransactionOptions.builder()
+						.walFileSizeBytes(4_096)
+						.walFileCountKept(2)
+						.maxQueueSize(16_384)
+						.build()
+				)
+				.server(
+					ServerOptions.builder()
+						.killTimedOutShortRunningThreadsEverySeconds(-1)
+						.closeSessionsAfterSecondsOfInactivity(-1)
+						.build()
+				)
+				.build()
+		);
+
+		try {
+			final String entityProduct = "product";
+			final String attributeUrl = "url";
+			final String attributeCode = "code";
+			final String attributeName = "name";
+			final String attributePrice = "price";
+
+			final Faker faker = new Faker(new Random(input.randomSeed()));
+			evita.defineCatalog(TEST_CATALOG)
+				.updateAndFetchViaNewSession(evita)
+				.openForWrite()
+				.withAttribute(attributeUrl, String.class)
+				.withEntitySchema(entityProduct, productSchema -> productSchema
+					.withoutGeneratedPrimaryKey()
+					.withGlobalAttribute(attributeUrl)
+					.withAttribute(attributeCode, String.class, thatIs -> thatIs.unique().sortable())
+					.withAttribute(attributeName, String.class, thatIs -> thatIs.filterable().sortable())
+					.withAttribute(attributePrice, BigDecimal.class, thatIs -> thatIs.filterable().sortable()))
+				.updateViaNewSession(evita);
+			evita.updateCatalog(
+				TEST_CATALOG, session -> {
+					session.createNewEntity(entityProduct, 1)
+						.setAttribute(attributeUrl, faker.internet().url())
+						.setAttribute(attributeCode, faker.code().isbn10())
+						.setAttribute(attributeName, faker.book().title())
+						.setAttribute(attributePrice, BigDecimal.valueOf(faker.number().randomDouble(2, 1, 1000)))
+						.upsertVia(session);
+					session.goLiveAndClose();
+				}
+			);
+
+			final LocalDateTime initialStart = LocalDateTime.now();
+			final AtomicReference<SealedEntity> lastVersionEntity = new AtomicReference<>();
+			Long expectedLastVersion = null;
+			long lastWaitCatalogVersion = 0L;
+			do {
+				try {
+					expectedLastVersion = evita.updateCatalogAsync(
+						TEST_CATALOG,
+						session -> {
+							final EntityBuilder entityBuilder = session.getEntity(
+									entityProduct, 1, attributeContentAll()
+								)
+								.map(SealedInstance::openForWrite)
+								.orElseThrow()
+								.setAttribute(attributeUrl, faker.internet().url())
+								.setAttribute(attributeCode, faker.code().isbn10())
+								.setAttribute(attributeName, faker.book().title())
+								.setAttribute(attributePrice, BigDecimal.valueOf(faker.number().randomDouble(2, 1, 1000)));
+							lastVersionEntity.set(entityBuilder.toInstance());
+							entityBuilder.upsertVia(session);
+						},
+						// fast track - we don't wait for anything (to cause as much "churn" as we can)
+						CommitBehavior.WAIT_FOR_CONFLICT_RESOLUTION
+					).get();
+
+					if (expectedLastVersion - 1000 > lastWaitCatalogVersion) {
+						lastWaitCatalogVersion = expectedLastVersion;
+						// wait a while to let the system breathing
+						synchronized (this) {
+							Thread.sleep(10_000);
+						}
+					}
+				} catch (Exception ex) {
+					// wait a while to let the system breathing
+					synchronized (this) {
+						Thread.sleep(10_000);
+					}
+				}
+
+			} while (Duration.between(initialStart, LocalDateTime.now()).toMinutes() < input.intervalInMinutes());
+
+			log.info("Waiting for catalog version " + expectedLastVersion + " to be processed.");
+
+			final LocalDateTime wait = LocalDateTime.now();
+			long lastReportedCatalogVersion = 0L;
+			do {
+				final Long currentCatalogVersion = evita.queryCatalog(
+					TEST_CATALOG,
+					EvitaSessionContract::getCatalogVersion
+				);
+				if (currentCatalogVersion >= expectedLastVersion) {
+					log.info("Catalog version " + expectedLastVersion + " finally processed.");
+					break;
+				} else if (currentCatalogVersion - 500 > lastReportedCatalogVersion) {
+					lastReportedCatalogVersion = currentCatalogVersion;
+					log.info("Waiting for catalog version " + expectedLastVersion + " to be processed (current " + currentCatalogVersion + ").");
+				}
+				Thread.onSpinWait();
+			} while (Duration.between(wait, LocalDateTime.now()).toMinutes() < 5);
+			assertTrue(expectedLastVersion > 10L, "At least 10 versions should be created!");
+
+			// close the evita
+			evita.close();
+
+			try (final Evita restartedEvita = new Evita(evita.getConfiguration())) {
+				assertInstanceOf(
+					Catalog.class, restartedEvita.getCatalogInstance(TEST_CATALOG).orElseThrow(),
+					"Catalog should be loaded from the disk!"
+				);
+
+				restartedEvita.queryCatalog(
+					TEST_CATALOG,
+					evitaSessionContract -> {
+						final Optional<SealedEntity> entity = evitaSessionContract.getEntity(entityProduct, 1, attributeContentAll());
+						assertTrue(entity.isPresent(), "Entity should be present in the catalog!");
+						final SealedEntity expectedEntity = lastVersionEntity.get();
+						final SealedEntity realEntity = entity.get();
+						assertEquals(expectedEntity.getAttribute(attributeCode, String.class), realEntity.getAttribute(attributeCode, String.class));
+						assertEquals(expectedEntity.getAttribute(attributeName, String.class), realEntity.getAttribute(attributeName, String.class));
+						assertEquals(expectedEntity.getAttribute(attributePrice, BigDecimal.class), realEntity.getAttribute(attributePrice, BigDecimal.class));
+						assertEquals(expectedEntity.getAttribute(attributeUrl, String.class), realEntity.getAttribute(attributeUrl, String.class));
+					}
+				);
+			}
+
+			// final solution
+			/*evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.getEntity(entityProduct, 1).isPresent());
+
+					// read entire history
+					DefaultCatalogPersistenceService.getBootstrapRecordStream(
+						TEST_CATALOG, evita.getConfiguration().storage()
+					).forEach(
+						record -> {
+							log.info("Bootstrap record: " + record);
+							// TOBEDONE #41 - reconstruct the catalog from that moment, which verifies the consistency
+						}
+					);
+				}
+			);*/
+		} catch (Exception ex) {
+			log.error("Exception thrown within test!", ex);
+			fail(ex);
+		} finally {
+			if (evita.isActive()) {
+				evita.close();
+			}
+		}
 	}
 
 	/**

--- a/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogIntegrationTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogIntegrationTest.java
@@ -64,6 +64,7 @@ import org.mockito.Mockito;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
@@ -158,7 +159,7 @@ class CatalogWriteAheadLogIntegrationTest {
 	}
 
 	@Test
-	void shouldReadFirstAndLastCatalogVersionOfPreviousWalFiles() {
+	void shouldReadFirstAndLastCatalogVersionOfPreviousWalFiles() throws FileNotFoundException {
 		wal = createCatalogWriteAheadLogOfSmallSize();
 
 		final int[] transactionSizes = {10, 15, 20, 15, 10};

--- a/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
@@ -65,6 +65,7 @@ class CatalogWriteAheadLogTest {
 	};
 	private final WalFileReference walFileReference = new WalFileReference(TEST_CATALOG, 0, null);
 	private final CatalogWriteAheadLog tested = new CatalogWriteAheadLog(
+		0L,
 		TEST_CATALOG,
 		walDirectory,
 		catalogKryoPool,

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/WriteOnlyFileHandle.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/WriteOnlyFileHandle.java
@@ -300,7 +300,15 @@ public class WriteOnlyFileHandle implements WriteOnlyHandle {
 
 	@Override
 	public void close() {
-		this.observableOutputKeeper.close(this.targetFile);
+		try {
+			this.handleLock.lockInterruptibly();
+			this.observableOutputKeeper.close(this.targetFile);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new StorageException("Failed to close file due to interrupt!");
+		} finally {
+			this.handleLock.unlock();
+		}
 	}
 
 	@Override

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/WriteOnlyOffHeapWithFileBackupHandle.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/WriteOnlyOffHeapWithFileBackupHandle.java
@@ -215,8 +215,7 @@ public class WriteOnlyOffHeapWithFileBackupHandle implements WriteOnlyHandle {
 	@Nonnull
 	public OffHeapWithFileBackupReference toReadOffHeapWithFileBackupReference() {
 		// sync to disk first
-		execute("flush", () -> {
-		}, (o) -> null, true);
+		execute("flush", () -> {}, (o) -> null, true);
 
 		if (offHeapMemoryOutput != null) {
 			final ByteBuffer byteBuffer = offHeapMemoryOutput.getOutputStream().getByteBuffer();

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -124,6 +124,7 @@ import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -210,6 +211,10 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	@Nonnull
 	private final AtomicReference<WriteOnlyFileHandle> bootstrapWriteHandle;
 	/**
+	 * This lock synchronizes the access to the bootstrap file.
+	 */
+	private final ReentrantLock bootstrapWriteLock = new ReentrantLock();
+	/**
 	 * Scheduled executor service is used for planning maintenance tasks on the data level.
 	 */
 	@Nonnull private final Scheduler scheduler;
@@ -227,6 +232,10 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		}
 	};
 	/**
+	 * Lock used for synchronization to {@link #catalogPersistenceServiceVersions} array.
+	 */
+	private final ReentrantLock cpsvLock = new ReentrantLock();
+	/**
 	 * Contains sorted array of {@link #catalogStoragePartPersistenceService} keys. It is used for fast lookup of the
 	 * storage part persistence service for a given catalog version.
 	 */
@@ -240,9 +249,13 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	 */
 	@Nullable private CatalogWriteAheadLog catalogWal;
 	/**
-	 * Contains information about the time the non-flushed block was reported.
+	 * Contains the millis from the time the non-flushed block was reported.
 	 */
 	private long lastReportTimestamp;
+	/**
+	 * Contains the millis from the time when catalog statistics was reported.
+	 */
+	private long lastCatalogStatisticsTimestamp;
 
 	/**
 	 * Check whether target directory exists and whether it is really directory.
@@ -420,6 +433,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	 *
 	 * BEWARE: work with {@link CatalogWriteAheadLog} is not thread safe and must be synchronized!
 	 *
+	 * @param catalogVersion     The version of the catalog.
 	 * @param catalogName        The name of the catalog.
 	 * @param catalogStoragePath The path to the storage location of the catalog.
 	 * @param catalogHeader      The catalog header object.
@@ -430,6 +444,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	 */
 	@Nullable
 	private static CatalogWriteAheadLog getCatalogWriteAheadLog(
+		long catalogVersion,
 		@Nonnull String catalogName,
 		@Nonnull Path catalogStoragePath,
 		@Nonnull CatalogHeader catalogHeader,
@@ -470,7 +485,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		return ofNullable(currentWalFileRef)
 			.map(
 				walFileReference -> new CatalogWriteAheadLog(
-					catalogName, catalogStoragePath, catalogKryoPool,
+					catalogVersion, catalogName, catalogStoragePath, catalogKryoPool,
 					storageOptions, transactionOptions, scheduler,
 					bootstrapFileTrimFunction
 				)
@@ -481,6 +496,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	/**
 	 * Creates a CatalogWriteAheadLog if there are any WAL files present in the catalog file path.
 	 *
+	 * @param catalogVersion     the version of the catalog
 	 * @param catalogName        the name of the catalog
 	 * @param storageOptions     the storage options
 	 * @param transactionOptions the transaction options
@@ -491,6 +507,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	 */
 	@Nullable
 	private static CatalogWriteAheadLog createWalIfAnyWalFilePresent(
+		long catalogVersion,
 		@Nonnull String catalogName,
 		@Nonnull StorageOptions storageOptions,
 		@Nonnull TransactionOptions transactionOptions,
@@ -505,7 +522,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		return walFiles == null || walFiles.length == 0 ?
 			null :
 			new CatalogWriteAheadLog(
-				catalogName, catalogFilePath, kryoPool,
+				catalogVersion, catalogName, catalogFilePath, kryoPool,
 				storageOptions, transactionOptions, scheduler,
 				bootstrapFileTrimFunction
 			);
@@ -575,8 +592,11 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 				this.observableOutputKeeper
 			)
 		);
+
+		final long catalogVersion = 0L;
 		this.catalogWal = createWalIfAnyWalFilePresent(
-			catalogName, storageOptions, transactionOptions, scheduler,
+			catalogVersion, catalogName,
+			storageOptions, transactionOptions, scheduler,
 			this::trimBootstrapFile,
 			this.catalogStoragePath, this.catalogKryoPool
 		);
@@ -584,7 +604,6 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		final String catalogFileName = getCatalogDataStoreFileName(catalogName, lastCatalogBootstrap.catalogFileIndex());
 		final Path catalogFilePath = this.catalogStoragePath.resolve(catalogFileName);
 
-		final long catalogVersion = 0L;
 		this.catalogStoragePartPersistenceService = CollectionUtils.createConcurrentHashMap(16);
 		this.catalogStoragePartPersistenceService.put(
 			catalogVersion,
@@ -600,7 +619,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 				observableOutputKeeper,
 				VERSIONED_KRYO_FACTORY,
 				nonFlushedBlock -> this.reportNonFlushedContents(catalogName, nonFlushedBlock),
-				oldestRecordTimestamp -> this.reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null))
+				oldestRecordTimestamp -> reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null))
 			)
 		);
 		this.catalogPersistenceServiceVersions = new long[]{catalogVersion};
@@ -652,13 +671,13 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		final String catalogFileName = getCatalogDataStoreFileName(catalogName, this.bootstrapUsed.catalogFileIndex());
 		final Path catalogFilePath = this.catalogStoragePath.resolve(catalogFileName);
 
+		final long catalogVersion = this.bootstrapUsed.catalogVersion();
 		this.catalogWal = createWalIfAnyWalFilePresent(
-			catalogName, storageOptions, transactionOptions, scheduler,
+			catalogVersion, catalogName, storageOptions, transactionOptions, scheduler,
 			this::trimBootstrapFile,
 			this.catalogStoragePath, this.catalogKryoPool
 		);
 
-		final long catalogVersion = this.bootstrapUsed.catalogVersion();
 		this.catalogStoragePartPersistenceService = CollectionUtils.createConcurrentHashMap(16);
 		final CatalogOffsetIndexStoragePartPersistenceService catalogStoragePartPersistenceService =
 			CatalogOffsetIndexStoragePartPersistenceService.create(
@@ -673,7 +692,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 				this.observableOutputKeeper,
 				VERSIONED_KRYO_FACTORY,
 				nonFlushedBlock -> this.reportNonFlushedContents(catalogName, nonFlushedBlock),
-				oldestRecordTimestamp -> this.reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null))
+				oldestRecordTimestamp -> reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null))
 			);
 		this.catalogStoragePartPersistenceService.put(
 			catalogVersion,
@@ -726,7 +745,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 			this.observableOutputKeeper,
 			VERSIONED_KRYO_FACTORY,
 			nonFlushedBlock -> this.reportNonFlushedContents(catalogName, nonFlushedBlock),
-			oldestRecordTimestamp -> this.reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null)),
+			oldestRecordTimestamp -> reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null)),
 			previousCatalogStoragePartPersistenceService
 		);
 		this.catalogStoragePartPersistenceService = CollectionUtils.createConcurrentHashMap(16);
@@ -804,15 +823,28 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	@Nonnull
 	@Override
 	public CatalogOffsetIndexStoragePartPersistenceService getStoragePartPersistenceService(long catalogVersion) {
-		final int index = Arrays.binarySearch(this.catalogPersistenceServiceVersions, catalogVersion);
-		final int lookupIndex = index >= 0 ? index : (-index - 2);
-		Assert.isPremiseValid(
-			lookupIndex >= 0 && lookupIndex < this.catalogPersistenceServiceVersions.length,
-			() -> new GenericEvitaInternalError("Catalog version " + catalogVersion + " not found in the catalog persistence service versions!")
-		);
-		return this.catalogStoragePartPersistenceService.get(
-			this.catalogPersistenceServiceVersions[lookupIndex]
-		);
+		try {
+			this.cpsvLock.lockInterruptibly();
+			final int index = Arrays.binarySearch(this.catalogPersistenceServiceVersions, catalogVersion);
+			final int lookupIndex = index >= 0 ? index : (-index - 2);
+			Assert.isPremiseValid(
+				lookupIndex >= 0 && lookupIndex < this.catalogPersistenceServiceVersions.length,
+				() -> new GenericEvitaInternalError("Catalog version " + catalogVersion + " not found in the catalog persistence service versions!")
+			);
+			return this.catalogStoragePartPersistenceService.get(
+				this.catalogPersistenceServiceVersions[lookupIndex]
+			);
+		} catch (InterruptedException e) {
+			throw new GenericEvitaInternalError(
+				"Interrupted while trying to lock the catalog persistence service versions!",
+				"Interrupted while trying to lock the catalog persistence service versions!",
+				e
+			);
+		} finally {
+			if (this.cpsvLock.isHeldByCurrentThread()) {
+				this.cpsvLock.unlock();
+			}
+		}
 	}
 
 	@Override
@@ -937,15 +969,24 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 			lastEntityCollectionPrimaryKey
 		);
 		this.bootstrapUsed = recordBootstrap(catalogVersion, this.catalogName, this.bootstrapUsed.catalogFileIndex());
+
+		// notify WAL that the new version was successfully stored
+		if (this.catalogWal != null) {
+			this.catalogWal.walProcessedUntil(catalogVersion);
+		}
+
 		// emit event if the number of collections has changed
-		new CatalogStatisticsEvent(
-			this.catalogName,
-			entityHeaders.size(),
-			FileUtils.getDirectorySize(this.catalogStoragePath),
-			getFirstCatalogBootstrap(this.catalogStoragePath, this.catalogName, this.storageOptions)
-				.map(CatalogBootstrap::timestamp)
-				.orElse(null)
-		).commit();
+		if (System.currentTimeMillis() - this.lastCatalogStatisticsTimestamp > 1000) {
+			new CatalogStatisticsEvent(
+				this.catalogName,
+				entityHeaders.size(),
+				FileUtils.getDirectorySize(this.catalogStoragePath),
+				getFirstCatalogBootstrap(this.catalogStoragePath, this.catalogName, this.storageOptions)
+					.map(CatalogBootstrap::timestamp)
+					.orElse(null)
+			).commit();
+			this.lastCatalogStatisticsTimestamp = System.currentTimeMillis();
+		}
 	}
 
 	@Nonnull
@@ -1093,7 +1134,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 			if (this.catalogWal == null) {
 				final CatalogHeader catalogHeader = getCatalogHeader(catalogVersion);
 				this.catalogWal = getCatalogWriteAheadLog(
-					this.catalogName, this.catalogStoragePath, catalogHeader, this.catalogKryoPool,
+					this.bootstrapUsed.catalogVersion(), this.catalogName, this.catalogStoragePath, catalogHeader, this.catalogKryoPool,
 					this.storageOptions, this.transactionOptions, this.scheduler, this::trimBootstrapFile
 				);
 			}
@@ -1632,29 +1673,46 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 				bootstrapWriteTime,
 				compactedDescriptor.fileLocation()
 			);
-			this.obsoleteFileMaintainer.removeFileWhenNotUsed(
-				catalogVersion,
-				this.catalogStoragePath.resolve(getCatalogDataStoreFileName(newCatalogName, catalogFileIndex)),
-				() -> removeCatalogPersistenceServiceForVersion(catalogVersion)
-			);
-			this.catalogStoragePartPersistenceService.put(
-				catalogVersion,
-				CatalogOffsetIndexStoragePartPersistenceService.create(
-					this.catalogName,
-					compactedFileName,
-					this.catalogStoragePath.resolve(compactedFileName),
-					this.storageOptions,
-					this.transactionOptions,
-					bootstrapRecord,
-					this.recordTypeRegistry,
-					this.offHeapMemoryManager,
-					this.observableOutputKeeper,
-					VERSIONED_KRYO_FACTORY,
-					nonFlushedBlock -> this.reportNonFlushedContents(catalogName, nonFlushedBlock),
-					oldestRecordTimestamp -> this.reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null))
-				)
-			);
-			this.catalogPersistenceServiceVersions = ArrayUtils.insertLongIntoOrderedArray(catalogVersion, this.catalogPersistenceServiceVersions);
+
+			try {
+				this.cpsvLock.lockInterruptibly();
+
+				final long currentVersion = this.catalogPersistenceServiceVersions[this.catalogPersistenceServiceVersions.length - 1];
+				this.obsoleteFileMaintainer.removeFileWhenNotUsed(
+					catalogVersion,
+					this.catalogStoragePath.resolve(getCatalogDataStoreFileName(newCatalogName, catalogFileIndex)),
+					() -> removeCatalogPersistenceServiceForVersion(currentVersion)
+				);
+
+				this.catalogStoragePartPersistenceService.put(
+					catalogVersion,
+					CatalogOffsetIndexStoragePartPersistenceService.create(
+						this.catalogName,
+						compactedFileName,
+						this.catalogStoragePath.resolve(compactedFileName),
+						this.storageOptions,
+						this.transactionOptions,
+						bootstrapRecord,
+						this.recordTypeRegistry,
+						this.offHeapMemoryManager,
+						this.observableOutputKeeper,
+						VERSIONED_KRYO_FACTORY,
+						nonFlushedBlock -> this.reportNonFlushedContents(catalogName, nonFlushedBlock),
+						oldestRecordTimestamp -> DefaultCatalogPersistenceService.reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null))
+					)
+				);
+				this.catalogPersistenceServiceVersions = ArrayUtils.insertLongIntoOrderedArray(catalogVersion, this.catalogPersistenceServiceVersions);
+			} catch (InterruptedException e) {
+				throw new GenericEvitaInternalError(
+					"Failed to lock the catalog persistence service for catalog `" + this.catalogName + "`!",
+					"Failed to lock the catalog persistence service!",
+					e
+				);
+			} finally {
+				if (this.cpsvLock.isHeldByCurrentThread()) {
+					this.cpsvLock.unlock();
+				}
+			}
 
 			// emit the event
 			event.finish().commit();
@@ -1669,6 +1727,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		}
 		final Kryo kryo = this.catalogKryoPool.obtain();
 		try {
+			this.bootstrapWriteLock.lockInterruptibly();
 			final WriteOnlyFileHandle originalBootstrapHandle = this.bootstrapWriteHandle.get();
 			final WriteOnlyFileHandle bootstrapHandle = getOrCreateNewBootstrapTempWriteHandle(
 				catalogVersion, newCatalogName, originalBootstrapHandle
@@ -1713,7 +1772,14 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 			}
 
 			return bootstrapRecord;
+		} catch (InterruptedException e) {
+			throw new GenericEvitaInternalError(
+				"Failed to lock the bootstrap file for catalog `" + this.catalogName + "`!",
+				"Failed to lock the bootstrap file!",
+				e
+			);
 		} finally {
+			this.bootstrapWriteLock.unlock();
 			this.catalogKryoPool.free(kryo);
 			log.debug("Catalog `{}` stored to `{}`.", newCatalogName, catalogStoragePath);
 		}
@@ -1734,6 +1800,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		);
 
 		try {
+			this.bootstrapWriteLock.lockInterruptibly();
 			final WriteOnlyFileHandle originalBootstrapHandle = this.bootstrapWriteHandle.get();
 			final WriteOnlyFileHandle newBootstrapHandle = createNewBootstrapTempWriteHandle(this.catalogName);
 
@@ -1756,7 +1823,14 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 				),
 				() -> new GenericEvitaInternalError("Failed to replace the bootstrap write handle in a critical section!")
 			);
+		} catch (InterruptedException e) {
+			throw new GenericEvitaInternalError(
+				"Failed to lock the bootstrap file for catalog `" + this.catalogName + "`!",
+				"Failed to lock the bootstrap file!",
+				e
+			);
 		} finally {
+			this.bootstrapWriteLock.unlock();
 			// emit the event
 			event.finish().commit();
 		}
@@ -1912,15 +1986,28 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	 * @param catalogVersion the catalog version to remove the persistence service for
 	 */
 	private void removeCatalogPersistenceServiceForVersion(long catalogVersion) {
-		final int index = Arrays.binarySearch(this.catalogPersistenceServiceVersions, catalogVersion);
-		final int lookupIndex = index >= 0 ? index : (-index - 2);
-		Assert.isPremiseValid(
-			lookupIndex >= 0 && lookupIndex < this.catalogPersistenceServiceVersions.length,
-			() -> new GenericEvitaInternalError("Catalog version " + catalogVersion + " not found in the catalog persistence service versions!")
-		);
-		final long versionToRemove = this.catalogPersistenceServiceVersions[lookupIndex];
-		this.catalogPersistenceServiceVersions = ArrayUtils.removeLongFromArrayOnIndex(this.catalogPersistenceServiceVersions, lookupIndex);
-		this.catalogStoragePartPersistenceService.remove(versionToRemove);
+		try {
+			this.cpsvLock.lockInterruptibly();
+			final int index = Arrays.binarySearch(this.catalogPersistenceServiceVersions, catalogVersion);
+			final int lookupIndex = index >= 0 ? index : (-index - 2);
+			Assert.isPremiseValid(
+				lookupIndex >= 0 && lookupIndex < this.catalogPersistenceServiceVersions.length,
+				() -> new GenericEvitaInternalError("Catalog version " + catalogVersion + " not found in the catalog persistence service versions!")
+			);
+			final long versionToRemove = this.catalogPersistenceServiceVersions[lookupIndex];
+			this.catalogPersistenceServiceVersions = ArrayUtils.removeLongFromArrayOnIndex(this.catalogPersistenceServiceVersions, lookupIndex);
+			this.catalogStoragePartPersistenceService.remove(versionToRemove);
+		} catch (InterruptedException e) {
+			throw new GenericEvitaInternalError(
+				"Failed to lock the catalog persistence service for catalog `" + this.catalogName + "`!",
+				"Failed to lock the catalog persistence service!",
+				e
+			);
+		} finally {
+			if (this.cpsvLock.isHeldByCurrentThread()) {
+				this.cpsvLock.unlock();
+			}
+		}
 	}
 
 	/**
@@ -2008,7 +2095,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	 * @param catalogName     name of the catalog
 	 * @param oldestHistoricalRecord oldest historical record
 	 */
-	private void reportOldestHistoricalRecord(@Nonnull String catalogName, @Nullable OffsetDateTime oldestHistoricalRecord) {
+	private static void reportOldestHistoricalRecord(@Nonnull String catalogName, @Nullable OffsetDateTime oldestHistoricalRecord) {
 		new OffsetIndexHistoryKeptEvent(
 			catalogName,
 			FileType.CATALOG,

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/supplier/AbstractMutationSupplier.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/supplier/AbstractMutationSupplier.java
@@ -37,6 +37,7 @@ import lombok.Getter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -55,7 +56,7 @@ import static java.util.Optional.ofNullable;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
-abstract sealed class AbstractMutationSupplier implements Supplier<Mutation>, AutoCloseable
+abstract sealed class AbstractMutationSupplier implements Supplier<Mutation>, Closeable
 	permits MutationSupplier, ReverseMutationSupplier {
 	/**
 	 * The Kryo pool for serializing {@link TransactionMutation} (given by outside).
@@ -134,7 +135,7 @@ abstract sealed class AbstractMutationSupplier implements Supplier<Mutation>, Au
 		this.transactionLocationsCache = transactionLocationsCache;
 		this.avoidPartiallyFilledBuffer = avoidPartiallyFilledBuffer;
 		this.onClose = onClose;
-		if (walFile.length() == 0) {
+		if (!this.walFile.exists() || this.walFile.length() < 4) {
 			this.catalogKryoPool = catalogKryoPool;
 			this.kryo = null;
 			this.observableInput = null;

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/supplier/TransactionLocations.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/supplier/TransactionLocations.java
@@ -146,7 +146,9 @@ public class TransactionLocations {
 						catalogVersion,
 						(transactionLocation, cv) -> Long.compare(transactionLocation.catalogVersion(), cv)
 					);
-					return index >= 0 ? locs.get(index).startPosition() : 0L;
+					return index >= 0 ?
+						locs.get(index).startPosition() :
+						ofNullable(locs.getLast()).map(TransactionLocation::startPosition).orElse(0L);
 				} finally {
 					lock.unlock();
 				}


### PR DESCRIPTION
It seems that when the catalog file exceeds the threshold size (100MB by default) and is compressed into a new file, it's somehow corrupted. The previous file is not deleted, but partially overwritten, and the new file is also corrupted. This was discovered by analyzing file remnants where the original file was much smaller than the 100MB it should have been, and the contents were completely corrupted. It is likely that different tasks are writing to corrupted versions of the file. We need to investigate this issue and write a more complex integration test for this scenario.