### PR TITLE
fix(#598): Selecting facet combination from different groups enables …

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/AbstractFacetFormulaGenerator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/facet/producer/AbstractFacetFormulaGenerator.java
@@ -512,7 +512,7 @@ public abstract class AbstractFacetFormulaGenerator implements FormulaVisitor {
 	 * @return The base entity IDs as a Bitmap.
 	 */
 	@Nonnull
-	protected Bitmap getBaseEntityIds(@Nonnull Bitmap[] facetEntityIds) {
+	protected static Bitmap getBaseEntityIds(@Nonnull Bitmap[] facetEntityIds) {
 		if (facetEntityIds.length == 0) {
 			return EmptyBitmap.INSTANCE;
 		} else if (facetEntityIds.length == 1) {
@@ -677,18 +677,27 @@ public abstract class AbstractFacetFormulaGenerator implements FormulaVisitor {
 		 */
 		private final Deque<Formula> formulaStack = new ArrayDeque<>(16);
 		/**
-		 * Flag that is set to true if the visitor found the target {@link MutableFormula}.
+		 * Reference to {@link MutableFormula} found.
 		 */
-		@Getter private boolean targetFound;
+		@Getter
+		private MutableFormula target;
+
+		/**
+		 * Returns true if the target {@link MutableFormula} has been found.
+		 * @return True if the target {@link MutableFormula} has been found.
+		 */
+		public boolean isTargetFound() {
+			return target != null;
+		}
 
 		@Override
 		public void visit(@Nonnull Formula formula) {
-			if (!targetFound) {
+			if (target == null) {
 				if (formula instanceof MutableFormula mutableFormula) {
-					if (targetFound) {
+					if (target != null) {
 						throw new GenericEvitaInternalError("Expected single MutableFormula in the formula tree!");
 					} else {
-						targetFound = true;
+						target = mutableFormula;
 						mutableFormula.setDelegate(formulaToReplaceSupplier.get());
 						for (Formula parentFormula : formulaStack) {
 							parentFormula.clearMemory();

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/builders/query/extraResults/GrpcFacetSummaryBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/builders/query/extraResults/GrpcFacetSummaryBuilder.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import io.evitadb.api.requestResponse.data.SealedEntity;
 import io.evitadb.api.requestResponse.data.structure.EntityReference;
 import io.evitadb.api.requestResponse.extraResult.FacetSummary;
 import io.evitadb.api.requestResponse.extraResult.FacetSummary.FacetGroupStatistics;
+import io.evitadb.api.requestResponse.extraResult.FacetSummary.RequestImpact;
 import io.evitadb.externalApi.grpc.generated.GrpcEntityReference;
 import io.evitadb.externalApi.grpc.generated.GrpcExtraResults.Builder;
 import io.evitadb.externalApi.grpc.generated.GrpcFacetGroupStatistics;
@@ -75,9 +76,12 @@ public class GrpcFacetSummaryBuilder {
 					statisticsBuilder.setFacetEntity(EntityConverter.toGrpcSealedEntity(entity));
 				}
 
-				if (facetStatistic.getImpact() != null) {
-					statisticsBuilder.setImpact(Int32Value.newBuilder().setValue(facetStatistic.getImpact().difference()).build());
-					statisticsBuilder.setMatchCount(Int32Value.newBuilder().setValue(facetStatistic.getImpact().matchCount()).build());
+				final RequestImpact impact = facetStatistic.getImpact();
+				if (impact != null) {
+					statisticsBuilder.
+						setImpact(Int32Value.newBuilder().setValue(impact.difference()).build())
+						.setMatchCount(Int32Value.newBuilder().setValue(impact.matchCount()).build())
+						.setHasSense(impact.hasSense());
 				}
 
 				final GrpcFacetStatistics statistics = statisticsBuilder.build();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcExtraResultsOuterClass.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcExtraResultsOuterClass.java
@@ -127,7 +127,7 @@ public final class GrpcExtraResultsOuterClass {
       "xternalApi.grpc.generated.GrpcSealedEnti" +
       "ty\022\r\n\005count\030\004 \001(\005\022S\n\017facetStatistics\030\005 \003" +
       "(\0132:.io.evitadb.externalApi.grpc.generat" +
-      "ed.GrpcFacetStatistics\"\275\002\n\023GrpcFacetStat" +
+      "ed.GrpcFacetStatistics\"\317\002\n\023GrpcFacetStat" +
       "istics\022X\n\024facetEntityReference\030\001 \001(\0132:.i" +
       "o.evitadb.externalApi.grpc.generated.Grp" +
       "cEntityReference\022L\n\013facetEntity\030\002 \001(\01327." +
@@ -135,49 +135,50 @@ public final class GrpcExtraResultsOuterClass {
       "pcSealedEntity\022\021\n\trequested\030\003 \001(\010\022\r\n\005cou" +
       "nt\030\004 \001(\005\022+\n\006impact\030\005 \001(\0132\033.google.protob" +
       "uf.Int32Value\022/\n\nmatchCount\030\006 \001(\0132\033.goog" +
-      "le.protobuf.Int32Value\"\320\001\n\rGrpcHierarchy" +
-      "\022V\n\thierarchy\030\001 \003(\0132C.io.evitadb.externa" +
-      "lApi.grpc.generated.GrpcHierarchy.Hierar" +
-      "chyEntry\032g\n\016HierarchyEntry\022\013\n\003key\030\001 \001(\t\022" +
-      "D\n\005value\030\002 \001(\01325.io.evitadb.externalApi." +
-      "grpc.generated.GrpcLevelInfos:\0028\001\"Z\n\016Grp" +
-      "cLevelInfos\022H\n\nlevelInfos\030\001 \003(\01324.io.evi" +
-      "tadb.externalApi.grpc.generated.GrpcLeve" +
-      "lInfo\"\362\002\n\rGrpcLevelInfo\022S\n\017entityReferen" +
-      "ce\030\001 \001(\0132:.io.evitadb.externalApi.grpc.g" +
-      "enerated.GrpcEntityReference\022G\n\006entity\030\002" +
-      " \001(\01327.io.evitadb.externalApi.grpc.gener" +
-      "ated.GrpcSealedEntity\0227\n\022queriedEntityCo" +
-      "unt\030\003 \001(\0132\033.google.protobuf.Int32Value\0222" +
-      "\n\rchildrenCount\030\004 \001(\0132\033.google.protobuf." +
-      "Int32Value\022C\n\005items\030\005 \003(\01324.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcLevelInfo\022" +
-      "\021\n\trequested\030\006 \001(\010\"\335\001\n\022GrpcQueryTelemetr" +
-      "y\022H\n\toperation\030\001 \001(\01625.io.evitadb.extern" +
-      "alApi.grpc.generated.GrpcQueryPhase\022\r\n\005s" +
-      "tart\030\002 \001(\003\022H\n\005steps\030\003 \003(\01329.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcQueryTelem" +
-      "etry\022\021\n\targuments\030\004 \003(\t\022\021\n\tspentTime\030\005 \001" +
-      "(\003\"\200\006\n\020GrpcExtraResults\022k\n\022attributeHist" +
-      "ogram\030\001 \003(\0132O.io.evitadb.externalApi.grp" +
-      "c.generated.GrpcExtraResults.AttributeHi" +
-      "stogramEntry\022L\n\016priceHistogram\030\002 \001(\01324.i" +
-      "o.evitadb.externalApi.grpc.generated.Grp" +
-      "cHistogram\022]\n\024facetGroupStatistics\030\003 \003(\013" +
-      "2?.io.evitadb.externalApi.grpc.generated" +
-      ".GrpcFacetGroupStatistics\022K\n\rselfHierarc" +
-      "hy\030\004 \001(\01324.io.evitadb.externalApi.grpc.g" +
-      "enerated.GrpcHierarchy\022Y\n\thierarchy\030\005 \003(" +
-      "\0132F.io.evitadb.externalApi.grpc.generate" +
-      "d.GrpcExtraResults.HierarchyEntry\022Q\n\016que" +
-      "ryTelemetry\030\006 \001(\01329.io.evitadb.externalA" +
-      "pi.grpc.generated.GrpcQueryTelemetry\032o\n\027" +
-      "AttributeHistogramEntry\022\013\n\003key\030\001 \001(\t\022C\n\005" +
-      "value\030\002 \001(\01324.io.evitadb.externalApi.grp" +
-      "c.generated.GrpcHistogram:\0028\001\032f\n\016Hierarc" +
-      "hyEntry\022\013\n\003key\030\001 \001(\t\022C\n\005value\030\002 \001(\01324.io" +
+      "le.protobuf.Int32Value\022\020\n\010hasSense\030\007 \001(\010" +
+      "\"\320\001\n\rGrpcHierarchy\022V\n\thierarchy\030\001 \003(\0132C." +
+      "io.evitadb.externalApi.grpc.generated.Gr" +
+      "pcHierarchy.HierarchyEntry\032g\n\016HierarchyE" +
+      "ntry\022\013\n\003key\030\001 \001(\t\022D\n\005value\030\002 \001(\01325.io.ev" +
+      "itadb.externalApi.grpc.generated.GrpcLev" +
+      "elInfos:\0028\001\"Z\n\016GrpcLevelInfos\022H\n\nlevelIn" +
+      "fos\030\001 \003(\01324.io.evitadb.externalApi.grpc." +
+      "generated.GrpcLevelInfo\"\362\002\n\rGrpcLevelInf" +
+      "o\022S\n\017entityReference\030\001 \001(\0132:.io.evitadb." +
+      "externalApi.grpc.generated.GrpcEntityRef" +
+      "erence\022G\n\006entity\030\002 \001(\01327.io.evitadb.exte" +
+      "rnalApi.grpc.generated.GrpcSealedEntity\022" +
+      "7\n\022queriedEntityCount\030\003 \001(\0132\033.google.pro" +
+      "tobuf.Int32Value\0222\n\rchildrenCount\030\004 \001(\0132" +
+      "\033.google.protobuf.Int32Value\022C\n\005items\030\005 " +
+      "\003(\01324.io.evitadb.externalApi.grpc.genera" +
+      "ted.GrpcLevelInfo\022\021\n\trequested\030\006 \001(\010\"\335\001\n" +
+      "\022GrpcQueryTelemetry\022H\n\toperation\030\001 \001(\01625" +
+      ".io.evitadb.externalApi.grpc.generated.G" +
+      "rpcQueryPhase\022\r\n\005start\030\002 \001(\003\022H\n\005steps\030\003 " +
+      "\003(\01329.io.evitadb.externalApi.grpc.genera" +
+      "ted.GrpcQueryTelemetry\022\021\n\targuments\030\004 \003(" +
+      "\t\022\021\n\tspentTime\030\005 \001(\003\"\200\006\n\020GrpcExtraResult" +
+      "s\022k\n\022attributeHistogram\030\001 \003(\0132O.io.evita" +
+      "db.externalApi.grpc.generated.GrpcExtraR" +
+      "esults.AttributeHistogramEntry\022L\n\016priceH" +
+      "istogram\030\002 \001(\01324.io.evitadb.externalApi." +
+      "grpc.generated.GrpcHistogram\022]\n\024facetGro" +
+      "upStatistics\030\003 \003(\0132?.io.evitadb.external" +
+      "Api.grpc.generated.GrpcFacetGroupStatist" +
+      "ics\022K\n\rselfHierarchy\030\004 \001(\01324.io.evitadb." +
+      "externalApi.grpc.generated.GrpcHierarchy" +
+      "\022Y\n\thierarchy\030\005 \003(\0132F.io.evitadb.externa" +
+      "lApi.grpc.generated.GrpcExtraResults.Hie" +
+      "rarchyEntry\022Q\n\016queryTelemetry\030\006 \001(\01329.io" +
       ".evitadb.externalApi.grpc.generated.Grpc" +
-      "Hierarchy:\0028\001B\014P\001\252\002\007EvitaDBb\006proto3"
+      "QueryTelemetry\032o\n\027AttributeHistogramEntr" +
+      "y\022\013\n\003key\030\001 \001(\t\022C\n\005value\030\002 \001(\01324.io.evita" +
+      "db.externalApi.grpc.generated.GrpcHistog" +
+      "ram:\0028\001\032f\n\016HierarchyEntry\022\013\n\003key\030\001 \001(\t\022C" +
+      "\n\005value\030\002 \001(\01324.io.evitadb.externalApi.g" +
+      "rpc.generated.GrpcHierarchy:\0028\001B\014P\001\252\002\007Ev" +
+      "itaDBb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -210,7 +211,7 @@ public final class GrpcExtraResultsOuterClass {
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcFacetStatistics_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcFacetStatistics_descriptor,
-        new java.lang.String[] { "FacetEntityReference", "FacetEntity", "Requested", "Count", "Impact", "MatchCount", });
+        new java.lang.String[] { "FacetEntityReference", "FacetEntity", "Requested", "Count", "Impact", "MatchCount", "HasSense", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcHierarchy_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcHierarchy_fieldAccessorTable = new

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetStatistics.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetStatistics.java
@@ -137,6 +137,11 @@ private static final long serialVersionUID = 0L;
 
             break;
           }
+          case 56: {
+
+            hasSense_ = input.readBool();
+            break;
+          }
           default: {
             if (!parseUnknownField(
                 input, unknownFields, extensionRegistry, tag)) {
@@ -354,6 +359,24 @@ private static final long serialVersionUID = 0L;
     return getMatchCount();
   }
 
+  public static final int HASSENSE_FIELD_NUMBER = 7;
+  private boolean hasSense_;
+  /**
+   * <pre>
+   * Selection has sense - TRUE if there is at least one entity still present in the result if
+   * the query is altered by adding this facet to filtering query. In case of OR relation between
+   * facets it's also true only if there is at least one entity present in the result when all other
+   * facets in the same group are removed and only this facet is requested.
+   * </pre>
+   *
+   * <code>bool hasSense = 7;</code>
+   * @return The hasSense.
+   */
+  @java.lang.Override
+  public boolean getHasSense() {
+    return hasSense_;
+  }
+
   private byte memoizedIsInitialized = -1;
   @java.lang.Override
   public final boolean isInitialized() {
@@ -385,6 +408,9 @@ private static final long serialVersionUID = 0L;
     }
     if (matchCount_ != null) {
       output.writeMessage(6, getMatchCount());
+    }
+    if (hasSense_ != false) {
+      output.writeBool(7, hasSense_);
     }
     unknownFields.writeTo(output);
   }
@@ -418,6 +444,10 @@ private static final long serialVersionUID = 0L;
     if (matchCount_ != null) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(6, getMatchCount());
+    }
+    if (hasSense_ != false) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeBoolSize(7, hasSense_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -458,6 +488,8 @@ private static final long serialVersionUID = 0L;
       if (!getMatchCount()
           .equals(other.getMatchCount())) return false;
     }
+    if (getHasSense()
+        != other.getHasSense()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -490,6 +522,9 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + MATCHCOUNT_FIELD_NUMBER;
       hash = (53 * hash) + getMatchCount().hashCode();
     }
+    hash = (37 * hash) + HASSENSE_FIELD_NUMBER;
+    hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+        getHasSense());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -655,6 +690,8 @@ private static final long serialVersionUID = 0L;
         matchCount_ = null;
         matchCountBuilder_ = null;
       }
+      hasSense_ = false;
+
       return this;
     }
 
@@ -703,6 +740,7 @@ private static final long serialVersionUID = 0L;
       } else {
         result.matchCount_ = matchCountBuilder_.build();
       }
+      result.hasSense_ = hasSense_;
       onBuilt();
       return result;
     }
@@ -768,6 +806,9 @@ private static final long serialVersionUID = 0L;
       }
       if (other.hasMatchCount()) {
         mergeMatchCount(other.getMatchCount());
+      }
+      if (other.getHasSense() != false) {
+        setHasSense(other.getHasSense());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -1511,6 +1552,58 @@ private static final long serialVersionUID = 0L;
         matchCount_ = null;
       }
       return matchCountBuilder_;
+    }
+
+    private boolean hasSense_ ;
+    /**
+     * <pre>
+     * Selection has sense - TRUE if there is at least one entity still present in the result if
+     * the query is altered by adding this facet to filtering query. In case of OR relation between
+     * facets it's also true only if there is at least one entity present in the result when all other
+     * facets in the same group are removed and only this facet is requested.
+     * </pre>
+     *
+     * <code>bool hasSense = 7;</code>
+     * @return The hasSense.
+     */
+    @java.lang.Override
+    public boolean getHasSense() {
+      return hasSense_;
+    }
+    /**
+     * <pre>
+     * Selection has sense - TRUE if there is at least one entity still present in the result if
+     * the query is altered by adding this facet to filtering query. In case of OR relation between
+     * facets it's also true only if there is at least one entity present in the result when all other
+     * facets in the same group are removed and only this facet is requested.
+     * </pre>
+     *
+     * <code>bool hasSense = 7;</code>
+     * @param value The hasSense to set.
+     * @return This builder for chaining.
+     */
+    public Builder setHasSense(boolean value) {
+
+      hasSense_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Selection has sense - TRUE if there is at least one entity still present in the result if
+     * the query is altered by adding this facet to filtering query. In case of OR relation between
+     * facets it's also true only if there is at least one entity present in the result when all other
+     * facets in the same group are removed and only this facet is requested.
+     * </pre>
+     *
+     * <code>bool hasSense = 7;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearHasSense() {
+
+      hasSense_ = false;
+      onChanged();
+      return this;
     }
     @java.lang.Override
     public final Builder setUnknownFields(

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetStatisticsOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetStatisticsOrBuilder.java
@@ -160,4 +160,17 @@ public interface GrpcFacetStatisticsOrBuilder extends
    * <code>.google.protobuf.Int32Value matchCount = 6;</code>
    */
   com.google.protobuf.Int32ValueOrBuilder getMatchCountOrBuilder();
+
+  /**
+   * <pre>
+   * Selection has sense - TRUE if there is at least one entity still present in the result if
+   * the query is altered by adding this facet to filtering query. In case of OR relation between
+   * facets it's also true only if there is at least one entity present in the result when all other
+   * facets in the same group are removed and only this facet is requested.
+   * </pre>
+   *
+   * <code>bool hasSense = 7;</code>
+   * @return The hasSense.
+   */
+  boolean getHasSense();
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/ResponseConverter.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/ResponseConverter.java
@@ -309,7 +309,8 @@ public class ResponseConverter {
 			grpcFacetStatistics.hasImpact() && grpcFacetStatistics.hasMatchCount() ?
 				new RequestImpact(
 					grpcFacetStatistics.getImpact().getValue(),
-					grpcFacetStatistics.getMatchCount().getValue()
+					grpcFacetStatistics.getMatchCount().getValue(),
+					grpcFacetStatistics.getHasSense()
 				) :
 				null
 		);

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcExtraResults.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcExtraResults.proto
@@ -74,6 +74,11 @@ message GrpcFacetStatistics {
   google.protobuf.Int32Value impact = 5;
   // Projected number of filtered entities if the query is altered by adding this facet to filtering constraint.
   google.protobuf.Int32Value matchCount = 6;
+  // Selection has sense - TRUE if there is at least one entity still present in the result if
+  // the query is altered by adding this facet to filtering query. In case of OR relation between
+  // facets it's also true only if there is at least one entity present in the result when all other
+  // facets in the same group are removed and only this facet is requested.
+  bool hasSense = 7;
 }
 
 // Contains list of statistics for the single level (probably root or whatever is filtered by the query) of

--- a/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/extraResult/FacetSummaryTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/extraResult/FacetSummaryTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ class FacetSummaryTest {
 	}
 
 	@Nonnull
-	private FacetSummary createFacetSummary() {
+	private static FacetSummary createFacetSummary() {
 		final ReferenceSchema parameter = ReferenceSchema._internalBuild(
 			"parameter", "parameter", false, Cardinality.ZERO_OR_MORE, "parameterGroup", false, true, true
 		);
@@ -66,8 +66,8 @@ class FacetSummaryTest {
 					14,
 					Arrays.asList(
 						new FacetStatistics(new EntityReference("parameter", 1), true, 5, null),
-						new FacetStatistics(new EntityReference("parameter", 2), false, 6, new RequestImpact(6, 11)),
-						new FacetStatistics(new EntityReference("parameter", 3), false, 3, new RequestImpact(3, 8))
+						new FacetStatistics(new EntityReference("parameter", 2), false, 6, new RequestImpact(6, 11, true)),
+						new FacetStatistics(new EntityReference("parameter", 3), false, 3, new RequestImpact(3, 8, true))
 					)
 				),
 				new FacetGroupStatistics(
@@ -76,8 +76,8 @@ class FacetSummaryTest {
 					14,
 					Arrays.asList(
 						new FacetStatistics(new EntityReference("parameter", 4), true, 5, null),
-						new FacetStatistics(new EntityReference("parameter", 5), false, 6, new RequestImpact(6, 11)),
-						new FacetStatistics(new EntityReference("parameter", 6), false, 3, new RequestImpact(3, 8))
+						new FacetStatistics(new EntityReference("parameter", 5), false, 6, new RequestImpact(6, 11, true)),
+						new FacetStatistics(new EntityReference("parameter", 6), false, 3, new RequestImpact(3, 8, true))
 					)
 				)
 			)

--- a/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/builders/query/extraResults/GrpcFacetSummaryBuilderTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/builders/query/extraResults/GrpcFacetSummaryBuilderTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -77,10 +77,10 @@ public class GrpcFacetSummaryBuilderTest {
 					new EntityReference(Objects.requireNonNull(types[0].getReferencedGroupType()), 1),
 					15,
 					List.of(
-						new FacetStatistics(new EntityReference(types[0].getReferencedEntityType(), 1), true, 5, new RequestImpact(1, 7)),
-						new FacetStatistics(new EntityReference(types[0].getReferencedEntityType(), 2), false, 4, new RequestImpact(5, 6)),
-						new FacetStatistics(new EntityReference(types[0].getReferencedEntityType(), 3), false, 5, new RequestImpact(6, 6)),
-						new FacetStatistics(new EntityReference(types[0].getReferencedEntityType(), 4), false, 1, new RequestImpact(4, 58))
+						new FacetStatistics(new EntityReference(types[0].getReferencedEntityType(), 1), true, 5, new RequestImpact(1, 7, true)),
+						new FacetStatistics(new EntityReference(types[0].getReferencedEntityType(), 2), false, 4, new RequestImpact(5, 6, true)),
+						new FacetStatistics(new EntityReference(types[0].getReferencedEntityType(), 3), false, 5, new RequestImpact(6, 6, true)),
+						new FacetStatistics(new EntityReference(types[0].getReferencedEntityType(), 4), false, 1, new RequestImpact(4, 58, true))
 					)
 				),
 				new FacetGroupStatistics(
@@ -88,10 +88,10 @@ public class GrpcFacetSummaryBuilderTest {
 					createGroupEntity("testGroup2"),
 					15,
 					List.of(
-						new FacetStatistics(createFacetEntity(types[1].getReferencedEntityType(), 1, "phone1"), true, 5, new RequestImpact(55, 7)),
-						new FacetStatistics(createFacetEntity(types[1].getReferencedEntityType(), 2, "phone2"), false, 4, new RequestImpact(7, 8)),
-						new FacetStatistics(createFacetEntity(types[1].getReferencedEntityType(), 3, "phone3"), false, 5, new RequestImpact(6, 6)),
-						new FacetStatistics(createFacetEntity(types[1].getReferencedEntityType(), 4, "phone4"), false, 1, new RequestImpact(7, 4))
+						new FacetStatistics(createFacetEntity(types[1].getReferencedEntityType(), 1, "phone1"), true, 5, new RequestImpact(55, 7, true)),
+						new FacetStatistics(createFacetEntity(types[1].getReferencedEntityType(), 2, "phone2"), false, 4, new RequestImpact(7, 8, true)),
+						new FacetStatistics(createFacetEntity(types[1].getReferencedEntityType(), 3, "phone3"), false, 5, new RequestImpact(6, 6, true)),
+						new FacetStatistics(createFacetEntity(types[1].getReferencedEntityType(), 4, "phone4"), false, 1, new RequestImpact(7, 4, true))
 					)
 				),
 				new FacetGroupStatistics(
@@ -99,10 +99,10 @@ public class GrpcFacetSummaryBuilderTest {
 					null,
 					29,
 					List.of(
-						new FacetStatistics(new EntityReference(types[2].getReferencedEntityType(), 1), true, 8, new RequestImpact(1, 5)),
-						new FacetStatistics(new EntityReference(types[2].getReferencedEntityType(), 2), false, 9, new RequestImpact(2, 66)),
-						new FacetStatistics(new EntityReference(types[2].getReferencedEntityType(), 3), false, 7, new RequestImpact(3, 76)),
-						new FacetStatistics(new EntityReference(types[2].getReferencedEntityType(), 4), false, 5, new RequestImpact(4, 8))
+						new FacetStatistics(new EntityReference(types[2].getReferencedEntityType(), 1), true, 8, new RequestImpact(1, 5, true)),
+						new FacetStatistics(new EntityReference(types[2].getReferencedEntityType(), 2), false, 9, new RequestImpact(2, 66, true)),
+						new FacetStatistics(new EntityReference(types[2].getReferencedEntityType(), 3), false, 7, new RequestImpact(3, 76, true)),
+						new FacetStatistics(new EntityReference(types[2].getReferencedEntityType(), 4), false, 5, new RequestImpact(4, 8, true))
 					)
 				)
 			)


### PR DESCRIPTION
…hasSense for invalid facets

Has-sense needs to be computed exactly and not derived from match-count. The problematic scenario is that when user selects facets A + B, from group 1 and the has-sense is calculated as false form facet C from group 2, then when he selects facet D from group 2, the facet C from group 2 becomes having sense because it starts from the baseline of facet D which is wrong.