### PR TITLE
fix(611): SortIndex handles BigDecimal in wrong way

### DIFF
--- a/evita_common/src/main/java/io/evitadb/utils/NumberUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/NumberUtils.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -205,6 +205,16 @@ public class NumberUtils {
 			(int) (number >> 32),
 			(int) (number)
 		};
+	}
+
+	/**
+	 * Normalizes BigDecimal value to the form which can be used as a reliable key in a map.
+	 * @param bigDecimal value to be normalized
+	 * @return normalized value
+	 */
+	@Nonnull
+	public static BigDecimal normalize(@Nonnull BigDecimal bigDecimal) {
+		return bigDecimal.stripTrailingZeros();
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndexChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndexChanges.java
@@ -253,7 +253,7 @@ public class SortIndexChanges implements Serializable {
 	}
 
 	/**
-	 * Computes value index if it hasn't exist yet. Result of this method is memoized. Method computes startung index
+	 * Computes value index if it hasn't exist yet. Result of this method is memoized. Method computes starting index
 	 * (position) of the record ids block that belongs to specific value from {@link SortIndex#sortedRecordsValues} and
 	 * {@link SortIndex#valueCardinalities} information.
 	 */

--- a/evita_engine/src/main/java/module-info.java
+++ b/evita_engine/src/main/java/module-info.java
@@ -94,7 +94,6 @@ module evita.engine {
 	requires roaringbitmap;
 	requires com.esotericsoftware.kryo;
 
-	requires jdk.httpserver;
 	requires jdk.jfr;
 
 	opens io.evitadb.core.metric.event to evita.common;

--- a/evita_functional_tests/src/test/java/io/evitadb/utils/NumberUtilsTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/utils/NumberUtilsTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,11 +26,13 @@ package io.evitadb.utils;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.Map;
 
 import static io.evitadb.utils.NumberUtils.join;
 import static io.evitadb.utils.NumberUtils.split;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -159,5 +161,22 @@ class NumberUtilsTest {
 		assertEquals(11020, NumberUtils.convertToInt(new BigDecimal("110.20"), 2));
 		assertEquals(11020, NumberUtils.convertToInt(new BigDecimal("110.2000"), 2));
 		assertThrows(IllegalArgumentException.class, () -> NumberUtils.convertToInt(new BigDecimal("110.202"), 2));
+	}
+
+	@Test
+	void shouldCorrectlyNormalizeBigDecimalForMapKey() {
+		final Map<BigDecimal, Integer> map = Map.of(
+			NumberUtils.normalize(new BigDecimal("110.2")), 1
+		);
+
+		assertEquals(1, map.get(NumberUtils.normalize(new BigDecimal("110.2"))));
+		assertEquals(1, map.get(NumberUtils.normalize(new BigDecimal("110.200"))));
+		assertEquals(1, map.get(NumberUtils.normalize(new BigDecimal("+110.2"))));
+		assertEquals(1, map.get(NumberUtils.normalize(new BigDecimal("+0110.2"))));
+		assertEquals(1, map.get(NumberUtils.normalize(new BigDecimal("+0110.200"))));
+		assertNull(map.get(NumberUtils.normalize(new BigDecimal("-0110.200"))));
+		assertNull(map.get(NumberUtils.normalize(new BigDecimal("-00110.200"))));
+		assertNull(map.get(NumberUtils.normalize(new BigDecimal("110.0200"))));
+		assertNull(map.get(NumberUtils.normalize(new BigDecimal("1010.0200"))));
 	}
 }


### PR DESCRIPTION
SortIndex internally holds Map, where key is the indexed value and value is the cardinality of the key. There is a normalizer implementation for certain types of keys (localized strings), but not for BigDecimal. But when the indexed values are BigDecimals and come in different forms - like `0` and `0.000` - they don't match in the map lookup unless normalized by `stripTrailingZeros()`. This causes the sort index to break during indexing.