### PR TITLE
feat(#609): Unique ID identifying the catalog

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/CatalogContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/CatalogContract.java
@@ -47,6 +47,7 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -65,6 +66,15 @@ import java.util.stream.Stream;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public interface CatalogContract {
+
+	/**
+	 * Returns unique catalog id that doesn't change with catalog schema changes - such as renaming.
+	 * The id is assigned to the catalog when it is created and never changes.
+	 *
+	 * @return unique catalog id
+	 */
+	@Nonnull
+	UUID getCatalogId();
 
 	/**
 	 * Returns read-only catalog configuration.

--- a/evita_api/src/main/java/io/evitadb/api/EvitaSessionContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/EvitaSessionContract.java
@@ -116,6 +116,15 @@ public interface EvitaSessionContract extends Comparable<EvitaSessionContract>, 
 	UUID getId();
 
 	/**
+	 * Returns unique catalog id that doesn't change with catalog schema changes - such as renaming.
+	 * The id is assigned to the catalog when it is created and never changes.
+	 *
+	 * @return unique catalog id
+	 */
+	@Nonnull
+	UUID getCatalogId();
+
+	/**
 	 * Returns catalog schema of the catalog this session is connected to.
 	 */
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/core/CorruptedCatalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/CorruptedCatalog.java
@@ -53,6 +53,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -77,6 +78,12 @@ public final class CorruptedCatalog implements CatalogContract {
 
 	@Override
 	public @Nonnull CatalogSchemaContract updateSchema(@Nonnull LocalCatalogSchemaMutation... schemaMutation) throws SchemaAlteringException {
+		throw new CatalogCorruptedException(this);
+	}
+
+	@Nonnull
+	@Override
+	public UUID getCatalogId() {
 		throw new CatalogCorruptedException(this);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/EvitaSession.java
+++ b/evita_engine/src/main/java/io/evitadb/core/EvitaSession.java
@@ -289,6 +289,12 @@ public final class EvitaSession implements EvitaInternalSessionContract {
 		return id;
 	}
 
+	@Nonnull
+	@Override
+	public UUID getCatalogId() {
+		return getCatalog().getCatalogId();
+	}
+
 	@Traced
 	@Nonnull
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/store/spi/CatalogPersistenceService.java
+++ b/evita_engine/src/main/java/io/evitadb/store/spi/CatalogPersistenceService.java
@@ -81,17 +81,6 @@ public non-sealed interface CatalogPersistenceService extends PersistenceService
 	String WAL_FILE_SUFFIX = ".wal";
 
 	/**
-	 * Method for internal use - allows emitting start events when observability facilities are already initialized.
-	 * If we didn't postpone this initialization, events would become lost.
-	 */
-	void emitStartObservabilityEvents();
-
-	/**
-	 * Method for internal use. Allows to emit events clearing the information about deleted catalog.
-	 */
-	void emitDeleteObservabilityEvents();
-
-	/**
 	 * Returns name of the bootstrap file that contains lead information to fetching the catalog header in fixed record
 	 * size format. This file can be traversed by jumping on expected offsets.
 	 */
@@ -165,6 +154,17 @@ public non-sealed interface CatalogPersistenceService extends PersistenceService
 	}
 
 	/**
+	 * Method for internal use - allows emitting start events when observability facilities are already initialized.
+	 * If we didn't postpone this initialization, events would become lost.
+	 */
+	void emitStartObservabilityEvents();
+
+	/**
+	 * Method for internal use. Allows to emit events clearing the information about deleted catalog.
+	 */
+	void emitDeleteObservabilityEvents();
+
+	/**
 	 * Retrieves the {@link CatalogStoragePartPersistenceService} associated with this {@link CatalogPersistenceService}.
 	 *
 	 * @param catalogVersion the version of the catalog
@@ -182,7 +182,7 @@ public non-sealed interface CatalogPersistenceService extends PersistenceService
 
 	/**
 	 * Returns {@link CatalogHeader} that is used for this service. The header is initialized in the instance constructor
-	 * and (because it's immutable) is exchanged with each {@link #storeHeader(CatalogState, long, int, TransactionMutation, List)}  method call.
+	 * and (because it's immutable) is exchanged with each {@link #storeHeader(UUID, CatalogState, long, int, TransactionMutation, List)}  method call.
 	 *
 	 * @param catalogVersion the version of the catalog
 	 * @return the header of the catalog
@@ -208,6 +208,7 @@ public non-sealed interface CatalogPersistenceService extends PersistenceService
 	/**
 	 * Serializes all {@link EntityCollection} of the catalog to the persistent storage.
 	 *
+	 * @param catalogId                      the id of the catalog which doesn't change with catalog rename
 	 * @param catalogState                   the state of the catalog
 	 * @param catalogVersion                 the version of the catalog
 	 * @param lastEntityCollectionPrimaryKey the last primary key of the entity collection
@@ -218,6 +219,7 @@ public non-sealed interface CatalogPersistenceService extends PersistenceService
 	 * @throws UnexpectedIOException       in case of any unknown IOException
 	 */
 	void storeHeader(
+		@Nonnull UUID catalogId,
 		@Nonnull CatalogState catalogState,
 		long catalogVersion,
 		int lastEntityCollectionPrimaryKey,
@@ -387,7 +389,7 @@ public non-sealed interface CatalogPersistenceService extends PersistenceService
 	/**
 	 * We need to forget all volatile data when the data written to catalog aren't going to be committed (incorporated
 	 * in the final state). Usually the data written by {@link #getStoragePartPersistenceService(long)}  are immediately
-	 * written to the disk and are volatile until {@link #storeHeader(CatalogState, long, int, TransactionMutation, List)}
+	 * written to the disk and are volatile until {@link #storeHeader(UUID, CatalogState, long, int, TransactionMutation, List)}
 	 * is called. But those data can be read within particular transaction from the volatile storage and we need to
 	 * forget them when the transaction is rolled back.
 	 */

--- a/evita_engine/src/main/java/io/evitadb/store/spi/CatalogStoragePartPersistenceService.java
+++ b/evita_engine/src/main/java/io/evitadb/store/spi/CatalogStoragePartPersistenceService.java
@@ -33,6 +33,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * A sub-interface of StoragePartPersistenceService that represents the persistence service extension for catalog.
@@ -55,14 +56,15 @@ public interface CatalogStoragePartPersistenceService extends StoragePartPersist
 	/**
 	 * Writes the catalog header with the specified information to the catalog.
 	 *
-	 * @param storageProtocolVersion              The storage protocol version.
-	 * @param catalogVersion                      The catalog version.
-	 * @param catalogStoragePath				  The catalog storage path, must not be null.
-	 * @param walFileLocation                     The WAL file location, may be null.
-	 * @param collectionFileReferenceIndex        The collection file reference index, must not be null.
-	 * @param catalogName                         The catalog name, must not be null.
-	 * @param catalogState                        The catalog state, must not be null.
-	 * @param lastEntityCollectionPrimaryKey      The last entity collection primary key.
+	 * @param storageProtocolVersion         The storage protocol version.
+	 * @param catalogVersion                 The catalog version.
+	 * @param catalogStoragePath             The catalog storage path, must not be null.
+	 * @param walFileLocation                The WAL file location, may be null.
+	 * @param collectionFileReferenceIndex   The collection file reference index, must not be null.
+	 * @param catalogId                      The catalog ID, which doesn't change with the catalog rename.
+	 * @param catalogName                    The catalog name, must not be null.
+	 * @param catalogState                   The catalog state, must not be null.
+	 * @param lastEntityCollectionPrimaryKey The last entity collection primary key.
 	 */
 	void writeCatalogHeader(
 		int storageProtocolVersion,
@@ -70,6 +72,7 @@ public interface CatalogStoragePartPersistenceService extends StoragePartPersist
 		@Nonnull Path catalogStoragePath,
 		@Nullable WalFileReference walFileLocation,
 		@Nonnull Map<String, CollectionFileReference> collectionFileReferenceIndex,
+		@Nonnull UUID catalogId,
 		@Nonnull String catalogName,
 		@Nonnull CatalogState catalogState,
 		int lastEntityCollectionPrimaryKey

--- a/evita_engine/src/main/java/io/evitadb/store/spi/model/CatalogHeader.java
+++ b/evita_engine/src/main/java/io/evitadb/store/spi/model/CatalogHeader.java
@@ -60,11 +60,11 @@ import static java.util.Optional.ofNullable;
  *                                       contains the information about the entity collection file
  * @param compressedKeys                 contains mapping of certain parts of {@link StoragePartKey} to an integer id
  *                                       that is used for compression of the original storage key
+ * @param catalogId                      contains the unique identifier of the catalog that doesn't change with catalog rename
  * @param catalogName                    contains name of the catalog that originates in {@link CatalogSchema#getName()}
  * @param catalogState                   contains the state of the catalog that originates in {@link Catalog#getCatalogState()}
  * @param lastEntityCollectionPrimaryKey contains the last assigned {@link EntityCollection#getEntityTypePrimaryKey()}
  * @param activeRecordShare              contains the share of active records in the catalog that is used for
- *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  * @see PersistentStorageHeader
  */

--- a/evita_engine/src/main/java/io/evitadb/store/spi/model/CatalogHeader.java
+++ b/evita_engine/src/main/java/io/evitadb/store/spi/model/CatalogHeader.java
@@ -41,6 +41,7 @@ import java.io.Serial;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static java.util.Optional.ofNullable;
 
@@ -73,20 +74,22 @@ public record CatalogHeader(
 	@Nullable WalFileReference walFileReference,
 	@Nonnull Map<String, CollectionFileReference> collectionFileIndex,
 	@Nonnull Map<Integer, Object> compressedKeys,
+	@Nonnull UUID catalogId,
 	@Nonnull String catalogName,
 	@Nonnull CatalogState catalogState,
 	int lastEntityCollectionPrimaryKey,
 	double activeRecordShare
 ) implements StoragePart {
-	@Serial private static final long serialVersionUID = -5987715153038480011L;
+	@Serial private static final long serialVersionUID = 4115945765677481853L;
 
-	public CatalogHeader(@Nonnull String catalogName) {
+	public CatalogHeader(@Nonnull UUID catalogId, @Nonnull String catalogName) {
 		this(
 			CatalogPersistenceService.STORAGE_PROTOCOL_VERSION,
 			0L,
 			null,
 			Map.of(),
 			Map.of(),
+			catalogId,
 			catalogName,
 			CatalogState.WARMING_UP,
 			0,

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
@@ -376,6 +376,7 @@ public class EvitaClient implements EvitaContract {
 			this.channelPool,
 			traits.catalogName(),
 			EvitaEnumConverter.toCatalogState(grpcResponse.getCatalogState()),
+			UUIDUtil.uuid(grpcResponse.getCatalogId()),
 			UUIDUtil.uuid(grpcResponse.getSessionId()),
 			EvitaEnumConverter.toCommitBehavior(grpcResponse.getCommitBehaviour()),
 			traits,

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientSession.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientSession.java
@@ -190,6 +190,11 @@ public class EvitaClientSession implements EvitaSessionContract {
 	 */
 	private final UUID sessionId;
 	/**
+	 * Contains unique catalog id that doesn't change with catalog schema changes - such as renaming.
+	 * The id is assigned to the catalog when it is created and never changes.
+	 */
+	private final UUID catalogId;
+	/**
 	 * Contains information passed at the time session was created that defines its behaviour
 	 */
 	private final SessionTraits sessionTraits;
@@ -262,6 +267,7 @@ public class EvitaClientSession implements EvitaSessionContract {
 		@Nonnull ChannelPool channelPool,
 		@Nonnull String catalogName,
 		@Nonnull CatalogState catalogState,
+		@Nonnull UUID catalogId,
 		@Nonnull UUID sessionId,
 		@Nonnull CommitBehavior commitBehaviour,
 		@Nonnull SessionTraits sessionTraits,
@@ -276,6 +282,7 @@ public class EvitaClientSession implements EvitaSessionContract {
 		this.catalogName = catalogName;
 		this.catalogState = catalogState;
 		this.commitBehaviour = commitBehaviour;
+		this.catalogId = catalogId;
 		this.sessionId = sessionId;
 		this.sessionTraits = sessionTraits;
 		this.onTerminationCallback = onTerminationCallback;
@@ -286,6 +293,12 @@ public class EvitaClientSession implements EvitaSessionContract {
 	@Override
 	public UUID getId() {
 		return sessionId;
+	}
+
+	@Nonnull
+	@Override
+	public UUID getCatalogId() {
+		return catalogId;
 	}
 
 	@Nonnull

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaService.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaService.java
@@ -294,6 +294,7 @@ public class EvitaService extends EvitaServiceGrpc.EvitaServiceImplBase {
 			final SessionFlags[] flags = getSessionFlags(sessionType, rollbackTransactions);
 			final EvitaSessionContract session = evita.createSession(new SessionTraits(catalogName, flags));
 			responseObserver.onNext(GrpcEvitaSessionResponse.newBuilder()
+				.setCatalogId(session.getCatalogId().toString())
 				.setSessionId(session.getId().toString())
 				.setCatalogState(toGrpcCatalogState(session.getCatalogState()))
 				.setSessionType(sessionType)

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaAPI.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaAPI.java
@@ -134,78 +134,78 @@ public final class GrpcEvitaAPI {
       "uest\022\023\n\013catalogName\030\001 \001(\t\022Q\n\016commitBehav" +
       "ior\030\002 \001(\01629.io.evitadb.externalApi.grpc." +
       "generated.GrpcCommitBehavior\022\016\n\006dryRun\030\003" +
-      " \001(\010\"\235\002\n\030GrpcEvitaSessionResponse\022\021\n\tses" +
+      " \001(\010\"\260\002\n\030GrpcEvitaSessionResponse\022\021\n\tses" +
       "sionId\030\001 \001(\t\022K\n\013sessionType\030\002 \001(\01626.io.e" +
       "vitadb.externalApi.grpc.generated.GrpcSe" +
       "ssionType\022R\n\017commitBehaviour\030\003 \001(\01629.io." +
       "evitadb.externalApi.grpc.generated.GrpcC" +
       "ommitBehavior\022M\n\014catalogState\030\004 \001(\01627.io" +
       ".evitadb.externalApi.grpc.generated.Grpc" +
-      "CatalogState\"L\n\"GrpcEvitaSessionTerminat" +
-      "ionRequest\022\023\n\013catalogName\030\001 \001(\t\022\021\n\tsessi" +
-      "onId\030\002 \001(\t\"9\n#GrpcEvitaSessionTerminatio" +
-      "nResponse\022\022\n\nterminated\030\001 \001(\010\"0\n\030GrpcCat" +
-      "alogNamesResponse\022\024\n\014catalogNames\030\001 \003(\t\"" +
-      "/\n\030GrpcDefineCatalogRequest\022\023\n\013catalogNa" +
-      "me\030\001 \001(\t\",\n\031GrpcDefineCatalogResponse\022\017\n" +
-      "\007success\030\001 \001(\010\"G\n\030GrpcRenameCatalogReque" +
-      "st\022\023\n\013catalogName\030\001 \001(\t\022\026\n\016newCatalogNam" +
-      "e\030\002 \001(\t\",\n\031GrpcRenameCatalogResponse\022\017\n\007" +
-      "success\030\001 \001(\010\"a\n\031GrpcReplaceCatalogReque" +
-      "st\022#\n\033catalogNameToBeReplacedWith\030\001 \001(\t\022" +
-      "\037\n\027catalogNameToBeReplaced\030\002 \001(\t\"-\n\032Grpc" +
-      "ReplaceCatalogResponse\022\017\n\007success\030\001 \001(\010\"" +
-      "7\n GrpcDeleteCatalogIfExistsRequest\022\023\n\013c" +
-      "atalogName\030\001 \001(\t\"4\n!GrpcDeleteCatalogIfE" +
-      "xistsResponse\022\017\n\007success\030\001 \001(\010\"{\n\026GrpcUp" +
-      "dateEvitaRequest\022a\n\017schemaMutations\030\001 \003(" +
-      "\0132H.io.evitadb.externalApi.grpc.generate" +
-      "d.GrpcTopLevelCatalogSchemaMutation2\336\r\n\014" +
-      "EvitaService\022l\n\014ServerStatus\022\026.google.pr" +
-      "otobuf.Empty\032D.io.evitadb.externalApi.gr" +
-      "pc.generated.GrpcEvitaServerStatusRespon" +
-      "se\022\230\001\n\025CreateReadOnlySession\022>.io.evitad" +
-      "b.externalApi.grpc.generated.GrpcEvitaSe" +
-      "ssionRequest\032?.io.evitadb.externalApi.gr" +
-      "pc.generated.GrpcEvitaSessionResponse\022\231\001" +
-      "\n\026CreateReadWriteSession\022>.io.evitadb.ex" +
-      "ternalApi.grpc.generated.GrpcEvitaSessio" +
-      "nRequest\032?.io.evitadb.externalApi.grpc.g" +
-      "enerated.GrpcEvitaSessionResponse\022\236\001\n\033Cr" +
-      "eateBinaryReadOnlySession\022>.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcEvitaSessi" +
-      "onRequest\032?.io.evitadb.externalApi.grpc." +
-      "generated.GrpcEvitaSessionResponse\022\237\001\n\034C" +
-      "reateBinaryReadWriteSession\022>.io.evitadb" +
+      "CatalogState\022\021\n\tcatalogId\030\005 \001(\t\"L\n\"GrpcE" +
+      "vitaSessionTerminationRequest\022\023\n\013catalog" +
+      "Name\030\001 \001(\t\022\021\n\tsessionId\030\002 \001(\t\"9\n#GrpcEvi" +
+      "taSessionTerminationResponse\022\022\n\nterminat" +
+      "ed\030\001 \001(\010\"0\n\030GrpcCatalogNamesResponse\022\024\n\014" +
+      "catalogNames\030\001 \003(\t\"/\n\030GrpcDefineCatalogR" +
+      "equest\022\023\n\013catalogName\030\001 \001(\t\",\n\031GrpcDefin" +
+      "eCatalogResponse\022\017\n\007success\030\001 \001(\010\"G\n\030Grp" +
+      "cRenameCatalogRequest\022\023\n\013catalogName\030\001 \001" +
+      "(\t\022\026\n\016newCatalogName\030\002 \001(\t\",\n\031GrpcRename" +
+      "CatalogResponse\022\017\n\007success\030\001 \001(\010\"a\n\031Grpc" +
+      "ReplaceCatalogRequest\022#\n\033catalogNameToBe" +
+      "ReplacedWith\030\001 \001(\t\022\037\n\027catalogNameToBeRep" +
+      "laced\030\002 \001(\t\"-\n\032GrpcReplaceCatalogRespons" +
+      "e\022\017\n\007success\030\001 \001(\010\"7\n GrpcDeleteCatalogI" +
+      "fExistsRequest\022\023\n\013catalogName\030\001 \001(\t\"4\n!G" +
+      "rpcDeleteCatalogIfExistsResponse\022\017\n\007succ" +
+      "ess\030\001 \001(\010\"{\n\026GrpcUpdateEvitaRequest\022a\n\017s" +
+      "chemaMutations\030\001 \003(\0132H.io.evitadb.extern" +
+      "alApi.grpc.generated.GrpcTopLevelCatalog" +
+      "SchemaMutation2\336\r\n\014EvitaService\022l\n\014Serve" +
+      "rStatus\022\026.google.protobuf.Empty\032D.io.evi" +
+      "tadb.externalApi.grpc.generated.GrpcEvit" +
+      "aServerStatusResponse\022\230\001\n\025CreateReadOnly" +
+      "Session\022>.io.evitadb.externalApi.grpc.ge" +
+      "nerated.GrpcEvitaSessionRequest\032?.io.evi" +
+      "tadb.externalApi.grpc.generated.GrpcEvit" +
+      "aSessionResponse\022\231\001\n\026CreateReadWriteSess" +
+      "ion\022>.io.evitadb.externalApi.grpc.genera" +
+      "ted.GrpcEvitaSessionRequest\032?.io.evitadb" +
       ".externalApi.grpc.generated.GrpcEvitaSes" +
-      "sionRequest\032?.io.evitadb.externalApi.grp" +
-      "c.generated.GrpcEvitaSessionResponse\022\251\001\n" +
-      "\020TerminateSession\022I.io.evitadb.externalA" +
-      "pi.grpc.generated.GrpcEvitaSessionTermin" +
-      "ationRequest\032J.io.evitadb.externalApi.gr" +
-      "pc.generated.GrpcEvitaSessionTermination" +
-      "Response\022j\n\017GetCatalogNames\022\026.google.pro" +
-      "tobuf.Empty\032?.io.evitadb.externalApi.grp" +
-      "c.generated.GrpcCatalogNamesResponse\022\222\001\n" +
-      "\rDefineCatalog\022?.io.evitadb.externalApi." +
-      "grpc.generated.GrpcDefineCatalogRequest\032" +
-      "@.io.evitadb.externalApi.grpc.generated." +
-      "GrpcDefineCatalogResponse\022\222\001\n\rRenameCata" +
-      "log\022?.io.evitadb.externalApi.grpc.genera" +
-      "ted.GrpcRenameCatalogRequest\032@.io.evitad" +
-      "b.externalApi.grpc.generated.GrpcRenameC" +
-      "atalogResponse\022\225\001\n\016ReplaceCatalog\022@.io.e" +
-      "vitadb.externalApi.grpc.generated.GrpcRe" +
-      "placeCatalogRequest\032A.io.evitadb.externa" +
-      "lApi.grpc.generated.GrpcReplaceCatalogRe" +
-      "sponse\022\252\001\n\025DeleteCatalogIfExists\022G.io.ev" +
-      "itadb.externalApi.grpc.generated.GrpcDel" +
-      "eteCatalogIfExistsRequest\032H.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcDeleteCata" +
-      "logIfExistsResponse\022_\n\006Update\022=.io.evita" +
-      "db.externalApi.grpc.generated.GrpcUpdate" +
-      "EvitaRequest\032\026.google.protobuf.EmptyB\014P\001" +
-      "\252\002\007EvitaDBb\006proto3"
+      "sionResponse\022\236\001\n\033CreateBinaryReadOnlySes" +
+      "sion\022>.io.evitadb.externalApi.grpc.gener" +
+      "ated.GrpcEvitaSessionRequest\032?.io.evitad" +
+      "b.externalApi.grpc.generated.GrpcEvitaSe" +
+      "ssionResponse\022\237\001\n\034CreateBinaryReadWriteS" +
+      "ession\022>.io.evitadb.externalApi.grpc.gen" +
+      "erated.GrpcEvitaSessionRequest\032?.io.evit" +
+      "adb.externalApi.grpc.generated.GrpcEvita" +
+      "SessionResponse\022\251\001\n\020TerminateSession\022I.i" +
+      "o.evitadb.externalApi.grpc.generated.Grp" +
+      "cEvitaSessionTerminationRequest\032J.io.evi" +
+      "tadb.externalApi.grpc.generated.GrpcEvit" +
+      "aSessionTerminationResponse\022j\n\017GetCatalo" +
+      "gNames\022\026.google.protobuf.Empty\032?.io.evit" +
+      "adb.externalApi.grpc.generated.GrpcCatal" +
+      "ogNamesResponse\022\222\001\n\rDefineCatalog\022?.io.e" +
+      "vitadb.externalApi.grpc.generated.GrpcDe" +
+      "fineCatalogRequest\032@.io.evitadb.external" +
+      "Api.grpc.generated.GrpcDefineCatalogResp" +
+      "onse\022\222\001\n\rRenameCatalog\022?.io.evitadb.exte" +
+      "rnalApi.grpc.generated.GrpcRenameCatalog" +
+      "Request\032@.io.evitadb.externalApi.grpc.ge" +
+      "nerated.GrpcRenameCatalogResponse\022\225\001\n\016Re" +
+      "placeCatalog\022@.io.evitadb.externalApi.gr" +
+      "pc.generated.GrpcReplaceCatalogRequest\032A" +
+      ".io.evitadb.externalApi.grpc.generated.G" +
+      "rpcReplaceCatalogResponse\022\252\001\n\025DeleteCata" +
+      "logIfExists\022G.io.evitadb.externalApi.grp" +
+      "c.generated.GrpcDeleteCatalogIfExistsReq" +
+      "uest\032H.io.evitadb.externalApi.grpc.gener" +
+      "ated.GrpcDeleteCatalogIfExistsResponse\022_" +
+      "\n\006Update\022=.io.evitadb.externalApi.grpc.g" +
+      "enerated.GrpcUpdateEvitaRequest\032\026.google" +
+      ".protobuf.EmptyB\014P\001\252\002\007EvitaDBb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -232,7 +232,7 @@ public final class GrpcEvitaAPI {
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEvitaSessionResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcEvitaSessionResponse_descriptor,
-        new java.lang.String[] { "SessionId", "SessionType", "CommitBehaviour", "CatalogState", });
+        new java.lang.String[] { "SessionId", "SessionType", "CommitBehaviour", "CatalogState", "CatalogId", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEvitaSessionTerminationRequest_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEvitaSessionTerminationRequest_fieldAccessorTable = new

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionResponse.java
@@ -47,6 +47,7 @@ private static final long serialVersionUID = 0L;
     sessionType_ = 0;
     commitBehaviour_ = 0;
     catalogState_ = 0;
+    catalogId_ = "";
   }
 
   @java.lang.Override
@@ -101,6 +102,12 @@ private static final long serialVersionUID = 0L;
             int rawValue = input.readEnum();
 
             catalogState_ = rawValue;
+            break;
+          }
+          case 42: {
+            java.lang.String s = input.readStringRequireUtf8();
+
+            catalogId_ = s;
             break;
           }
           default: {
@@ -262,6 +269,52 @@ private static final long serialVersionUID = 0L;
     return result == null ? io.evitadb.externalApi.grpc.generated.GrpcCatalogState.UNRECOGNIZED : result;
   }
 
+  public static final int CATALOGID_FIELD_NUMBER = 5;
+  private volatile java.lang.Object catalogId_;
+  /**
+   * <pre>
+   * UUID of the catalog the session is bound to.
+   * </pre>
+   *
+   * <code>string catalogId = 5;</code>
+   * @return The catalogId.
+   */
+  @java.lang.Override
+  public java.lang.String getCatalogId() {
+    java.lang.Object ref = catalogId_;
+    if (ref instanceof java.lang.String) {
+      return (java.lang.String) ref;
+    } else {
+      com.google.protobuf.ByteString bs =
+          (com.google.protobuf.ByteString) ref;
+      java.lang.String s = bs.toStringUtf8();
+      catalogId_ = s;
+      return s;
+    }
+  }
+  /**
+   * <pre>
+   * UUID of the catalog the session is bound to.
+   * </pre>
+   *
+   * <code>string catalogId = 5;</code>
+   * @return The bytes for catalogId.
+   */
+  @java.lang.Override
+  public com.google.protobuf.ByteString
+      getCatalogIdBytes() {
+    java.lang.Object ref = catalogId_;
+    if (ref instanceof java.lang.String) {
+      com.google.protobuf.ByteString b =
+          com.google.protobuf.ByteString.copyFromUtf8(
+              (java.lang.String) ref);
+      catalogId_ = b;
+      return b;
+    } else {
+      return (com.google.protobuf.ByteString) ref;
+    }
+  }
+
   private byte memoizedIsInitialized = -1;
   @java.lang.Override
   public final boolean isInitialized() {
@@ -288,6 +341,9 @@ private static final long serialVersionUID = 0L;
     if (catalogState_ != io.evitadb.externalApi.grpc.generated.GrpcCatalogState.WARMING_UP.getNumber()) {
       output.writeEnum(4, catalogState_);
     }
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(catalogId_)) {
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 5, catalogId_);
+    }
     unknownFields.writeTo(output);
   }
 
@@ -312,6 +368,9 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeEnumSize(4, catalogState_);
     }
+    if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(catalogId_)) {
+      size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, catalogId_);
+    }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
@@ -332,6 +391,8 @@ private static final long serialVersionUID = 0L;
     if (sessionType_ != other.sessionType_) return false;
     if (commitBehaviour_ != other.commitBehaviour_) return false;
     if (catalogState_ != other.catalogState_) return false;
+    if (!getCatalogId()
+        .equals(other.getCatalogId())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -351,6 +412,8 @@ private static final long serialVersionUID = 0L;
     hash = (53 * hash) + commitBehaviour_;
     hash = (37 * hash) + CATALOGSTATE_FIELD_NUMBER;
     hash = (53 * hash) + catalogState_;
+    hash = (37 * hash) + CATALOGID_FIELD_NUMBER;
+    hash = (53 * hash) + getCatalogId().hashCode();
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -496,6 +559,8 @@ private static final long serialVersionUID = 0L;
 
       catalogState_ = 0;
 
+      catalogId_ = "";
+
       return this;
     }
 
@@ -526,6 +591,7 @@ private static final long serialVersionUID = 0L;
       result.sessionType_ = sessionType_;
       result.commitBehaviour_ = commitBehaviour_;
       result.catalogState_ = catalogState_;
+      result.catalogId_ = catalogId_;
       onBuilt();
       return result;
     }
@@ -586,6 +652,10 @@ private static final long serialVersionUID = 0L;
       }
       if (other.catalogState_ != 0) {
         setCatalogStateValue(other.getCatalogStateValue());
+      }
+      if (!other.getCatalogId().isEmpty()) {
+        catalogId_ = other.catalogId_;
+        onChanged();
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -930,6 +1000,102 @@ private static final long serialVersionUID = 0L;
     public Builder clearCatalogState() {
 
       catalogState_ = 0;
+      onChanged();
+      return this;
+    }
+
+    private java.lang.Object catalogId_ = "";
+    /**
+     * <pre>
+     * UUID of the catalog the session is bound to.
+     * </pre>
+     *
+     * <code>string catalogId = 5;</code>
+     * @return The catalogId.
+     */
+    public java.lang.String getCatalogId() {
+      java.lang.Object ref = catalogId_;
+      if (!(ref instanceof java.lang.String)) {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        catalogId_ = s;
+        return s;
+      } else {
+        return (java.lang.String) ref;
+      }
+    }
+    /**
+     * <pre>
+     * UUID of the catalog the session is bound to.
+     * </pre>
+     *
+     * <code>string catalogId = 5;</code>
+     * @return The bytes for catalogId.
+     */
+    public com.google.protobuf.ByteString
+        getCatalogIdBytes() {
+      java.lang.Object ref = catalogId_;
+      if (ref instanceof String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        catalogId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+    /**
+     * <pre>
+     * UUID of the catalog the session is bound to.
+     * </pre>
+     *
+     * <code>string catalogId = 5;</code>
+     * @param value The catalogId to set.
+     * @return This builder for chaining.
+     */
+    public Builder setCatalogId(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+
+      catalogId_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * UUID of the catalog the session is bound to.
+     * </pre>
+     *
+     * <code>string catalogId = 5;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearCatalogId() {
+
+      catalogId_ = getDefaultInstance().getCatalogId();
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * UUID of the catalog the session is bound to.
+     * </pre>
+     *
+     * <code>string catalogId = 5;</code>
+     * @param value The bytes for catalogId to set.
+     * @return This builder for chaining.
+     */
+    public Builder setCatalogIdBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+
+      catalogId_ = value;
       onChanged();
       return this;
     }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionResponseOrBuilder.java
@@ -106,4 +106,24 @@ public interface GrpcEvitaSessionResponseOrBuilder extends
    * @return The catalogState.
    */
   io.evitadb.externalApi.grpc.generated.GrpcCatalogState getCatalogState();
+
+  /**
+   * <pre>
+   * UUID of the catalog the session is bound to.
+   * </pre>
+   *
+   * <code>string catalogId = 5;</code>
+   * @return The catalogId.
+   */
+  java.lang.String getCatalogId();
+  /**
+   * <pre>
+   * UUID of the catalog the session is bound to.
+   * </pre>
+   *
+   * <code>string catalogId = 5;</code>
+   * @return The bytes for catalogId.
+   */
+  com.google.protobuf.ByteString
+      getCatalogIdBytes();
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaAPI.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaAPI.proto
@@ -45,6 +45,8 @@ message GrpcEvitaSessionResponse {
   GrpcCommitBehavior commitBehaviour = 3;
   // State of the catalog after the session was created.
   GrpcCatalogState catalogState = 4;
+  // UUID of the catalog the session is bound to.
+  string catalogId = 5;
 }
 
 // Request to terminate a session.

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EvitaBackwardCompatibilityTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EvitaBackwardCompatibilityTest.java
@@ -42,10 +42,12 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.UUID;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * This test verifies that data stored in older versions of evitaDB are still readable by the current version.
@@ -118,5 +120,12 @@ public class EvitaBackwardCompatibilityTest implements EvitaTestSupport {
 		final SystemStatus status = evita.getSystemStatus();
 		assertEquals(0, status.catalogsCorrupted());
 		assertEquals(1, status.catalogsOk());
+
+		// check the catalog has its own id
+		final UUID catalogId = evita.queryCatalog(
+			"evita",
+			EvitaSessionContract::getCatalogId
+		);
+		assertNotNull(catalogId);
 	}
 }

--- a/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DefaultCatalogPersistenceServiceTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DefaultCatalogPersistenceServiceTest.java
@@ -139,6 +139,7 @@ class DefaultCatalogPersistenceServiceTest implements EvitaTestSupport {
 	private final DataGenerator dataGenerator = new DataGenerator();
 	private final SequenceService sequenceService = new SequenceService();
 
+	private final UUID catalogId = UUID.randomUUID();
 	private final UUID transactionId = UUID.randomUUID();
 	private final Path walFile = getTestDirectory().resolve(transactionId.toString());
 	private final Kryo kryo = KryoFactory.createKryo(WalKryoConfigurer.INSTANCE);
@@ -269,7 +270,7 @@ class DefaultCatalogPersistenceServiceTest implements EvitaTestSupport {
 		entityHeaders.add(storeCollection.flush());
 
 		// try to serialize
-		ioService.storeHeader(CatalogState.WARMING_UP, 0, 0, null, entityHeaders);
+		ioService.storeHeader(catalogId, CatalogState.WARMING_UP, 0, 0, null, entityHeaders);
 
 		// try to deserialize again
 		final CatalogHeader catalogHeader = ioService.getCatalogHeader(0L);
@@ -310,6 +311,7 @@ class DefaultCatalogPersistenceServiceTest implements EvitaTestSupport {
 
 		// try to serialize
 		ioService.storeHeader(
+			catalogId,
 			CatalogState.WARMING_UP,
 			0L, 0, null,
 			Arrays.asList(
@@ -478,6 +480,7 @@ class DefaultCatalogPersistenceServiceTest implements EvitaTestSupport {
 			cps.getStoragePartPersistenceService(0L)
 				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
 			cps.storeHeader(
+				catalogId,
 				CatalogState.ALIVE,
 				2L,
 				0,

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/CatalogHeaderKryoConfigurer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/CatalogHeaderKryoConfigurer.java
@@ -29,6 +29,7 @@ import io.evitadb.api.requestResponse.schema.dto.CatalogSchema;
 import io.evitadb.index.price.model.PriceIndexKey;
 import io.evitadb.store.catalog.serializer.CatalogHeaderSerializer;
 import io.evitadb.store.catalog.serializer.CatalogHeaderSerializer_2024_05;
+import io.evitadb.store.catalog.serializer.CatalogHeaderSerializer_2024_08;
 import io.evitadb.store.catalog.serializer.EntityCollectionHeaderSerializer;
 import io.evitadb.store.catalog.serializer.EntityCollectionHeaderSerializer_2024_5;
 import io.evitadb.store.dataType.serializer.EnumNameSerializer;
@@ -63,7 +64,8 @@ public class CatalogHeaderKryoConfigurer implements Consumer<Kryo> {
 		kryo.register(
 			CatalogHeader.class,
 			new SerialVersionBasedSerializer<>(new CatalogHeaderSerializer(), CatalogHeader.class)
-				.addBackwardCompatibleSerializer(-3595987669559870397L, new CatalogHeaderSerializer_2024_05()),
+				.addBackwardCompatibleSerializer(-3595987669559870397L, new CatalogHeaderSerializer_2024_05())
+				.addBackwardCompatibleSerializer(-5987715153038480011L, new CatalogHeaderSerializer_2024_08()),
 			index++
 		);
 		kryo.register(CatalogSchema.class, new SerialVersionBasedSerializer<>(new CatalogSchemaSerializer(), CatalogSchema.class), index++);

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/CatalogOffsetIndexStoragePartPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/CatalogOffsetIndexStoragePartPersistenceService.java
@@ -56,6 +56,7 @@ import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -83,7 +84,6 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 	 * because the super constructor needs to be called first.
 	 *
 	 * @param catalogName            The name of the catalog.
-	 * @param catalogFileName        The file name of the catalog.
 	 * @param catalogFilePath        The file path of the catalog.
 	 * @param storageOptions         The storage options.
 	 * @param transactionOptions     The transaction options.
@@ -97,7 +97,6 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 	@Nonnull
 	public static CatalogOffsetIndexStoragePartPersistenceService create(
 		@Nonnull String catalogName,
-		@Nonnull String catalogFileName,
 		@Nonnull Path catalogFilePath,
 		@Nonnull StorageOptions storageOptions,
 		@Nonnull TransactionOptions transactionOptions,
@@ -108,7 +107,7 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 		@Nonnull Function<VersionedKryoKeyInputs, VersionedKryo> kryoFactory,
 		@Nullable Consumer<NonFlushedBlock> nonFlushedBlockObserver,
 		@Nullable Consumer<Optional<OffsetDateTime>> historyKeptObserver
-		) {
+	) {
 		final AtomicReference<CatalogHeader> catalogHeaderRef = new AtomicReference<>();
 		final OffsetIndex offsetIndex = loadOffsetIndex(
 			catalogName, catalogFilePath, storageOptions,
@@ -118,7 +117,6 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 		);
 		return new CatalogOffsetIndexStoragePartPersistenceService(
 			lastCatalogBootstrap.catalogVersion(),
-			catalogFileName,
 			catalogHeaderRef.get(),
 			transactionOptions,
 			offsetIndex,
@@ -180,12 +178,57 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 		);
 		return new CatalogOffsetIndexStoragePartPersistenceService(
 			lastCatalogBootstrap.catalogVersion(),
-			catalogName,
 			catalogHeader,
 			transactionOptions,
 			offsetIndex,
 			offHeapMemoryManager, observableOutputKeeper,
 			kryoFactory
+		);
+	}
+
+	/**
+	 * Loads an offset index descriptor based on the given parameters.
+	 *
+	 * @param catalogFilePath       the file to load offset index descriptor from
+	 * @param recordRegistry        the record registry
+	 * @param kryoFactory           the factory to create Kryo instances
+	 * @param catalogHeaderConsumer the consumer to accept the catalog header
+	 * @param indexBuilder          the index builder to use
+	 * @param theInput              the observable input
+	 * @param fileLocation          the file location to read record from
+	 * @return the loaded offset index descriptor
+	 */
+	@Nonnull
+	static OffsetIndexDescriptor loadOffsetIndexDescriptor(
+		@Nonnull Path catalogFilePath,
+		@Nonnull OffsetIndexRecordTypeRegistry recordRegistry,
+		@Nonnull Function<VersionedKryoKeyInputs, VersionedKryo> kryoFactory,
+		@Nonnull Consumer<CatalogHeader> catalogHeaderConsumer,
+		@Nonnull FileOffsetIndexBuilder indexBuilder,
+		@Nonnull ObservableInput<?> theInput,
+		@Nonnull FileLocation fileLocation
+	) {
+		// and load the catalog header
+		final FileLocation catalogHeaderLocation = indexBuilder.getBuiltIndex().get(
+			new RecordKey(recordRegistry.idFor(CatalogHeader.class), 1L)
+		);
+		final Kryo kryo = KryoFactory.createKryo(
+			SharedClassesConfigurer.INSTANCE.andThen(CatalogHeaderKryoConfigurer.INSTANCE)
+		);
+		final CatalogHeader theCatalogHeader = StorageRecord.read(
+			theInput, catalogHeaderLocation,
+			(input, recordLength) -> kryo.readObject(input, CatalogHeader.class)
+		).payload();
+
+		catalogHeaderConsumer.accept(theCatalogHeader);
+		return new OffsetIndexDescriptor(
+			theCatalogHeader.version(),
+			fileLocation,
+			theCatalogHeader.compressedKeys(),
+			kryoFactory,
+			// we don't know here yet - this will be recomputed on first flush
+			theCatalogHeader.activeRecordShare(),
+			catalogFilePath.toFile().length()
 		);
 	}
 
@@ -240,7 +283,7 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 				nonFlushedBlockObserver,
 				historyKeptObserver
 			);
-			final CatalogHeader newHeader = new CatalogHeader(catalogName);
+			final CatalogHeader newHeader = new CatalogHeader(UUID.randomUUID(), catalogName);
 			newOffsetIndex.put(0L, newHeader);
 			catalogHeaderConsumer.accept(newHeader);
 			return newOffsetIndex;
@@ -269,54 +312,8 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 		}
 	}
 
-	/**
-	 * Loads an offset index descriptor based on the given parameters.
-	 * @param catalogFilePath the file to load offset index descriptor from
-	 * @param recordRegistry the record registry
-	 * @param kryoFactory the factory to create Kryo instances
-	 * @param catalogHeaderConsumer the consumer to accept the catalog header
-	 * @param indexBuilder the index builder to use
-	 * @param theInput the observable input
-	 * @param fileLocation the file location to read record from
-	 * @return the loaded offset index descriptor
-	 */
-	@Nonnull
-	static OffsetIndexDescriptor loadOffsetIndexDescriptor(
-		@Nonnull Path catalogFilePath,
-		@Nonnull OffsetIndexRecordTypeRegistry recordRegistry,
-		@Nonnull Function<VersionedKryoKeyInputs, VersionedKryo> kryoFactory,
-		@Nonnull Consumer<CatalogHeader> catalogHeaderConsumer,
-		@Nonnull FileOffsetIndexBuilder indexBuilder,
-		@Nonnull ObservableInput<?> theInput,
-		@Nonnull FileLocation fileLocation
-	) {
-		// and load the catalog header
-		final FileLocation catalogHeaderLocation = indexBuilder.getBuiltIndex().get(
-			new RecordKey(recordRegistry.idFor(CatalogHeader.class), 1L)
-		);
-		final Kryo kryo = KryoFactory.createKryo(
-			SharedClassesConfigurer.INSTANCE.andThen(CatalogHeaderKryoConfigurer.INSTANCE)
-		);
-		final CatalogHeader theCatalogHeader = StorageRecord.read(
-			theInput, catalogHeaderLocation,
-			(input, recordLength) -> kryo.readObject(input, CatalogHeader.class)
-		).payload();
-
-		catalogHeaderConsumer.accept(theCatalogHeader);
-		return new OffsetIndexDescriptor(
-			theCatalogHeader.version(),
-			fileLocation,
-			theCatalogHeader.compressedKeys(),
-			kryoFactory,
-			// we don't know here yet - this will be recomputed on first flush
-			theCatalogHeader.activeRecordShare(),
-			catalogFilePath.toFile().length()
-		);
-	}
-
 	private CatalogOffsetIndexStoragePartPersistenceService(
 		long catalogVersion,
-		@Nonnull String catalogName,
 		@Nullable CatalogHeader catalogHeader,
 		@Nonnull TransactionOptions transactionOptions,
 		@Nonnull OffsetIndex offsetIndex,
@@ -354,6 +351,7 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 		@Nonnull Path catalogStoragePath,
 		@Nullable WalFileReference walFileLocation,
 		@Nonnull Map<String, CollectionFileReference> collectionFileReferenceIndex,
+		@Nonnull UUID catalogId,
 		@Nonnull String catalogName,
 		@Nonnull CatalogState catalogState,
 		int lastEntityCollectionPrimaryKey
@@ -364,6 +362,7 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 			walFileLocation,
 			collectionFileReferenceIndex,
 			offsetIndex.getCompressedKeys(),
+			catalogId,
 			catalogName,
 			catalogState,
 			lastEntityCollectionPrimaryKey,

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -694,7 +694,6 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 			catalogVersion,
 			CatalogOffsetIndexStoragePartPersistenceService.create(
 				this.catalogName,
-				catalogFileName,
 				catalogFilePath,
 				this.storageOptions,
 				this.transactionOptions,
@@ -767,7 +766,6 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		final CatalogOffsetIndexStoragePartPersistenceService catalogStoragePartPersistenceService =
 			CatalogOffsetIndexStoragePartPersistenceService.create(
 				this.catalogName,
-				catalogFileName,
 				catalogFilePath,
 				this.storageOptions,
 				this.transactionOptions,
@@ -1001,6 +999,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 
 	@Override
 	public void storeHeader(
+		@Nonnull UUID catalogId,
 		@Nonnull CatalogState catalogState,
 		long catalogVersion,
 		int lastEntityCollectionPrimaryKey,
@@ -1049,6 +1048,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 						Function.identity()
 					)
 				),
+			catalogId,
 			this.catalogName,
 			catalogState,
 			lastEntityCollectionPrimaryKey
@@ -1283,6 +1283,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 			newPath,
 			catalogHeader.walFileReference(),
 			catalogHeader.collectionFileIndex(),
+			catalogHeader.catalogId(),
 			catalogNameToBeReplaced,
 			catalogHeader.catalogState(),
 			catalogHeader.lastEntityCollectionPrimaryKey()
@@ -1773,7 +1774,6 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 					catalogVersion,
 					CatalogOffsetIndexStoragePartPersistenceService.create(
 						this.catalogName,
-						compactedFileName,
 						this.catalogStoragePath.resolve(compactedFileName),
 						this.storageOptions,
 						this.transactionOptions,

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/serializer/CatalogHeaderSerializer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/serializer/CatalogHeaderSerializer.java
@@ -39,6 +39,7 @@ import io.evitadb.utils.CollectionUtils;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * This {@link Serializer} implementation reads/writes {@link CatalogHeader} from/to binary format.
@@ -51,6 +52,7 @@ public class CatalogHeaderSerializer extends AbstractPersistentStorageHeaderSeri
 	public void write(Kryo kryo, Output output, CatalogHeader object) {
 		output.writeVarInt(object.storageProtocolVersion(), true);
 		output.writeString(object.catalogName());
+		kryo.writeObject(output, object.catalogId());
 		output.writeVarLong(object.version(), true);
 		output.writeVarInt(object.lastEntityCollectionPrimaryKey(), true);
 		output.writeDouble(object.activeRecordShare());
@@ -91,6 +93,7 @@ public class CatalogHeaderSerializer extends AbstractPersistentStorageHeaderSeri
 			)
 		);
 		final String catalogName = input.readString();
+		final UUID catalogId = kryo.readObject(input, UUID.class);
 		final long version = input.readVarLong(true);
 		final int lastEntityCollectionPrimaryKey = input.readVarInt(true);
 		final double activeRecordShare = input.readDouble();
@@ -137,6 +140,7 @@ public class CatalogHeaderSerializer extends AbstractPersistentStorageHeaderSeri
 			walFileReference,
 			collectionFileIndex,
 			compressedKeys,
+			catalogId,
 			catalogName,
 			catalogState,
 			lastEntityCollectionPrimaryKey,

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/serializer/CatalogHeaderSerializer_2024_08.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/serializer/CatalogHeaderSerializer_2024_08.java
@@ -43,12 +43,11 @@ import java.util.Map;
 
 /**
  * This {@link Serializer} implementation reads/writes {@link CatalogHeader} from/to binary format.
- * TOBEDONE #538 - Remove this class in the future.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 @Deprecated
-public class CatalogHeaderSerializer_2024_05 extends AbstractPersistentStorageHeaderSerializer<CatalogHeader> {
+public class CatalogHeaderSerializer_2024_08 extends AbstractPersistentStorageHeaderSerializer<CatalogHeader> {
 
 	@Override
 	public void write(Kryo kryo, Output output, CatalogHeader object) {
@@ -56,6 +55,7 @@ public class CatalogHeaderSerializer_2024_05 extends AbstractPersistentStorageHe
 		output.writeString(object.catalogName());
 		output.writeVarLong(object.version(), true);
 		output.writeVarInt(object.lastEntityCollectionPrimaryKey(), true);
+		output.writeDouble(object.activeRecordShare());
 
 		final WalFileReference walFileReference = object.walFileReference();
 		if (walFileReference != null) {
@@ -95,6 +95,7 @@ public class CatalogHeaderSerializer_2024_05 extends AbstractPersistentStorageHe
 		final String catalogName = input.readString();
 		final long version = input.readVarLong(true);
 		final int lastEntityCollectionPrimaryKey = input.readVarInt(true);
+		final double activeRecordShare = input.readDouble();
 
 		final WalFileReference walFileReference;
 		if (input.readBoolean()) {
@@ -142,7 +143,7 @@ public class CatalogHeaderSerializer_2024_05 extends AbstractPersistentStorageHe
 			catalogName,
 			catalogState,
 			lastEntityCollectionPrimaryKey,
-			1.0
+			activeRecordShare
 		);
 	}
 


### PR DESCRIPTION
Catalogs are uniquely identified by their name. However, this name can change using `rename' and `replace' operations on the catalog. So if we have catalogs `a` and `b`, and later `b` replaces `a` and starts using the `a` catalog name, we cannot distinguish it from the original `a` catalog. By introducing a new internally assigned UUID for each catalog, we can still distinguish catalog `a` with UUID `1` from catalog `a` with UUID 2. This internal ID can be used by the outside world to infer the identity of the catalog and be used for synchronization purposes.