### PR TITLE
fix(#638): Nested entities are not sorted when `hierarchy` requiremen…

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/producer/HierarchySet.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/producer/HierarchySet.java
@@ -40,6 +40,7 @@ import org.roaringbitmap.RoaringBitmapWriter;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -103,7 +104,9 @@ public class HierarchySet {
 				)
 			);
 		} else {
-			return result;
+			return Collections.singletonList(
+				levelInfoToSort[0]
+			);
 		}
 	}
 


### PR DESCRIPTION
…t is used

The problem occurs only in case when the calculated response contains exactly one root item. In such case its children are not sorted.