### PR TITLE
fix(#685): Currency & Locale cannot be inserted as filtered / sortabl…

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute/AttributeMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute/AttributeMutation.java
@@ -36,8 +36,6 @@ import io.evitadb.api.requestResponse.schema.EntitySchemaEditor.EntitySchemaBuil
 import io.evitadb.api.requestResponse.schema.EvolutionMode;
 import io.evitadb.dataType.ContainerType;
 import io.evitadb.dataType.EvitaDataTypes;
-import io.evitadb.dataType.Predecessor;
-import io.evitadb.dataType.ReferencedEntityPredecessor;
 import io.evitadb.utils.Assert;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -105,13 +103,6 @@ public abstract class AttributeMutation implements NamedLocalMutation<AttributeV
 	) throws InvalidMutationException {
 		// when attribute definition is known execute first encounter formal verification
 		if (attributeSchema != null) {
-			// we need to unwrap array classes - we need to check base class for compatibility with Comparable
-			final Class<?> attributeClass;
-			if (attributeValue instanceof Object[]) {
-				attributeClass = attributeValue.getClass().getComponentType();
-			} else {
-				attributeClass = attributeValue.getClass();
-			}
 			Assert.isTrue(
 				(attributeSchema.getType().isPrimitive() ?
 					EvitaDataTypes.getWrappingPrimitiveClass(attributeSchema.getType()) : attributeSchema.getType())
@@ -122,15 +113,6 @@ public abstract class AttributeMutation implements NamedLocalMutation<AttributeV
 						"All values of attribute `" + attributeKey.attributeName() + "` must respect this data type!"
 				)
 			);
-			if (attributeSchema.isSortable()) {
-				Assert.isTrue(
-					Comparable.class.isAssignableFrom(attributeClass) || attributeValue instanceof Predecessor || attributeValue instanceof ReferencedEntityPredecessor,
-					() -> new InvalidMutationException(
-						"Attribute `" + attributeKey.attributeName() + "` in schema `" + entitySchemaBuilder.getName() + "` is sortable and needs to implement " +
-							"Comparable interface (or be Predecessor/ReferencedEntityPredecessor), but it doesn't: `" + attributeValue.getClass() + "`!"
-					)
-				);
-			}
 			if (attributeSchema.isLocalized()) {
 				Assert.isTrue(
 					attributeKey.localized(),

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/AbstractAttributeSchemaBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/AbstractAttributeSchemaBuilder.java
@@ -435,6 +435,8 @@ public abstract sealed class AbstractAttributeSchemaBuilder<T extends AttributeS
 			!currentSchema.isSortable() ||
 				plainType.isPrimitive() ||
 				Comparable.class.isAssignableFrom(plainType) ||
+				Currency.class.isAssignableFrom(plainType) ||
+				Locale.class.isAssignableFrom(plainType) ||
 				Predecessor.class.isAssignableFrom(plainType) ||
 				ReferencedEntityPredecessor.class.isAssignableFrom(plainType),
 			() -> new InvalidSchemaMutationException("Data type `" + currentSchema.getType() + "` in attribute schema `" + currentSchema.getName() + "` must implement Comparable (or must be Predecessor/ReferencedEntityPredecessor) in order to be usable for sort index!")

--- a/evita_common/src/main/java/io/evitadb/dataType/ComparableCurrency.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/ComparableCurrency.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.dataType;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Currency;
+
+/**
+ * Comparable wrapper for {@link Currency} object. This class is used to provide {@link Comparable} interface for
+ * {@link Currency} object, which is not {@link Comparable} by default.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+@RequiredArgsConstructor
+public class ComparableCurrency implements Comparable<ComparableCurrency>, Serializable {
+	@Serial private static final long serialVersionUID = -8356388816362776092L;
+	@Getter private final Currency currency;
+
+	@Override
+	public int compareTo(@Nonnull ComparableCurrency o) {
+		return currency.toString().compareTo(o.currency.toString());
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		ComparableCurrency that = (ComparableCurrency) o;
+		return currency.equals(that.currency);
+	}
+
+	@Override
+	public int hashCode() {
+		return currency.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return currency.getCurrencyCode();
+	}
+}

--- a/evita_common/src/main/java/io/evitadb/dataType/ComparableLocale.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/ComparableLocale.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.dataType;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Locale;
+
+/**
+ * Comparable wrapper for {@link Locale} object. This class is used to provide {@link Comparable} interface for
+ * {@link Locale} object, which is not {@link Comparable} by default.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+@RequiredArgsConstructor
+public class ComparableLocale implements Comparable<ComparableLocale>, Serializable {
+	@Serial private static final long serialVersionUID = -3500017809507870169L;
+	@Getter private final Locale locale;
+
+	@Override
+	public int compareTo(@Nonnull ComparableLocale o) {
+		return locale.toLanguageTag().compareTo(o.locale.toLanguageTag());
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		ComparableLocale that = (ComparableLocale) o;
+		return locale.equals(that.locale);
+	}
+
+	@Override
+	public int hashCode() {
+		return locale.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return locale.toLanguageTag();
+	}
+}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/attribute/AttributeFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/attribute/AttributeFormula.java
@@ -26,6 +26,7 @@ package io.evitadb.core.query.algebra.attribute;
 import io.evitadb.api.query.require.AttributeHistogram;
 import io.evitadb.api.query.require.EntityRequire;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.prefetch.RequirementsDefiner;
@@ -69,11 +70,20 @@ public class AttributeFormula extends AbstractFormula implements RequirementsDef
 	 */
 	@Getter private final Predicate<BigDecimal> requestedPredicate;
 
-	public AttributeFormula(boolean targetsGlobalAttribute, @Nonnull AttributeKey attributeKey, @Nonnull Formula innerFormula) {
+	public AttributeFormula(
+		boolean targetsGlobalAttribute,
+		@Nonnull AttributeKey attributeKey,
+		@Nonnull Formula innerFormula
+	) {
 		this(targetsGlobalAttribute, attributeKey, innerFormula, null);
 	}
 
-	public AttributeFormula(boolean targetsGlobalAttribute, @Nonnull AttributeKey attributeKey, @Nonnull Formula innerFormula, @Nullable Predicate<BigDecimal> requestedPredicate) {
+	public AttributeFormula(
+		boolean targetsGlobalAttribute,
+		@Nonnull AttributeKey attributeKey,
+		@Nonnull Formula innerFormula,
+		@Nullable Predicate<BigDecimal> requestedPredicate
+	) {
 		this.targetsGlobalAttribute = targetsGlobalAttribute;
 		this.attributeKey = attributeKey;
 		this.requestedPredicate = requestedPredicate;

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/PrefetchFormulaVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/PrefetchFormulaVisitor.java
@@ -229,6 +229,7 @@ public class PrefetchFormulaVisitor implements FormulaVisitor, FormulaPostProces
 	/**
 	 * Returns set of requirements to fetch entities with.
 	 */
+	@Nonnull
 	protected EntityFetchRequire getRequirements() {
 		return new EntityFetch(
 			requirements.values().toArray(new EntityContentRequire[0])
@@ -255,6 +256,7 @@ public class PrefetchFormulaVisitor implements FormulaVisitor, FormulaPostProces
 	/**
 	 * Returns entity primary keys to fetch.
 	 */
+	@Nonnull
 	private Bitmap getConjunctiveEntities() {
 		return estimatedBitmapCardinality <= BITMAP_SIZE_THRESHOLD ?
 			conjunctiveEntityIds.stream()

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/AttributeHistogramTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/AttributeHistogramTranslator.java
@@ -26,6 +26,7 @@ package io.evitadb.core.query.extraResult.translator.histogram;
 import io.evitadb.api.exception.AttributeNotFoundException;
 import io.evitadb.api.query.require.AttributeHistogram;
 import io.evitadb.api.query.require.HistogramBehavior;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.api.requestResponse.extraResult.Histogram;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
@@ -102,7 +103,13 @@ public class AttributeHistogramTranslator implements RequireConstraintTranslator
 
 			// register computational lambda for producing attribute histogram
 			attributeHistogramProducer.addAttributeHistogramRequest(
-				attributeSchema, attributeIndexes, attributeFormulas.get(attributeName)
+				attributeSchema,
+				FilterIndex.getComparator(
+					new AttributeKey(attributeName, extraResultPlanner.getLocale()),
+					attributeSchema.getPlainType()
+				),
+				attributeIndexes,
+				attributeFormulas.get(attributeName)
 			);
 		}
 		return attributeHistogramProducer;

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AbstractAttributeComparisonTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AbstractAttributeComparisonTranslator.java
@@ -1,0 +1,236 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.filter.translator.attribute;
+
+
+import io.evitadb.api.query.filter.AbstractAttributeFilterComparisonConstraintLeaf;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
+import io.evitadb.api.requestResponse.extraResult.HistogramContract.Bucket;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
+import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
+import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.attribute.AttributeFormula;
+import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
+import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
+import io.evitadb.core.query.filter.FilterByVisitor;
+import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
+import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
+import io.evitadb.dataType.EvitaDataTypes;
+import io.evitadb.index.attribute.FilterIndex;
+import lombok.RequiredArgsConstructor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * An abstract class designed to translate attribute comparison constraints into specific filtering formulas.
+ * Extends functionality to handle attribute-based filtering with various predicates to compare results.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+@RequiredArgsConstructor
+class AbstractAttributeComparisonTranslator extends AbstractAttributeTranslator {
+	/**
+	 * The predicate used to compare the result of the filtering operation.
+	 */
+	private final IntPredicate comparisonResultPredicate;
+	/**
+	 * The function that will extract formula matching the searched string from the filter index.
+	 */
+	private final BiFunction<FilterIndex, Serializable, Formula> filterIndexResolver;
+	/**
+	 * The description of the attribute comparison filter.
+	 */
+	private final String description;
+
+	/**
+	 * Translates the provided attribute constraint into a filtering formula.
+	 * This method processes the attribute constraint using the visitor to
+	 * apply the appropriate filter based on the attribute name and value.
+	 *
+	 * @param attributeConstraint The attribute filter constraint that contains the attribute name and value to be filtered.
+	 * @param filterByVisitor The visitor used to traverse and process filter constraints.
+	 * @return The resulting formula based on the attribute constraint and the visitor's filtering logic.
+	 */
+	@Nonnull
+	protected Formula translateInternal(@Nonnull AbstractAttributeFilterComparisonConstraintLeaf attributeConstraint, @Nonnull FilterByVisitor filterByVisitor) {
+		final String attributeName = attributeConstraint.getAttributeName();
+		final Serializable attributeValue = attributeConstraint.getAttributeValue();
+		final Optional<GlobalAttributeSchemaContract> optionalGlobalAttributeSchema = getOptionalGlobalAttributeSchema(filterByVisitor, attributeName);
+
+		if (filterByVisitor.isEntityTypeKnown() || optionalGlobalAttributeSchema.isPresent()) {
+			final AttributeSchemaContract attributeDefinition = optionalGlobalAttributeSchema
+				.map(AttributeSchemaContract.class::cast)
+				.orElseGet(() -> filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE));
+			final AttributeKey attributeKey = createAttributeKey(filterByVisitor, attributeDefinition);
+
+			final Class<? extends Serializable> attributeType = attributeDefinition.getPlainType();
+			final Serializable comparableValue = EvitaDataTypes.toTargetType(attributeValue, attributeType);
+			final AttributeFormula filteringFormula = new AttributeFormula(
+				attributeDefinition instanceof GlobalAttributeSchemaContract,
+				attributeKey,
+				filterByVisitor.applyOnFilterIndexes(
+					attributeDefinition, index -> this.filterIndexResolver.apply(index, comparableValue)
+				),
+				createHistogramRequestedPredicate(attributeType, comparableValue, this.comparisonResultPredicate)
+			);
+			if (filterByVisitor.isPrefetchPossible()) {
+				return new SelectionFormula(
+					filteringFormula,
+					createAlternativeBitmapFilter(filterByVisitor, attributeName, attributeValue, this.comparisonResultPredicate)
+				);
+			} else {
+				return filteringFormula;
+			}
+		} else {
+			return new EntityFilteringFormula(
+				"attribute " + this.description + " filter",
+				createAlternativeBitmapFilter(filterByVisitor, attributeName, attributeValue, this.comparisonResultPredicate)
+			);
+		}
+
+	}
+
+	/**
+	 * Creates an {@link AttributeBitmapFilter} for the provided attribute key and value. The filter is used to filter
+	 * prefetched entities based on the attribute key and value.
+	 *
+	 * @param filterByVisitor The visitor used to traverse and process filters.
+	 * @param attributeName The name of the attribute to be used in the filter.
+	 * @param attributeValue The value of the attribute to be used in the filter.
+	 * @return An instance of {@link AttributeBitmapFilter} configured with the given attribute key and value.
+	 */
+	@Nonnull
+	static AttributeBitmapFilter createAlternativeBitmapFilter(
+		@Nonnull FilterByVisitor filterByVisitor,
+		@Nonnull String attributeName,
+		@Nonnull Serializable attributeValue,
+		@Nonnull IntPredicate comparisonResultPredicate
+	) {
+		final ProcessingScope<?> processingScope = filterByVisitor.getProcessingScope();
+		return new AttributeBitmapFilter(
+			attributeName,
+			processingScope.getRequirements(),
+			processingScope::getAttributeSchema,
+			(entityContract, theAttributeName) -> processingScope.getAttributeValueStream(entityContract, theAttributeName, filterByVisitor.getLocale()),
+			attributeSchema -> {
+				final Function<Serializable, Predicate<Stream<Optional<AttributeValue>>>> predicateFactory = valueToCompare -> getPredicate(
+					attributeSchema,
+					attributeSchema.isLocalized() ?
+						new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
+					valueToCompare,
+					comparisonResultPredicate
+				);
+
+				if (attributeValue.getClass().isArray()) {
+					final Serializable[] valueItems = (Serializable[]) attributeValue;
+					Predicate<Stream<Optional<AttributeValue>>> thePredicate = null;
+					for (Serializable valueItem : valueItems) {
+						final Serializable comparableValue = EvitaDataTypes.toTargetType(valueItem, attributeSchema.getPlainType());
+						thePredicate = thePredicate == null ?
+							predicateFactory.apply(comparableValue) : thePredicate.or(predicateFactory.apply(comparableValue));
+					}
+					return thePredicate;
+				} else {
+					final Serializable comparableValue = EvitaDataTypes.toTargetType(attributeValue, attributeSchema.getPlainType());
+					return predicateFactory.apply(comparableValue);
+				}
+			}
+		);
+	}
+
+	/**
+	 * Generates a predicate to evaluate whether a stream of attribute values matches a given schema, key, and comparable value.
+	 *
+	 * @param attributeSchema the schema of the attribute containing type details
+	 * @param attributeKey the key representing the specific attribute
+	 * @param comparableValue the value to compare against attribute values
+	 * @return a predicate for evaluating whether the stream contains matching attribute values
+	 */
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	@Nonnull
+	static Predicate<Stream<Optional<AttributeValue>>> getPredicate(
+		@Nonnull AttributeSchemaContract attributeSchema,
+		@Nonnull AttributeKey attributeKey,
+		@Nullable Serializable comparableValue,
+		@Nonnull IntPredicate comparisonPredicate
+	) {
+		final Comparator comparator = FilterIndex.getComparator(attributeKey, attributeSchema.getPlainType());
+		final Function<Object, Serializable> normalizer = FilterIndex.getNormalizer(attributeSchema.getPlainType());
+		final Serializable comparedValue = normalizer.apply(comparableValue);
+		final Predicate<Comparable> predicate = theValue -> theValue != null && comparisonPredicate.test(comparator.compare(theValue, comparedValue));
+
+		return attrStream -> attrStream.anyMatch(
+			attr -> {
+				if (attr.isEmpty()) {
+					return false;
+				} else {
+					final Serializable theValue = attr.get().value();
+					if (theValue.getClass().isArray()) {
+						return Arrays.stream((Object[])theValue).map(normalizer).map(Comparable.class::cast).anyMatch(predicate);
+					} else {
+						return predicate.test((Comparable)normalizer.apply(theValue));
+					}
+				}
+			}
+		);
+	}
+
+	/**
+	 * Creates a predicate based on the provided attribute type and comparable value for histogram requests.
+	 * The predicate is used to determine {@link Bucket#requested()} property.
+	 *
+	 * @param attributeType The type of the attribute to compare.
+	 * @param comparableValue The value to compare the attribute against.
+	 * @return A predicate to apply on BigDecimal values, or null if the attribute type is not a Number.
+	 */
+	@Nullable
+	private static Predicate<BigDecimal> createHistogramRequestedPredicate(
+		@Nonnull Class<? extends Serializable> attributeType,
+		@Nonnull Serializable comparableValue,
+		@Nonnull IntPredicate comparisonPredicate
+	) {
+		final Predicate<BigDecimal> requestedPredicate;
+		if (Number.class.isAssignableFrom(attributeType)) {
+			final BigDecimal fromBigDecimal = EvitaDataTypes.toTargetType(comparableValue, BigDecimal.class);
+			requestedPredicate = threshold -> fromBigDecimal == null || comparisonPredicate.test(threshold.compareTo(fromBigDecimal));
+		} else {
+			requestedPredicate = null;
+		}
+		return requestedPredicate;
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AbstractAttributeStringSearchTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AbstractAttributeStringSearchTranslator.java
@@ -1,0 +1,206 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.filter.translator.attribute;
+
+
+import io.evitadb.api.query.filter.AbstractAttributeFilterStringSearchConstraintLeaf;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
+import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
+import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.attribute.AttributeFormula;
+import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
+import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
+import io.evitadb.core.query.filter.FilterByVisitor;
+import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
+import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
+import io.evitadb.index.attribute.FilterIndex;
+import io.evitadb.utils.Assert;
+import lombok.RequiredArgsConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * AbstractAttributeStringSearchTranslator is an abstract class that extends the AbstractAttributeTranslator.
+ * It provides methods to generate filtering formulas based on string attribute searches, applying specific
+ * predicates for filtering.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+@RequiredArgsConstructor
+class AbstractAttributeStringSearchTranslator extends AbstractAttributeTranslator {
+	/**
+	 * The description of the filter.
+	 */
+	private final String description;
+	/**
+	 * The function that will extract formula matching the searched string from the filter index.
+	 */
+	private final BiFunction<FilterIndex, String, Formula> filterIndexResolver;
+	/**
+	 * The predicate to test each attribute string value.
+	 */
+	private final BiPredicate<String, String> stringPredicate;
+
+	/**
+	 * Asserts that the provided attribute definition is of type String.
+	 * This method ensures that the attribute constraint is applied only
+	 * to attributes with a String type.
+	 *
+	 * @param attributeConstraint the attribute filter string search constraint
+	 *                            that requires the attribute to be of type String
+	 * @param attributeDefinition the schema definition of the attribute being validated
+	 */
+	static void assertStringType(
+		@Nonnull AbstractAttributeFilterStringSearchConstraintLeaf attributeConstraint,
+		@Nonnull AttributeSchemaContract attributeDefinition
+	) {
+		Assert.isTrue(
+			String.class.equals(attributeDefinition.getType()),
+			() -> attributeConstraint.getClass().getSimpleName() + " constraint can be used only on String attributes - `" + attributeDefinition.getName() + "` is `" + attributeDefinition.getType() + "`!"
+		);
+	}
+
+	/**
+	 * Transforms a {@link Predicate} of type {@link String} to a {@link Predicate} of type {@link Stream}<{@link Optional}<{@link AttributeValue}>>.
+	 * The transformation involves inspecting the stream of attribute values, checking if each attribute
+	 * meets the given string predicate.
+	 *
+	 * @param predicate the predicate to test each attribute string value.
+	 * @return a predicate applied to a stream of optional attribute values.
+	 */
+	@Nonnull
+	static Predicate<Stream<Optional<AttributeValue>>> transformPredicate(@Nonnull Predicate<String> predicate) {
+		return attrStream -> attrStream.anyMatch(
+			attr -> {
+				if (attr.isEmpty()) {
+					return false;
+				} else {
+					final Serializable theValue = attr.get().value();
+					if (theValue.getClass().isArray()) {
+						return Arrays.stream((Object[]) theValue).map(String.class::cast).anyMatch(predicate);
+					} else {
+						return predicate.test((String) theValue);
+					}
+				}
+			}
+		);
+	}
+
+	/**
+	 * Creates an alternative bitmap filter for processing attribute conditions.
+	 *
+	 * @param filterByVisitor     the visitor handling the filter-by processing context
+	 * @param attributeConstraint the attribute filter string search constraint leaf that provides the attribute name and the text to search for
+	 * @param attributeName       the name of the attribute to filter by
+	 * @param predicate           the predicate to test each attribute string value
+	 * @return an instance of AttributeBitmapFilter configured with the specified parameters
+	 */
+	@Nonnull
+	private static AttributeBitmapFilter createAlternativeBitmapFilter(
+		@Nonnull FilterByVisitor filterByVisitor,
+		@Nonnull AbstractAttributeFilterStringSearchConstraintLeaf attributeConstraint,
+		@Nonnull String attributeName,
+		@Nonnull Predicate<String> predicate
+	) {
+		final ProcessingScope<?> processingScope = filterByVisitor.getProcessingScope();
+		return new AttributeBitmapFilter(
+			attributeName,
+			processingScope.getRequirements(),
+			processingScope::getAttributeSchema,
+			(entityContract, theAttributeName) -> processingScope.getAttributeValueStream(entityContract, theAttributeName, filterByVisitor.getLocale()),
+			attributeSchema -> {
+				assertStringType(attributeConstraint, attributeSchema);
+				return transformPredicate(predicate);
+			}
+		);
+	}
+
+	/**
+	 * Translates the given attribute string search constraint into a filtering formula suitable for application on a filter index.
+	 * This method is intended for internal use to assist the filtering process by generating an appropriate formula based on the given
+	 * constraints and the current state of the filter visitor.
+	 *
+	 * @param attributeConstraint the attribute filter string search constraint leaf that provides the attribute name and the text to search for
+	 * @param filterByVisitor     the filter by visitor context that provides methods to retrieve attribute schema, check entity type knowledge,
+	 *                            and apply filters on index
+	 * @return a Formula object representing the filtering formula based on the given constraints and visitor context
+	 */
+	@Nonnull
+	protected Formula translateInternal(
+		@Nonnull AbstractAttributeFilterStringSearchConstraintLeaf attributeConstraint,
+		@Nonnull FilterByVisitor filterByVisitor
+	) {
+		final String attributeName = attributeConstraint.getAttributeName();
+		final String textToSearch = attributeConstraint.getTextToSearch();
+		final Optional<GlobalAttributeSchemaContract> optionalGlobalAttributeSchema = getOptionalGlobalAttributeSchema(filterByVisitor, attributeName);
+
+		if (filterByVisitor.isEntityTypeKnown() || optionalGlobalAttributeSchema.isPresent()) {
+			final AttributeSchemaContract attributeDefinition = optionalGlobalAttributeSchema
+				.map(AttributeSchemaContract.class::cast)
+				.orElseGet(() -> filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE));
+			final AttributeKey attributeKey = createAttributeKey(filterByVisitor, attributeDefinition);
+			assertStringType(attributeConstraint, attributeDefinition);
+
+			final AttributeFormula filteringFormula = new AttributeFormula(
+				attributeDefinition instanceof GlobalAttributeSchemaContract,
+				attributeKey,
+				filterByVisitor.applyOnFilterIndexes(
+					attributeDefinition,
+					index -> this.filterIndexResolver.apply(index, textToSearch)
+				)
+			);
+
+			if (filterByVisitor.isPrefetchPossible()) {
+				return new SelectionFormula(
+					filteringFormula,
+					createAlternativeBitmapFilter(
+						filterByVisitor, attributeConstraint, attributeName,
+						value -> this.stringPredicate.test(value, textToSearch)
+					)
+				);
+			} else {
+				return filteringFormula;
+			}
+		} else {
+			return new EntityFilteringFormula(
+				"attribute " + this.description + " filter",
+				createAlternativeBitmapFilter(
+					filterByVisitor, attributeConstraint, attributeName,
+					value -> this.stringPredicate.test(value, textToSearch)
+				)
+			);
+		}
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AbstractAttributeTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AbstractAttributeTranslator.java
@@ -1,0 +1,90 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.filter.translator.attribute;
+
+
+import io.evitadb.api.exception.EntityLocaleMissingException;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
+import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
+import io.evitadb.core.query.filter.FilterByVisitor;
+import io.evitadb.utils.Assert;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+/**
+ * The AbstractAttributeTranslator class provides utility methods for handling attribute keys within
+ * the filtering and translation process. Specifically, it can generate AttributeKey objects using
+ * given parameters such as the filterByVisitor and attributeDefinition.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+class AbstractAttributeTranslator {
+
+	/**
+	 * Generates an AttributeKey object based on the provided filterByVisitor and attributeDefinition.
+	 * If the attribute is localized, it requires a locale specification within the filterByVisitor.
+	 *
+	 * @param filterByVisitor the visitor that provides context information, including locale.
+	 * @param attributeDefinition the schema contract that contains the attribute details.
+	 * @return an AttributeKey object representing the specific attribute.
+	 * @throws AssertionError if the attribute requires localization but no locale is provided in the filterByVisitor.
+	 */
+	@Nonnull
+	public static AttributeKey createAttributeKey(
+		@Nonnull FilterByVisitor filterByVisitor,
+		@Nonnull AttributeSchemaContract attributeDefinition
+	) {
+		final String attributeName = attributeDefinition.getName();
+		Assert.isTrue(
+			!attributeDefinition.isLocalized() || filterByVisitor.getLocale() != null ||
+				(attributeDefinition.isUnique() && !attributeDefinition.isUniqueWithinLocale()),
+			() -> new EntityLocaleMissingException("Localized attribute `" + attributeName + "` requires locale specification in the input query!")
+		);
+
+		return attributeDefinition.isLocalized() ?
+			new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName);
+	}
+
+	/**
+	 * Retrieves an optional global attribute schema based on the provided attribute name and filter visitor.
+	 * The global schema is not returned in case the reference schema is present in the processing scope - i.e. it means
+	 * that the search lookup is limited to attributes of particular reference schema.
+	 *
+	 * @param filterByVisitor the visitor that provides context information, including the processing scope and catalog schema.
+	 * @param attributeName the name of the attribute for which the schema is to be retrieved.
+	 * @return an Optional containing the GlobalAttributeSchemaContract if the attribute exists in the catalog schema,
+	 * or an empty Optional if the reference schema is not null contextually.
+	 */
+	@Nonnull
+	protected static Optional<GlobalAttributeSchemaContract> getOptionalGlobalAttributeSchema(
+		@Nonnull FilterByVisitor filterByVisitor,
+		@Nonnull String attributeName
+	) {
+		return filterByVisitor.getProcessingScope().getReferenceSchema() == null ?
+			filterByVisitor.getCatalogSchema().getAttribute(attributeName) : Optional.empty();
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeBetweenTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeBetweenTranslator.java
@@ -48,6 +48,7 @@ import io.evitadb.dataType.NumberRange;
 import io.evitadb.dataType.Range;
 import io.evitadb.dataType.ShortNumberRange;
 import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.index.attribute.FilterIndex;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -55,7 +56,9 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -67,93 +70,385 @@ import static java.util.Optional.ofNullable;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AttributeBetweenTranslator implements FilteringConstraintTranslator<AttributeBetween> {
+public class AttributeBetweenTranslator extends AbstractAttributeTranslator
+	implements FilteringConstraintTranslator<AttributeBetween> {
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	/**
+	 * Generates a predicate to determine if a stream of optional attribute values contains an element
+	 * that falls within the specified date-time range.
+	 *
+	 * @param from the starting bound of the range (inclusive), can be null.
+	 * @param to the ending bound of the range (inclusive), can be null.
+	 * @return a predicate that evaluates whether any element within the stream falls within the specified date-time range.
+	 */
+	@Nonnull
+	public static Predicate<Stream<Optional<AttributeValue>>> getDateTimePredicate(
+		@Nullable OffsetDateTime from,
+		@Nullable OffsetDateTime to
+	) {
+		return attrStream -> attrStream.anyMatch(
+			attr -> {
+				if (attr.isEmpty()) {
+					return false;
+				} else {
+					//noinspection rawtypes
+					final Predicate<Comparable> predicate = theValue -> {
+						if (theValue == null) {
+							return false;
+						} else if (from != null && to != null) {
+							return ((DateTimeRange) theValue).overlaps(DateTimeRange.between(from, to));
+						} else if (from != null) {
+							return ((DateTimeRange) theValue).overlaps(DateTimeRange.since(from));
+						} else if (to != null) {
+							return ((DateTimeRange) theValue).overlaps(DateTimeRange.until(to));
+						} else {
+							throw new GenericEvitaInternalError("Between query can never be created with both bounds null!");
+						}
+					};
+					final Serializable theValue = attr.get().value();
+					if (theValue.getClass().isArray()) {
+						return Arrays.stream((Object[]) theValue).map(Comparable.class::cast).anyMatch(predicate);
+					} else {
+						//noinspection rawtypes
+						return predicate.test((Comparable) theValue);
+					}
+				}
+			}
+		);
+	}
+
+	/**
+	 * Generates a predicate to determine if a stream of optional attribute values contains an element
+	 * that falls within the specified numerical range.
+	 *
+	 * @param from the starting bound of the range (inclusive), can be null.
+	 * @param to the ending bound of the range (inclusive), can be null.
+	 * @return a predicate that evaluates whether any element within the stream falls within the specified numerical range.
+	 */
+	@Nonnull
+	public static Predicate<Stream<Optional<AttributeValue>>> getNumberRangePredicate(
+		@Nullable Number from,
+		@Nullable Number to
+	) {
+		return attrStream -> attrStream.anyMatch(
+			attr -> {
+				if (attr.isEmpty()) {
+					return false;
+				} else {
+					//noinspection rawtypes
+					final Predicate<Comparable> predicate = theValue -> {
+						if (theValue == null) {
+							return false;
+						} else if (from != null && to != null) {
+							if (from instanceof BigDecimal || to instanceof BigDecimal) {
+								return ((BigDecimalNumberRange) theValue).overlaps(BigDecimalNumberRange.between((BigDecimal) from, (BigDecimal) to));
+							} else if (from instanceof Long || to instanceof Long) {
+								return ((LongNumberRange) theValue).overlaps(LongNumberRange.between((Long) from, (Long) to));
+							} else if (from instanceof Integer || to instanceof Integer) {
+								return ((IntegerNumberRange) theValue).overlaps(IntegerNumberRange.between((Integer) from, (Integer) to));
+							} else if (from instanceof Short || to instanceof Short) {
+								return ((ShortNumberRange) theValue).overlaps(ShortNumberRange.between((Short) from, (Short) to));
+							} else if (from instanceof Byte || to instanceof Byte) {
+								return ((ByteNumberRange) theValue).overlaps(ByteNumberRange.between((Byte) from, (Byte) to));
+							} else {
+								throw new GenericEvitaInternalError("Unexpected input type: " + from + ", " + to);
+							}
+						} else if (from != null) {
+							if (from instanceof BigDecimal) {
+								return ((BigDecimalNumberRange) theValue).overlaps(BigDecimalNumberRange.from((BigDecimal) from));
+							} else if (from instanceof Long) {
+								return ((LongNumberRange) theValue).overlaps(LongNumberRange.from((Long) from));
+							} else if (from instanceof Integer) {
+								return ((IntegerNumberRange) theValue).overlaps(IntegerNumberRange.from((Integer) from));
+							} else if (from instanceof Short) {
+								return ((ShortNumberRange) theValue).overlaps(ShortNumberRange.from((Short) from));
+							} else if (from instanceof Byte) {
+								return ((ByteNumberRange) theValue).overlaps(ByteNumberRange.from((Byte) from));
+							} else {
+								throw new GenericEvitaInternalError("Unexpected input type: " + from);
+							}
+						} else if (to != null) {
+							if (to instanceof BigDecimal) {
+								return ((BigDecimalNumberRange) theValue).overlaps(BigDecimalNumberRange.to((BigDecimal) to));
+							} else if (to instanceof Long) {
+								return ((LongNumberRange) theValue).overlaps(LongNumberRange.to((Long) to));
+							} else if (to instanceof Integer) {
+								return ((IntegerNumberRange) theValue).overlaps(IntegerNumberRange.to((Integer) to));
+							} else if (to instanceof Short) {
+								return ((ShortNumberRange) theValue).overlaps(ShortNumberRange.to((Short) to));
+							} else if (to instanceof Byte) {
+								return ((ByteNumberRange) theValue).overlaps(ByteNumberRange.to((Byte) to));
+							} else {
+								throw new GenericEvitaInternalError("Unexpected input type: " + to);
+							}
+						} else {
+							throw new GenericEvitaInternalError("Between query can never be created with both bounds null!");
+						}
+					};
+					final Serializable theValue = attr.get().value();
+					if (theValue.getClass().isArray()) {
+						return Arrays.stream((Object[]) theValue).map(Comparable.class::cast).anyMatch(predicate);
+					} else {
+						//noinspection rawtypes
+						return predicate.test((Comparable) theValue);
+					}
+				}
+			}
+		);
+	}
+
+	/**
+	 * Creates a predicate for filtering streams of optional attribute values, ensuring that the attributes fall within a specified range.
+	 *
+	 * @param normalizer The function used to normalize the attribute values.
+	 * @param comparator The comparator used to compare the attribute values.
+	 * @param from The lower bound of the comparable range, may be null.
+	 * @param to The upper bound of the comparable range, may be null.
+	 * @return A predicate that returns true if any attribute in the stream falls within the specified range.
+	 */
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	@Nonnull
+	public static Predicate<Stream<Optional<AttributeValue>>> getComparablePredicate(
+		@Nonnull Function<Object, Serializable> normalizer,
+		@Nonnull Comparator comparator,
+		@Nullable Serializable from,
+		@Nullable Serializable to
+	) {
+		return attrStream -> attrStream.anyMatch(
+			attr -> {
+				if (attr.isEmpty()) {
+					return false;
+				} else {
+					final Predicate<Comparable> predicate = theValue -> {
+						if (theValue == null) {
+							return false;
+						} else {
+							if (from != null && to != null) {
+								return comparator.compare(theValue, from) >= 0 &&
+									comparator.compare(theValue, to) <= 0;
+							} else if (from != null) {
+								return comparator.compare(theValue, from) >= 0;
+							} else if (to != null) {
+								return comparator.compare(theValue, to) <= 0;
+							} else {
+								throw new GenericEvitaInternalError("Between query can never be created with both bounds null!");
+							}
+						}
+					};
+					final Serializable theValue = attr.get().value();
+					if (theValue.getClass().isArray()) {
+						return Arrays.stream((Object[]) theValue)
+							.map(normalizer)
+							.map(Comparable.class::cast)
+							.anyMatch(predicate);
+					} else {
+						return predicate.test((Comparable) normalizer.apply(theValue));
+					}
+				}
+			}
+		);
+	}
+
+	/**
+	 * Creates a predicate for filtering {@link BigDecimal} objects within a specified range.
+	 *
+	 * @param from The lower bound of the range, may be null.
+	 * @param to   The upper bound of the range, may be null.
+	 * @return A predicate that returns true if the {@link BigDecimal} object falls within the specified range.
+	 */
+	@Nonnull
+	private static Predicate<BigDecimal> createBigDecimalPredicate(@Nullable BigDecimal from, @Nullable BigDecimal to) {
+		return threshold -> (from == null || threshold.compareTo(from) >= 0) &&
+			(to == null || threshold.compareTo(to) <= 0);
+	}
+
+	/**
+	 * Creates an {@link AttributeFormula} for a range attribute based on the provided parameters.
+	 *
+	 * @param filterByVisitor     The visitor used to apply filter indexes.
+	 * @param from                The starting value of the range.
+	 * @param to                  The ending value of the range.
+	 * @param attributeDefinition The schema definition of the attribute.
+	 * @param attributeKey        The key of the attribute being filtered.
+	 * @return The constructed {@link AttributeFormula}.
+	 */
+	@Nonnull
+	private static AttributeFormula createRangeAttributeFormula(
+		@Nonnull FilterByVisitor filterByVisitor,
+		@Nonnull Serializable from,
+		@Nonnull Serializable to,
+		@Nonnull AttributeSchemaContract attributeDefinition,
+		@Nonnull AttributeKey attributeKey
+	) {
+		final Predicate<BigDecimal> requestedPredicate;
+		final long comparableFrom;
+		final long comparableTo;
+
+		final Class<? extends Serializable> attributeType = attributeDefinition.getPlainType();
+		if (NumberRange.class.isAssignableFrom(attributeType)) {
+			final BigDecimal fromBigDecimal = EvitaDataTypes.toTargetType(from, BigDecimal.class);
+			final BigDecimal toBigDecimal = EvitaDataTypes.toTargetType(to, BigDecimal.class);
+			if (attributeDefinition.getIndexedDecimalPlaces() > 0) {
+				comparableFrom = getBigDecimalComparable(fromBigDecimal, attributeDefinition.getIndexedDecimalPlaces(), Long.MIN_VALUE);
+				comparableTo = getBigDecimalComparable(toBigDecimal, attributeDefinition.getIndexedDecimalPlaces(), Long.MAX_VALUE);
+			} else {
+				comparableFrom = getLongComparable(toTargetType(from, Long.class), Long.MIN_VALUE);
+				comparableTo = getLongComparable(toTargetType(to, Long.class), Long.MAX_VALUE);
+			}
+			requestedPredicate = createBigDecimalPredicate(fromBigDecimal, toBigDecimal);
+		} else if (DateTimeRange.class.isAssignableFrom(attributeType)) {
+			comparableFrom = getOffsetDateTimeComparable(toTargetType(from, OffsetDateTime.class), Long.MIN_VALUE);
+			comparableTo = getOffsetDateTimeComparable(toTargetType(to, OffsetDateTime.class), Long.MAX_VALUE);
+			requestedPredicate = null;
+		} else {
+			throw new GenericEvitaInternalError("Unexpected Range type!");
+		}
+		return new AttributeFormula(
+			attributeDefinition instanceof GlobalAttributeSchemaContract,
+			attributeKey,
+			filterByVisitor.applyOnFilterIndexes(
+				attributeDefinition, index -> index.getRecordsOverlappingFormula(comparableFrom, comparableTo)
+			),
+			requestedPredicate
+		);
+	}
+
+	/**
+	 * Creates an alternative bitmap filter for a specified attribute within a range defined by 'from' and 'to'.
+	 *
+	 * @param filterByVisitor The visitor used to apply filter indexes.
+	 * @param attributeName The name of the attribute to filter.
+	 * @param from The starting value of the range.
+	 * @param to The ending value of the range.
+	 * @return The constructed AttributeBitmapFilter.
+	 */
+	@Nonnull
+	private static AttributeBitmapFilter createAlternativeBitmapFilter(
+		@Nonnull FilterByVisitor filterByVisitor,
+		@Nonnull String attributeName,
+		@Nonnull Serializable from,
+		@Nonnull Serializable to
+	) {
+		final ProcessingScope<?> processingScope = filterByVisitor.getProcessingScope();
+		return new AttributeBitmapFilter(
+			attributeName,
+			processingScope.getRequirements(),
+			processingScope::getAttributeSchema,
+			(entityContract, theAttributeName) -> processingScope.getAttributeValueStream(entityContract, theAttributeName, filterByVisitor.getLocale()),
+			attributeSchema -> {
+				final Class<? extends Serializable> attributeType = attributeSchema.getPlainType();
+				//noinspection rawtypes
+				final Comparator comparator = FilterIndex.getComparator(
+					attributeSchema.isLocalized() ?
+						new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
+					attributeType
+				);
+				final Function<Object, Serializable> normalizer = FilterIndex.getNormalizer(attributeType);
+				final Serializable comparableFrom = normalizer.apply(from);
+				final Serializable comparableTo = normalizer.apply(to);
+
+				if (Range.class.isAssignableFrom(attributeType)) {
+					if (NumberRange.class.isAssignableFrom(attributeType)) {
+						return getNumberRangePredicate((Number) comparableFrom, (Number) comparableTo);
+					} else if (DateTimeRange.class.isAssignableFrom(attributeType)) {
+						return getDateTimePredicate((OffsetDateTime) comparableFrom, (OffsetDateTime) comparableTo);
+					} else {
+						throw new GenericEvitaInternalError("Unexpected type!");
+					}
+				} else {
+					return getComparablePredicate(normalizer, comparator, comparableFrom, comparableTo);
+				}
+			},
+			AttributeTrait.FILTERABLE
+		);
+	}
+
+	/**
+	 * Converts an OffsetDateTime value to a comparable long representation.
+	 * If the given OffsetDateTime value is null, a default value is returned.
+	 *
+	 * @param value        The OffsetDateTime value to be converted, may be null.
+	 * @param defaultValue The default long value to return if the OffsetDateTime value is null.
+	 * @return The long representation of the OffsetDateTime value, or the default value if the OffsetDateTime is null.
+	 */
+	@Nonnull
+	private static Long getOffsetDateTimeComparable(@Nullable OffsetDateTime value, long defaultValue) {
+		return ofNullable(value).map(DateTimeRange::toComparableLong).orElse(defaultValue);
+	}
+
+	/**
+	 * Returns a Long value that is either the provided value or a default value if the provided value is null.
+	 *
+	 * @param value        The possibly null Long to be returned.
+	 * @param defaultValue The long value to be returned if the provided value is null.
+	 * @return The provided Long value, or the default value if the provided value is null.
+	 */
+	@Nonnull
+	private static Long getLongComparable(@Nullable Long value, long defaultValue) {
+		return ofNullable(value).orElse(defaultValue);
+	}
+
+	/**
+	 * Converts a BigDecimal value to a comparable long representation based on the specified number of decimal places.
+	 * If the given BigDecimal value is null, a default value is returned.
+	 *
+	 * @param value                The BigDecimal value to be converted, may be null.
+	 * @param indexedDecimalPlaces The number of decimal places to consider in the conversion.
+	 * @param defaultValue         The default long value to return if the BigDecimal value is null.
+	 * @return The long representation of the BigDecimal value or the default value if the BigDecimal is null.
+	 */
+	@Nonnull
+	private static Long getBigDecimalComparable(@Nullable BigDecimal value, int indexedDecimalPlaces, long defaultValue) {
+		return ofNullable(value)
+			.map(it -> BigDecimalNumberRange.toComparableLong(it, indexedDecimalPlaces))
+			.orElse(defaultValue);
+	}
+
 	@Override
 	@Nonnull
 	public Formula translate(@Nonnull AttributeBetween filterConstraint, @Nonnull FilterByVisitor filterByVisitor) {
 		final String attributeName = filterConstraint.getAttributeName();
+
 		final Serializable from = filterConstraint.getFrom();
 		final Serializable to = filterConstraint.getTo();
 
-		if (filterByVisitor.isEntityTypeKnown()) {
-			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
+		final Optional<GlobalAttributeSchemaContract> optionalGlobalAttributeSchema = getOptionalGlobalAttributeSchema(filterByVisitor, attributeName);
+		if (filterByVisitor.isEntityTypeKnown() || optionalGlobalAttributeSchema.isPresent()) {
+			final AttributeSchemaContract attributeDefinition = optionalGlobalAttributeSchema
+				.map(AttributeSchemaContract.class::cast)
+				.orElseGet(() -> filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE));
+			final AttributeKey attributeKey = createAttributeKey(filterByVisitor, attributeDefinition);
 			final Class<? extends Serializable> attributeType = attributeDefinition.getPlainType();
+
 			final AttributeFormula filteringFormula;
 			final Predicate<BigDecimal> requestedPredicate;
 			if (Range.class.isAssignableFrom(attributeType)) {
-				final long comparableFrom;
-				final long comparableTo;
-				if (NumberRange.class.isAssignableFrom(attributeType)) {
-					final BigDecimal fromBigDecimal = toTargetType(from, BigDecimal.class);
-					final BigDecimal toBigDecimal = toTargetType(to, BigDecimal.class);
-					requestedPredicate = threshold -> {
-						if (fromBigDecimal != null && threshold.compareTo(fromBigDecimal) < 0) {
-							return false;
-						}
-						if (toBigDecimal != null && threshold.compareTo(toBigDecimal) > 0) {
-							return false;
-						}
-						return true;
-					};
-
-					if (attributeDefinition.getIndexedDecimalPlaces() > 0) {
-						comparableFrom = getBigDecimalComparable(fromBigDecimal, attributeDefinition.getIndexedDecimalPlaces(), Long.MIN_VALUE);
-						comparableTo = getBigDecimalComparable(toBigDecimal, attributeDefinition.getIndexedDecimalPlaces(), Long.MAX_VALUE);
-					} else {
-						comparableFrom = getLongComparable(toTargetType(from, Long.class), Long.MIN_VALUE);
-						comparableTo = getLongComparable(toTargetType(to, Long.class), Long.MAX_VALUE);
-					}
-				} else if (DateTimeRange.class.isAssignableFrom(attributeType)) {
-					comparableFrom = getOffsetDateTimeComparable(toTargetType(from, OffsetDateTime.class), Long.MIN_VALUE);
-					comparableTo = getOffsetDateTimeComparable(toTargetType(to, OffsetDateTime.class), Long.MAX_VALUE);
-					requestedPredicate = null;
-				} else {
-					throw new GenericEvitaInternalError("Unexpected Range type!");
-				}
-				filteringFormula = new AttributeFormula(
-					attributeDefinition instanceof GlobalAttributeSchemaContract,
-					attributeDefinition.isLocalized() ?
-						new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-					filterByVisitor.applyOnFilterIndexes(
-						attributeDefinition, index -> index.getRecordsOverlappingFormula(comparableFrom, comparableTo)
-					),
-					requestedPredicate
+				filteringFormula = createRangeAttributeFormula(
+					filterByVisitor, from, to, attributeDefinition, attributeKey
 				);
 			} else {
-				final Comparable comparableFrom = (Comparable) toTargetType(from, attributeType);
-				final Comparable comparableTo = (Comparable) toTargetType(to, attributeType);
-
 				if (Number.class.isAssignableFrom(attributeType)) {
-					final BigDecimal fromBigDecimal = EvitaDataTypes.toTargetType((Serializable) comparableFrom, BigDecimal.class);
-					final BigDecimal toBigDecimal = EvitaDataTypes.toTargetType((Serializable) comparableTo, BigDecimal.class);
-					requestedPredicate = threshold -> {
-						if (fromBigDecimal != null && threshold.compareTo(fromBigDecimal) < 0) {
-							return false;
-						}
-						if (toBigDecimal != null && threshold.compareTo(toBigDecimal) > 0) {
-							return false;
-						}
-						return true;
-					};
+					final BigDecimal fromBigDecimal = EvitaDataTypes.toTargetType(from, BigDecimal.class);
+					final BigDecimal toBigDecimal = EvitaDataTypes.toTargetType(to, BigDecimal.class);
+					requestedPredicate = createBigDecimalPredicate(fromBigDecimal, toBigDecimal);
 				} else {
 					requestedPredicate = null;
 				}
 
+				final Serializable convertedFrom = EvitaDataTypes.toTargetType(from, attributeType);
+				final Serializable convertedTo = EvitaDataTypes.toTargetType(to, attributeType);
 				filteringFormula = new AttributeFormula(
 					attributeDefinition instanceof GlobalAttributeSchemaContract,
-					attributeDefinition.isLocalized() ?
-						new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
+					attributeKey,
 					filterByVisitor.applyOnFilterIndexes(
 						attributeDefinition,
 						index -> {
-							if (comparableFrom != null && comparableTo != null) {
-								return index.getRecordsBetweenFormula(comparableFrom, comparableTo);
-							} else if (comparableFrom == null) {
-								return index.getRecordsLesserThanEqFormula(comparableTo);
+							if (convertedFrom != null && convertedTo != null) {
+								return index.getRecordsBetweenFormula(convertedFrom, convertedTo);
+							} else if (convertedFrom == null) {
+								return index.getRecordsLesserThanEqFormula(convertedTo);
 							} else {
-								return index.getRecordsGreaterThanEqFormula(comparableFrom);
+								return index.getRecordsGreaterThanEqFormula(convertedFrom);
 							}
 						}
 					),
@@ -174,187 +469,6 @@ public class AttributeBetweenTranslator implements FilteringConstraintTranslator
 				createAlternativeBitmapFilter(filterByVisitor, attributeName, from, to)
 			);
 		}
-	}
-
-	@SuppressWarnings("rawtypes")
-	@Nonnull
-	private static AttributeBitmapFilter createAlternativeBitmapFilter(
-		@Nonnull FilterByVisitor filterByVisitor,
-		@Nonnull String attributeName,
-		@Nonnull Serializable from,
-		@Nonnull Serializable to
-	) {
-		final ProcessingScope processingScope = filterByVisitor.getProcessingScope();
-		return new AttributeBitmapFilter(
-			attributeName,
-			processingScope.getRequirements(),
-			processingScope::getAttributeSchema,
-			(entityContract, theAttributeName) -> processingScope.getAttributeValueStream(entityContract, theAttributeName, filterByVisitor.getLocale()),
-			attributeSchema -> {
-				final Comparable comparableFrom = (Comparable) toTargetType(from, attributeSchema.getPlainType());
-				final Comparable comparableTo = (Comparable) toTargetType(to, attributeSchema.getPlainType());
-				if (Range.class.isAssignableFrom(attributeSchema.getPlainType())) {
-					if (NumberRange.class.isAssignableFrom(attributeSchema.getPlainType())) {
-						return getNumberRangePredicate((Number) comparableFrom, (Number) comparableTo);
-					} else if (DateTimeRange.class.isAssignableFrom(attributeSchema.getPlainType())) {
-						return getDateTimePredicate((OffsetDateTime) comparableFrom, (OffsetDateTime) comparableTo);
-					} else {
-						throw new GenericEvitaInternalError("Unexpected type!");
-					}
-				} else {
-					return getComparablePredicate(comparableFrom, comparableTo);
-				}
-			},
-			AttributeTrait.FILTERABLE
-		);
-	}
-
-	@Nonnull
-	private static Long getOffsetDateTimeComparable(@Nullable OffsetDateTime value, long defaultValue) {
-		return ofNullable(value).map(DateTimeRange::toComparableLong).orElse(defaultValue);
-	}
-
-	@Nonnull
-	private static Long getLongComparable(@Nullable Long value, long defaultValue) {
-		return ofNullable(value).orElse(defaultValue);
-	}
-
-	@Nonnull
-	private static Long getBigDecimalComparable(@Nullable BigDecimal value, int indexedDecimalPlaces, long defaultValue) {
-		return ofNullable(value)
-			.map(it -> BigDecimalNumberRange.toComparableLong(it, indexedDecimalPlaces))
-			.orElse(defaultValue);
-	}
-
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getDateTimePredicate(@Nullable OffsetDateTime comparableValueFrom, @Nullable OffsetDateTime comparableValueTo) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<Comparable> predicate = theValue -> {
-						if (theValue == null) {
-							return false;
-						} else if (comparableValueFrom != null && comparableValueTo != null) {
-							return ((DateTimeRange) theValue).overlaps(DateTimeRange.between(comparableValueFrom, comparableValueTo));
-						} else if (comparableValueFrom != null) {
-							return ((DateTimeRange) theValue).overlaps(DateTimeRange.since(comparableValueFrom));
-						} else if (comparableValueTo != null) {
-							return ((DateTimeRange) theValue).overlaps(DateTimeRange.until(comparableValueTo));
-						} else {
-							throw new GenericEvitaInternalError("Between query can never be created with both bounds null!");
-						}
-					};
-					final Serializable theValue = attr.get().value();
-					if (theValue.getClass().isArray()) {
-						return Arrays.stream((Object[])theValue).map(Comparable.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((Comparable)theValue);
-					}
-				}
-			}
-		);
-	}
-
-	@SuppressWarnings("ConstantConditions")
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getNumberRangePredicate(@Nullable Number comparableValueFrom, @Nullable Number comparableValueTo) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<Comparable> predicate = theValue -> {
-						if (theValue == null) {
-							return false;
-						} else if (comparableValueFrom != null && comparableValueTo != null) {
-							if (comparableValueFrom instanceof BigDecimal || comparableValueTo instanceof BigDecimal) {
-								return ((BigDecimalNumberRange) theValue).overlaps(BigDecimalNumberRange.between((BigDecimal) comparableValueFrom, (BigDecimal) comparableValueTo));
-							} else if (comparableValueFrom instanceof Long || comparableValueTo instanceof Long) {
-								return ((LongNumberRange) theValue).overlaps(LongNumberRange.between((Long) comparableValueFrom, (Long) comparableValueTo));
-							} else if (comparableValueFrom instanceof Integer || comparableValueTo instanceof Integer) {
-								return ((IntegerNumberRange) theValue).overlaps(IntegerNumberRange.between((Integer) comparableValueFrom, (Integer) comparableValueTo));
-							} else if (comparableValueFrom instanceof Short || comparableValueTo instanceof Short) {
-								return ((ShortNumberRange) theValue).overlaps(ShortNumberRange.between((Short) comparableValueFrom, (Short) comparableValueTo));
-							} else if (comparableValueFrom instanceof Byte || comparableValueTo instanceof Byte) {
-								return ((ByteNumberRange) theValue).overlaps(ByteNumberRange.between((Byte) comparableValueFrom, (Byte) comparableValueTo));
-							} else {
-								throw new GenericEvitaInternalError("Unexpected input type: " + comparableValueFrom + ", " + comparableValueTo);
-							}
-						} else if (comparableValueFrom != null) {
-							if (comparableValueFrom instanceof BigDecimal) {
-								return ((BigDecimalNumberRange) theValue).overlaps(BigDecimalNumberRange.from((BigDecimal) comparableValueFrom));
-							} else if (comparableValueFrom instanceof Long) {
-								return ((LongNumberRange) theValue).overlaps(LongNumberRange.from((Long) comparableValueFrom));
-							} else if (comparableValueFrom instanceof Integer) {
-								return ((IntegerNumberRange) theValue).overlaps(IntegerNumberRange.from((Integer) comparableValueFrom));
-							} else if (comparableValueFrom instanceof Short) {
-								return ((ShortNumberRange) theValue).overlaps(ShortNumberRange.from((Short) comparableValueFrom));
-							} else if (comparableValueFrom instanceof Byte) {
-								return ((ByteNumberRange) theValue).overlaps(ByteNumberRange.from((Byte) comparableValueFrom));
-							} else {
-								throw new GenericEvitaInternalError("Unexpected input type: " + comparableValueFrom);
-							}
-						} else if (comparableValueTo != null) {
-							if (comparableValueTo instanceof BigDecimal) {
-								return ((BigDecimalNumberRange) theValue).overlaps(BigDecimalNumberRange.to((BigDecimal) comparableValueTo));
-							} else if (comparableValueTo instanceof Long) {
-								return ((LongNumberRange) theValue).overlaps(LongNumberRange.to((Long) comparableValueTo));
-							} else if (comparableValueTo instanceof Integer) {
-								return ((IntegerNumberRange) theValue).overlaps(IntegerNumberRange.to((Integer) comparableValueTo));
-							} else if (comparableValueTo instanceof Short) {
-								return ((ShortNumberRange) theValue).overlaps(ShortNumberRange.to((Short) comparableValueTo));
-							} else if (comparableValueTo instanceof Byte) {
-								return ((ByteNumberRange) theValue).overlaps(ByteNumberRange.to((Byte) comparableValueTo));
-							} else {
-								throw new GenericEvitaInternalError("Unexpected input type: " + comparableValueTo);
-							}
-						} else {
-							throw new GenericEvitaInternalError("Between query can never be created with both bounds null!");
-						}
-					};
-					final Serializable theValue = attr.get().value();
-					if (theValue.getClass().isArray()) {
-						return Arrays.stream((Object[])theValue).map(Comparable.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((Comparable)theValue);
-					}
-				}
-			}
-		);
-	}
-
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getComparablePredicate(@Nullable Comparable<?> comparableFrom, @Nullable Comparable<?> comparableTo) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<Comparable> predicate = theValue -> {
-						if (theValue == null) {
-							return false;
-						} else if (comparableFrom != null && comparableTo != null) {
-							return theValue.compareTo(comparableFrom) >= 0 && theValue.compareTo(comparableTo) <= 0;
-						} else if (comparableFrom != null) {
-							return theValue.compareTo(comparableFrom) >= 0;
-						} else if (comparableTo != null) {
-							return theValue.compareTo(comparableTo) <= 0;
-						} else {
-							throw new GenericEvitaInternalError("Between query can never be created with both bounds null!");
-						}
-					};
-					final Serializable theValue = attr.get().value();
-					if (theValue.getClass().isArray()) {
-						return Arrays.stream((Object[])theValue).map(Comparable.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((Comparable)theValue);
-					}
-				}
-			}
-		);
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeContainsTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeContainsTranslator.java
@@ -24,113 +24,45 @@
 package io.evitadb.core.query.filter.translator.attribute;
 
 import io.evitadb.api.query.filter.AttributeContains;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
-import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
-import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
-import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
-import io.evitadb.core.query.algebra.attribute.AttributeFormula;
-import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
-import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
 import io.evitadb.core.query.filter.FilterByVisitor;
-import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
-import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
-import io.evitadb.utils.Assert;
+import io.evitadb.index.attribute.FilterIndex;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
+import java.util.function.BiPredicate;
 
 /**
  * This implementation of {@link FilteringConstraintTranslator} converts {@link AttributeContains} to {@link AbstractFormula}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AttributeContainsTranslator implements FilteringConstraintTranslator<AttributeContains> {
+public class AttributeContainsTranslator extends AbstractAttributeStringSearchTranslator
+	implements FilteringConstraintTranslator<AttributeContains> {
+
+	public AttributeContainsTranslator() {
+		super(
+			"contains",
+			FilterIndex::getRecordsWhoseValuesContains,
+			createPredicate()
+		);
+	}
+
+	/**
+	 * Creates a BiPredicate that evaluates whether a given string contains another string.
+	 *
+	 * @return a BiPredicate that checks if the first string contains the second string, avoiding null values.
+	 */
+	@Nonnull
+	static BiPredicate<String, String> createPredicate() {
+		return (theValue, textToSearch) -> theValue != null && theValue.contains(textToSearch);
+	}
 
 	@Nonnull
 	@Override
 	public Formula translate(@Nonnull AttributeContains attributeContains, @Nonnull FilterByVisitor filterByVisitor) {
-		final String attributeName = attributeContains.getAttributeName();
-		final String textToSearch = attributeContains.getTextToSearch();
-
-		if (filterByVisitor.isEntityTypeKnown()) {
-			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
-			assertStringType(attributeDefinition);
-
-			final AttributeFormula filteringFormula = new AttributeFormula(
-				attributeDefinition instanceof GlobalAttributeSchemaContract,
-				attributeDefinition.isLocalized() ?
-					new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-				filterByVisitor.applyOnFilterIndexes(
-					attributeDefinition, index -> index.getRecordsWhoseValuesContains(textToSearch)
-				)
-			);
-			if (filterByVisitor.isPrefetchPossible()) {
-				return new SelectionFormula(
-					filteringFormula,
-					createAlternativeBitmapFilter(filterByVisitor, attributeName, textToSearch)
-				);
-			} else {
-				return filteringFormula;
-			}
-		} else {
-			return new EntityFilteringFormula(
-				"attribute contains filter",
-				createAlternativeBitmapFilter(filterByVisitor, attributeName, textToSearch)
-			);
-		}
-	}
-
-	@Nonnull
-	private static AttributeBitmapFilter createAlternativeBitmapFilter(
-		@Nonnull FilterByVisitor filterByVisitor,
-		@Nonnull String attributeName,
-		@Nonnull String textToSearch
-	) {
-		final ProcessingScope<?> processingScope = filterByVisitor.getProcessingScope();
-		return new AttributeBitmapFilter(
-			attributeName,
-			processingScope.getRequirements(),
-			processingScope::getAttributeSchema,
-			(entityContract, theAttributeName) -> processingScope.getAttributeValueStream(entityContract, theAttributeName, filterByVisitor.getLocale()),
-			attributeSchema -> {
-				assertStringType(attributeSchema);
-				return getPredicate(textToSearch);
-			}
-		);
-	}
-
-	static void assertStringType(@Nonnull AttributeSchemaContract attributeDefinition) {
-		Assert.isTrue(
-			String.class.equals(attributeDefinition.getType()),
-			"StartsWith constraint can be used only on String attributes - `" + attributeDefinition.getName() + "` is `" + attributeDefinition.getType() + "`!"
-		);
-	}
-
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getPredicate(@Nonnull String textToSearch) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<String> predicate = theValue -> theValue != null && theValue.contains(textToSearch);
-					final Serializable theValue = attr.get().value();
-					if (theValue.getClass().isArray()) {
-						return Arrays.stream((Object[])theValue).map(String.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((String)theValue);
-					}
-				}
-			}
-		);
+		return translateInternal(attributeContains, filterByVisitor);
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeEndsWithTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeEndsWithTranslator.java
@@ -24,106 +24,47 @@
 package io.evitadb.core.query.filter.translator.attribute;
 
 import io.evitadb.api.query.filter.AttributeEndsWith;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
-import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
-import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
-import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
-import io.evitadb.core.query.algebra.attribute.AttributeFormula;
-import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
-import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
 import io.evitadb.core.query.filter.FilterByVisitor;
-import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
-import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
+import io.evitadb.index.attribute.FilterIndex;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
-
-import static io.evitadb.core.query.filter.translator.attribute.AttributeContainsTranslator.assertStringType;
+import java.util.function.BiPredicate;
 
 /**
  * This implementation of {@link FilteringConstraintTranslator} converts {@link AttributeEndsWith} to {@link AbstractFormula}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AttributeEndsWithTranslator implements FilteringConstraintTranslator<AttributeEndsWith> {
+public class AttributeEndsWithTranslator
+	extends AbstractAttributeStringSearchTranslator
+	implements FilteringConstraintTranslator<AttributeEndsWith> {
+
+	public AttributeEndsWithTranslator() {
+		super(
+			"ends with",
+			FilterIndex::getRecordsWhoseValuesEndsWith,
+			createPredicate()
+		);
+	}
+
+	/**
+	 * Creates a BiPredicate that tests whether a given string ends with another specified string.
+	 * The predicate will return false if the string to test is null.
+	 *
+	 * @return a BiPredicate that evaluates to true if the first string ends with the second string, otherwise false
+	 */
+	@Nonnull
+	static BiPredicate<String, String> createPredicate() {
+		return (theValue, textToSearch) -> theValue != null && theValue.endsWith(textToSearch);
+	}
 
 	@Nonnull
 	@Override
 	public Formula translate(@Nonnull AttributeEndsWith attributeEndsWith, @Nonnull FilterByVisitor filterByVisitor) {
-		final String attributeName = attributeEndsWith.getAttributeName();
-		final String textToSearch = attributeEndsWith.getTextToSearch();
-
-		if (filterByVisitor.isEntityTypeKnown()) {
-			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
-			assertStringType(attributeDefinition);
-			final Formula filteringFormula = filterByVisitor.applyOnFilterIndexes(
-				attributeDefinition, index -> index.getRecordsWhoseValuesEndsWith(textToSearch)
-			);
-			if (filterByVisitor.isPrefetchPossible()) {
-				return new SelectionFormula(
-					new AttributeFormula(
-						attributeDefinition instanceof GlobalAttributeSchemaContract,
-						attributeDefinition.isLocalized() ?
-							new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-						filteringFormula
-					),
-					createAlternativeBitmapFilter(filterByVisitor, attributeName, textToSearch)
-				);
-			} else {
-				return filteringFormula;
-			}
-		} else {
-			return new EntityFilteringFormula(
-				"attribute ends with filter",
-				createAlternativeBitmapFilter(filterByVisitor, attributeName, textToSearch)
-			);
-		}
-	}
-
-	@Nonnull
-	private static AttributeBitmapFilter createAlternativeBitmapFilter(
-		@Nonnull FilterByVisitor filterByVisitor,
-		@Nonnull String attributeName,
-		@Nonnull String textToSearch
-	) {
-		final ProcessingScope processingScope = filterByVisitor.getProcessingScope();
-		return new AttributeBitmapFilter(
-			attributeName,
-			processingScope.getRequirements(),
-			processingScope::getAttributeSchema,
-			(entityContract, theAttributeName) -> processingScope.getAttributeValueStream(entityContract, theAttributeName, filterByVisitor.getLocale()),
-			attributeSchema -> {
-				assertStringType(attributeSchema);
-				return getPredicate(textToSearch);
-			}
-		);
-	}
-
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getPredicate(String textToSearch) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<String> predicate = theValue -> theValue != null && theValue.endsWith(textToSearch);
-					final Serializable theValue = attr.get().value();
-					if (theValue.getClass().isArray()) {
-						return Arrays.stream((Object[])theValue).map(String.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((String)theValue);
-					}
-				}
-			}
-		);
+		return translateInternal(attributeEndsWith, filterByVisitor);
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeGreaterThanEqualsTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeGreaterThanEqualsTranslator.java
@@ -25,126 +25,34 @@ package io.evitadb.core.query.filter.translator.attribute;
 
 import io.evitadb.api.query.filter.AttributeGreaterThan;
 import io.evitadb.api.query.filter.AttributeGreaterThanEquals;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
-import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
-import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
-import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
-import io.evitadb.core.query.algebra.attribute.AttributeFormula;
-import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
-import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
 import io.evitadb.core.query.filter.FilterByVisitor;
-import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
-import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
-import io.evitadb.dataType.EvitaDataTypes;
+import io.evitadb.index.attribute.FilterIndex;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 /**
  * This implementation of {@link FilteringConstraintTranslator} converts {@link AttributeGreaterThan} to {@link AbstractFormula}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AttributeGreaterThanEqualsTranslator implements FilteringConstraintTranslator<AttributeGreaterThanEquals> {
+public class AttributeGreaterThanEqualsTranslator extends AbstractAttributeComparisonTranslator
+	implements FilteringConstraintTranslator<AttributeGreaterThanEquals> {
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
+	public AttributeGreaterThanEqualsTranslator() {
+		super(
+			result -> result >= 0,
+			FilterIndex::getRecordsGreaterThanEqFormula,
+			"greater than or equals"
+		);
+	}
+
 	@Nonnull
 	@Override
 	public Formula translate(@Nonnull AttributeGreaterThanEquals attributeGreaterThanEquals, @Nonnull FilterByVisitor filterByVisitor) {
-		final String attributeName = attributeGreaterThanEquals.getAttributeName();
-		final Serializable attributeValue = attributeGreaterThanEquals.getAttributeValue();
-
-		if (filterByVisitor.isEntityTypeKnown()) {
-			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
-			final Class<? extends Serializable> attributeType = attributeDefinition.getPlainType();
-			final Comparable comparableValue = (Comparable) EvitaDataTypes.toTargetType(attributeValue, attributeType);
-
-			final Predicate<BigDecimal> requestedPredicate;
-			if (Number.class.isAssignableFrom(attributeType)) {
-				final BigDecimal fromBigDecimal = EvitaDataTypes.toTargetType((Serializable) comparableValue, BigDecimal.class);
-				requestedPredicate = threshold -> {
-					if (fromBigDecimal != null && threshold.compareTo(fromBigDecimal) < 0) {
-						return false;
-					}
-					return true;
-				};
-			} else {
-				requestedPredicate = null;
-			}
-
-			final AttributeFormula filteringFormula = new AttributeFormula(
-				attributeDefinition instanceof GlobalAttributeSchemaContract,
-				attributeDefinition.isLocalized() ?
-					new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-				filterByVisitor.applyOnFilterIndexes(
-					attributeDefinition, index -> index.getRecordsGreaterThanEqFormula(comparableValue)
-				),
-				requestedPredicate
-			);
-			if (filterByVisitor.isPrefetchPossible()) {
-				return new SelectionFormula(
-					filteringFormula,
-					createAlternativeBitmapFilter(filterByVisitor, attributeName, attributeValue)
-				);
-			} else {
-				return filteringFormula;
-			}
-		} else {
-			return new EntityFilteringFormula(
-				"attribute greater than or equals filter",
-				createAlternativeBitmapFilter(filterByVisitor, attributeName, attributeValue)
-			);
-		}
-
-	}
-
-	@SuppressWarnings("rawtypes")
-	@Nonnull
-	private static AttributeBitmapFilter createAlternativeBitmapFilter(
-		@Nonnull FilterByVisitor filterByVisitor,
-		@Nonnull String attributeName,
-		@Nonnull Serializable attributeValue
-	) {
-		final ProcessingScope processingScope = filterByVisitor.getProcessingScope();
-		return new AttributeBitmapFilter(
-			attributeName,
-			processingScope.getRequirements(),
-			processingScope::getAttributeSchema,
-			(entityContract, theAttributeName) -> processingScope.getAttributeValueStream(entityContract, theAttributeName, filterByVisitor.getLocale()),
-			attributeSchema -> {
-				final Comparable comparableValue = (Comparable) EvitaDataTypes.toTargetType(attributeValue, attributeSchema.getPlainType());
-				return getPredicate(comparableValue);
-			}
-		);
-	}
-
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getPredicate(Comparable<?> comparableValue) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<Comparable> predicate = theValue -> theValue != null && theValue.compareTo(comparableValue) >= 0;
-					final Serializable theValue = attr.get().value();
-					if (theValue.getClass().isArray()) {
-						return Arrays.stream((Object[])theValue).map(Comparable.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((Comparable)theValue);
-					}
-				}
-			}
-		);
+		return translateInternal(attributeGreaterThanEquals, filterByVisitor);
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeGreaterThanTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeGreaterThanTranslator.java
@@ -24,125 +24,34 @@
 package io.evitadb.core.query.filter.translator.attribute;
 
 import io.evitadb.api.query.filter.AttributeGreaterThan;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
-import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
-import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
-import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
-import io.evitadb.core.query.algebra.attribute.AttributeFormula;
-import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
-import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
 import io.evitadb.core.query.filter.FilterByVisitor;
-import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
-import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
-import io.evitadb.dataType.EvitaDataTypes;
+import io.evitadb.index.attribute.FilterIndex;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 /**
  * This implementation of {@link FilteringConstraintTranslator} converts {@link AttributeGreaterThan} to {@link AbstractFormula}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AttributeGreaterThanTranslator implements FilteringConstraintTranslator<AttributeGreaterThan> {
+public class AttributeGreaterThanTranslator extends AbstractAttributeComparisonTranslator
+	implements FilteringConstraintTranslator<AttributeGreaterThan> {
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	public AttributeGreaterThanTranslator() {
+		super(
+			result -> result > 0,
+			FilterIndex::getRecordsGreaterThanFormula,
+			"greater than"
+		);
+	}
+
 	@Nonnull
 	@Override
 	public Formula translate(@Nonnull AttributeGreaterThan attributeGreaterThan, @Nonnull FilterByVisitor filterByVisitor) {
-		final String attributeName = attributeGreaterThan.getAttributeName();
-		final Serializable attributeValue = attributeGreaterThan.getAttributeValue();
-
-		if (filterByVisitor.isEntityTypeKnown()) {
-			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
-			final Class<? extends Serializable> attributeType = attributeDefinition.getPlainType();
-			final Comparable comparableValue = (Comparable) EvitaDataTypes.toTargetType(attributeValue, attributeType);
-
-			final Predicate<BigDecimal> requestedPredicate;
-			if (Number.class.isAssignableFrom(attributeType)) {
-				final BigDecimal fromBigDecimal = EvitaDataTypes.toTargetType((Serializable) comparableValue, BigDecimal.class);
-				requestedPredicate = threshold -> {
-					if (fromBigDecimal != null && threshold.compareTo(fromBigDecimal) <= 0) {
-						return false;
-					}
-					return true;
-				};
-			} else {
-				requestedPredicate = null;
-			}
-
-			final AttributeFormula filteringFormula = new AttributeFormula(
-				attributeDefinition instanceof GlobalAttributeSchemaContract,
-				attributeDefinition.isLocalized() ?
-					new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-				filterByVisitor.applyOnFilterIndexes(
-					attributeDefinition, index -> index.getRecordsGreaterThanFormula(comparableValue)
-				),
-				requestedPredicate
-			);
-			if (filterByVisitor.isPrefetchPossible()) {
-				return new SelectionFormula(
-					filteringFormula,
-					createAlternativeBitmapFilter(filterByVisitor, attributeName, attributeValue)
-				);
-			} else {
-				return filteringFormula;
-			}
-		} else {
-			return new EntityFilteringFormula(
-				"attribute greater than filter",
-				createAlternativeBitmapFilter(filterByVisitor, attributeName, attributeValue)
-			);
-		}
-	}
-
-	@SuppressWarnings("rawtypes")
-	@Nonnull
-	private static AttributeBitmapFilter createAlternativeBitmapFilter(
-		@Nonnull FilterByVisitor filterByVisitor,
-		@Nonnull String attributeName,
-		@Nonnull Serializable attributeValue
-	) {
-		final ProcessingScope processingScope = filterByVisitor.getProcessingScope();
-		return new AttributeBitmapFilter(
-			attributeName,
-			processingScope.getRequirements(),
-			processingScope::getAttributeSchema,
-			(entityContract, theAttributeName) -> processingScope.getAttributeValueStream(entityContract, theAttributeName, filterByVisitor.getLocale()),
-			attributeSchema -> {
-				final Comparable comparableValue = (Comparable) EvitaDataTypes.toTargetType(attributeValue, attributeSchema.getPlainType());
-				return getPredicate(comparableValue);
-			}
-		);
-	}
-
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getPredicate(Comparable<?> comparableValue) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<Comparable> predicate = theValue -> theValue != null && theValue.compareTo(comparableValue) > 0;
-					final Serializable theValue = attr.get().value();
-					if (theValue.getClass().isArray()) {
-						return Arrays.stream((Object[])theValue).map(Comparable.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((Comparable)theValue);
-					}
-				}
-			}
-		);
+		return translateInternal(attributeGreaterThan, filterByVisitor);
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeInRangeTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeInRangeTranslator.java
@@ -60,47 +60,106 @@ import static java.util.Optional.ofNullable;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AttributeInRangeTranslator implements FilteringConstraintTranslator<AttributeInRange> {
+public class AttributeInRangeTranslator extends AbstractAttributeTranslator
+	implements FilteringConstraintTranslator<AttributeInRange> {
 
+	/**
+	 * Creates a predicate to check if any attribute value in a stream is valid within a given date-time range.
+	 * The predicate will evaluate each optional attribute value in the stream and determine if it falls within the date-time range specified by the given moment.
+	 *
+	 * @param theMoment The date-time moment against which the attribute values are validated.
+	 * @return A predicate that evaluates whether any attribute value within the stream is within the specified date-time range.
+	 */
 	@Nonnull
-	@Override
-	public Formula translate(@Nonnull AttributeInRange attributeInRange, @Nonnull FilterByVisitor filterByVisitor) {
-		final String attributeName = attributeInRange.getAttributeName();
-
-		if (filterByVisitor.isEntityTypeKnown()) {
-			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
-			final long comparableValue = getComparableValue(attributeInRange, filterByVisitor, attributeDefinition);
-			final AttributeFormula filteringFormula = new AttributeFormula(
-				attributeDefinition instanceof GlobalAttributeSchemaContract,
-				attributeDefinition.isLocalized() ?
-					new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-				filterByVisitor.applyOnFilterIndexes(
-					attributeDefinition, index -> index.getRecordsValidInFormula(comparableValue)
-				)
-			);
-			if (filterByVisitor.isPrefetchPossible()) {
-				return new SelectionFormula(
-					filteringFormula,
-					createAlternativeBitmapFilter(attributeInRange, filterByVisitor, attributeName)
-				);
-			} else {
-				return filteringFormula;
+	public static Predicate<Stream<Optional<AttributeValue>>> getDateTimeRangePredicate(@Nonnull OffsetDateTime theMoment) {
+		return attrStream -> attrStream.anyMatch(
+			attr -> {
+				if (attr.isEmpty()) {
+					return false;
+				} else {
+					final Predicate<DateTimeRange> predicate = attrValue -> attrValue != null && attrValue.isValidFor(theMoment);
+					final Serializable attrValue = attr.get().value();
+					if (attrValue.getClass().isArray()) {
+						return Arrays.stream((Object[]) attrValue).map(DateTimeRange.class::cast).anyMatch(predicate);
+					} else {
+						return predicate.test((DateTimeRange) attrValue);
+					}
+				}
 			}
-		} else {
-			return new EntityFilteringFormula(
-				"attribute in range filter",
-				createAlternativeBitmapFilter(attributeInRange, filterByVisitor, attributeName)
-			);
-		}
+		);
 	}
 
+	/**
+	 * Creates a predicate to check if any attribute value in a stream is valid within a given numeric range.
+	 * The predicate will evaluate each optional attribute value in the stream and determine if it falls within
+	 * the range specified by the given BigDecimal value.
+	 *
+	 * @param theValue The BigDecimal value against which the attribute values are validated.
+	 * @return A predicate that evaluates whether any attribute value within the stream is within the specified numeric range.
+	 */
+	@Nonnull
+	public static Predicate<Stream<Optional<AttributeValue>>> getNumberRangePredicate(@Nonnull BigDecimal theValue) {
+		return attrStream -> attrStream.anyMatch(
+			attr -> {
+				if (attr.isEmpty()) {
+					return false;
+				} else {
+					final Predicate<BigDecimalNumberRange> predicate = attrValue -> attrValue != null && attrValue.isWithin(theValue);
+					final Serializable attrValue = attr.get().value();
+					if (attrValue.getClass().isArray()) {
+						return Arrays.stream((Object[]) attrValue).map(BigDecimalNumberRange.class::cast).anyMatch(predicate);
+					} else {
+						return predicate.test((BigDecimalNumberRange) attrValue);
+					}
+				}
+			}
+		);
+	}
+
+	/**
+	 * Creates a predicate to check if any attribute value in a stream is valid within a given numeric range.
+	 * The predicate will evaluate each optional attribute value in the stream and determine if it falls within
+	 * the range specified by the given Number value.
+	 *
+	 * @param theValue The Number value against which the attribute values are validated.
+	 * @return A predicate that evaluates whether any attribute value within the stream is within the specified numeric range.
+	 */
+	@Nonnull
+	public static Predicate<Stream<Optional<AttributeValue>>> getNumberRangePredicate(@Nonnull Number theValue) {
+		return attrStream -> attrStream.anyMatch(
+			attr -> {
+				if (attr.isEmpty()) {
+					return false;
+				} else {
+					final Predicate<NumberRange<Number>> predicate = attrValue -> attrValue != null && attrValue.isWithin(theValue);
+					final Serializable attrValue = attr.get().value();
+					if (attrValue.getClass().isArray()) {
+						//noinspection unchecked
+						return Arrays.stream((Object[]) attrValue).anyMatch(it -> predicate.test((NumberRange<Number>) it));
+					} else {
+						//noinspection unchecked
+						return predicate.test((NumberRange<Number>) attrValue);
+					}
+				}
+			}
+		);
+	}
+
+	/**
+	 * Creates an {@link AttributeBitmapFilter} instance to filter entities based on a range constraint on an attribute.
+	 *
+	 * @param attributeInRange an instance of {@link AttributeInRange} containing the range constraint information.
+	 * @param filterByVisitor  an instance of {@link FilterByVisitor} providing the current processing context and helper methods.
+	 * @param attributeName    the name of the attribute to apply the filter on.
+	 * @return an {@link AttributeBitmapFilter} that can be applied to filter entities based on the given range constraint.
+	 */
 	@Nonnull
 	private static AttributeBitmapFilter createAlternativeBitmapFilter(
 		@Nonnull AttributeInRange attributeInRange,
 		@Nonnull FilterByVisitor filterByVisitor,
 		@Nonnull String attributeName
 	) {
-		final ProcessingScope processingScope = filterByVisitor.getProcessingScope();
+		final ProcessingScope<?> processingScope = filterByVisitor.getProcessingScope();
 		return new AttributeBitmapFilter(
 			attributeName,
 			processingScope.getRequirements(),
@@ -125,85 +184,66 @@ public class AttributeInRangeTranslator implements FilteringConstraintTranslator
 		);
 	}
 
+	/**
+	 * Computes a comparable long value from the provided filter constraint based on the attribute definition type.
+	 *
+	 * @param filterConstraint    AttributeInRange object containing the constraint information.
+	 * @param filterByVisitor     FilterByVisitor object providing additional context and operations.
+	 * @param attributeDefinition AttributeSchemaContract object defining the attribute schema.
+	 * @return A long representation of the comparable value derived from the filter constraint.
+	 * @throws EvitaInvalidUsageException If the attribute type is not supported.
+	 */
 	private static long getComparableValue(
 		@Nonnull AttributeInRange filterConstraint,
 		@Nonnull FilterByVisitor filterByVisitor,
 		@Nonnull AttributeSchemaContract attributeDefinition
 	) {
-		final long comparableValue;
 		if (NumberRange.class.isAssignableFrom(attributeDefinition.getPlainType())) {
 			final Number theValue = filterConstraint.getTheValue();
 			Assert.notNull(theValue, "Argument of InRange must not be null.");
 			if (theValue instanceof BigDecimal) {
-				comparableValue = BigDecimalNumberRange.toComparableLong((BigDecimal) theValue, attributeDefinition.getIndexedDecimalPlaces());
+				return BigDecimalNumberRange.toComparableLong((BigDecimal) theValue, attributeDefinition.getIndexedDecimalPlaces());
 			} else {
-				comparableValue = theValue.longValue();
+				return theValue.longValue();
 			}
 		} else if (DateTimeRange.class.isAssignableFrom(attributeDefinition.getPlainType())) {
 			final OffsetDateTime theMoment = ofNullable(filterConstraint.getTheMoment()).orElseGet(filterByVisitor::getNow);
-			comparableValue = DateTimeRange.toComparableLong(theMoment);
+			return DateTimeRange.toComparableLong(theMoment);
 		} else {
 			throw new EvitaInvalidUsageException("Range types accepts only Number or DateTime types - type " + filterConstraint.getUnknownArgument() + " cannot be used!");
 		}
-		return comparableValue;
 	}
 
 	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getDateTimeRangePredicate(@Nonnull OffsetDateTime theMoment) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<DateTimeRange> predicate = attrValue -> attrValue != null && attrValue.isValidFor(theMoment);
-					final Serializable attrValue = attr.get().value();
-					if (attrValue.getClass().isArray()) {
-						return Arrays.stream((Object[])attrValue).map(DateTimeRange.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((DateTimeRange) attrValue);
-					}
-				}
-			}
-		);
-	}
+	@Override
+	public Formula translate(@Nonnull AttributeInRange attributeInRange, @Nonnull FilterByVisitor filterByVisitor) {
+		final String attributeName = attributeInRange.getAttributeName();
 
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getNumberRangePredicate(@Nonnull BigDecimal theValue) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<BigDecimalNumberRange> predicate = attrValue -> attrValue != null && attrValue.isWithin(theValue);
-					final Serializable attrValue = attr.get().value();
-					if (attrValue.getClass().isArray()) {
-						return Arrays.stream((Object[])attrValue).map(BigDecimalNumberRange.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((BigDecimalNumberRange) attrValue);
-					}
-				}
+		if (filterByVisitor.isEntityTypeKnown()) {
+			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
+			final AttributeKey attributeKey = createAttributeKey(filterByVisitor, attributeDefinition);
+			final long comparableValue = getComparableValue(attributeInRange, filterByVisitor, attributeDefinition);
+			final AttributeFormula filteringFormula = new AttributeFormula(
+				attributeDefinition instanceof GlobalAttributeSchemaContract,
+				attributeKey,
+				filterByVisitor.applyOnFilterIndexes(
+					attributeDefinition, index -> index.getRecordsValidInFormula(comparableValue)
+				)
+			);
+			if (filterByVisitor.isPrefetchPossible()) {
+				return new SelectionFormula(
+					filteringFormula,
+					createAlternativeBitmapFilter(attributeInRange, filterByVisitor, attributeName)
+				);
+			} else {
+				return filteringFormula;
 			}
-		);
-	}
-
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getNumberRangePredicate(@Nonnull Number theValue) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<NumberRange> predicate = attrValue -> attrValue != null && attrValue.isWithin(theValue);
-					final Serializable attrValue = attr.get().value();
-					if (attrValue.getClass().isArray()) {
-						return Arrays.stream((Object[])attrValue).map(NumberRange.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((NumberRange) attrValue);
-					}
-				}
-			}
-		);
+		} else {
+			return new EntityFilteringFormula(
+				"attribute in range filter",
+				createAlternativeBitmapFilter(attributeInRange, filterByVisitor, attributeName)
+			);
+		}
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeInSetTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeInSetTranslator.java
@@ -25,7 +25,6 @@ package io.evitadb.core.query.filter.translator.attribute;
 
 import io.evitadb.api.query.filter.AttributeInSet;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
-import io.evitadb.api.requestResponse.data.EntityReferenceContract;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.dto.GlobalAttributeSchema;
@@ -35,10 +34,13 @@ import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.attribute.AttributeFormula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
 import io.evitadb.core.query.algebra.prefetch.MultipleEntityFormula;
 import io.evitadb.core.query.filter.FilterByVisitor;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
 import io.evitadb.dataType.EvitaDataTypes;
+import io.evitadb.index.attribute.EntityReferenceWithLocale;
+import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.bitmap.ArrayBitmap;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.utils.ArrayUtils;
@@ -48,7 +50,10 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
 
+import static io.evitadb.core.query.filter.translator.attribute.AbstractAttributeComparisonTranslator.createAlternativeBitmapFilter;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -56,77 +61,157 @@ import static java.util.Optional.ofNullable;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AttributeInSetTranslator implements FilteringConstraintTranslator<AttributeInSet> {
+public class AttributeInSetTranslator extends AbstractAttributeTranslator
+	implements FilteringConstraintTranslator<AttributeInSet> {
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	/**
+	 * Creates an AttributeFormula that targets globally unique attributes.
+	 * When the entity type is not known and the attribute is unique globally,
+	 * it accesses the catalog index instead.
+	 *
+	 * @param filterByVisitor       The visitor used to apply filters to global unique indices.
+	 * @param globalAttributeSchema The schema of the global attribute.
+	 * @param attributeKey          The key of the attribute.
+	 * @param theComparedValues     A list of values to be compared against.
+	 * @return The created AttributeFormula for the globally unique attributes.
+	 */
+	@Nonnull
+	private static AttributeFormula createGloballyUniqueAttributeFormula(
+		@Nonnull FilterByVisitor filterByVisitor,
+		@Nonnull GlobalAttributeSchema globalAttributeSchema,
+		@Nonnull AttributeKey attributeKey,
+		@Nonnull List<? extends Serializable> theComparedValues
+	) {
+		// when entity type is not known and attribute is unique globally - access catalog index instead
+		return new AttributeFormula(
+			true,
+			attributeKey,
+			filterByVisitor.applyOnGlobalUniqueIndex(
+				globalAttributeSchema,
+				index -> {
+					final EntityReferenceWithLocale[] filteredEntityMaskedIds = theComparedValues.stream()
+						.map(it -> index.getEntityReferenceByUniqueValue(it, attributeKey.locale()))
+						.filter(Objects::nonNull)
+						.toArray(EntityReferenceWithLocale[]::new);
+
+					return ArrayUtils.isEmpty(filteredEntityMaskedIds) ?
+						EmptyFormula.INSTANCE :
+						new MultipleEntityFormula(
+							new long[]{index.getId()},
+							new BaseBitmap(
+								filterByVisitor.translateEntityReference(filteredEntityMaskedIds)
+							)
+						);
+				}
+			)
+		);
+	}
+
+	/**
+	 * Creates an AttributeFormula for a unique attribute by utilizing hash map lookups for efficient access.
+	 *
+	 * @param filterByVisitor     The visitor used to apply filters to unique indexes.
+	 * @param attributeDefinition The schema of the attribute.
+	 * @param attributeKey        The key of the attribute.
+	 * @param theComparedValues   A list of values to be compared against.
+	 * @return The created AttributeFormula for the given attribute parameters.
+	 */
+	@Nonnull
+	private static AttributeFormula createUniqueAttributeFormula(
+		@Nonnull FilterByVisitor filterByVisitor,
+		@Nonnull AttributeSchemaContract attributeDefinition,
+		@Nonnull AttributeKey attributeKey,
+		@Nonnull List<? extends Serializable> theComparedValues
+	) {
+		// if attribute is unique prefer O(1) hash map lookup over histogram
+		return new AttributeFormula(
+			attributeDefinition instanceof GlobalAttributeSchemaContract,
+			attributeKey,
+			filterByVisitor.applyStreamOnUniqueIndexes(
+				attributeDefinition,
+				index -> theComparedValues
+					.stream()
+					.map(
+						it -> ofNullable(index.getRecordIdByUniqueValue(it))
+							.map(x -> (Formula) new ConstantFormula(new ArrayBitmap(x)))
+							.orElse(EmptyFormula.INSTANCE)
+					)
+			)
+		);
+	}
+
+	/**
+	 * Creates an AttributeFormula that uses histogram lookup for filterable attributes.
+	 * This method constructs an AttributeFormula by leveraging the FilterByVisitor
+	 * for applying specific filters to attribute indices.
+	 *
+	 * @param filterByVisitor     The visitor used to apply filters to filterable indexes.
+	 * @param attributeDefinition The schema of the attribute.
+	 * @param attributeKey        The key of the attribute.
+	 * @param theComparedValues   A list of values to be compared against.
+	 * @return The created AttributeFormula for the given filterable attribute parameters.
+	 */
+	@Nonnull
+	private static AttributeFormula createFilterableAttributeFormula(
+		@Nonnull FilterByVisitor filterByVisitor,
+		@Nonnull AttributeSchemaContract attributeDefinition,
+		@Nonnull AttributeKey attributeKey,
+		@Nonnull List<? extends Serializable> theComparedValues
+	) {
+		// use histogram lookup
+		return new AttributeFormula(
+			attributeDefinition instanceof GlobalAttributeSchemaContract,
+			attributeKey,
+			filterByVisitor.applyStreamOnFilterIndexes(
+				attributeDefinition,
+				index -> theComparedValues.stream().map(index::getRecordsEqualToFormula)
+			)
+		);
+	}
+
 	@Nonnull
 	@Override
 	public Formula translate(@Nonnull AttributeInSet attributeInSet, @Nonnull FilterByVisitor filterByVisitor) {
-		final String attributeName = attributeInSet.getAttributeName();
 		final Serializable[] comparedValues = attributeInSet.getAttributeValues();
-
 		if (ArrayUtils.isEmpty(comparedValues)) {
 			return EmptyFormula.INSTANCE;
 		}
 
-		final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
-		final List<? extends Serializable> valueStream = Arrays.stream(comparedValues)
-			.map(it -> EvitaDataTypes.toTargetType(it, attributeDefinition.getPlainType()))
-			.map(it -> it instanceof Comparable<?> comparable ? comparable : String.valueOf(it))
-			.map(it -> (Serializable) it)
-			.toList();
+		final String attributeName = attributeInSet.getAttributeName();
+		final Optional<GlobalAttributeSchemaContract> optionalGlobalAttributeSchema = getOptionalGlobalAttributeSchema(filterByVisitor, attributeName);
 
-		if (attributeDefinition instanceof GlobalAttributeSchema globalAttributeSchema &&
-			globalAttributeSchema.isUniqueGlobally()) {
-			// when entity type is not known and attribute is unique globally - access catalog index instead
-			return new AttributeFormula(
-				true,
-				attributeDefinition.isLocalized() ?
-					new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-				filterByVisitor.applyOnGlobalUniqueIndex(
-					globalAttributeSchema,
-					index -> {
-						final EntityReferenceContract[] filteredEntityMaskedIds = valueStream.stream()
-							.map(it -> index.getEntityReferenceByUniqueValue(it, filterByVisitor.getLocale()))
-							.filter(Objects::nonNull)
-							.toArray(EntityReferenceContract[]::new);
+		if (filterByVisitor.isEntityTypeKnown() || optionalGlobalAttributeSchema.isPresent()) {
+			final AttributeSchemaContract attributeDefinition = optionalGlobalAttributeSchema
+				.map(AttributeSchemaContract.class::cast)
+				.orElseGet(() -> filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE));
+			final AttributeKey attributeKey = createAttributeKey(filterByVisitor, attributeDefinition);
 
-						return ArrayUtils.isEmpty(filteredEntityMaskedIds) ?
-							EmptyFormula.INSTANCE :
-							new MultipleEntityFormula(
-								new long[] { index.getId() },
-								new BaseBitmap(
-									filterByVisitor.translateEntityReference(filteredEntityMaskedIds)
-								)
-							);
-					}
-				)
-			);
-		} else if (attributeDefinition.isUnique()) {
-			// if attribute is unique prefer O(1) hash map lookup over histogram
-			return new AttributeFormula(
-				attributeDefinition instanceof GlobalAttributeSchemaContract,
-				attributeDefinition.isLocalized() ?
-					new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-				filterByVisitor.applyStreamOnUniqueIndexes(
-					attributeDefinition,
-					index -> valueStream.stream().map(it ->
-						ofNullable(index.getRecordIdByUniqueValue(it))
-							.map(x -> (Formula) new ConstantFormula(new ArrayBitmap(x)))
-							.orElse(EmptyFormula.INSTANCE)
-					)
-				)
-			);
+			final Class<? extends Serializable> plainType = attributeDefinition.getPlainType();
+			final Function<Object, Serializable> normalizer = FilterIndex.getNormalizer(plainType);
+
+			final List<? extends Serializable> theComparedValues = Arrays.stream(comparedValues)
+				.map(it -> EvitaDataTypes.toTargetType(it, plainType))
+				.map(normalizer)
+				.toList();
+
+			if (attributeDefinition instanceof GlobalAttributeSchema globalAttributeSchema &&
+				globalAttributeSchema.isUniqueGlobally()) {
+				return createGloballyUniqueAttributeFormula(
+					filterByVisitor, globalAttributeSchema, attributeKey, theComparedValues
+				);
+			} else if (attributeDefinition.isUnique()) {
+				return createUniqueAttributeFormula(
+					filterByVisitor, attributeDefinition, attributeKey, theComparedValues
+				);
+			} else {
+				return createFilterableAttributeFormula(
+					filterByVisitor, attributeDefinition, attributeKey, theComparedValues
+				);
+			}
 		} else {
-			// use histogram lookup
-			return new AttributeFormula(
-				attributeDefinition instanceof GlobalAttributeSchemaContract,
-				attributeDefinition.isLocalized() ?
-					new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-				filterByVisitor.applyStreamOnFilterIndexes(
-					attributeDefinition,
-					index -> valueStream.stream().map(it -> index.getRecordsEqualToFormula((Comparable) it))
-				)
+			return new EntityFilteringFormula(
+				"attribute in set filter",
+				createAlternativeBitmapFilter(filterByVisitor, attributeName, comparedValues, result -> result == 0)
 			);
 		}
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeIsTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeIsTranslator.java
@@ -42,7 +42,11 @@ import io.evitadb.core.query.filter.FilterByVisitor;
 import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
 import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
+import io.evitadb.index.CatalogIndex;
+import io.evitadb.index.CatalogIndexKey;
+import io.evitadb.index.EntityIndex;
 import io.evitadb.index.attribute.FilterIndex;
+import io.evitadb.index.attribute.GlobalUniqueIndex;
 import io.evitadb.index.attribute.UniqueIndex;
 
 import javax.annotation.Nonnull;
@@ -53,73 +57,44 @@ import java.util.Optional;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AttributeIsTranslator implements FilteringConstraintTranslator<AttributeIs> {
+public class AttributeIsTranslator extends AbstractAttributeTranslator
+	implements FilteringConstraintTranslator<AttributeIs> {
 
+	/**
+	 * Translates an "IS NULL" attribute condition into a corresponding Formula.
+	 *
+	 * @param attributeName   the name of the attribute to be checked for null values
+	 * @param filterByVisitor the visitor responsible for filtering operations
+	 * @return a Formula representing the translated "IS NULL" condition for the specified attribute
+	 */
 	@Nonnull
-	@Override
-	public Formula translate(@Nonnull AttributeIs attributeIs, @Nonnull FilterByVisitor filterByVisitor) {
-		final String attributeName = attributeIs.getAttributeName();
-
-		// also consider the possibly more special values supported in the future
-		return switch (attributeIs.getAttributeSpecialValue()) {
-			case NULL -> translateIsNull(attributeName, filterByVisitor);
-			case NOT_NULL -> translateIsNotNull(attributeName, filterByVisitor);
-		};
-	}
-
-	@Nonnull
-	private static Formula translateIsNull(@Nonnull String attributeName, @Nonnull FilterByVisitor filterByVisitor) {
+	private static Formula translateIsNull(
+		@Nonnull String attributeName,
+		@Nonnull FilterByVisitor filterByVisitor
+	) {
 		if (filterByVisitor.isEntityTypeKnown()) {
-			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
+			final AttributeSchemaContract attributeDefinition = getOptionalGlobalAttributeSchema(filterByVisitor, attributeName)
+				.map(AttributeSchemaContract.class::cast)
+				.orElseGet(() -> filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE));
+			final AttributeKey attributeKey = createAttributeKey(filterByVisitor, attributeDefinition);
+
 			// if attribute is unique prefer O(1) hash map lookup over inverted index
-			if (attributeDefinition.isUnique()) {
+			if (attributeDefinition instanceof GlobalAttributeSchemaContract globalAttributeSchema &&
+				globalAttributeSchema.isUniqueGlobally()
+			) {
 				return FutureNotFormula.postProcess(
-					filterByVisitor.getEntityIndexStream().map(it -> {
-						final UniqueIndex uniqueIndex = it.getUniqueIndex(attributeDefinition, filterByVisitor.getLocale());
-						if (uniqueIndex == null) {
-							return EmptyFormula.INSTANCE;
-						}
-						return new NotFormula(
-							uniqueIndex.getRecordIdsFormula(),
-							it.getAllPrimaryKeysFormula()
-						);
-					}).toArray(Formula[]::new),
-					formulas -> {
-						if (formulas.length == 0) {
-							return EmptyFormula.INSTANCE;
-						} else {
-							return new AttributeFormula(
-								attributeDefinition instanceof GlobalAttributeSchemaContract,
-								attributeDefinition.isLocalized() ?
-									new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-								FormulaFactory.or(formulas));
-						}
-					}
+					createNullGloballyUniqueSubtractionFormula(globalAttributeSchema, filterByVisitor),
+					formulas -> aggregateFormulas(attributeDefinition, attributeKey, formulas)
+				);
+			} else if (attributeDefinition.isUnique()) {
+				return FutureNotFormula.postProcess(
+					createNullUniqueSubtractionFormula(attributeDefinition, filterByVisitor),
+					formulas -> aggregateFormulas(attributeDefinition, attributeKey, formulas)
 				);
 			} else {
 				return FutureNotFormula.postProcess(
-					filterByVisitor.getEntityIndexStream().map(it -> {
-						final FilterIndex filterIndex = it.getFilterIndex(attributeDefinition.getName(), filterByVisitor.getLocale());
-						if (filterIndex == null) {
-							return it.getAllPrimaryKeysFormula();
-						}
-						return new NotFormula(
-							filterIndex.getAllRecordsFormula(),
-							it.getAllPrimaryKeysFormula()
-						);
-					}).toArray(Formula[]::new),
-					formulas -> {
-						if (formulas.length == 0) {
-							return EmptyFormula.INSTANCE;
-						} else {
-							return new AttributeFormula(
-								attributeDefinition instanceof GlobalAttributeSchemaContract,
-								attributeDefinition.isLocalized() ?
-									new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-								FormulaFactory.or(formulas)
-							);
-						}
-					}
+					createNullFilterableSubtractionFormula(attributeDefinition, filterByVisitor),
+					formulas -> aggregateFormulas(attributeDefinition, attributeKey, formulas)
 				);
 			}
 		} else {
@@ -130,33 +105,174 @@ public class AttributeIsTranslator implements FilteringConstraintTranslator<Attr
 		}
 	}
 
+	/**
+	 * Creates an array of Formulas for filtering entities where a specified attribute is null based on information
+	 * in filter indexes. The formulas apply a subtraction operation to filter out records with non-null attributes.
+	 *
+	 * @param attributeDefinition the schema definition of the attribute being processed
+	 * @param filterByVisitor     the visitor responsible for filtering operations
+	 * @return an array of Formulas representing the null filterable subtraction conditions
+	 */
 	@Nonnull
-	private static Formula translateIsNotNull(@Nonnull String attributeName, @Nonnull FilterByVisitor filterByVisitor) {
+	private static Formula[] createNullFilterableSubtractionFormula(
+		@Nonnull AttributeSchemaContract attributeDefinition,
+		@Nonnull FilterByVisitor filterByVisitor
+	) {
+		return filterByVisitor.getEntityIndexStream()
+			.map(
+				it -> {
+					final FilterIndex filterIndex = it.getFilterIndex(attributeDefinition.getName(), filterByVisitor.getLocale());
+					if (filterIndex == null) {
+						return it.getAllPrimaryKeysFormula();
+					}
+					return new NotFormula(
+						filterIndex.getAllRecordsFormula(),
+						it.getAllPrimaryKeysFormula()
+					);
+				}
+			)
+			.toArray(Formula[]::new);
+	}
+
+	/**
+	 * Creates an array of Formulas for filtering entities where a specified attribute is null based on information
+	 * in unique indexes. The formulas apply a subtraction operation to filter out records with non-null attributes.
+	 *
+	 * @param attributeDefinition the schema definition of the attribute being processed
+	 * @param filterByVisitor     the visitor responsible for filtering operations
+	 * @return an array of Formulas representing the null filterable subtraction conditions
+	 */
+	@Nonnull
+	private static Formula[] createNullGloballyUniqueSubtractionFormula(
+		@Nonnull GlobalAttributeSchemaContract attributeDefinition,
+		@Nonnull FilterByVisitor filterByVisitor
+	) {
+		return filterByVisitor.getIndex(CatalogIndexKey.INSTANCE)
+			.map(
+				it -> {
+					final CatalogIndex catalogIndex = (CatalogIndex) it;
+					final GlobalUniqueIndex uniqueIndex = catalogIndex.getGlobalUniqueIndex(attributeDefinition, filterByVisitor.getLocale());
+					return new Formula[] {
+						uniqueIndex == null ?
+							EmptyFormula.INSTANCE :
+							new NotFormula(
+								uniqueIndex.getRecordIdsFormula(filterByVisitor.getEntityType()),
+								FormulaFactory.or(
+									filterByVisitor.getEntityIndexStream()
+										.map(EntityIndex::getAllPrimaryKeysFormula)
+										.toArray(Formula[]::new)
+								)
+							)
+					};
+				}
+			)
+			.orElse(new Formula[0]);
+	}
+
+	/**
+	 * Creates an array of Formulas for filtering entities where a specified attribute is null based on information
+	 * in unique indexes. The formulas apply a subtraction operation to filter out records with non-null attributes.
+	 *
+	 * @param attributeDefinition the schema definition of the attribute being processed
+	 * @param filterByVisitor     the visitor responsible for filtering operations
+	 * @return an array of Formulas representing the null filterable subtraction conditions
+	 */
+	@Nonnull
+	private static Formula[] createNullUniqueSubtractionFormula(
+		@Nonnull AttributeSchemaContract attributeDefinition,
+		@Nonnull FilterByVisitor filterByVisitor
+	) {
+		return filterByVisitor.getEntityIndexStream()
+			.map(
+				it -> {
+					final UniqueIndex uniqueIndex = it.getUniqueIndex(attributeDefinition, filterByVisitor.getLocale());
+					return uniqueIndex == null ?
+						EmptyFormula.INSTANCE :
+						new NotFormula(
+							uniqueIndex.getRecordIdsFormula(),
+							it.getAllPrimaryKeysFormula()
+						);
+				}
+			)
+			.toArray(Formula[]::new);
+	}
+
+	/**
+	 * Aggregates the provided formulas into a single Formula (either empty formula or disjunctive join).
+	 *
+	 * @param attributeDefinition the schema definition of the attribute being processed
+	 * @param attributeKey        the key of the attribute being processed
+	 * @param formulas            an array of formulas to be aggregated
+	 * @return an AbstractFormula that represents the aggregation of the input formulas
+	 */
+	@Nonnull
+	private static Formula aggregateFormulas(
+		@Nonnull AttributeSchemaContract attributeDefinition,
+		@Nonnull AttributeKey attributeKey,
+		@Nonnull Formula[] formulas
+	) {
+		if (formulas.length == 0) {
+			return EmptyFormula.INSTANCE;
+		} else {
+			return new AttributeFormula(
+				attributeDefinition instanceof GlobalAttributeSchemaContract,
+				attributeKey,
+				FormulaFactory.or(formulas)
+			);
+		}
+	}
+
+	/**
+	 * Translates an "IS NOT NULL" attribute condition into a corresponding Formula.
+	 *
+	 * @param attributeName   the name of the attribute to be checked for non-null values
+	 * @param filterByVisitor the visitor responsible for filtering operations
+	 * @return a Formula representing the translated "IS NOT NULL" condition for the specified attribute
+	 */
+	@Nonnull
+	private static Formula translateIsNotNull(
+		@Nonnull String attributeName,
+		@Nonnull FilterByVisitor filterByVisitor
+	) {
 		if (filterByVisitor.isEntityTypeKnown()) {
-			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName);
+			final AttributeSchemaContract attributeDefinition = getOptionalGlobalAttributeSchema(filterByVisitor, attributeName)
+				.map(AttributeSchemaContract.class::cast)
+				.orElseGet(() -> filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE));
+			final AttributeKey attributeKey = createAttributeKey(filterByVisitor, attributeDefinition);
 			// if attribute is unique prefer O(1) hash map lookup over histogram
-			if (attributeDefinition.isUnique()) {
+			if (attributeDefinition instanceof GlobalAttributeSchemaContract globalAttributeSchema &&
+				globalAttributeSchema.isUniqueGlobally()
+			) {
+				return new AttributeFormula(
+					true,
+					attributeKey,
+					filterByVisitor.applyOnGlobalUniqueIndex(
+						globalAttributeSchema,
+						index -> new ConstantFormula(index.getRecordIds(filterByVisitor.getEntityType()))
+					)
+				);
+			} else if (attributeDefinition.isUnique()) {
 				return new AttributeFormula(
 					attributeDefinition instanceof GlobalAttributeSchemaContract,
-					attributeDefinition.isLocalized() ?
-						new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
+					attributeKey,
 					filterByVisitor.applyOnUniqueIndexes(
-						attributeDefinition, index -> new ConstantFormula(index.getRecordIds())
+						attributeDefinition,
+						index -> new ConstantFormula(index.getRecordIds())
 					)
 				);
 			} else {
 				final AttributeFormula filteringFormula = new AttributeFormula(
 					attributeDefinition instanceof GlobalAttributeSchemaContract,
-					attributeDefinition.isLocalized() ?
-						new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
+					attributeKey,
 					filterByVisitor.applyOnFilterIndexes(
-						attributeDefinition, FilterIndex::getAllRecordsFormula
+						attributeDefinition,
+						FilterIndex::getAllRecordsFormula
 					)
 				);
 				if (filterByVisitor.isPrefetchPossible()) {
 					return new SelectionFormula(
 						filteringFormula,
-						createAlternativeNotNullBitmapFilter(attributeName, filterByVisitor)
+						createAlternativeNotNullBitmapFilter(attributeKey.attributeName(), filterByVisitor)
 					);
 				} else {
 					return filteringFormula;
@@ -170,9 +286,19 @@ public class AttributeIsTranslator implements FilteringConstraintTranslator<Attr
 		}
 	}
 
+	/**
+	 * Creates an AttributeBitmapFilter that checks for the absence of a specified attribute.
+	 *
+	 * @param attributeName   the name of the attribute to be checked for absence
+	 * @param filterByVisitor the visitor responsible for filtering operations
+	 * @return an AttributeBitmapFilter instance configured to check for attribute absence
+	 */
 	@Nonnull
-	private static AttributeBitmapFilter createAlternativeNullBitmapFilter(@Nonnull String attributeName, @Nonnull FilterByVisitor filterByVisitor) {
-		final ProcessingScope processingScope = filterByVisitor.getProcessingScope();
+	private static AttributeBitmapFilter createAlternativeNullBitmapFilter(
+		@Nonnull String attributeName,
+		@Nonnull FilterByVisitor filterByVisitor
+	) {
+		final ProcessingScope<?> processingScope = filterByVisitor.getProcessingScope();
 		return new AttributeBitmapFilter(
 			attributeName,
 			processingScope.getRequirements(),
@@ -183,9 +309,19 @@ public class AttributeIsTranslator implements FilteringConstraintTranslator<Attr
 		);
 	}
 
+	/**
+	 * Creates an AttributeBitmapFilter that ensures a specified attribute is not null.
+	 *
+	 * @param attributeName   the name of the attribute to check for non-null values
+	 * @param filterByVisitor the visitor responsible for filtering operations
+	 * @return an AttributeBitmapFilter instance configured to check for non-null attribute values
+	 */
 	@Nonnull
-	private static AttributeBitmapFilter createAlternativeNotNullBitmapFilter(@Nonnull String attributeName, @Nonnull FilterByVisitor filterByVisitor) {
-		final ProcessingScope processingScope = filterByVisitor.getProcessingScope();
+	private static AttributeBitmapFilter createAlternativeNotNullBitmapFilter(
+		@Nonnull String attributeName,
+		@Nonnull FilterByVisitor filterByVisitor
+	) {
+		final ProcessingScope<?> processingScope = filterByVisitor.getProcessingScope();
 		return new AttributeBitmapFilter(
 			attributeName,
 			processingScope.getRequirements(),
@@ -194,6 +330,18 @@ public class AttributeIsTranslator implements FilteringConstraintTranslator<Attr
 			attributeSchema -> optionalStream -> optionalStream.anyMatch(Optional::isPresent),
 			AttributeTrait.FILTERABLE
 		);
+	}
+
+	@Nonnull
+	@Override
+	public Formula translate(@Nonnull AttributeIs attributeIs, @Nonnull FilterByVisitor filterByVisitor) {
+		final String attributeName = attributeIs.getAttributeName();
+
+		// also consider the possibly more special values supported in the future
+		return switch (attributeIs.getAttributeSpecialValue()) {
+			case NULL -> translateIsNull(attributeName, filterByVisitor);
+			case NOT_NULL -> translateIsNotNull(attributeName, filterByVisitor);
+		};
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeLessThanEqualsTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeLessThanEqualsTranslator.java
@@ -24,125 +24,34 @@
 package io.evitadb.core.query.filter.translator.attribute;
 
 import io.evitadb.api.query.filter.AttributeLessThanEquals;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
-import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
-import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
-import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
-import io.evitadb.core.query.algebra.attribute.AttributeFormula;
-import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
-import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
 import io.evitadb.core.query.filter.FilterByVisitor;
-import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
-import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
-import io.evitadb.dataType.EvitaDataTypes;
+import io.evitadb.index.attribute.FilterIndex;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 /**
  * This implementation of {@link FilteringConstraintTranslator} converts {@link AttributeLessThanEquals} to {@link AbstractFormula}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AttributeLessThanEqualsTranslator implements FilteringConstraintTranslator<AttributeLessThanEquals> {
+public class AttributeLessThanEqualsTranslator extends AbstractAttributeComparisonTranslator
+	implements FilteringConstraintTranslator<AttributeLessThanEquals> {
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	public AttributeLessThanEqualsTranslator() {
+		super(
+			result -> result <= 0,
+			FilterIndex::getRecordsLesserThanEqFormula,
+			"lesser than or equals"
+		);
+	}
+
 	@Nonnull
 	@Override
 	public Formula translate(@Nonnull AttributeLessThanEquals attributeLessThanEquals, @Nonnull FilterByVisitor filterByVisitor) {
-		final String attributeName = attributeLessThanEquals.getAttributeName();
-		final Serializable attributeValue = attributeLessThanEquals.getAttributeValue();
-
-		if (filterByVisitor.isEntityTypeKnown()) {
-			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
-			final Class<? extends Serializable> attributeType = attributeDefinition.getPlainType();
-			final Comparable comparableValue = (Comparable) EvitaDataTypes.toTargetType(attributeValue, attributeType);
-
-			final Predicate<BigDecimal> requestedPredicate;
-			if (Number.class.isAssignableFrom(attributeType)) {
-				final BigDecimal toBigDecimal = EvitaDataTypes.toTargetType((Serializable) comparableValue, BigDecimal.class);
-				requestedPredicate = threshold -> {
-					if (toBigDecimal != null && threshold.compareTo(toBigDecimal) > 0) {
-						return false;
-					}
-					return true;
-				};
-			} else {
-				requestedPredicate = null;
-			}
-
-			final AttributeFormula filteringFormula = new AttributeFormula(
-				attributeDefinition instanceof GlobalAttributeSchemaContract,
-				attributeDefinition.isLocalized() ?
-					new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-				filterByVisitor.applyOnFilterIndexes(
-					attributeDefinition, index -> index.getRecordsLesserThanEqFormula(comparableValue)
-				),
-				requestedPredicate
-			);
-			if (filterByVisitor.isPrefetchPossible()) {
-				return new SelectionFormula(
-					filteringFormula,
-					createAlternativeBitmapFilter(filterByVisitor, attributeName, attributeValue)
-				);
-			} else {
-				return filteringFormula;
-			}
-		} else {
-			return new EntityFilteringFormula(
-				"attribute less than or equals filter",
-				createAlternativeBitmapFilter(filterByVisitor, attributeName, attributeValue)
-			);
-		}
-	}
-
-	@SuppressWarnings("rawtypes")
-	@Nonnull
-	private static AttributeBitmapFilter createAlternativeBitmapFilter(
-		@Nonnull FilterByVisitor filterByVisitor,
-		@Nonnull String attributeName,
-		@Nonnull Serializable attributeValue
-	) {
-		final ProcessingScope processingScope = filterByVisitor.getProcessingScope();
-		return new AttributeBitmapFilter(
-			attributeName,
-			processingScope.getRequirements(),
-			processingScope::getAttributeSchema,
-			(entityContract, theAttributeName) -> processingScope.getAttributeValueStream(entityContract, theAttributeName, filterByVisitor.getLocale()),
-			attributeSchema -> {
-				final Comparable comparableValue = (Comparable) EvitaDataTypes.toTargetType(attributeValue, attributeSchema.getPlainType());
-				return getPredicate(comparableValue);
-			}
-		);
-	}
-
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getPredicate(Comparable<?> comparableValue) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<Comparable> predicate = theValue -> theValue != null && theValue.compareTo(comparableValue) <= 0;
-					final Serializable theValue = attr.get().value();
-					if (theValue.getClass().isArray()) {
-						return Arrays.stream((Object[])theValue).map(Comparable.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((Comparable)theValue);
-					}
-				}
-			}
-		);
+		return translateInternal(attributeLessThanEquals, filterByVisitor);
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeLessThanTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeLessThanTranslator.java
@@ -24,125 +24,34 @@
 package io.evitadb.core.query.filter.translator.attribute;
 
 import io.evitadb.api.query.filter.AttributeLessThan;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
-import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
-import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
-import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
-import io.evitadb.core.query.algebra.attribute.AttributeFormula;
-import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
-import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
 import io.evitadb.core.query.filter.FilterByVisitor;
-import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
-import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
-import io.evitadb.dataType.EvitaDataTypes;
+import io.evitadb.index.attribute.FilterIndex;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 /**
  * This implementation of {@link FilteringConstraintTranslator} converts {@link AttributeLessThan} to {@link AbstractFormula}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AttributeLessThanTranslator implements FilteringConstraintTranslator<AttributeLessThan> {
+public class AttributeLessThanTranslator extends AbstractAttributeComparisonTranslator
+	implements FilteringConstraintTranslator<AttributeLessThan> {
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	public AttributeLessThanTranslator() {
+		super(
+			result -> result < 0,
+			FilterIndex::getRecordsLesserThanFormula,
+			"lesser than"
+		);
+	}
+
 	@Nonnull
 	@Override
 	public Formula translate(@Nonnull AttributeLessThan attributeLessThan, @Nonnull FilterByVisitor filterByVisitor) {
-		final String attributeName = attributeLessThan.getAttributeName();
-		final Serializable attributeValue = attributeLessThan.getAttributeValue();
-
-		if (filterByVisitor.isEntityTypeKnown()) {
-			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
-			final Class<? extends Serializable> attributeType = attributeDefinition.getPlainType();
-			final Comparable comparableValue = (Comparable) EvitaDataTypes.toTargetType(attributeValue, attributeType);
-
-			final Predicate<BigDecimal> requestedPredicate;
-			if (Number.class.isAssignableFrom(attributeType)) {
-				final BigDecimal toBigDecimal = EvitaDataTypes.toTargetType((Serializable) comparableValue, BigDecimal.class);
-				requestedPredicate = threshold -> {
-					if (toBigDecimal != null && threshold.compareTo(toBigDecimal) >= 0) {
-						return false;
-					}
-					return true;
-				};
-			} else {
-				requestedPredicate = null;
-			}
-
-			final AttributeFormula filteringFormula = new AttributeFormula(
-				attributeDefinition instanceof GlobalAttributeSchemaContract,
-				attributeDefinition.isLocalized() ?
-					new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-				filterByVisitor.applyOnFilterIndexes(
-					attributeDefinition, index -> index.getRecordsLesserThanFormula(comparableValue)
-				),
-				requestedPredicate
-			);
-			if (filterByVisitor.isPrefetchPossible()) {
-				return new SelectionFormula(
-					filteringFormula,
-					createAlternativeBitmapFilter(filterByVisitor, attributeName, attributeValue)
-				);
-			} else {
-				return filteringFormula;
-			}
-		} else {
-			return new EntityFilteringFormula(
-				"attribute less than filter",
-				createAlternativeBitmapFilter(filterByVisitor, attributeName, attributeValue)
-			);
-		}
-	}
-
-	@SuppressWarnings("rawtypes")
-	@Nonnull
-	private static AttributeBitmapFilter createAlternativeBitmapFilter(
-		@Nonnull FilterByVisitor filterByVisitor,
-		@Nonnull String attributeName,
-		@Nonnull Serializable attributeValue
-	) {
-		final ProcessingScope processingScope = filterByVisitor.getProcessingScope();
-		return new AttributeBitmapFilter(
-			attributeName,
-			processingScope.getRequirements(),
-			processingScope::getAttributeSchema,
-			(entityContract, theAttributeName) -> processingScope.getAttributeValueStream(entityContract, theAttributeName, filterByVisitor.getLocale()),
-			attributeSchema -> {
-				final Comparable comparableValue = (Comparable) EvitaDataTypes.toTargetType(attributeValue, attributeSchema.getPlainType());
-				return getPredicate(comparableValue);
-			}
-		);
-	}
-
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getPredicate(Comparable<?> comparableValue) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<Comparable> predicate = theValue -> theValue != null && theValue.compareTo(comparableValue) < 0;
-					final Serializable theValue = attr.get().value();
-					if (theValue.getClass().isArray()) {
-						return Arrays.stream((Object[])theValue).map(Comparable.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((Comparable)theValue);
-					}
-				}
-			}
-		);
+		return translateInternal(attributeLessThan, filterByVisitor);
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeStartsWithTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeStartsWithTranslator.java
@@ -24,111 +24,44 @@
 package io.evitadb.core.query.filter.translator.attribute;
 
 import io.evitadb.api.query.filter.AttributeStartsWith;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
-import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
-import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
-import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
-import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
-import io.evitadb.core.query.algebra.attribute.AttributeFormula;
-import io.evitadb.core.query.algebra.prefetch.EntityFilteringFormula;
-import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
 import io.evitadb.core.query.filter.FilterByVisitor;
-import io.evitadb.core.query.filter.FilterByVisitor.ProcessingScope;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
-import io.evitadb.core.query.filter.translator.attribute.alternative.AttributeBitmapFilter;
+import io.evitadb.index.attribute.FilterIndex;
 
 import javax.annotation.Nonnull;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
-
-import static io.evitadb.core.query.filter.translator.attribute.AttributeContainsTranslator.assertStringType;
+import java.util.function.BiPredicate;
 
 /**
  * This implementation of {@link FilteringConstraintTranslator} converts {@link AttributeStartsWith} to {@link AbstractFormula}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AttributeStartsWithTranslator implements FilteringConstraintTranslator<AttributeStartsWith> {
+public class AttributeStartsWithTranslator extends AbstractAttributeStringSearchTranslator
+	implements FilteringConstraintTranslator<AttributeStartsWith> {
+
+	public AttributeStartsWithTranslator() {
+		super(
+			"starts with",
+			FilterIndex::getRecordsWhoseValuesStartWith,
+			createPredicate()
+		);
+	}
+
+	/**
+	 * Creates a BiPredicate that checks if a given string starts with another string.
+	 *
+	 * @return a BiPredicate that returns true if the first string is not null and starts with the second string.
+	 */
+	@Nonnull
+	static BiPredicate<String, String> createPredicate() {
+		return (theValue, textToSearch) -> theValue != null && theValue.startsWith(textToSearch);
+	}
 
 	@Nonnull
 	@Override
 	public Formula translate(@Nonnull AttributeStartsWith attributeStartsWith, @Nonnull FilterByVisitor filterByVisitor) {
-		final String attributeName = attributeStartsWith.getAttributeName();
-		final String textToSearch = attributeStartsWith.getTextToSearch();
-
-		if (filterByVisitor.isEntityTypeKnown()) {
-			final AttributeSchemaContract attributeDefinition = filterByVisitor.getAttributeSchema(attributeName, AttributeTrait.FILTERABLE);
-			assertStringType(attributeDefinition);
-
-			final AttributeFormula filteringFormula = new AttributeFormula(
-				attributeDefinition instanceof GlobalAttributeSchemaContract,
-				attributeDefinition.isLocalized() ?
-					new AttributeKey(attributeName, filterByVisitor.getLocale()) : new AttributeKey(attributeName),
-				filterByVisitor.applyOnFilterIndexes(
-					attributeDefinition, index -> {
-						/* TOBEDONE JNO naive and slow - use RadixTree */
-						return index.getRecordsWhoseValuesStartWith(textToSearch);
-					}
-				)
-			);
-
-			if (filterByVisitor.isPrefetchPossible()) {
-				return new SelectionFormula(
-					filteringFormula,
-					createAlternativeBitmapFilter(filterByVisitor, attributeName, textToSearch)
-				);
-			} else {
-				return filteringFormula;
-			}
-		} else {
-			return new EntityFilteringFormula(
-				"attribute starts with filter",
-				createAlternativeBitmapFilter(filterByVisitor, attributeName, textToSearch)
-			);
-		}
+		return translateInternal(attributeStartsWith, filterByVisitor);
 	}
-
-	@Nonnull
-	private static AttributeBitmapFilter createAlternativeBitmapFilter(
-		@Nonnull FilterByVisitor filterByVisitor,
-		@Nonnull String attributeName,
-		@Nonnull String textToSearch
-	) {
-		final ProcessingScope processingScope = filterByVisitor.getProcessingScope();
-		return new AttributeBitmapFilter(
-			attributeName,
-			processingScope.getRequirements(),
-			processingScope::getAttributeSchema,
-			(entityContract, theAttributeName) -> processingScope.getAttributeValueStream(entityContract, theAttributeName, filterByVisitor.getLocale()),
-			attributeSchema -> {
-				assertStringType(attributeSchema);
-				return getPredicate(textToSearch);
-			}
-		);
-	}
-
-	@Nonnull
-	public static Predicate<Stream<Optional<AttributeValue>>> getPredicate(String textToSearch) {
-		return attrStream -> attrStream.anyMatch(
-			attr -> {
-				if (attr.isEmpty()) {
-					return false;
-				} else {
-					final Predicate<String> predicate = theValue -> theValue != null && theValue.startsWith(textToSearch);
-					final Serializable theValue = attr.get().value();
-					if (theValue.getClass().isArray()) {
-						return Arrays.stream((Object[])theValue).map(String.class::cast).anyMatch(predicate);
-					} else {
-						return predicate.test((String)theValue);
-					}
-				}
-			}
-		);
-	}
-
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/AttributeComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/AttributeComparator.java
@@ -66,16 +66,16 @@ public class AttributeComparator implements EntityComparator {
 		final ComparatorSource comparatorSource = new ComparatorSource(
 			type, orderDirection, OrderBehaviour.NULLS_LAST
 		);
-		final Optional<UnaryOperator<Comparable<?>>> normalizerFor = createNormalizerFor(comparatorSource);
-		final UnaryOperator<Comparable<?>> normalizer = normalizerFor.orElseGet(UnaryOperator::identity);
+		final Optional<UnaryOperator<Object>> normalizerFor = createNormalizerFor(comparatorSource);
+		final UnaryOperator<Object> normalizer = normalizerFor.orElseGet(UnaryOperator::identity);
 		this.pkComparator = orderDirection == OrderDirection.ASC ?
 			Comparator.comparingInt(EntityContract::getPrimaryKey) :
 			Comparator.comparingInt(EntityContract::getPrimaryKey).reversed();
 		//noinspection unchecked
 		this.comparator = createComparatorFor(locale, comparatorSource);
 		this.attributeValueFetcher = locale == null ?
-			entityContract -> normalizer.apply(attributeExtractor.extract(entityContract, attributeName)) :
-			entityContract -> normalizer.apply(attributeExtractor.extract(entityContract, attributeName, locale));
+			entityContract -> (Comparable<?>) normalizer.apply(attributeExtractor.extract(entityContract, attributeName)) :
+			entityContract -> (Comparable<?>) normalizer.apply(attributeExtractor.extract(entityContract, attributeName, locale));
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/AttributeExtractor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/AttributeExtractor.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -42,13 +42,13 @@ public sealed interface AttributeExtractor permits EntityAttributeExtractor, Ent
 	 * Returns attribute value for particular `attributeName` from the `entity`.
 	 */
 	@Nullable
-	Comparable<?> extract(@Nonnull EntityContract entity, @Nonnull String attributeName);
+	Object extract(@Nonnull EntityContract entity, @Nonnull String attributeName);
 
 	/**
 	 * Returns attribute value for particular combination of `attributeName` and `locale` from the `entity`.
 	 */
 	@Nullable
-	Comparable<?> extract(@Nonnull EntityContract entity, @Nonnull String attributeName, @Nonnull Locale locale);
+	Object extract(@Nonnull EntityContract entity, @Nonnull String attributeName, @Nonnull Locale locale);
 
 	/**
 	 * Requirements that will trigger fetching appropriate container to access attribute in {@link EntityContract}.

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/CompoundAttributeComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/CompoundAttributeComparator.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.UnaryOperator;
 
 import static io.evitadb.index.attribute.SortIndex.createCombinedComparatorFor;
 import static io.evitadb.index.attribute.SortIndex.createNormalizerFor;
@@ -60,11 +59,11 @@ public class CompoundAttributeComparator implements EntityComparator, Serializab
 	/**
 	 * Function for fetching the attribute value from the entity.
 	 */
-	@Nonnull private final BiFunction<EntityContract, String, Comparable<?>> attributeValueFetcher;
+	@Nonnull private final BiFunction<EntityContract, String, Object> attributeValueFetcher;
 	/**
 	 * Function for normalizing the attribute values (such as string values or BigDecimals).
 	 */
-	@Nonnull private final UnaryOperator<Object> normalizer;
+	@Nonnull private final Function<Object, Object> normalizer;
 	/**
 	 * Comparator for comparing the normalized attribute values.
 	 */
@@ -135,7 +134,7 @@ public class CompoundAttributeComparator implements EntityComparator, Serializab
 	private ComparableArray getAndMemoizeValue(@Nonnull EntityContract entity) {
 		ComparableArray value = this.memoizedValues.get(entity.getPrimaryKey());
 		if (value == null) {
-			final Comparable<?>[] valueArray = new Comparable<?>[this.attributeElements.length];
+			final Object[] valueArray = new Comparable<?>[this.attributeElements.length];
 			for (int i = 0; i < this.attributeElements.length; i++) {
 				final AttributeElement attributeElement = this.attributeElements[i];
 				valueArray[i] = this.attributeValueFetcher.apply(entity, attributeElement.attributeName());

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/EntityAttributeExtractor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/EntityAttributeExtractor.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -45,13 +45,13 @@ public final class EntityAttributeExtractor implements AttributeExtractor {
 
 	@Nullable
 	@Override
-	public Comparable<?> extract(@Nonnull EntityContract entity, @Nonnull String attributeName) {
+	public Object extract(@Nonnull EntityContract entity, @Nonnull String attributeName) {
 		return entity.getAttribute(attributeName);
 	}
 
 	@Nullable
 	@Override
-	public Comparable<?> extract(@Nonnull EntityContract entity, @Nonnull String attributeName, @Nonnull Locale locale) {
+	public Object extract(@Nonnull EntityContract entity, @Nonnull String attributeName, @Nonnull Locale locale) {
 		return entity.getAttribute(attributeName, locale);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/EntityReferenceAttributeExtractor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/EntityReferenceAttributeExtractor.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -46,10 +46,10 @@ public final class EntityReferenceAttributeExtractor implements AttributeExtract
 
 	@Nullable
 	@Override
-	public Comparable<?> extract(@Nonnull EntityContract entity, @Nonnull String attributeName) {
+	public Object extract(@Nonnull EntityContract entity, @Nonnull String attributeName) {
 		return entity.getReferences(referenceName)
 			.stream()
-			.map(it -> (Comparable<?>)it.getAttribute(attributeName))
+			.map(it -> it.getAttribute(attributeName))
 			.filter(Objects::nonNull)
 			.findFirst()
 			.orElse(null);
@@ -57,11 +57,11 @@ public final class EntityReferenceAttributeExtractor implements AttributeExtract
 
 	@Nullable
 	@Override
-	public Comparable<?> extract(@Nonnull EntityContract entity, @Nonnull String attributeName, @Nonnull Locale locale) {
+	public Object extract(@Nonnull EntityContract entity, @Nonnull String attributeName, @Nonnull Locale locale) {
 		//noinspection ConstantConditions
 		return entity.getReferences(referenceName)
 			.stream()
-			.map(it -> (Comparable<?>)it.getAttribute(attributeName, locale))
+			.map(it -> it.getAttribute(attributeName, locale))
 			.findFirst()
 			.orElse(null);
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -33,6 +33,8 @@ import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer;
+import io.evitadb.dataType.ComparableCurrency;
+import io.evitadb.dataType.ComparableLocale;
 import io.evitadb.dataType.Range;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.index.IndexDataStructure;
@@ -58,7 +60,9 @@ import java.lang.reflect.Array;
 import java.time.OffsetDateTime;
 import java.util.BitSet;
 import java.util.Comparator;
+import java.util.Currency;
 import java.util.LinkedList;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -77,8 +81,8 @@ import static java.util.Optional.ofNullable;
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, IndexDataStructure, Serializable {
 	public static final String ERROR_RANGE_TYPE_NOT_SUPPORTED = "This filter index doesn't handle Range type!";
+	public static final Function<Object, Serializable> NO_NORMALIZATION = o -> (Serializable) o;
 	@Serial private static final long serialVersionUID = -6813305126746774103L;
-	private static final Function<Comparable, Comparable> NO_NORMALIZATION = Function.identity();
 	public static final Comparator<Comparable> DEFAULT_COMPARATOR = Comparator.naturalOrder();
 	@Getter private final long id = TransactionalObjectVersion.SEQUENCE.nextId();
 	/**
@@ -92,7 +96,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	/**
 	 * Histogram is the main data structure that holds the information about value to record ids relation.
 	 */
-	@Nonnull @Getter private final InvertedIndex<? extends Comparable<?>> invertedIndex;
+	@Nonnull @Getter private final InvertedIndex invertedIndex;
 	/**
 	 * Range index is used only for attribute types that are assignable to {@link Range} and can answer questions like:
 	 * <p>
@@ -109,7 +113,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * Instance of conversion function that converts the value before it's placed into internal index or looked up
 	 * in it by {@link Comparator} interface.
 	 */
-	@Nonnull private final Function<Comparable, Comparable> normalizer;
+	@Nonnull private final Function<Object, Serializable> normalizer;
 	/**
 	 * Instance of comparator that should be used for sorting values in this filter index.
 	 */
@@ -118,7 +122,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * Value index is auxiliary data structure that allows fast O(1) access to the records of specified value.
 	 * It is created on demand on first use.
 	 */
-	@Nullable private transient Map<? extends Comparable<?>, Integer> valueIndex;
+	@Nullable private transient Map<Serializable, Integer> valueIndex;
 	/**
 	 * This field speeds up all requests for all data in this index (which happens quite often). This formula can be
 	 * computed anytime by calling `((InvertedIndex) this.histogram).getSortedRecords(null, null)`. Original operation
@@ -126,6 +130,16 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 */
 	@Nullable private transient Formula memoizedAllRecordsFormula;
 
+	/**
+	 * Verifies that the provided value is an array of Serializable objects and
+	 * returns it as an array of Comparable objects. If the elements in the value array
+	 * are not Comparable, they are converted to a String representation and
+	 * returned as a String array.
+	 *
+	 * @param value the object to be verified and converted
+	 * @return an array of Comparable objects or a String array if elements are not Comparable
+	 */
+	@Nonnull
 	private static Comparable[] verifyValueArray(@Nonnull Object value) {
 		isTrue(Serializable.class.isAssignableFrom(value.getClass().getComponentType()), "Value `" + unknownToString(value) + "` is expected to be Serializable, but it is not!");
 		if (Comparable.class.isAssignableFrom(value.getClass().getComponentType())) {
@@ -137,15 +151,6 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 				valuesAsString[i] = String.valueOf(Array.get(value, i));
 			}
 			return valuesAsString;
-		}
-	}
-
-	private static Comparable verifyValue(@Nonnull Object value) {
-		isTrue(value instanceof Serializable, "Value `" + unknownToString(value) + "` is expected to be Serializable, but it is not!");
-		if (value instanceof Comparable) {
-			return (Comparable) value;
-		} else {
-			return value.toString();
 		}
 	}
 
@@ -185,11 +190,17 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * @return appropriate comparator
 	 */
 	@Nonnull
-	private static Function<Comparable, Comparable> getNormalizer(@Nonnull Class<?> attributeType) {
+	public static Function<Object, Serializable> getNormalizer(@Nonnull Class<?> attributeType) {
 		if (OffsetDateTime.class.isAssignableFrom(attributeType)) {
-			return comparable -> comparable instanceof OffsetDateTime offsetDateTime ? offsetDateTime.toInstant() : comparable;
-		} else {
+			return comparable -> comparable instanceof OffsetDateTime offsetDateTime ? offsetDateTime.toInstant() : (Serializable) comparable;
+		} else if (Currency.class.isAssignableFrom(attributeType)) {
+			return comparable -> comparable instanceof Currency currency ? new ComparableCurrency(currency) : (Serializable) comparable;
+		} else if (Locale.class.isAssignableFrom(attributeType)) {
+			return comparable -> comparable instanceof Locale locale ? new ComparableLocale(locale) : (Serializable) comparable;
+		} else if (Comparable.class.isAssignableFrom(attributeType)) {
 			return NO_NORMALIZATION;
+		} else {
+			throw new EvitaInvalidUsageException("Unsupported attribute type `" + attributeType + "`! The type is not comparable!");
 		}
 	}
 
@@ -201,7 +212,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * @return appropriate comparator
 	 */
 	@Nonnull
-	private static Comparator<? extends Comparable> getComparator(@Nonnull AttributeKey attributeKey, @Nonnull Class<?> attributeType) {
+	public static Comparator<? extends Comparable> getComparator(@Nonnull AttributeKey attributeKey, @Nonnull Class<?> attributeType) {
 		if (String.class.isAssignableFrom(attributeType) && attributeKey.localized()) {
 			return new LocalizedStringComparator(attributeKey.locale());
 		} else {
@@ -216,12 +227,12 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 		this.rangeIndex = Range.class.isAssignableFrom(attributeType) ? new RangeIndex() : null;
 		this.comparator = getComparator(attributeKey, attributeType);
 		this.normalizer = getNormalizer(attributeType);
-		this.invertedIndex = new InvertedIndex<>(this.comparator);
+		this.invertedIndex = new InvertedIndex(this.normalizer, this.comparator);
 	}
 
-	public <T extends Comparable<T>> FilterIndex(
+	public FilterIndex(
 		@Nonnull AttributeKey attributeKey,
-		@Nonnull ValueToRecordBitmap<T>[] valueToRecords,
+		@Nonnull ValueToRecordBitmap[] valueToRecords,
 		@Nullable RangeIndex rangeIndex,
 		@Nonnull Class<?> attributeType
 	) {
@@ -231,13 +242,13 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 		this.rangeIndex = rangeIndex;
 		this.comparator = getComparator(attributeKey, attributeType);
 		this.normalizer = getNormalizer(attributeType);
-		this.invertedIndex = new InvertedIndex<>(valueToRecords, (Comparator<T>) this.comparator);
+		this.invertedIndex = new InvertedIndex(valueToRecords, this.normalizer, this.comparator);
 	}
 
 	//	TOBEDONE #538 - remove unnecessary constructor
-	public <T extends Comparable<T>> FilterIndex(
+	public FilterIndex(
 		@Nonnull AttributeKey attributeKey,
-		@Nonnull ValueToRecordBitmap<T>[] valueToRecords,
+		@Nonnull ValueToRecordBitmap[] valueToRecords,
 		@Nullable RangeIndex rangeIndex,
 		@Nonnull Class<?> attributeType,
 		boolean updateSortedValues
@@ -251,21 +262,21 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 		if (updateSortedValues) {
 			if (this.normalizer != NO_NORMALIZATION) {
 				for (int i = 0; i < valueToRecords.length; i++) {
-					final ValueToRecordBitmap<T> valueToRecord = valueToRecords[i];
-					valueToRecords[i] = new ValueToRecordBitmap<>(this.normalizer.apply(valueToRecord.getValue()), valueToRecord.getRecordIds());
+					final ValueToRecordBitmap valueToRecord = valueToRecords[i];
+					valueToRecords[i] = new ValueToRecordBitmap(this.normalizer.apply(valueToRecord.getValue()), valueToRecord.getRecordIds());
 				}
 			}
 			if (this.comparator != DEFAULT_COMPARATOR) {
-				ArrayUtils.sortArray((o1, o2) -> ((Comparator<T>) this.comparator).compare(o1.getValue(), o2.getValue()), valueToRecords);
+				ArrayUtils.sortArray((o1, o2) -> ((Comparator) this.comparator).compare(o1.getValue(), o2.getValue()), valueToRecords);
 			}
 		}
-		InvertedIndex<T> theInvertedIndex;
+		InvertedIndex theInvertedIndex;
 		try {
-			theInvertedIndex = new InvertedIndex<>(valueToRecords, (Comparator<T>) this.comparator);
+			theInvertedIndex = new InvertedIndex(valueToRecords, this.normalizer, this.comparator);
 		} catch (MonotonicRowCorruptedException ex) {
 			if (this.comparator != DEFAULT_COMPARATOR) {
-				ArrayUtils.sortArray((o1, o2) -> ((Comparator<T>) this.comparator).compare(o1.getValue(), o2.getValue()), valueToRecords);
-				theInvertedIndex = new InvertedIndex<>(valueToRecords, (Comparator<T>) this.comparator);
+				ArrayUtils.sortArray((o1, o2) -> ((Comparator) this.comparator).compare(o1.getValue(), o2.getValue()), valueToRecords);
+				theInvertedIndex = new InvertedIndex(valueToRecords, this.normalizer, this.comparator);
 			} else {
 				throw ex;
 			}
@@ -273,13 +284,13 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 		this.invertedIndex = theInvertedIndex;
 	}
 
-	private <T extends Comparable<T>> FilterIndex(
+	private FilterIndex(
 		@Nonnull AttributeKey attributeKey,
 		@Nonnull Class<?> attributeType,
-		@Nonnull InvertedIndex<T> invertedIndex,
+		@Nonnull InvertedIndex invertedIndex,
 		@Nullable RangeIndex rangeIndex,
 		@Nonnull Comparator<? extends Comparable> comparator,
-		@Nonnull Function<Comparable, Comparable> normalizer
+		@Nonnull Function<Object, Serializable> normalizer
 	) {
 		this.attributeKey = attributeKey;
 		this.attributeType = attributeType;
@@ -299,10 +310,12 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 
 	/**
 	 * Returns formula of record ids whose String attribute starts with particular prefix.
+	 *
+	 * TOBEDONE JNO naive and slow - use RadixTree
 	 */
 	@Nonnull
 	public Formula getRecordsWhoseValuesStartWith(@Nonnull String prefix) {
-		final ValueToRecordBitmap<? extends Comparable<?>>[] buckets = invertedIndex.getValueToRecordBitmap();
+		final ValueToRecordBitmap[] buckets = invertedIndex.getValueToRecordBitmap();
 		final int matchIndex = ArrayUtils.binarySearch(
 			buckets,
 			prefix,
@@ -318,7 +331,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 			final LinkedList<Formula> formulas = new LinkedList<>();
 			// find all matching values to the end of the bucket list
 			for (int i = matchIndex; i < buckets.length; i++) {
-				final ValueToRecordBitmap<? extends Comparable<?>> bucket = buckets[i];
+				final ValueToRecordBitmap bucket = buckets[i];
 				final String value = String.valueOf(bucket.getValue());
 				if (value.startsWith(prefix)) {
 					formulas.add(new ConstantFormula(bucket.getRecordIds()));
@@ -329,7 +342,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 			}
 			// find all matching values to the start of the bucket list
 			for (int i = matchIndex - 1; i >= 0; i--) {
-				final ValueToRecordBitmap<? extends Comparable<?>> bucket = buckets[i];
+				final ValueToRecordBitmap bucket = buckets[i];
 				final String value = String.valueOf(bucket.getValue());
 				if (value.startsWith(prefix)) {
 					formulas.add(new ConstantFormula(bucket.getRecordIds()));
@@ -384,7 +397,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * @param <T>      the type of the value, must implement Comparable<T>
 	 * @throws EvitaInvalidUsageException when the value is not of type Range in case of range index
 	 */
-	public <T extends Comparable<T>> void addRecord(int recordId, @Nonnull Object value) throws EvitaInvalidUsageException {
+	public <T extends Serializable> void addRecord(int recordId, @Nonnull Object value) throws EvitaInvalidUsageException {
 		// if current attribute is Range based assign record also to range index
 		if (rangeIndex != null) {
 			if (value instanceof Range[] valueArray) {
@@ -403,7 +416,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 				addRecordToHistogramAndValueIndex(recordId, (T) valueItem);
 			}
 		} else {
-			addRecordToHistogramAndValueIndex(recordId, (T) verifyValue(value));
+			addRecordToHistogramAndValueIndex(recordId, (T) value);
 		}
 
 		if (!isTransactionAvailable()) {
@@ -423,12 +436,13 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * @param <T>      the type of the attribute value
 	 * @throws EvitaInvalidUsageException when the value is not of type Range in case of range index
 	 */
-	public <T extends Comparable<T>> void addRecordDelta(int recordId, @Nonnull Object[] value) throws EvitaInvalidUsageException {
+	public <T extends Serializable> void addRecordDelta(int recordId, @Nonnull Object[] value) throws EvitaInvalidUsageException {
 		// if current attribute is Range based assign record also to range index
-		if (rangeIndex != null) {
+		//noinspection VariableNotUsedInsideIf
+		if (this.rangeIndex != null) {
 			if (value instanceof Range[] valueArray) {
 				// this is quite expensive operation, but we need to do it to be able to remove and add the record
-				@SuppressWarnings("SuspiciousArrayCast") final Range[] existingRanges = (Range[]) ((InvertedIndex) this.invertedIndex).getValuesForRecord(recordId, Range.class);
+				final Range[] existingRanges = this.invertedIndex.getValuesForRecord(recordId, Range.class);
 				final Range[] aggregatedRanges = ArrayUtils.mergeArrays(existingRanges, valueArray);
 
 				removeRange(recordId, existingRanges);
@@ -457,7 +471,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * @throws EvitaInvalidUsageException when the removed record is not actually registered for the attribute or
 	 *                                    when the value is not of type Range in case of range index
 	 */
-	public <T extends Comparable<T>> void removeRecord(int recordId, @Nonnull Object value) throws EvitaInvalidUsageException {
+	public <T extends Serializable> void removeRecord(int recordId, @Nonnull Object value) throws EvitaInvalidUsageException {
 		// if current attribute is Range based assign record also to range index
 		if (this.rangeIndex != null) {
 			if (value instanceof Object[]) {
@@ -476,12 +490,10 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 		}
 
 		if (value instanceof final Object[] valueArray) {
-			verifyValueArray(value);
-			for (Object valueItem : valueArray) {
+			for (Object valueItem : verifyValueArray(valueArray)) {
 				removeRecordFromHistogramAndValueIndex(recordId, (T) valueItem);
 			}
 		} else {
-			verifyValue(value);
 			removeRecordFromHistogramAndValueIndex(recordId, (T) value);
 		}
 
@@ -502,12 +514,13 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * @param <T>      the type of the attribute value
 	 * @throws EvitaInvalidUsageException when the value is not of type Range in case of range index
 	 */
-	public <T extends Comparable<T>> void removeRecordDelta(int recordId, @Nonnull Object[] value) {
+	public <T extends Serializable> void removeRecordDelta(int recordId, @Nonnull Object[] value) {
 		// if current attribute is Range based assign record also to range index
+		//noinspection VariableNotUsedInsideIf
 		if (this.rangeIndex != null) {
 			if (value instanceof Range[] valueArray) {
 				// this is quite expensive operation, but we need to do it to be able to remove and add the record
-				@SuppressWarnings("SuspiciousArrayCast") final Range[] existingRanges = (Range[]) ((InvertedIndex) this.invertedIndex).getValuesForRecord(recordId, Range.class);
+				final Range[] existingRanges = this.invertedIndex.getValuesForRecord(recordId, Range.class);
 				final Range[] remainingRanges = getRemainingRanges(valueArray, existingRanges);
 
 				removeRange(recordId, existingRanges);
@@ -539,7 +552,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * Returns bitmap of all record ids connected with the value in the argument
 	 */
 	@Nonnull
-	public <T extends Comparable<T>> Bitmap getRecordsEqualTo(@Nonnull T attributeValue) {
+	public <T> Bitmap getRecordsEqualTo(@Nonnull T attributeValue) {
 		return ofNullable(getValueIndex().get(this.normalizer.apply(attributeValue)))
 			.map(invertedIndex::getRecordsAtIndex)
 			.orElse(EmptyBitmap.INSTANCE);
@@ -549,17 +562,17 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * Returns bitmap of all record ids connected with the value in the argument
 	 */
 	@Nonnull
-	public <T extends Comparable<T>> Formula getRecordsEqualToFormula(@Nonnull T attributeValue) {
+	public <T> Formula getRecordsEqualToFormula(@Nonnull T attributeValue) {
 		return ofNullable(getValueIndex().get(this.normalizer.apply(attributeValue)))
-			.map(it -> (Formula) new ConstantFormula(invertedIndex.getRecordsAtIndex(it)))
+			.map(it -> (Formula) new ConstantFormula(this.invertedIndex.getRecordsAtIndex(it)))
 			.orElse(EmptyFormula.INSTANCE);
 	}
 
 	/**
 	 * Returns all records present in filter index in the form of {@link InvertedIndexSubSet}.
 	 */
-	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfAllRecords() {
-		return ((InvertedIndex) this.invertedIndex).getSortedRecords(null, null);
+	public InvertedIndexSubSet getHistogramOfAllRecords() {
+		return this.invertedIndex.getSortedRecords(null, null);
 	}
 
 	/**
@@ -588,15 +601,15 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	/**
 	 * Returns all records lesser than or equals attribute value passed in the argument in the form of {@link InvertedIndexSubSet}.
 	 */
-	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsLesserThanEq(@Nonnull T to) {
-		return ((InvertedIndex) this.invertedIndex).getSortedRecords(null, this.normalizer.apply(to));
+	public InvertedIndexSubSet getHistogramOfRecordsLesserThanEq(@Nonnull Serializable to) {
+		return this.invertedIndex.getSortedRecords(null, to);
 	}
 
 	/**
 	 * Returns all records lesser than or equals attribute value passed in the argument in the form of {@link Bitmap}.
 	 */
 	@Nonnull
-	public <T extends Comparable<T>> Bitmap getRecordsLesserThanEq(@Nonnull T to) {
+	public Bitmap getRecordsLesserThanEq(@Nonnull Serializable to) {
 		final Formula recordsLesserThanEqFormula = getRecordsLesserThanEqFormula(to);
 		return recordsLesserThanEqFormula.compute();
 	}
@@ -604,22 +617,22 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	/**
 	 * Returns all records lesser than or equals attribute value passed in the argument in the form of {@link Bitmap}.
 	 */
-	public <T extends Comparable<T>> Formula getRecordsLesserThanEqFormula(@Nonnull T to) {
+	public Formula getRecordsLesserThanEqFormula(@Nonnull Serializable to) {
 		return getHistogramOfRecordsLesserThanEq(to).getFormula();
 	}
 
 	/**
 	 * Returns all records greater than or equals attribute value passed in the argument in the form of {@link InvertedIndexSubSet}.
 	 */
-	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsGreaterThanEq(@Nonnull T from) {
-		return ((InvertedIndex) this.invertedIndex).getSortedRecords(this.normalizer.apply(from), null);
+	public InvertedIndexSubSet getHistogramOfRecordsGreaterThanEq(@Nonnull Serializable from) {
+		return this.invertedIndex.getSortedRecords(from, null);
 	}
 
 	/**
 	 * Returns all records greater than or equals attribute value passed in the argument in the form of {@link Bitmap}.
 	 */
 	@Nonnull
-	public <T extends Comparable<T>> Bitmap getRecordsGreaterThanEq(@Nonnull T from) {
+	public Bitmap getRecordsGreaterThanEq(@Nonnull Serializable from) {
 		final Formula recordsGreaterThanEqFormula = getRecordsGreaterThanEqFormula(from);
 		return recordsGreaterThanEqFormula.compute();
 	}
@@ -627,22 +640,22 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	/**
 	 * Returns all records greater than or equals attribute value passed in the argument in the form of {@link AbstractFormula}.
 	 */
-	public <T extends Comparable<T>> Formula getRecordsGreaterThanEqFormula(@Nonnull T to) {
+	public Formula getRecordsGreaterThanEqFormula(@Nonnull Serializable to) {
 		return getHistogramOfRecordsGreaterThanEq(to).getFormula();
 	}
 
 	/**
 	 * Returns all records lesser than attribute value passed in the argument in the form of {@link InvertedIndexSubSet}.
 	 */
-	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsLesserThan(@Nonnull T to) {
-		return ((InvertedIndex) this.invertedIndex).getSortedRecordsExclusive(null, this.normalizer.apply(to));
+	public InvertedIndexSubSet getHistogramOfRecordsLesserThan(@Nonnull Serializable to) {
+		return this.invertedIndex.getSortedRecordsExclusive(null, to);
 	}
 
 	/**
 	 * Returns all records lesser than attribute value passed in the argument in the form of {@link Bitmap}.
 	 */
 	@Nonnull
-	public <T extends Comparable<T>> Bitmap getRecordsLesserThan(@Nonnull T to) {
+	public Bitmap getRecordsLesserThan(@Nonnull Serializable to) {
 		final Formula recordsLesserThanFormula = getRecordsLesserThanFormula(to);
 		return recordsLesserThanFormula.compute();
 	}
@@ -650,22 +663,22 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	/**
 	 * Returns all records lesser than attribute value passed in the argument in the form of {@link AbstractFormula}.
 	 */
-	public <T extends Comparable<T>> Formula getRecordsLesserThanFormula(@Nonnull T from) {
+	public Formula getRecordsLesserThanFormula(@Nonnull Serializable from) {
 		return getHistogramOfRecordsLesserThan(from).getFormula();
 	}
 
 	/**
 	 * Returns all records greater than attribute value passed in the argument in the form of {@link InvertedIndexSubSet}.
 	 */
-	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsGreaterThan(@Nonnull T from) {
-		return ((InvertedIndex) this.invertedIndex).getSortedRecordsExclusive(this.normalizer.apply(from), null);
+	public InvertedIndexSubSet getHistogramOfRecordsGreaterThan(@Nonnull Serializable from) {
+		return this.invertedIndex.getSortedRecordsExclusive(from, null);
 	}
 
 	/**
 	 * Returns all records greater than attribute value passed in the argument in the form of {@link Bitmap}.
 	 */
 	@Nonnull
-	public <T extends Comparable<T>> Bitmap getRecordsGreaterThan(@Nonnull T from) {
+	public Bitmap getRecordsGreaterThan(@Nonnull Serializable from) {
 		final Formula recordsGreaterThanFormula = getRecordsGreaterThanFormula(from);
 		return recordsGreaterThanFormula.compute();
 	}
@@ -673,7 +686,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	/**
 	 * Returns all records greater than attribute value passed in the argument in the form of {@link AbstractFormula}.
 	 */
-	public <T extends Comparable<T>> Formula getRecordsGreaterThanFormula(@Nonnull T from) {
+	public Formula getRecordsGreaterThanFormula(@Nonnull Serializable from) {
 		return getHistogramOfRecordsGreaterThan(this.normalizer.apply(from)).getFormula();
 	}
 
@@ -681,8 +694,8 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * Returns all records with attribute values between `from` and `to` (inclusive) passed in the argument
 	 * in the form of {@link InvertedIndexSubSet}.
 	 */
-	public <T extends Comparable<T>> InvertedIndexSubSet<T> getHistogramOfRecordsBetween(@Nonnull T from, @Nonnull T to) {
-		return ((InvertedIndex) this.invertedIndex).getSortedRecords(this.normalizer.apply(from), this.normalizer.apply(to));
+	public InvertedIndexSubSet getHistogramOfRecordsBetween(@Nonnull Serializable from, @Nonnull Serializable to) {
+		return this.invertedIndex.getSortedRecords(from, to);
 	}
 
 	/**
@@ -690,7 +703,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * in the form of {@link Bitmap}.
 	 */
 	@Nonnull
-	public <T extends Comparable<T>> Bitmap getRecordsBetween(@Nonnull T from, @Nonnull T to) {
+	public Bitmap getRecordsBetween(@Nonnull Serializable from, @Nonnull Serializable to) {
 		final Formula recordsBetweenFormula = getRecordsBetweenFormula(from, to);
 		return recordsBetweenFormula.compute();
 	}
@@ -699,7 +712,7 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	 * Returns all records with attribute values between `from` and `to` (inclusive) passed in the argument
 	 * in the form of {@link AbstractFormula}.
 	 */
-	public <T extends Comparable<T>> Formula getRecordsBetweenFormula(@Nonnull T from, @Nonnull T to) {
+	public Formula getRecordsBetweenFormula(@Nonnull Serializable from, @Nonnull Serializable to) {
 		return getHistogramOfRecordsBetween(from, to).getFormula();
 	}
 
@@ -825,12 +838,12 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 	}
 
 	@Nonnull
-	private Map<? extends Comparable<?>, Integer> getValueIndex() {
+	private Map<Serializable, Integer> getValueIndex() {
 		if (valueIndex == null) {
-			final Map<Comparable<?>, Integer> bucketValueToPositionIndex = createHashMap(invertedIndex.getBucketCount());
-			final ValueToRecordBitmap<? extends Comparable<?>>[] buckets = invertedIndex.getValueToRecordBitmap();
+			final Map<Serializable, Integer> bucketValueToPositionIndex = createHashMap(invertedIndex.getBucketCount());
+			final ValueToRecordBitmap[] buckets = invertedIndex.getValueToRecordBitmap();
 			for (int i = 0; i < buckets.length; i++) {
-				final ValueToRecordBitmap<? extends Comparable<?>> bucket = buckets[i];
+				final ValueToRecordBitmap bucket = buckets[i];
 				bucketValueToPositionIndex.put(bucket.getValue(), i);
 			}
 			this.valueIndex = bucketValueToPositionIndex;
@@ -838,13 +851,13 @@ public class FilterIndex implements VoidTransactionMemoryProducer<FilterIndex>, 
 		return valueIndex;
 	}
 
-	private <T extends Comparable<T>> void addRecordToHistogramAndValueIndex(int recordId, @Nonnull T value) {
-		((InvertedIndex) this.invertedIndex).addRecord(this.normalizer.apply(value), recordId);
+	private <T extends Serializable> void addRecordToHistogramAndValueIndex(int recordId, @Nonnull T value) {
+		this.invertedIndex.addRecord(value, recordId);
 		this.valueIndex = null;
 	}
 
-	private <T extends Comparable<T>> void removeRecordFromHistogramAndValueIndex(int recordId, @Nonnull T value) {
-		final int removalIndex = ((InvertedIndex) this.invertedIndex).removeRecord(this.normalizer.apply(value), recordId);
+	private <T extends Serializable> void removeRecordFromHistogramAndValueIndex(int recordId, @Nonnull T value) {
+		final int removalIndex = this.invertedIndex.removeRecord(value, recordId);
 		isTrue(removalIndex >= 0, "Sanity check - record not found!");
 		this.valueIndex = null;
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndex.java
@@ -36,6 +36,8 @@ import io.evitadb.core.query.sort.SortedRecordsSupplierFactory;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
+import io.evitadb.dataType.ComparableCurrency;
+import io.evitadb.dataType.ComparableLocale;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.IndexDataStructure;
 import io.evitadb.index.array.TransactionalObjArray;
@@ -63,6 +65,7 @@ import java.math.BigDecimal;
 import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Currency;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -89,6 +92,7 @@ import static java.util.Optional.ofNullable;
 @ThreadSafe
 public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLayerProducer<SortIndexChanges, SortIndex>, IndexDataStructure, Serializable {
 	@Serial private static final long serialVersionUID = 5862170244589598450L;
+	@Getter private final long id = TransactionalObjectVersion.SEQUENCE.nextId();
 	/**
 	 * Contains record ids sorted by assigned values. The array is divided in so called record ids block that respects
 	 * order in {@link #sortedRecordsValues}. Record ids within the same block are sorted naturally by their integer id.
@@ -103,12 +107,10 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 	 * with low cardinality so this should save a lot of memory.
 	 */
 	final TransactionalMap<Comparable<?>, Integer> valueCardinalities;
-	@Getter private final long id = TransactionalObjectVersion.SEQUENCE.nextId();
 	/**
 	 * The array contains the descriptor allowing to create {@link #normalizer} and {@link #comparator} instances.
 	 */
-	@Nonnull
-	final ComparatorSource[] comparatorBase;
+	@Nonnull final ComparatorSource[] comparatorBase;
 	/**
 	 * Contains key identifying the attribute.
 	 */
@@ -138,33 +140,10 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 	private SortIndexChanges sortIndexChanges;
 
 	/**
-	 * Inverts positions by subtracting from largest value.
-	 */
-	@Nonnull
-	static int[] invert(@Nonnull int[] positions) {
-		final int lastPosition = positions.length - 1;
-		final int[] inverted = new int[positions.length];
-		for (int i = 0; i < positions.length; i++) {
-			inverted[i] = lastPosition - positions[i];
-		}
-		return inverted;
-	}
-
-	/**
-	 * Verifies that the given attribute type is comparable.
-	 */
-	private static void assertComparable(@Nonnull Class<?> attributeType) {
-		isTrue(
-			Comparable.class.isAssignableFrom(attributeType) || attributeType.isPrimitive(),
-			"Type `" + attributeType + "` is expected to be Comparable, but it is not!"
-		);
-	}
-
-	/**
 	 * Method creates a comparator that compares {@link ComparableArray} respecting the comparator base requirements
 	 * and the localization specific for {@link String} type.
 	 *
-	 * @param locale locale to use for sorting
+	 * @param locale         locale to use for sorting
 	 * @param comparatorBase the descriptor that needs to be respected by the comparator
 	 * @return the comparator that respects the given descriptor
 	 */
@@ -182,7 +161,8 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 
 	/**
 	 * Method creates a comparator that respect the localization specific for {@link String} type.
-	 * @param locale locale to use for sorting
+	 *
+	 * @param locale           locale to use for sorting
 	 * @param comparatorSource the descriptor that needs to be respected by the comparator
 	 * @return the comparator that respects the given descriptor
 	 */
@@ -243,8 +223,42 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 			return Optional.of(text -> text == null ? null : (T) Normalizer.normalize(String.valueOf(text), Normalizer.Form.NFD));
 		} else if (BigDecimal.class.isAssignableFrom(comparatorBase.type())) {
 			return Optional.of(value -> value == null ? null : (T) NumberUtils.normalize((BigDecimal) value));
+		} else if (Locale.class.isAssignableFrom(comparatorBase.type())) {
+			return Optional.of(value -> value == null ? null : (T) new ComparableLocale((Locale) value));
+		} else if (Currency.class.isAssignableFrom(comparatorBase.type())) {
+			return Optional.of(value -> value == null ? null : (T) new ComparableCurrency((Currency) value));
 		} else {
 			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Inverts positions by subtracting from the largest value.
+	 */
+	@Nonnull
+	static int[] invert(@Nonnull int[] positions) {
+		final int lastPosition = positions.length - 1;
+		final int[] inverted = new int[positions.length];
+		for (int i = 0; i < positions.length; i++) {
+			inverted[i] = lastPosition - positions[i];
+		}
+		return inverted;
+	}
+
+	/**
+	 * Verifies that the given attribute type is comparable.
+	 */
+	private static Class<?> assertComparable(@Nonnull Class<?> attributeType) {
+		if (Currency.class.isAssignableFrom(attributeType)) {
+			return ComparableCurrency.class;
+		} else if (Locale.class.isAssignableFrom(attributeType)) {
+			return ComparableLocale.class;
+		} else {
+			isTrue(
+				Comparable.class.isAssignableFrom(attributeType) || attributeType.isPrimitive(),
+				"Type `" + attributeType + "` is expected to be Comparable, but it is not!"
+			);
+			return attributeType;
 		}
 	}
 
@@ -253,9 +267,9 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 		@Nonnull Class<?> attributeType,
 		@Nonnull AttributeKey attributeKey
 	) {
-		assertComparable(attributeType);
+		final Class<?> normalizedAttributeType = assertComparable(attributeType);
 		this.dirty = new TransactionalBoolean();
-		this.comparatorBase = new ComparatorSource[] {
+		this.comparatorBase = new ComparatorSource[]{
 			new ComparatorSource(
 				attributeType,
 				OrderDirection.ASC,
@@ -267,7 +281,7 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 		this.comparator = createComparatorFor(this.attributeKey.locale(), this.comparatorBase[0]);
 		this.sortedRecords = new TransactionalUnorderedIntArray();
 		//noinspection rawtypes
-		this.sortedRecordsValues = new TransactionalObjArray<>((T[]) Array.newInstance(attributeType, 0), (Comparator) this.comparator);
+		this.sortedRecordsValues = new TransactionalObjArray<>((T[]) Array.newInstance(normalizedAttributeType, 0), (Comparator) this.comparator);
 		this.valueCardinalities = new TransactionalMap<>(new HashMap<>());
 	}
 
@@ -306,7 +320,7 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 		}
 		this.attributeKey = attributeKey;
 		if (this.comparatorBase.length == 1) {
-			this.normalizer = createNormalizerFor(this.comparatorBase[0]).orElseGet(UnaryOperator::identity);;
+			this.normalizer = createNormalizerFor(this.comparatorBase[0]).orElseGet(UnaryOperator::identity);
 			this.comparator = createComparatorFor(this.attributeKey.locale(), this.comparatorBase[0]);
 		} else {
 			this.normalizer = createNormalizerFor(this.comparatorBase);
@@ -351,44 +365,6 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 	}
 
 	/**
-	 * Shared internal implementation of the record insertion.
-	 */
-	private <T extends Comparable<T>> void addRecordInternal(@Nonnull T normalizedValue, int recordId) {
-		@SuppressWarnings("unchecked")
-		final TransactionalObjArray<T> theSortedRecordsValues = (TransactionalObjArray<T>) this.sortedRecordsValues;
-		final SortIndexChanges sortIndexChanges = getOrCreateSortIndexChanges();
-
-		// prepare internal datastructures
-		sortIndexChanges.prepare();
-
-		// add record id on the computed position
-		final int previousRecordId = sortIndexChanges.computePreviousRecord(normalizedValue, recordId, comparator);
-		this.sortedRecords.add(previousRecordId, recordId);
-
-		// is the value already known?
-		final int index = theSortedRecordsValues.indexOf(normalizedValue);
-		if (index >= 0) {
-			// value is already present - just update cardinality
-			this.valueCardinalities.compute(
-				normalizedValue,
-				(it, existingCardinality) ->
-					ofNullable(existingCardinality)
-						.map(crd -> crd + 1)
-						.orElse(2)
-			);
-			// update help data structure
-			sortIndexChanges.valueCardinalityIncreased(normalizedValue, comparator);
-		} else {
-			// insert new value into the sorted value array
-			theSortedRecordsValues.add(normalizedValue);
-			// update help data structure
-			sortIndexChanges.valueAdded(normalizedValue, comparator);
-		}
-
-		this.dirty.setToTrue();
-	}
-
-	/**
 	 * Unregisters existing record for passed comparable value. Single record must be linked to only single value.
 	 *
 	 * @throws IllegalArgumentException if value is not linked to passed record id
@@ -396,8 +372,7 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 	public void removeRecord(@Nonnull Object[] value, int recordId) {
 		final Object[] normalizedValue = (Object[]) normalizer.apply(value);
 		final ComparableArray normalizedValueArray = new ComparableArray(this.comparatorBase, normalizedValue);
-		@SuppressWarnings("unchecked")
-		final TransactionalObjArray<ComparableArray> theSortedRecordsValues = (TransactionalObjArray<ComparableArray>) this.sortedRecordsValues;
+		@SuppressWarnings("unchecked") final TransactionalObjArray<ComparableArray> theSortedRecordsValues = (TransactionalObjArray<ComparableArray>) this.sortedRecordsValues;
 		final SortIndexChanges sortIndexChanges = getOrCreateSortIndexChanges();
 		final int index = theSortedRecordsValues.indexOf(normalizedValueArray);
 		isTrue(
@@ -423,45 +398,6 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 			"Value `" + value + "` is not present in the sort index of attribute `" + this.attributeKey + "`!"
 		);
 		removeRecordInternal((T) normalizedValue, recordId, theSortedRecordsValues, this.valueCardinalities, sortIndexChanges);
-	}
-
-	/**
-	 * Shared internal implementation of the record removal.
-	 */
-	private <T extends Comparable<T>> void removeRecordInternal(
-		@Nonnull T normalizedValue,
-		int recordId,
-		@Nonnull TransactionalObjArray<T> theSortedRecordsValues,
-		@Nonnull TransactionalMap<Comparable<?>, Integer> theValueCardinalities,
-		@Nonnull SortIndexChanges sortIndexChanges
-	) {
-		// prepare internal datastructures
-		sortIndexChanges.prepare();
-
-		// remove record id from the array
-		this.sortedRecords.remove(recordId);
-		// had the value cardinality >= 2?
-		final Integer cardinality = theValueCardinalities.get(normalizedValue);
-		if (cardinality != null) {
-			// update help data structure first
-			sortIndexChanges.valueCardinalityDecreased(normalizedValue, comparator);
-			if (cardinality > 2) {
-				// decrease cardinality
-				theValueCardinalities.computeIfPresent(normalizedValue, (t, crd) -> crd - 1);
-			} else if (cardinality == 2) {
-				// remove cardinality altogether - cardinality = 1 is not maintained to save memory
-				theValueCardinalities.remove(normalizedValue);
-			} else {
-				throw new GenericEvitaInternalError("Unexpected cardinality: " + cardinality);
-			}
-		} else {
-			// remove the entire value - there is no more record ids for it
-			theSortedRecordsValues.remove(normalizedValue);
-			// update help data structure
-			sortIndexChanges.valueRemoved(normalizedValue, comparator);
-		}
-
-		this.dirty.setToTrue();
 	}
 
 	/**
@@ -514,34 +450,6 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 	}
 
 	/**
-	 * Returns bitmap of all record ids connected with the value in the argument.
-	 */
-	@Nonnull
-	private <T extends Comparable<T>> BaseBitmap getRecordsEqualToInternal(T normalizedValue) {
-		// add record id from the array
-		final ValueStartIndex[] valueIndex = getOrCreateSortIndexChanges()
-			.getValueIndex(this.sortedRecordsValues, this.valueCardinalities);
-
-		@SuppressWarnings({"rawtypes", "unchecked"}) final int theValueIndex = ArrayUtils.binarySearch(
-			valueIndex, normalizedValue,
-			(valueStartIndex, theValue) -> ((Comparator)comparator).compare(valueStartIndex.getValue(), theValue)
-		);
-
-		// had the value cardinality >= 2?
-		final Integer cardinality = this.valueCardinalities.get(normalizedValue);
-		final int recordIdIndex = valueIndex[theValueIndex].getIndex();
-		if (cardinality != null) {
-			return new BaseBitmap(
-				this.sortedRecords.getSubArray(recordIdIndex, recordIdIndex + cardinality)
-			);
-		} else {
-			return new BaseBitmap(
-				this.sortedRecords.get(recordIdIndex)
-			);
-		}
-	}
-
-	/**
 	 * Returns true if {@link SortIndex} contains no data.
 	 */
 	public boolean isEmpty() {
@@ -589,10 +497,6 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 		this.dirty.reset();
 	}
 
-	/*
-		Implementation of TransactionalLayerProducer
-	 */
-
 	@Override
 	public SortIndexChanges createLayer() {
 		return new SortIndexChanges(this);
@@ -622,6 +526,114 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 			);
 		} else {
 			return this;
+		}
+	}
+
+	/*
+		Implementation of TransactionalLayerProducer
+	 */
+
+	/**
+	 * Shared internal implementation of the record insertion.
+	 */
+	private <T extends Comparable<T>> void addRecordInternal(@Nonnull T normalizedValue, int recordId) {
+		@SuppressWarnings("unchecked") final TransactionalObjArray<T> theSortedRecordsValues = (TransactionalObjArray<T>) this.sortedRecordsValues;
+		final SortIndexChanges sortIndexChanges = getOrCreateSortIndexChanges();
+
+		// prepare internal datastructures
+		sortIndexChanges.prepare();
+
+		// add record id on the computed position
+		final int previousRecordId = sortIndexChanges.computePreviousRecord(normalizedValue, recordId, comparator);
+		this.sortedRecords.add(previousRecordId, recordId);
+
+		// is the value already known?
+		final int index = theSortedRecordsValues.indexOf(normalizedValue);
+		if (index >= 0) {
+			// value is already present - just update cardinality
+			this.valueCardinalities.compute(
+				normalizedValue,
+				(it, existingCardinality) ->
+					ofNullable(existingCardinality)
+						.map(crd -> crd + 1)
+						.orElse(2)
+			);
+			// update help data structure
+			sortIndexChanges.valueCardinalityIncreased(normalizedValue, comparator);
+		} else {
+			// insert new value into the sorted value array
+			theSortedRecordsValues.add(normalizedValue);
+			// update help data structure
+			sortIndexChanges.valueAdded(normalizedValue, comparator);
+		}
+
+		this.dirty.setToTrue();
+	}
+
+	/**
+	 * Shared internal implementation of the record removal.
+	 */
+	private <T extends Comparable<T>> void removeRecordInternal(
+		@Nonnull T normalizedValue,
+		int recordId,
+		@Nonnull TransactionalObjArray<T> theSortedRecordsValues,
+		@Nonnull TransactionalMap<Comparable<?>, Integer> theValueCardinalities,
+		@Nonnull SortIndexChanges sortIndexChanges
+	) {
+		// prepare internal datastructures
+		sortIndexChanges.prepare();
+
+		// remove record id from the array
+		this.sortedRecords.remove(recordId);
+		// had the value cardinality >= 2?
+		final Integer cardinality = theValueCardinalities.get(normalizedValue);
+		if (cardinality != null) {
+			// update help data structure first
+			sortIndexChanges.valueCardinalityDecreased(normalizedValue, comparator);
+			if (cardinality > 2) {
+				// decrease cardinality
+				theValueCardinalities.computeIfPresent(normalizedValue, (t, crd) -> crd - 1);
+			} else if (cardinality == 2) {
+				// remove cardinality altogether - cardinality = 1 is not maintained to save memory
+				theValueCardinalities.remove(normalizedValue);
+			} else {
+				throw new GenericEvitaInternalError("Unexpected cardinality: " + cardinality);
+			}
+		} else {
+			// remove the entire value - there is no more record ids for it
+			theSortedRecordsValues.remove(normalizedValue);
+			// update help data structure
+			sortIndexChanges.valueRemoved(normalizedValue, comparator);
+		}
+
+		this.dirty.setToTrue();
+	}
+
+	/**
+	 * Returns bitmap of all record ids connected with the value in the argument.
+	 */
+	@Nonnull
+	private <T extends Comparable<T>> BaseBitmap getRecordsEqualToInternal(T normalizedValue) {
+		// add record id from the array
+		final ValueStartIndex[] valueIndex = getOrCreateSortIndexChanges()
+			.getValueIndex(this.sortedRecordsValues, this.valueCardinalities);
+
+		@SuppressWarnings({"rawtypes", "unchecked"}) final int theValueIndex = ArrayUtils.binarySearch(
+			valueIndex, normalizedValue,
+			(valueStartIndex, theValue) -> ((Comparator) comparator).compare(valueStartIndex.getValue(), theValue)
+		);
+
+		// had the value cardinality >= 2?
+		final Integer cardinality = this.valueCardinalities.get(normalizedValue);
+		final int recordIdIndex = valueIndex[theValueIndex].getIndex();
+		if (cardinality != null) {
+			return new BaseBitmap(
+				this.sortedRecords.getSubArray(recordIdIndex, recordIdIndex + cardinality)
+			);
+		} else {
+			return new BaseBitmap(
+				this.sortedRecords.get(recordIdIndex)
+			);
 		}
 	}
 
@@ -683,7 +695,7 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 		public ComparableArray(@Nonnull ComparatorSource[] comparatorBase, @Nonnull Object[] value) {
 			this(
 				Arrays.stream(value)
-					.map(v -> (Comparable<?>)v)
+					.map(v -> (Comparable<?>) v)
 					.toArray(Comparable[]::new)
 			);
 			for (int i = 0; i < comparatorBase.length; i++) {
@@ -715,8 +727,7 @@ public class SortIndex implements SortedRecordsSupplierFactory, TransactionalLay
 		@Override
 		public int compareTo(@Nonnull ComparableArray o) {
 			for (int i = 0; i < array.length; i++) {
-				@SuppressWarnings({"unchecked", "rawtypes"})
-				final int result = ((Comparable)array[i]).compareTo(o.array[i]);
+				@SuppressWarnings({"unchecked", "rawtypes"}) final int result = ((Comparable) array[i]).compareTo(o.array[i]);
 				if (result != 0) {
 					return result;
 				}

--- a/evita_engine/src/main/java/io/evitadb/index/invertedIndex/InvertedIndexSubSet.java
+++ b/evita_engine/src/main/java/io/evitadb/index/invertedIndex/InvertedIndexSubSet.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import io.evitadb.utils.ArrayUtils;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.io.Serializable;
 import java.util.function.BiFunction;
 
 /**
@@ -39,10 +40,10 @@ import java.util.function.BiFunction;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 @RequiredArgsConstructor
-public class InvertedIndexSubSet<T extends Comparable<T>> {
+public class InvertedIndexSubSet {
 	private final long indexTransactionId;
-	@Getter private final ValueToRecordBitmap<T>[] histogramBuckets;
-	private final BiFunction<Long, ValueToRecordBitmap<T>[], Formula> aggregationLambda;
+	@Getter private final ValueToRecordBitmap[] histogramBuckets;
+	private final BiFunction<Long, ValueToRecordBitmap[], Formula> aggregationLambda;
 	private Formula memoizedResult;
 
 	/**
@@ -77,14 +78,14 @@ public class InvertedIndexSubSet<T extends Comparable<T>> {
 	/**
 	 * Returns minimal {@link ValueToRecordBitmap#getValue()} of buckets in this histogram subset.
 	 */
-	public Comparable<?> getMinimalValue() {
+	public Serializable getMinimalValue() {
 		return isEmpty() ? null : histogramBuckets[0].getValue();
 	}
 
 	/**
 	 * Returns maximal {@link ValueToRecordBitmap#getValue()} of buckets in this histogram subset.
 	 */
-	public Comparable<?> getMaximalValue() {
+	public Serializable getMaximalValue() {
 		return isEmpty() ? null : histogramBuckets[histogramBuckets.length - 1].getValue();
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/index/invertedIndex/suppliers/HistogramBitmapSupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/invertedIndex/suppliers/HistogramBitmapSupplier.java
@@ -45,9 +45,9 @@ import java.util.stream.Stream;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
-public class HistogramBitmapSupplier<T extends Comparable<T>> implements BitmapSupplier {
+public class HistogramBitmapSupplier implements BitmapSupplier {
 	private static final long CLASS_ID = 516692463222738021L;
-	private final ValueToRecordBitmap<T>[] histogramBuckets;
+	private final ValueToRecordBitmap[] histogramBuckets;
 	/**
 	 * Contains memoized result once {@link #get()} is invoked for the first time. Additional calls of
 	 * {@link #get()} will return this memoized result without paying the computational costs
@@ -82,7 +82,7 @@ public class HistogramBitmapSupplier<T extends Comparable<T>> implements BitmapS
 	 */
 	private final Long transactionalIdHash;
 
-	public HistogramBitmapSupplier(ValueToRecordBitmap<T>[] histogramBuckets) {
+	public HistogramBitmapSupplier(@Nonnull ValueToRecordBitmap[] histogramBuckets) {
 		this.histogramBuckets = histogramBuckets;
 		this.hash = HASH_FUNCTION.hashLongs(
 			Stream.of(

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/index/AttributeIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/index/AttributeIndexMutator.java
@@ -112,8 +112,8 @@ public interface AttributeIndexMutator {
 					if (undoActionConsumer != null) {
 						undoActionConsumer.accept(() -> entityIndex.insertUniqueAttribute(attributeDefinition, allowedLocales, locale, theValue.value(), entityPrimaryKey));
 					}
-					if (String.class.equals(attributeDefinition.getType()) && !attributeDefinition.isFilterable()) {
-						// TOBEDONE JNO this should be replaced with RadixTree
+					if (!attributeDefinition.isFilterable()) {
+						// TOBEDONE JNO this should be replaced with RadixTree (for String values)
 						entityIndex.removeFilterAttribute(attributeDefinition, allowedLocales, locale, theValue.value(), entityPrimaryKey);
 						if (undoActionConsumer != null) {
 							undoActionConsumer.accept(() -> entityIndex.insertFilterAttribute(attributeDefinition, allowedLocales, locale, theValue.value(), entityPrimaryKey));
@@ -124,8 +124,8 @@ public interface AttributeIndexMutator {
 				if (undoActionConsumer != null) {
 					undoActionConsumer.accept(() -> entityIndex.removeUniqueAttribute(attributeDefinition, allowedLocales, locale, valueToInsert, entityPrimaryKey));
 				}
-				if (String.class.equals(attributeDefinition.getType()) && !attributeDefinition.isFilterable()) {
-					// TOBEDONE JNO this should be replaced with RadixTree
+				if (!attributeDefinition.isFilterable()) {
+					// TOBEDONE JNO this should be replaced with RadixTree (for String values)
 					entityIndex.insertFilterAttribute(attributeDefinition, allowedLocales, locale, valueToInsert, entityPrimaryKey);
 					if (undoActionConsumer != null) {
 						undoActionConsumer.accept(() -> entityIndex.removeFilterAttribute(attributeDefinition, allowedLocales, locale, valueToInsert, entityPrimaryKey));
@@ -253,8 +253,8 @@ public interface AttributeIndexMutator {
 						)
 					);
 				}
-				if (String.class.equals(attributeDefinition.getType()) && !attributeDefinition.isFilterable()) {
-					// TOBEDONE JNO this should be replaced with RadixTree
+				if (!attributeDefinition.isFilterable()) {
+					// TOBEDONE JNO this should be replaced with RadixTree (for String values)
 					entityIndex.removeFilterAttribute(
 						attributeDefinition, allowedLocales, locale, valueToRemoveSupplier.get(),
 						executor.getPrimaryKeyToIndex(IndexType.ATTRIBUTE_FILTER_INDEX)

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EntityByAttributeFilteringFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EntityByAttributeFilteringFunctionalTest.java
@@ -108,7 +108,7 @@ public class EntityByAttributeFilteringFunctionalTest {
 	private static final String ATTRIBUTE_CREATED = "created";
 	private static final String ATTRIBUTE_CURRENCY = "currency";
 	private static final String ATTRIBUTE_UUID = "uuid";
-	private static final String ATTRIBUTE_LOCALE = "localizedInto";
+	private static final String ATTRIBUTE_LOCALE = "localizedInfo";
 	private static final String ATTRIBUTE_MANUFACTURED = "manufactured";
 	private static final String ATTRIBUTE_COMBINED_PRIORITY = "combinedPriority";
 	private static final String ATTRIBUTE_VISIBLE = "visible";
@@ -281,17 +281,15 @@ public class EntityByAttributeFilteringFunctionalTest {
 			final List<EntityReference> storedBrands = dataGenerator.generateEntities(
 					dataGenerator.getSampleBrandSchema(
 						session,
-						schemaBuilder -> {
-							return schemaBuilder
-								.withReflectedReferenceToEntity(
-									REFERENCE_BRAND_PRODUCTS,
-									Entities.PRODUCT,
-									Entities.BRAND,
-									whichIs -> whichIs
-										.withCardinality(Cardinality.ZERO_OR_MORE)
-										.withAttributesInherited()
-								).updateAndFetchVia(session);
-						}
+						schemaBuilder -> schemaBuilder
+							.withReflectedReferenceToEntity(
+								REFERENCE_BRAND_PRODUCTS,
+								Entities.PRODUCT,
+								Entities.BRAND,
+								whichIs -> whichIs
+									.withCardinality(Cardinality.ZERO_OR_MORE)
+									.withAttributesInherited()
+							).updateAndFetchVia(session)
 					),
 					randomEntityPicker,
 					SEED
@@ -335,10 +333,10 @@ public class EntityByAttributeFilteringFunctionalTest {
 								.withAttribute(ATTRIBUTE_SIZE, IntegerNumberRange[].class, whichIs -> whichIs.filterable().nullable())
 								.withAttribute(ATTRIBUTE_CREATED, OffsetDateTime.class, whichIs -> whichIs.filterable().sortable())
 								.withAttribute(ATTRIBUTE_MANUFACTURED, LocalDate.class, whichIs -> whichIs.filterable().sortable())
-								.withAttribute(ATTRIBUTE_CURRENCY, Currency.class, whichIs -> whichIs.filterable())
-								.withAttribute(ATTRIBUTE_UUID, UUID.class, whichIs -> whichIs.unique())
+								.withAttribute(ATTRIBUTE_CURRENCY, Currency.class, whichIs -> whichIs.filterable().sortable())
+								.withAttribute(ATTRIBUTE_UUID, UUID.class, whichIs -> whichIs.unique().sortable())
 								.withAttribute(ATTRIBUTE_NATIONAL_CODE, String.class, whichIs -> whichIs.localized().uniqueWithinLocale())
-								.withAttribute(ATTRIBUTE_LOCALE, Locale.class, whichIs -> whichIs.filterable())
+								.withAttribute(ATTRIBUTE_LOCALE, Locale.class, whichIs -> whichIs.filterable().sortable())
 								.withSortableAttributeCompound(
 									ATTRIBUTE_COMBINED_PRIORITY,
 									attributeElement(ATTRIBUTE_PRIORITY, DESC, OrderBehaviour.NULLS_LAST),
@@ -548,13 +546,66 @@ public class EntityByAttributeFilteringFunctionalTest {
 			.filter(it -> it.getAttribute(ATTRIBUTE_CODE) != null && it.getAttribute(ATTRIBUTE_QUANTITY) != null)
 			.filter(it -> rnd.nextInt(100) > 85)
 			.findFirst()
-			.get();
+			.orElseThrow();
 
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
 				final EvitaResponse<EntityReference> result = session.query(
 					query(
+						filterBy(
+							and(
+								attributeEquals(ATTRIBUTE_CODE, selectedEntity.getAttribute(ATTRIBUTE_CODE)),
+								ofNullable(selectedEntity.getAttribute(ATTRIBUTE_ALIAS))
+									.map(it -> attributeIsNotNull(ATTRIBUTE_ALIAS))
+									.orElse(attributeIsNull(ATTRIBUTE_ALIAS)),
+								or(
+									// this cannot be ever true
+									ofNullable(selectedEntity.getAttribute(ATTRIBUTE_ALIAS))
+										.map(it -> attributeIsNull(ATTRIBUTE_ALIAS))
+										.orElse(attributeIsNotNull(ATTRIBUTE_ALIAS)),
+									// but this will
+									attributeGreaterThanEquals(
+										ATTRIBUTE_QUANTITY,
+										selectedEntity.getAttribute(ATTRIBUTE_QUANTITY)
+									)
+								)
+							)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				assertResultIs(
+					originalProductEntities,
+					sealedEntity -> Objects.equals(selectedEntity.getPrimaryKey(), sealedEntity.getPrimaryKey()),
+					result.getRecordData()
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities of explicit type by equals to global attribute (String) and filtering by additional attributes")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnEntitiesOfExplicitTypeByGlobalAttributeEqualToStringAndAdditionalConstraints(Evita evita, List<SealedEntity> originalProductEntities) {
+		final Random rnd = new Random(SEED);
+		final SealedEntity selectedEntity = originalProductEntities.stream()
+			.filter(it -> it.getAttribute(ATTRIBUTE_CODE) != null && it.getAttribute(ATTRIBUTE_QUANTITY) != null)
+			.filter(it -> rnd.nextInt(100) > 85)
+			.findFirst()
+			.orElseThrow();
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
 						filterBy(
 							and(
 								attributeEquals(ATTRIBUTE_CODE, selectedEntity.getAttribute(ATTRIBUTE_CODE)),
@@ -818,6 +869,544 @@ public class EntityByAttributeFilteringFunctionalTest {
 					originalProductEntities,
 					sealedEntity -> codeAttribute.equals(sealedEntity.getAttribute(ATTRIBUTE_CODE)),
 					result.getRecordData()
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities sorted and filtered by currency")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterAndSortByCurrencyAttribute(Evita evita, List<SealedEntity> originalProductEntities) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeInSet(ATTRIBUTE_CURRENCY, CURRENCY_EUR, CURRENCY_CZK)
+						),
+						orderBy(
+							attributeNatural(ATTRIBUTE_CURRENCY, ASC)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				assertSortedResultIs(
+					originalProductEntities,
+					result.getRecordData(),
+					sealedEntity -> CURRENCY_CZK.equals(sealedEntity.getAttribute(ATTRIBUTE_CURRENCY)) ||
+						CURRENCY_EUR.equals(sealedEntity.getAttribute(ATTRIBUTE_CURRENCY)),
+					(o1, o2) -> {
+						final Currency c1 = o1.getAttribute(ATTRIBUTE_CURRENCY);
+						final Currency c2 = o2.getAttribute(ATTRIBUTE_CURRENCY);
+						final int cmpResult = c1.getCurrencyCode().compareTo(c2.getCurrencyCode());
+						return cmpResult == 0 ? o1.getPrimaryKey().compareTo(o2.getPrimaryKey()) : cmpResult;
+					}
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities sorted and filtered by currency in prefetch")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterAndSortByCurrencyAttributeInPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
+		final int[] pks = originalProductEntities.stream()
+			.filter(it -> CURRENCY_EUR.equals(it.getAttribute(ATTRIBUTE_CURRENCY)) || CURRENCY_CZK.equals(it.getAttribute(ATTRIBUTE_CURRENCY)))
+			.mapToInt(EntityContract::getPrimaryKey)
+			.limit(10)
+			.toArray();
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							entityPrimaryKeyInSet(pks),
+							attributeInSet(ATTRIBUTE_CURRENCY, CURRENCY_EUR, CURRENCY_CZK)
+						),
+						orderBy(
+							attributeNatural(ATTRIBUTE_CURRENCY, ASC)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.PREFER_PREFETCHING)
+						)
+					),
+					EntityReference.class
+				);
+
+				Set<Integer> pksAsSet = Arrays.stream(pks).boxed().collect(Collectors.toSet());
+				assertSortedResultIs(
+					originalProductEntities,
+					result.getRecordData(),
+					sealedEntity -> pksAsSet.contains(sealedEntity.getPrimaryKey()) && (
+						CURRENCY_CZK.equals(sealedEntity.getAttribute(ATTRIBUTE_CURRENCY)) ||
+							CURRENCY_EUR.equals(sealedEntity.getAttribute(ATTRIBUTE_CURRENCY))
+					),
+					(o1, o2) -> {
+						final Currency c1 = o1.getAttribute(ATTRIBUTE_CURRENCY);
+						final Currency c2 = o2.getAttribute(ATTRIBUTE_CURRENCY);
+						final int cmpResult = c1.getCurrencyCode().compareTo(c2.getCurrencyCode());
+						return cmpResult == 0 ? o1.getPrimaryKey().compareTo(o2.getPrimaryKey()) : cmpResult;
+					}
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities filtered by currency (greater than)")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterByGreaterThanCurrencyAttribute(Evita evita, List<SealedEntity> originalProductEntities) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeGreaterThanEquals(ATTRIBUTE_CURRENCY, CURRENCY_EUR)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				assertResultIs(
+					originalProductEntities,
+					sealedEntity -> !CURRENCY_CZK.equals(sealedEntity.getAttribute(ATTRIBUTE_CURRENCY)),
+					result.getRecordData()
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities filtered by currency (greater by) in prefetch")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterByCurrencyGreaterThanAttributeInPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
+		final int[] pks = originalProductEntities.stream()
+			.filter(it -> CURRENCY_EUR.equals(it.getAttribute(ATTRIBUTE_CURRENCY)) || CURRENCY_CZK.equals(it.getAttribute(ATTRIBUTE_CURRENCY)))
+			.mapToInt(EntityContract::getPrimaryKey)
+			.limit(10)
+			.toArray();
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							entityPrimaryKeyInSet(pks),
+							attributeGreaterThanEquals(ATTRIBUTE_CURRENCY, CURRENCY_EUR)
+						),
+						orderBy(
+							attributeNatural(ATTRIBUTE_CURRENCY, ASC)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.PREFER_PREFETCHING)
+						)
+					),
+					EntityReference.class
+				);
+
+				Set<Integer> pksAsSet = Arrays.stream(pks).boxed().collect(Collectors.toSet());
+				assertResultIs(
+					originalProductEntities,
+					sealedEntity -> pksAsSet.contains(sealedEntity.getPrimaryKey()) && (
+						!CURRENCY_CZK.equals(sealedEntity.getAttribute(ATTRIBUTE_CURRENCY))
+					),
+					result.getRecordData()
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities filtered by currency (greater than) in prefetch")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterByGreaterThanCurrencyAttributeInPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
+		final int[] pks = originalProductEntities.stream()
+			.filter(it -> CURRENCY_EUR.equals(it.getAttribute(ATTRIBUTE_CURRENCY)) || CURRENCY_USD.equals(it.getAttribute(ATTRIBUTE_CURRENCY)))
+			.mapToInt(EntityContract::getPrimaryKey)
+			.limit(10)
+			.toArray();
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							entityPrimaryKeyInSet(pks),
+							attributeGreaterThanEquals(ATTRIBUTE_CURRENCY, CURRENCY_EUR)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.PREFER_PREFETCHING)
+						)
+					),
+					EntityReference.class
+				);
+
+				Set<Integer> pksAsSet = Arrays.stream(pks).boxed().collect(Collectors.toSet());
+				assertResultIs(
+					originalProductEntities,
+					sealedEntity -> pksAsSet.contains(sealedEntity.getPrimaryKey()) &&
+						!CURRENCY_CZK.equals(sealedEntity.getAttribute(ATTRIBUTE_CURRENCY)),
+					result.getRecordData()
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities sorted and filtered by locale")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterAndSortByLocaleAttribute(Evita evita, List<SealedEntity> originalProductEntities) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeInSet(ATTRIBUTE_LOCALE, Locale.ENGLISH, CZECH_LOCALE)
+						),
+						orderBy(
+							attributeNatural(ATTRIBUTE_LOCALE, ASC)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				assertSortedResultIs(
+					originalProductEntities,
+					result.getRecordData(),
+					sealedEntity -> CZECH_LOCALE.equals(sealedEntity.getAttribute(ATTRIBUTE_LOCALE)) ||
+						Locale.ENGLISH.equals(sealedEntity.getAttribute(ATTRIBUTE_LOCALE)),
+					(o1, o2) -> {
+						final Locale l1 = o1.getAttribute(ATTRIBUTE_LOCALE);
+						final Locale l2 = o2.getAttribute(ATTRIBUTE_LOCALE);
+						final int cmpResult = l1.toLanguageTag().compareTo(l2.toLanguageTag());
+						return cmpResult == 0 ? o1.getPrimaryKey().compareTo(o2.getPrimaryKey()) : cmpResult;
+					}
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities sorted and filtered by locale in prefetch")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterAndSortByLocaleAttributeInPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
+		final int[] pks = originalProductEntities.stream()
+			.filter(it -> CZECH_LOCALE.equals(it.getAttribute(ATTRIBUTE_LOCALE)) || Locale.ENGLISH.equals(it.getAttribute(ATTRIBUTE_LOCALE)))
+			.mapToInt(EntityContract::getPrimaryKey)
+			.limit(10)
+			.toArray();
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							entityPrimaryKeyInSet(pks),
+							attributeInSet(ATTRIBUTE_LOCALE, Locale.ENGLISH, CZECH_LOCALE)
+						),
+						orderBy(
+							attributeNatural(ATTRIBUTE_LOCALE, ASC)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.PREFER_PREFETCHING)
+						)
+					),
+					EntityReference.class
+				);
+
+				Set<Integer> pksAsSet = Arrays.stream(pks).boxed().collect(Collectors.toSet());
+				assertSortedResultIs(
+					originalProductEntities,
+					result.getRecordData(),
+					sealedEntity -> pksAsSet.contains(sealedEntity.getPrimaryKey()) && (
+						Locale.ENGLISH.equals(sealedEntity.getAttribute(ATTRIBUTE_LOCALE)) ||
+							CZECH_LOCALE.equals(sealedEntity.getAttribute(ATTRIBUTE_LOCALE))
+					),
+					(o1, o2) -> {
+						final Locale l1 = o1.getAttribute(ATTRIBUTE_LOCALE);
+						final Locale l2 = o2.getAttribute(ATTRIBUTE_LOCALE);
+						final int cmpResult = l1.toLanguageTag().compareTo(l2.toLanguageTag());
+						return cmpResult == 0 ? o1.getPrimaryKey().compareTo(o2.getPrimaryKey()) : cmpResult;
+					}
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities filtered (greater than) by locale")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterByLocaleGreaterThanAttribute(Evita evita, List<SealedEntity> originalProductEntities) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeGreaterThanEquals(ATTRIBUTE_LOCALE, Locale.ENGLISH)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				assertResultIs(
+					originalProductEntities,
+					sealedEntity -> Locale.ENGLISH.equals(sealedEntity.getAttribute(ATTRIBUTE_LOCALE))
+						|| Locale.FRENCH.equals(sealedEntity.getAttribute(ATTRIBUTE_LOCALE)),
+					result.getRecordData()
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities filtered (greater than) by locale in prefetch")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterByLocaleGreaterThanAttributeInPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
+		final int[] pks = originalProductEntities.stream()
+			.filter(it -> CZECH_LOCALE.equals(it.getAttribute(ATTRIBUTE_LOCALE)) || Locale.ENGLISH.equals(it.getAttribute(ATTRIBUTE_LOCALE)))
+			.mapToInt(EntityContract::getPrimaryKey)
+			.limit(10)
+			.toArray();
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							entityPrimaryKeyInSet(pks),
+							attributeGreaterThanEquals(ATTRIBUTE_LOCALE, Locale.ENGLISH)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.PREFER_PREFETCHING)
+						)
+					),
+					EntityReference.class
+				);
+
+				Set<Integer> pksAsSet = Arrays.stream(pks).boxed().collect(Collectors.toSet());
+				assertResultIs(
+					originalProductEntities,
+					sealedEntity -> pksAsSet.contains(sealedEntity.getPrimaryKey()) &&
+						(Locale.ENGLISH.equals(sealedEntity.getAttribute(ATTRIBUTE_LOCALE))
+							|| Locale.FRENCH.equals(sealedEntity.getAttribute(ATTRIBUTE_LOCALE))),
+					result.getRecordData()
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities sorted and filtered by UUID")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterAndSortByUuidAttribute(Evita evita, List<SealedEntity> originalProductEntities) {
+		final UUID uuidAttribute1 = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_UUID, 5);
+		final UUID uuidAttribute2 = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_UUID, 10);
+		final UUID uuidAttribute3 = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_UUID, 15);
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeInSet(ATTRIBUTE_UUID, uuidAttribute1, uuidAttribute2, uuidAttribute3)
+						),
+						orderBy(
+							attributeNatural(ATTRIBUTE_UUID, ASC)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				final Set<UUID> uuidsAsSet = Set.of(
+					uuidAttribute1,
+					uuidAttribute2,
+					uuidAttribute3
+				);
+				assertSortedResultIs(
+					originalProductEntities,
+					result.getRecordData(),
+					sealedEntity -> uuidsAsSet.contains(sealedEntity.getAttribute(ATTRIBUTE_UUID, UUID.class)),
+					Comparator.comparing(o -> o.getAttribute(ATTRIBUTE_UUID, UUID.class))
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities sorted and filtered by UUID in prefetch")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterAndSortByUUIDAttributeInPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
+		final UUID uuidAttribute1 = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_UUID, 5);
+		final UUID uuidAttribute2 = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_UUID, 10);
+		final UUID uuidAttribute3 = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_UUID, 15);
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeInSet(ATTRIBUTE_UUID, uuidAttribute1, uuidAttribute2, uuidAttribute3)
+						),
+						orderBy(
+							attributeNatural(ATTRIBUTE_UUID, ASC)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.PREFER_PREFETCHING)
+						)
+					),
+					EntityReference.class
+				);
+
+				final Set<UUID> uuidsAsSet = Set.of(
+					uuidAttribute1,
+					uuidAttribute2,
+					uuidAttribute3
+				);
+				assertSortedResultIs(
+					originalProductEntities,
+					result.getRecordData(),
+					sealedEntity -> uuidsAsSet.contains(sealedEntity.getAttribute(ATTRIBUTE_UUID, UUID.class)),
+					Comparator.comparing(o -> o.getAttribute(ATTRIBUTE_UUID, UUID.class))
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities filtered by UUID greater than in prefetch")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterByGreaterThanByUUIDAttribute(Evita evita, List<SealedEntity> originalProductEntities) {
+		final UUID uuidAttribute = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_UUID);
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeGreaterThanEquals(ATTRIBUTE_UUID, uuidAttribute)
+						),
+						orderBy(
+							attributeNatural(ATTRIBUTE_UUID, ASC)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+
+				assertSortedResultIs(
+					originalProductEntities,
+					result.getRecordData(),
+					sealedEntity -> sealedEntity.getAttribute(ATTRIBUTE_UUID, UUID.class).compareTo(uuidAttribute) >= 0,
+					Comparator.comparing(o -> o.getAttribute(ATTRIBUTE_UUID, UUID.class))
+				);
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should return entities filtered by UUID greater than in prefetch")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldFilterByGreaterThanByUUIDAttributeInPrefetch(Evita evita, List<SealedEntity> originalProductEntities) {
+		final UUID uuidAttribute1 = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_UUID, 5);
+		final UUID uuidAttribute2 = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_UUID, 10);
+		final UUID uuidAttribute3 = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_UUID, 15);
+		final UUID[] sortedUuids = Arrays.stream(new UUID[]{uuidAttribute1, uuidAttribute2, uuidAttribute3})
+			.sorted()
+			.toArray(UUID[]::new);
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							attributeInSet(ATTRIBUTE_UUID, uuidAttribute1, uuidAttribute2, uuidAttribute3),
+							attributeGreaterThanEquals(ATTRIBUTE_UUID, sortedUuids[1])
+						),
+						orderBy(
+							attributeNatural(ATTRIBUTE_UUID, ASC)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.PREFER_PREFETCHING)
+						)
+					),
+					EntityReference.class
+				);
+
+				final Set<UUID> uuidsAsSet = Set.of(
+					Arrays.copyOfRange(sortedUuids, 1, sortedUuids.length)
+				);
+				assertSortedResultIs(
+					originalProductEntities,
+					result.getRecordData(),
+					sealedEntity -> uuidsAsSet.contains(sealedEntity.getAttribute(ATTRIBUTE_UUID, UUID.class)),
+					Comparator.comparing(o -> o.getAttribute(ATTRIBUTE_UUID, UUID.class))
 				);
 				return null;
 			}
@@ -1595,9 +2184,9 @@ public class EntityByAttributeFilteringFunctionalTest {
 										attributeEquals(ATTRIBUTE_ALIAS, false),
 										attributeInSet(
 											ATTRIBUTE_PRIORITY,
-											(Long) withFalseAlias.get(0).getAttribute(ATTRIBUTE_PRIORITY),
-											(Long) withFalseAlias.get(1).getAttribute(ATTRIBUTE_PRIORITY),
-											(Long) withFalseAlias.get(2).getAttribute(ATTRIBUTE_PRIORITY),
+											withFalseAlias.get(0).getAttribute(ATTRIBUTE_PRIORITY),
+											withFalseAlias.get(1).getAttribute(ATTRIBUTE_PRIORITY),
+											withFalseAlias.get(2).getAttribute(ATTRIBUTE_PRIORITY),
 											(Long) withFalseAlias.get(3).getAttribute(ATTRIBUTE_PRIORITY)
 										)
 									)
@@ -1829,8 +2418,8 @@ public class EntityByAttributeFilteringFunctionalTest {
 			one = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_CREATED, rnd.nextInt(originalProductEntities.size()));
 			two = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_CREATED, rnd.nextInt(originalProductEntities.size()));
 		} while (Objects.equals(one, two));
-		final OffsetDateTime from = one.compareTo(two) < 0 ? one : two;
-		final OffsetDateTime to = one.compareTo(two) < 0 ? two : one;
+		final OffsetDateTime from = one.isBefore(two) ? one : two;
+		final OffsetDateTime to = one.isBefore(two) ? two : one;
 
 		evita.queryCatalog(
 			TEST_CATALOG,
@@ -1872,8 +2461,8 @@ public class EntityByAttributeFilteringFunctionalTest {
 			one = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_CREATED, rnd.nextInt(originalProductEntities.size()));
 			two = getRandomAttributeValue(originalProductEntities, ATTRIBUTE_CREATED, rnd.nextInt(originalProductEntities.size()));
 		} while (Objects.equals(one, two));
-		final OffsetDateTime from = one.compareTo(two) < 0 ? one : two;
-		final OffsetDateTime to = one.compareTo(two) < 0 ? two : one;
+		final OffsetDateTime from = one.isBefore(two) ? one : two;
+		final OffsetDateTime to = one.isBefore(two) ? two : one;
 
 		evita.queryCatalog(
 			TEST_CATALOG,

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EvitaIndexingTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EvitaIndexingTest.java
@@ -1881,69 +1881,6 @@ class EvitaIndexingTest implements EvitaTestSupport {
 	}
 
 	@Test
-	void shouldFailToMarkCurrencyAsSortable() {
-		assertThrows(
-			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
-				TEST_CATALOG,
-				session -> {
-					session.getCatalogSchema()
-						.openForWrite()
-						.withEntitySchema(
-							"whatever",
-							whichIs -> whichIs.withAttribute("whatever", Currency.class, AttributeSchemaEditor::sortable)
-						)
-						.updateVia(session);
-				}
-			)
-		);
-	}
-
-	@Test
-	void shouldMarkLocaleAsFilterable() {
-		evita.updateCatalog(
-			TEST_CATALOG,
-			session -> {
-				session.getCatalogSchema()
-					.openForWrite()
-					.withEntitySchema(
-						"whatever",
-						whichIs -> whichIs.withAttribute("whatever", Locale.class, AttributeSchemaEditor::filterable)
-					)
-					.updateVia(session);
-			}
-		);
-
-		evita.queryCatalog(
-			TEST_CATALOG,
-			session -> {
-				assertTrue(
-					session.getEntitySchemaOrThrow("whatever").getAttribute("whatever").orElseThrow().isFilterable()
-				);
-			}
-		);
-	}
-
-	@Test
-	void shouldFailToMarkLocaleAsSortable() {
-		assertThrows(
-			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
-				TEST_CATALOG,
-				session -> {
-					session.getCatalogSchema()
-						.openForWrite()
-						.withEntitySchema(
-							"whatever",
-							whichIs -> whichIs.withAttribute("whatever", Locale.class, AttributeSchemaEditor::sortable)
-						)
-						.updateVia(session);
-				}
-			)
-		);
-	}
-
-	@Test
 	void shouldFailToSetNonNullableAssociatedDataToNull() {
 		try {
 			evita.updateCatalog(

--- a/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/producer/AttributeHistogramProducerTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/producer/AttributeHistogramProducerTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
 import org.junit.jupiter.api.Test;
 
+import java.util.Comparator;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
@@ -35,21 +37,21 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 class AttributeHistogramProducerTest {
 
 	@Test
 	void shouldReturnSimpleBuckets() {
 		final ValueToRecordBitmap[] input = {
-			new ValueToRecordBitmap<>(1, 1),
-			new ValueToRecordBitmap<>(2, 2),
-			new ValueToRecordBitmap<>(3, 3)
+			new ValueToRecordBitmap(1, 1),
+			new ValueToRecordBitmap(2, 2),
+			new ValueToRecordBitmap(3, 3)
 		};
 		final ValueToRecordBitmap[] output = AttributeHistogramProducer.getCombinedAndFilteredBucketArray(
 			new ConstantFormula(new BaseBitmap(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)),
 			new ValueToRecordBitmap[][]{
 				input
-			}
+			},
+			Comparator.naturalOrder()
 		);
 		assertArrayEquals(input, output);
 	}
@@ -60,17 +62,18 @@ class AttributeHistogramProducerTest {
 			new ConstantFormula(new BaseBitmap(2, 4, 6, 8, 10)),
 			new ValueToRecordBitmap[][]{
 				new ValueToRecordBitmap[]{
-					new ValueToRecordBitmap<>(1, 1, 2, 3),
-					new ValueToRecordBitmap<>(2, 4, 5, 6),
-					new ValueToRecordBitmap<>(3, 7, 8, 9)
+					new ValueToRecordBitmap(1, 1, 2, 3),
+					new ValueToRecordBitmap(2, 4, 5, 6),
+					new ValueToRecordBitmap(3, 7, 8, 9)
 				}
-			}
+			},
+			Comparator.naturalOrder()
 		);
 		assertArrayEquals(
 			new ValueToRecordBitmap[]{
-				new ValueToRecordBitmap<>(1, 2),
-				new ValueToRecordBitmap<>(2, 4, 6),
-				new ValueToRecordBitmap<>(3, 8)
+				new ValueToRecordBitmap(1, 2),
+				new ValueToRecordBitmap(2, 4, 6),
+				new ValueToRecordBitmap(3, 8)
 			},
 			output
 		);
@@ -82,28 +85,29 @@ class AttributeHistogramProducerTest {
 			new ConstantFormula(new BaseBitmap(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)),
 			new ValueToRecordBitmap[][]{
 				new ValueToRecordBitmap[]{
-					new ValueToRecordBitmap<>(1, 1, 3),
-					new ValueToRecordBitmap<>(3, 8, 9)
+					new ValueToRecordBitmap(1, 1, 3),
+					new ValueToRecordBitmap(3, 8, 9)
 				},
 				new ValueToRecordBitmap[]{
-					new ValueToRecordBitmap<>(1, 1),
-					new ValueToRecordBitmap<>(2, 6)
+					new ValueToRecordBitmap(1, 1),
+					new ValueToRecordBitmap(2, 6)
 				},
 				new ValueToRecordBitmap[]{
-					new ValueToRecordBitmap<>(1, 2),
-					new ValueToRecordBitmap<>(2, 6),
-					new ValueToRecordBitmap<>(3, 7)
+					new ValueToRecordBitmap(1, 2),
+					new ValueToRecordBitmap(2, 6),
+					new ValueToRecordBitmap(3, 7)
 				},
 				new ValueToRecordBitmap[]{
-					new ValueToRecordBitmap<>(2, 4, 5)
+					new ValueToRecordBitmap(2, 4, 5)
 				}
-			}
+			},
+			Comparator.naturalOrder()
 		);
 		assertArrayEquals(
 			new ValueToRecordBitmap[]{
-				new ValueToRecordBitmap<>(1, 1, 2, 3),
-				new ValueToRecordBitmap<>(2, 4, 5, 6),
-				new ValueToRecordBitmap<>(3, 7, 8, 9)
+				new ValueToRecordBitmap(1, 1, 2, 3),
+				new ValueToRecordBitmap(2, 4, 5, 6),
+				new ValueToRecordBitmap(3, 7, 8, 9)
 			},
 			output
 		);
@@ -115,28 +119,29 @@ class AttributeHistogramProducerTest {
 			new ConstantFormula(new BaseBitmap(2, 4, 6, 8, 10)),
 			new ValueToRecordBitmap[][]{
 				new ValueToRecordBitmap[]{
-					new ValueToRecordBitmap<>(1, 1, 3),
-					new ValueToRecordBitmap<>(2, 6)
+					new ValueToRecordBitmap(1, 1, 3),
+					new ValueToRecordBitmap(2, 6)
 				},
 				new ValueToRecordBitmap[]{
-					new ValueToRecordBitmap<>(1, 1),
-					new ValueToRecordBitmap<>(3, 8, 9)
+					new ValueToRecordBitmap(1, 1),
+					new ValueToRecordBitmap(3, 8, 9)
 				},
 				new ValueToRecordBitmap[]{
-					new ValueToRecordBitmap<>(1, 2),
-					new ValueToRecordBitmap<>(2, 6),
-					new ValueToRecordBitmap<>(3, 7)
+					new ValueToRecordBitmap(1, 2),
+					new ValueToRecordBitmap(2, 6),
+					new ValueToRecordBitmap(3, 7)
 				},
 				new ValueToRecordBitmap[]{
-					new ValueToRecordBitmap<>(2, 4, 5)
+					new ValueToRecordBitmap(2, 4, 5)
 				}
-			}
+			},
+			Comparator.naturalOrder()
 		);
 		assertArrayEquals(
 			new ValueToRecordBitmap[]{
-				new ValueToRecordBitmap<>(1, 2),
-				new ValueToRecordBitmap<>(2, 4, 6),
-				new ValueToRecordBitmap<>(3, 8)
+				new ValueToRecordBitmap(1, 2),
+				new ValueToRecordBitmap(2, 4, 6),
+				new ValueToRecordBitmap(3, 8)
 			},
 			output
 		);

--- a/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/producer/HistogramDataCruncherTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/producer/HistogramDataCruncherTest.java
@@ -183,13 +183,13 @@ class HistogramDataCruncherTest {
 
 	@Test
 	void computeHistogramFromDistinctValuesWithLessStepsAndSpecificWeight() {
-		final HistogramDataCruncher<ValueToRecordBitmap<Integer>> cruncher = createHistogramBucketCruncher(
+		final HistogramDataCruncher<ValueToRecordBitmap> cruncher = createHistogramBucketCruncher(
 			3,
-			new ValueToRecordBitmap<>(100, 1, 11, 12, 13, 14, 15, 16, 17, 18, 19),
-			new ValueToRecordBitmap<>(200, 2, 21),
-			new ValueToRecordBitmap<>(300, 3, 31, 32, 33, 34),
-			new ValueToRecordBitmap<>(400, 4, 41, 42),
-			new ValueToRecordBitmap<>(500, 5, 51, 52, 53, 54, 55)
+			new ValueToRecordBitmap(100, 1, 11, 12, 13, 14, 15, 16, 17, 18, 19),
+			new ValueToRecordBitmap(200, 2, 21),
+			new ValueToRecordBitmap(300, 3, 31, 32, 33, 34),
+			new ValueToRecordBitmap(400, 4, 41, 42),
+			new ValueToRecordBitmap(500, 5, 51, 52, 53, 54, 55)
 		);
 		assertArrayEquals(
 			new CacheableBucket[]{
@@ -372,12 +372,12 @@ class HistogramDataCruncherTest {
 	}
 
 	@Nonnull
-	private static HistogramDataCruncher<ValueToRecordBitmap<Integer>> createHistogramBucketCruncher(int stepCount, ValueToRecordBitmap<Integer>... data) {
+	private static HistogramDataCruncher<ValueToRecordBitmap> createHistogramBucketCruncher(int stepCount, ValueToRecordBitmap... data) {
 		return new HistogramDataCruncher<>(
 			"test histogram",
 			stepCount, 0,
 			data,
-			ValueToRecordBitmap::getValue,
+			it -> (int) it.getValue(),
 			CacheableBucket -> CacheableBucket.getRecordIds().size(),
 			BigDecimal::new,
 			BigDecimal::intValueExact

--- a/evita_functional_tests/src/test/java/io/evitadb/index/invertedIndex/HistogramSubSetTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/index/invertedIndex/HistogramSubSetTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -39,8 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 class HistogramSubSetTest {
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	private final InvertedIndexSubSet<Integer> tested = new InvertedIndexSubSet<>(
+	private final InvertedIndexSubSet tested = new InvertedIndexSubSet(
 		1L,
 		new ValueToRecordBitmap[]{
 			new ValueToRecordBitmap(1, 1, 2),

--- a/evita_functional_tests/src/test/java/io/evitadb/index/invertedIndex/InvertedIndexTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/index/invertedIndex/InvertedIndexTest.java
@@ -29,6 +29,7 @@ import com.esotericsoftware.kryo.io.Output;
 import io.evitadb.ConsistencySensitiveDataStructure.ConsistencyReport;
 import io.evitadb.ConsistencySensitiveDataStructure.ConsistencyState;
 import io.evitadb.comparator.LocalizedStringComparator;
+import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.bitmap.TransactionalBitmap;
 import io.evitadb.store.index.serializer.InvertedIndexSerializer;
 import io.evitadb.store.index.serializer.TransactionalIntegerBitmapSerializer;
@@ -43,6 +44,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import javax.annotation.Nonnull;
+import java.io.Serializable;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Function;
@@ -110,7 +112,7 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 		"horší",
 		"hostina"
 	};
-	private final InvertedIndex<Integer> tested = new InvertedIndex<>((Comparator<Integer>) Comparator.naturalOrder());
+	private final InvertedIndex tested = new InvertedIndex(FilterIndex.NO_NORMALIZATION, Comparator.naturalOrder());
 
 	@BeforeEach
 	void setUp() {
@@ -143,12 +145,12 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(1, 10),
-						new ValueToRecordBitmap<>(5, 1, 7, 20),
-						new ValueToRecordBitmap<>(10, 3),
-						new ValueToRecordBitmap<>(12, 18),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5, 11)
+						new ValueToRecordBitmap(1, 10),
+						new ValueToRecordBitmap(5, 1, 7, 20),
+						new ValueToRecordBitmap(10, 3),
+						new ValueToRecordBitmap(12, 18),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5, 11)
 					},
 					original.getValueToRecordBitmap()
 				);
@@ -157,10 +159,10 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 				assertNull(committed);
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(5, 1, 20),
-						new ValueToRecordBitmap<>(10, 3),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5)
+						new ValueToRecordBitmap(5, 1, 20),
+						new ValueToRecordBitmap(10, 3),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5)
 					},
 					original.getValueToRecordBitmap()
 				);
@@ -177,11 +179,11 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(5, 1, 20),
-						new ValueToRecordBitmap<>(10, 3),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5),
-						new ValueToRecordBitmap<>(55, 78)
+						new ValueToRecordBitmap(5, 1, 20),
+						new ValueToRecordBitmap(10, 3),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5),
+						new ValueToRecordBitmap(55, 78)
 					},
 					original.getValueToRecordBitmap()
 				);
@@ -189,20 +191,20 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 			(original, committed) -> {
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(5, 1, 20),
-						new ValueToRecordBitmap<>(10, 3),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5)
+						new ValueToRecordBitmap(5, 1, 20),
+						new ValueToRecordBitmap(10, 3),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5)
 					},
 					original.getValueToRecordBitmap()
 				);
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(5, 1, 20),
-						new ValueToRecordBitmap<>(10, 3),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5),
-						new ValueToRecordBitmap<>(55, 78)
+						new ValueToRecordBitmap(5, 1, 20),
+						new ValueToRecordBitmap(10, 3),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5),
+						new ValueToRecordBitmap(55, 78)
 					},
 					committed.getValueToRecordBitmap()
 				);
@@ -219,9 +221,9 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(5, 1, 20),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5)
+						new ValueToRecordBitmap(5, 1, 20),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5)
 					},
 					original.getValueToRecordBitmap()
 				);
@@ -229,18 +231,18 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 			(original, committed) -> {
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(5, 1, 20),
-						new ValueToRecordBitmap<>(10, 3),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5)
+						new ValueToRecordBitmap(5, 1, 20),
+						new ValueToRecordBitmap(10, 3),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5)
 					},
 					original.getValueToRecordBitmap()
 				);
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(5, 1, 20),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5)
+						new ValueToRecordBitmap(5, 1, 20),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5)
 					},
 					committed.getValueToRecordBitmap()
 				);
@@ -260,12 +262,12 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(1, 10),
-						new ValueToRecordBitmap<>(5, 1, 7, 20),
-						new ValueToRecordBitmap<>(10, 3),
-						new ValueToRecordBitmap<>(12, 18),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5, 11)
+						new ValueToRecordBitmap(1, 10),
+						new ValueToRecordBitmap(5, 1, 7, 20),
+						new ValueToRecordBitmap(10, 3),
+						new ValueToRecordBitmap(12, 18),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5, 11)
 					},
 					original.getValueToRecordBitmap()
 				);
@@ -273,21 +275,21 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 			(original, committed) -> {
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(5, 1, 20),
-						new ValueToRecordBitmap<>(10, 3),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5)
+						new ValueToRecordBitmap(5, 1, 20),
+						new ValueToRecordBitmap(10, 3),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5)
 					},
 					original.getValueToRecordBitmap()
 				);
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(1, 10),
-						new ValueToRecordBitmap<>(5, 1, 7, 20),
-						new ValueToRecordBitmap<>(10, 3),
-						new ValueToRecordBitmap<>(12, 18),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5, 11)
+						new ValueToRecordBitmap(1, 10),
+						new ValueToRecordBitmap(5, 1, 7, 20),
+						new ValueToRecordBitmap(10, 3),
+						new ValueToRecordBitmap(12, 18),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5, 11)
 					},
 					committed.getValueToRecordBitmap()
 				);
@@ -298,7 +300,7 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 	@Test
 	void shouldAddAndRemoveItemsInTransaction() {
 		assertStateAfterCommit(
-			new InvertedIndex<Integer>(Comparator.naturalOrder()),
+			new InvertedIndex(FilterIndex.NO_NORMALIZATION, Comparator.naturalOrder()),
 			original -> {
 				original.addRecord(5, 7);
 				original.addRecord(12, 18);
@@ -334,8 +336,8 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(5, 20),
-						new ValueToRecordBitmap<>(15, 2, 4)
+						new ValueToRecordBitmap(5, 20),
+						new ValueToRecordBitmap(15, 2, 4)
 					},
 					original.getValueToRecordBitmap()
 				);
@@ -343,17 +345,17 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 			(original, committed) -> {
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(5, 1, 20),
-						new ValueToRecordBitmap<>(10, 3),
-						new ValueToRecordBitmap<>(15, 2, 4),
-						new ValueToRecordBitmap<>(20, 5)
+						new ValueToRecordBitmap(5, 1, 20),
+						new ValueToRecordBitmap(10, 3),
+						new ValueToRecordBitmap(15, 2, 4),
+						new ValueToRecordBitmap(20, 5)
 					},
 					original.getValueToRecordBitmap()
 				);
 				assertArrayEquals(
 					new ValueToRecordBitmap[]{
-						new ValueToRecordBitmap<>(5, 20),
-						new ValueToRecordBitmap<>(15, 2, 4)
+						new ValueToRecordBitmap(5, 20),
+						new ValueToRecordBitmap(15, 2, 4)
 					},
 					committed.getValueToRecordBitmap()
 				);
@@ -401,7 +403,7 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 
 		byte[] bytes = output.getBuffer();
 
-		final InvertedIndex<?> deserializedTested = kryo.readObject(new Input(bytes), InvertedIndex.class);
+		final InvertedIndex deserializedTested = kryo.readObject(new Input(bytes), InvertedIndex.class);
 		assertEquals(tested, deserializedTested);
 	}
 
@@ -502,7 +504,7 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 
 	@Test
 	void shouldGenerationalTestPass() {
-		final InvertedIndex<Long> histogram = new InvertedIndex<>((Comparator<Long>) Comparator.naturalOrder());
+		final InvertedIndex histogram = new InvertedIndex(FilterIndex.NO_NORMALIZATION, Comparator.naturalOrder());
 		histogram.addRecord(64L, 36, 47);
 		histogram.addRecord(0L, 10);
 		histogram.addRecord(65L, 90);
@@ -661,14 +663,14 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 	void generationalProofTestLocalized(GenerationalTestInput input) {
 		doExecute(
 			100,
-			new GenerationalTestInput(1, 1),
+			input,
 			String.class,
 			new LocalizedStringComparator(new Locale("cs")),
 			random -> NATIONAL_SPECIFIC_WORDS[random.nextInt(NATIONAL_SPECIFIC_WORDS.length)]
 		);
 	}
 
-	private <T extends Comparable<T>> void doExecute(
+	private <T extends Serializable> void doExecute(
 		int initialCount,
 		@Nonnull GenerationalTestInput input,
 		@Nonnull Class<T> type,
@@ -697,7 +699,7 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 					)
 					.append("\nOps:\n");
 
-				final InvertedIndex<T> histogram = new InvertedIndex<>(comparator);
+				final InvertedIndex histogram = new InvertedIndex(FilterIndex.NO_NORMALIZATION, comparator);
 				for (Entry<T, List<Integer>> entry : mapToCompare.entrySet()) {
 					histogram.addRecord(
 						entry.getKey(),
@@ -808,11 +810,11 @@ class InvertedIndexTest implements TimeBoundedTestSupport {
 		);
 	}
 
-	private static <T extends Comparable<T>> int indexOf(@Nonnull Set<T> values, @Nonnull T valueToFind) {
+	private static <T extends Serializable> int indexOf(@Nonnull Set<T> values, @Nonnull T valueToFind) {
 		int result = -1;
 		for (T value : values) {
 			result++;
-			if (valueToFind.compareTo(value) == 0) {
+			if (((Comparable)valueToFind).compareTo(value) == 0) {
 				return result;
 			}
 		}

--- a/evita_performance_tests/src/main/java/io/evitadb/spike/FormulaCostMeasurement.java
+++ b/evita_performance_tests/src/main/java/io/evitadb/spike/FormulaCostMeasurement.java
@@ -237,7 +237,7 @@ public class FormulaCostMeasurement {
 
 	@Benchmark
 	public void histogramBitmapSupplier(BucketsRecordState bucketDataSet, Blackhole blackhole) {
-		final HistogramBitmapSupplier<Integer> testedFormula = new HistogramBitmapSupplier<>(
+		final HistogramBitmapSupplier testedFormula = new HistogramBitmapSupplier(
 			bucketDataSet.getBuckets()
 		);
 		blackhole.consume(testedFormula.get());

--- a/evita_performance_tests/src/main/java/io/evitadb/spike/mock/BucketsRecordState.java
+++ b/evita_performance_tests/src/main/java/io/evitadb/spike/mock/BucketsRecordState.java
@@ -42,6 +42,7 @@ import org.openjdk.jmh.annotations.State;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Random;
 
 /**
@@ -55,7 +56,7 @@ public class BucketsRecordState {
 	private static final int BUCKET_COUNT = 2000;
 	private static final int VALUE_COUNT = 100_000;
 	private static final Random random = new Random(42);
-	@Getter private ValueToRecordBitmap<Integer>[] buckets;
+	@Getter private ValueToRecordBitmap[] buckets;
 	@Getter private Bitmap entityIds;
 	@Getter private AttributeHistogramRequest request;
 	@Getter private Formula formula;
@@ -68,6 +69,7 @@ public class BucketsRecordState {
 		entityIds = generateBitmap(VALUE_COUNT, 1);
 		request = new AttributeHistogramRequest(
 			AttributeSchema._internalBuild("whatever", Integer.class, false),
+			Comparator.naturalOrder(),
 			Arrays.asList(
 				new FilterIndex(new AttributeKey("whatever"), generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5), new RangeIndex(), Integer.class),
 				new FilterIndex(new AttributeKey("whatever"), generateBuckets(BUCKET_COUNT, VALUE_COUNT / 5), new RangeIndex(), Integer.class),
@@ -81,20 +83,20 @@ public class BucketsRecordState {
 		this.formula = new ConstantFormula(entityIds);
 	}
 
-	private ValueToRecordBitmap<Integer>[] generateBuckets(int bucketCount, int valueCount) {
-		@SuppressWarnings("unchecked") final ValueToRecordBitmap<Integer>[] result = new ValueToRecordBitmap[bucketCount];
+	private static ValueToRecordBitmap[] generateBuckets(int bucketCount, int valueCount) {
+		final ValueToRecordBitmap[] result = new ValueToRecordBitmap[bucketCount];
 		int theValue = random.nextInt(100);
 		int recId = 1;
 		for (int i = 0; i < bucketCount; i++) {
 			theValue += random.nextInt(100) + 1;
 			final Bitmap recordIds = generateBitmap(valueCount / bucketCount, recId);
 			recId = recordIds.getLast();
-			result[i] = new ValueToRecordBitmap<>(theValue, recordIds);
+			result[i] = new ValueToRecordBitmap(theValue, recordIds);
 		}
 		return result;
 	}
 
-	private Bitmap generateBitmap(int valueCount, int startValue) {
+	private static Bitmap generateBitmap(int valueCount, int startValue) {
 		final CompositeIntArray intArray = new CompositeIntArray();
 		final ArrayBitmap bitmap = new ArrayBitmap(intArray);
 		int recId = startValue;

--- a/evita_query/src/main/java/io/evitadb/api/query/QueryConstraints.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/QueryConstraints.java
@@ -433,7 +433,7 @@ public interface QueryConstraints {
 	 * <p><a href="https://evitadb.io/documentation/query/filtering/comparable#attribute-between">Visit detailed user documentation</a></p>
 	*/
 	@Nullable
-	static <T extends Serializable & Comparable<?>> AttributeBetween attributeBetween(@Nullable String attributeName, @Nullable T from, @Nullable T to) {
+	static <T extends Serializable> AttributeBetween attributeBetween(@Nullable String attributeName, @Nullable T from, @Nullable T to) {
 		if (attributeName == null || (from == null && to == null)) {
 			return null;
 		} else {
@@ -581,7 +581,7 @@ public interface QueryConstraints {
 	 * <p><a href="https://evitadb.io/documentation/query/filtering/comparable#attribute-less-than">Visit detailed user documentation</a></p>
 	*/
 	@Nullable
-	static <T extends Serializable & Comparable<?>> AttributeLessThan attributeLessThan(@Nullable String attributeName, @Nullable T attributeValue) {
+	static <T extends Serializable> AttributeLessThan attributeLessThan(@Nullable String attributeName, @Nullable T attributeValue) {
 		return attributeName == null || attributeValue == null ? null : new AttributeLessThan(attributeName, attributeValue);
 	}
 
@@ -606,7 +606,7 @@ public interface QueryConstraints {
 	 * <p><a href="https://evitadb.io/documentation/query/filtering/comparable#attribute-less-than-equals">Visit detailed user documentation</a></p>
 	*/
 	@Nullable
-	static <T extends Serializable & Comparable<?>> AttributeLessThanEquals attributeLessThanEquals(@Nullable String attributeName, @Nullable T attributeValue) {
+	static <T extends Serializable> AttributeLessThanEquals attributeLessThanEquals(@Nullable String attributeName, @Nullable T attributeValue) {
 		return attributeName == null || attributeValue == null ? null : new AttributeLessThanEquals(attributeName, attributeValue);
 	}
 
@@ -630,7 +630,7 @@ public interface QueryConstraints {
 	 * <p><a href="https://evitadb.io/documentation/query/filtering/comparable#attribute-greater-than">Visit detailed user documentation</a></p>
 	*/
 	@Nullable
-	static <T extends Serializable & Comparable<?>> AttributeGreaterThan attributeGreaterThan(@Nullable String attributeName, @Nullable T attributeValue) {
+	static <T extends Serializable> AttributeGreaterThan attributeGreaterThan(@Nullable String attributeName, @Nullable T attributeValue) {
 		return attributeName == null || attributeValue == null ? null : new AttributeGreaterThan(attributeName, attributeValue);
 	}
 
@@ -655,7 +655,7 @@ public interface QueryConstraints {
 	 * <p><a href="https://evitadb.io/documentation/query/filtering/comparable#attribute-greater-than-equals">Visit detailed user documentation</a></p>
 	*/
 	@Nullable
-	static <T extends Serializable & Comparable<?>> AttributeGreaterThanEquals attributeGreaterThanEquals(@Nullable String attributeName, @Nullable T attributeValue) {
+	static <T extends Serializable> AttributeGreaterThanEquals attributeGreaterThanEquals(@Nullable String attributeName, @Nullable T attributeValue) {
 		return attributeName == null || attributeValue == null ? null : new AttributeGreaterThanEquals(attributeName, attributeValue);
 	}
 

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AbstractAttributeFilterComparisonConstraintLeaf.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AbstractAttributeFilterComparisonConstraintLeaf.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,33 +23,31 @@
 
 package io.evitadb.api.query.filter;
 
-import io.evitadb.api.query.AttributeConstraint;
-import io.evitadb.api.query.FilterConstraint;
 
 import javax.annotation.Nonnull;
 import java.io.Serial;
 import java.io.Serializable;
 
 /**
- * Represents base query leaf accepting only filtering constraints and having first argument attribute name.
+ * Abstract base class for attribute filter constraints that require comparison.
+ * This class extends AbstractAttributeFilterConstraintLeaf and represents
+ * constraints that compare attribute values against a specified value.
  *
- * @author Jan Novotný, FG Forrest a.s. (c) 2021
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
-public abstract class AbstractAttributeFilterConstraintLeaf extends AbstractFilterConstraintLeaf
-	implements AttributeConstraint<FilterConstraint>, FilterConstraint {
-	@Serial private static final long serialVersionUID = 3153809771456358624L;
+public abstract class AbstractAttributeFilterComparisonConstraintLeaf
+	extends AbstractAttributeFilterConstraintLeaf {
+	@Serial private static final long serialVersionUID = 2078148475923740022L;
 
-	protected AbstractAttributeFilterConstraintLeaf(Serializable... arguments) {
+	protected AbstractAttributeFilterComparisonConstraintLeaf(Serializable... arguments) {
 		super(arguments);
 	}
 
 	/**
-	 * Returns attribute name that needs to be examined.
+	 * Returns value which needs to be compared with the attribute value.
+	 * @return value to be compared with the attribute value
 	 */
-	@Override
 	@Nonnull
-	public String getAttributeName() {
-		return (String) getArguments()[0];
-	}
+	public abstract <T extends Serializable> T getAttributeValue();
 
 }

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AbstractAttributeFilterStringSearchConstraintLeaf.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AbstractAttributeFilterStringSearchConstraintLeaf.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,33 +23,32 @@
 
 package io.evitadb.api.query.filter;
 
-import io.evitadb.api.query.AttributeConstraint;
-import io.evitadb.api.query.FilterConstraint;
 
 import javax.annotation.Nonnull;
 import java.io.Serial;
 import java.io.Serializable;
 
 /**
- * Represents base query leaf accepting only filtering constraints and having first argument attribute name.
+ * The AbstractAttributeFilterStringSearchConstraintLeaf class is an abstract base class that represents a specific type
+ * of attribute filter constraint focusing on string search operations. It inherits from the
+ * AbstractAttributeFilterConstraintLeaf class and provides a method to retrieve the string that needs to be searched
+ * within attribute values.
  *
- * @author Jan Novotný, FG Forrest a.s. (c) 2021
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
-public abstract class AbstractAttributeFilterConstraintLeaf extends AbstractFilterConstraintLeaf
-	implements AttributeConstraint<FilterConstraint>, FilterConstraint {
-	@Serial private static final long serialVersionUID = 3153809771456358624L;
+public abstract class AbstractAttributeFilterStringSearchConstraintLeaf
+	extends AbstractAttributeFilterConstraintLeaf {
+	@Serial private static final long serialVersionUID = 219317868969717309L;
 
-	protected AbstractAttributeFilterConstraintLeaf(Serializable... arguments) {
+	protected AbstractAttributeFilterStringSearchConstraintLeaf(Serializable... arguments) {
 		super(arguments);
 	}
 
 	/**
-	 * Returns attribute name that needs to be examined.
+	 * Returns part of attribute value that needs to be looked up for.
+	 * @return part of attribute value that needs to be looked up for
 	 */
-	@Override
 	@Nonnull
-	public String getAttributeName() {
-		return (String) getArguments()[0];
-	}
+	public abstract String getTextToSearch();
 
 }

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeBetween.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeBetween.java
@@ -100,7 +100,7 @@ public class AttributeBetween extends AbstractAttributeFilterConstraintLeaf impl
 	}
 
 	@Creator
-	public <T extends Serializable & Comparable<?>> AttributeBetween(@Nonnull @Classifier String attributeName,
+	public <T extends Serializable> AttributeBetween(@Nonnull @Classifier String attributeName,
 	                                                                 @Nullable @Value(requiresPlainType = true) T from,
 	                                                                 @Nullable @Value(requiresPlainType = true) T to) {
 		super(attributeName, from, to);
@@ -110,7 +110,7 @@ public class AttributeBetween extends AbstractAttributeFilterConstraintLeaf impl
 	 * Returns lower bound of attribute value (inclusive).
 	 */
 	@Nullable
-	public <T extends Serializable & Comparable<?>> T getFrom() {
+	public <T extends Serializable> T getFrom() {
 		//noinspection unchecked
 		return (T) getArguments()[1];
 	}
@@ -119,7 +119,7 @@ public class AttributeBetween extends AbstractAttributeFilterConstraintLeaf impl
 	 * Returns upper bound of attribute value (inclusive).
 	 */
 	@Nullable
-	public <T extends Serializable & Comparable<?>> T getTo() {
+	public <T extends Serializable> T getTo() {
 		//noinspection unchecked
 		return (T) getArguments()[2];
 	}

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeContains.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeContains.java
@@ -67,7 +67,7 @@ import java.io.Serializable;
 	supportedIn = {ConstraintDomain.ENTITY, ConstraintDomain.REFERENCE, ConstraintDomain.INLINE_REFERENCE},
 	supportedValues = @ConstraintSupportedValues(supportedTypes = String.class, arraysSupported = true)
 )
-public class AttributeContains extends AbstractAttributeFilterConstraintLeaf {
+public class AttributeContains extends AbstractAttributeFilterStringSearchConstraintLeaf {
 	@Serial private static final long serialVersionUID = 5307621598413172503L;
 
 	private AttributeContains(Serializable... arguments) {
@@ -80,9 +80,8 @@ public class AttributeContains extends AbstractAttributeFilterConstraintLeaf {
 		super(attributeName, textToSearch);
 	}
 
-	/**
-	 * Returns part of attribute value that needs to be looked up for.
-	 */
+	@Override
+	@Nonnull
 	public String getTextToSearch() {
 		return (String) getArguments()[1];
 	}

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeEndsWith.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeEndsWith.java
@@ -68,7 +68,7 @@ import java.io.Serializable;
 	supportedIn = { ConstraintDomain.ENTITY, ConstraintDomain.REFERENCE, ConstraintDomain.INLINE_REFERENCE },
 	supportedValues = @ConstraintSupportedValues(supportedTypes = String.class, arraysSupported = true)
 )
-public class AttributeEndsWith extends AbstractAttributeFilterConstraintLeaf {
+public class AttributeEndsWith extends AbstractAttributeFilterStringSearchConstraintLeaf {
 	@Serial private static final long serialVersionUID = -8551542903236177197L;
 
 	private AttributeEndsWith(Serializable... arguments) {
@@ -81,9 +81,7 @@ public class AttributeEndsWith extends AbstractAttributeFilterConstraintLeaf {
 		super(attributeName, textToSearch);
 	}
 
-	/**
-	 * Returns part of attribute value that needs to be looked up for.
-	 */
+	@Override
 	@Nonnull
 	public String getTextToSearch() {
 		return (String) getArguments()[1];

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeEquals.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeEquals.java
@@ -69,7 +69,7 @@ import java.io.Serializable;
 	supportedIn = { ConstraintDomain.ENTITY, ConstraintDomain.REFERENCE, ConstraintDomain.INLINE_REFERENCE },
 	supportedValues = @ConstraintSupportedValues(allTypesSupported = true, arraysSupported = true)
 )
-public class AttributeEquals extends AbstractAttributeFilterConstraintLeaf implements FilterConstraint {
+public class AttributeEquals extends AbstractAttributeFilterComparisonConstraintLeaf implements FilterConstraint {
 	@Serial private static final long serialVersionUID = 3928023999412612529L;
 
 	private AttributeEquals(Serializable... arguments) {
@@ -85,6 +85,7 @@ public class AttributeEquals extends AbstractAttributeFilterConstraintLeaf imple
 	/**
 	 * Returns value that must be equals to attribute value.
 	 */
+	@Nonnull
 	public <T extends Serializable> T getAttributeValue() {
 		//noinspection unchecked
 		return (T) getArguments()[1];

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeGreaterThan.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeGreaterThan.java
@@ -60,10 +60,10 @@ import java.io.Serializable;
 	name = "greaterThan",
 	shortDescription = "Compares value of the attribute with passed value and checks if the value of that attribute is greater than the passed value.",
 	userDocsLink = "/documentation/query/filtering/comparable#attribute-greater-than",
-	supportedIn = { ConstraintDomain.ENTITY, ConstraintDomain.REFERENCE, ConstraintDomain.INLINE_REFERENCE },
+	supportedIn = {ConstraintDomain.ENTITY, ConstraintDomain.REFERENCE, ConstraintDomain.INLINE_REFERENCE},
 	supportedValues = @ConstraintSupportedValues(allTypesSupported = true, arraysSupported = true)
 )
-public class AttributeGreaterThan extends AbstractAttributeFilterConstraintLeaf implements FilterConstraint {
+public class AttributeGreaterThan extends AbstractAttributeFilterComparisonConstraintLeaf implements FilterConstraint {
 	@Serial private static final long serialVersionUID = -4468753216715311483L;
 
 	private AttributeGreaterThan(Serializable... arguments) {
@@ -71,8 +71,10 @@ public class AttributeGreaterThan extends AbstractAttributeFilterConstraintLeaf 
 	}
 
 	@Creator
-	public <T extends Serializable & Comparable<?>> AttributeGreaterThan(@Nonnull @Classifier String attributeName,
-	                                                                     @Nonnull @Value(requiresPlainType = true) T attributeValue) {
+	public <T extends Serializable> AttributeGreaterThan(
+		@Nonnull @Classifier String attributeName,
+		@Nonnull @Value(requiresPlainType = true) T attributeValue
+	) {
 		super(attributeName, attributeValue);
 	}
 
@@ -80,7 +82,7 @@ public class AttributeGreaterThan extends AbstractAttributeFilterConstraintLeaf 
 	 * Returns value that must be more than attribute value.
 	 */
 	@Nonnull
-	public <T extends Serializable & Comparable<?>> T getAttributeValue() {
+	public <T extends Serializable> T getAttributeValue() {
 		//noinspection unchecked
 		return (T) getArguments()[1];
 	}

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeGreaterThanEquals.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeGreaterThanEquals.java
@@ -64,7 +64,7 @@ import java.io.Serializable;
 	supportedIn = { ConstraintDomain.ENTITY, ConstraintDomain.REFERENCE, ConstraintDomain.INLINE_REFERENCE },
 	supportedValues = @ConstraintSupportedValues(allTypesSupported = true, arraysSupported = true)
 )
-public class AttributeGreaterThanEquals extends AbstractAttributeFilterConstraintLeaf implements FilterConstraint {
+public class AttributeGreaterThanEquals extends AbstractAttributeFilterComparisonConstraintLeaf implements FilterConstraint {
 	@Serial private static final long serialVersionUID = -7346624370759447859L;
 
 	private AttributeGreaterThanEquals(Serializable... arguments) {
@@ -72,7 +72,7 @@ public class AttributeGreaterThanEquals extends AbstractAttributeFilterConstrain
 	}
 
 	@Creator
-	public <T extends Serializable & Comparable<?>> AttributeGreaterThanEquals(@Nonnull @Classifier String attributeName,
+	public <T extends Serializable> AttributeGreaterThanEquals(@Nonnull @Classifier String attributeName,
 	                                                                           @Nonnull @Value(requiresPlainType = true) T attributeValue) {
 		super(attributeName, attributeValue);
 	}
@@ -81,7 +81,7 @@ public class AttributeGreaterThanEquals extends AbstractAttributeFilterConstrain
 	 * Returns value that must be more than or equals attribute value.
 	 */
 	@Nonnull
-	public <T extends Serializable & Comparable<?>> T getAttributeValue() {
+	public <T extends Serializable> T getAttributeValue() {
 		//noinspection unchecked
 		return (T) getArguments()[1];
 	}

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeInRange.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeInRange.java
@@ -104,7 +104,7 @@ public class AttributeInRange extends AbstractAttributeFilterConstraintLeaf impl
 	}
 
 	@Creator
-	private <T extends Serializable & Comparable<?>> AttributeInRange(
+	private <T extends Serializable> AttributeInRange(
 		@Nonnull @Classifier String attributeName,
 		@Nonnull @Value(requiresPlainType = true) T value
 	) {

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeLessThan.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeLessThan.java
@@ -63,7 +63,7 @@ import java.io.Serializable;
 	supportedIn = { ConstraintDomain.ENTITY, ConstraintDomain.REFERENCE, ConstraintDomain.INLINE_REFERENCE },
 	supportedValues = @ConstraintSupportedValues(allTypesSupported = true, arraysSupported = true)
 )
-public class AttributeLessThan extends AbstractAttributeFilterConstraintLeaf implements FilterConstraint {
+public class AttributeLessThan extends AbstractAttributeFilterComparisonConstraintLeaf implements FilterConstraint {
 	@Serial private static final long serialVersionUID = -1531450217250657781L;
 
 	private AttributeLessThan(Serializable... arguments) {
@@ -71,7 +71,7 @@ public class AttributeLessThan extends AbstractAttributeFilterConstraintLeaf imp
 	}
 
 	@Creator
-	public <T extends Serializable & Comparable<?>> AttributeLessThan(@Nonnull @Classifier String attributeName,
+	public <T extends Serializable> AttributeLessThan(@Nonnull @Classifier String attributeName,
 	                                                                  @Nonnull @Value(requiresPlainType = true) T attributeValue) {
 		super(attributeName, attributeValue);
 	}
@@ -80,7 +80,7 @@ public class AttributeLessThan extends AbstractAttributeFilterConstraintLeaf imp
 	 * Returns value that must be less than attribute value.
 	 */
 	@Nonnull
-	public <T extends Serializable & Comparable<?>> T getAttributeValue() {
+	public <T extends Serializable> T getAttributeValue() {
 		//noinspection unchecked
 		return (T) getArguments()[1];
 	}

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeLessThanEquals.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeLessThanEquals.java
@@ -64,7 +64,7 @@ import java.io.Serializable;
 	supportedIn = { ConstraintDomain.ENTITY, ConstraintDomain.REFERENCE, ConstraintDomain.INLINE_REFERENCE },
 	supportedValues = @ConstraintSupportedValues(allTypesSupported = true, arraysSupported = true)
 )
-public class AttributeLessThanEquals extends AbstractAttributeFilterConstraintLeaf implements FilterConstraint {
+public class AttributeLessThanEquals extends AbstractAttributeFilterComparisonConstraintLeaf implements FilterConstraint {
 	@Serial private static final long serialVersionUID = -6991102136613476099L;
 
 	private AttributeLessThanEquals(Serializable... arguments) {
@@ -72,7 +72,7 @@ public class AttributeLessThanEquals extends AbstractAttributeFilterConstraintLe
 	}
 
 	@Creator
-	public <T extends Serializable & Comparable<?>> AttributeLessThanEquals(@Nonnull @Classifier String attributeName,
+	public <T extends Serializable> AttributeLessThanEquals(@Nonnull @Classifier String attributeName,
 	                                                                        @Nonnull @Value(requiresPlainType = true) T attributeValue) {
 		super(attributeName, attributeValue);
 	}
@@ -81,7 +81,7 @@ public class AttributeLessThanEquals extends AbstractAttributeFilterConstraintLe
 	 * Returns value that must be less than or equals attribute value.
 	 */
 	@Nonnull
-	public <T extends Serializable & Comparable<?>> T getAttributeValue() {
+	public <T extends Serializable> T getAttributeValue() {
 		//noinspection unchecked
 		return (T) getArguments()[1];
 	}

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeStartsWith.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/AttributeStartsWith.java
@@ -71,7 +71,7 @@ import java.io.Serializable;
 		arraysSupported = true
 	)
 )
-public class AttributeStartsWith extends AbstractAttributeFilterConstraintLeaf implements FilterConstraint {
+public class AttributeStartsWith extends AbstractAttributeFilterStringSearchConstraintLeaf implements FilterConstraint {
 	@Serial private static final long serialVersionUID = 5516189083269213655L;
 
 	private AttributeStartsWith(Serializable... arguments) {
@@ -84,9 +84,7 @@ public class AttributeStartsWith extends AbstractAttributeFilterConstraintLeaf i
 		super(attributeName, textToSearch);
 	}
 
-	/**
-	 * Returns part of attribute value that needs to be looked up for.
-	 */
+	@Override
 	@Nonnull
 	public String getTextToSearch() {
 		return (String) getArguments()[1];

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/IndexStoragePartConfigurer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/IndexStoragePartConfigurer.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@
 package io.evitadb.store.index;
 
 import com.esotericsoftware.kryo.Kryo;
+import io.evitadb.dataType.ComparableCurrency;
+import io.evitadb.dataType.ComparableLocale;
 import io.evitadb.index.EntityIndexType;
 import io.evitadb.index.bitmap.TransactionalBitmap;
 import io.evitadb.index.cardinality.CardinalityIndex;
@@ -93,6 +95,8 @@ public class IndexStoragePartConfigurer implements Consumer<Kryo> {
 		kryo.register(HierarchyIndexStoragePart.class, new SerialVersionBasedSerializer<>(new HierarchyIndexStorgePartSerializer(), HierarchyIndexStoragePart.class), index++);
 
 		kryo.register(FacetIndexStoragePart.class, new SerialVersionBasedSerializer<>(new FacetIndexStoragePartSerializer(), FacetIndexStoragePart.class), index++);
+		kryo.register(ComparableLocale.class, new SerialVersionBasedSerializer<>(new ComparableLocaleSerializer(), ComparableLocale.class), index++);
+		kryo.register(ComparableCurrency.class, new SerialVersionBasedSerializer<>(new ComparableCurrencySerializer(), ComparableCurrency.class), index++);
 
 		Assert.isPremiseValid(index < 700, "Index count overflow.");
 	}

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/ComparableCurrencySerializer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/ComparableCurrencySerializer.java
@@ -27,30 +27,21 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import io.evitadb.index.bitmap.Bitmap;
-import io.evitadb.index.bitmap.TransactionalBitmap;
-import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
-
-import java.io.Serializable;
+import io.evitadb.dataType.ComparableCurrency;
 
 /**
- * Class handles Kryo (de)serialization of {@link ValueToRecordBitmap} instances.
+ * Class handles Kryo (de)serialization of {@link ComparableCurrency} instances.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
-@SuppressWarnings("rawtypes")
-public class ValueToRecordBitmapSerializer extends Serializer<ValueToRecordBitmap> {
+public class ComparableCurrencySerializer extends Serializer<ComparableCurrency> {
 
-	public void write(Kryo kryo, Output output, ValueToRecordBitmap valueToRecordBitmap) {
-		kryo.writeClassAndObject(output, valueToRecordBitmap.getValue());
-		final Bitmap bitmap = valueToRecordBitmap.getRecordIds();
-		kryo.writeObject(output, bitmap);
+	public void write(Kryo kryo, Output output, ComparableCurrency currency) {
+		kryo.writeObject(output, currency.getCurrency());
 	}
 
-	public ValueToRecordBitmap read(Kryo kryo, Input input, Class<? extends ValueToRecordBitmap> type) {
-		final Serializable comparable = (Serializable) kryo.readClassAndObject(input);
-		final TransactionalBitmap bitmap = kryo.readObject(input, TransactionalBitmap.class);
-		return new ValueToRecordBitmap(comparable, bitmap);
+	public ComparableCurrency read(Kryo kryo, Input input, Class<? extends ComparableCurrency> type) {
+		return kryo.readObject(input, ComparableCurrency.class);
 	}
 
 }

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/ComparableLocaleSerializer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/ComparableLocaleSerializer.java
@@ -27,30 +27,21 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import io.evitadb.index.bitmap.Bitmap;
-import io.evitadb.index.bitmap.TransactionalBitmap;
-import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
-
-import java.io.Serializable;
+import io.evitadb.dataType.ComparableLocale;
 
 /**
- * Class handles Kryo (de)serialization of {@link ValueToRecordBitmap} instances.
+ * Class handles Kryo (de)serialization of {@link ComparableLocale} instances.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
-@SuppressWarnings("rawtypes")
-public class ValueToRecordBitmapSerializer extends Serializer<ValueToRecordBitmap> {
+public class ComparableLocaleSerializer extends Serializer<ComparableLocale> {
 
-	public void write(Kryo kryo, Output output, ValueToRecordBitmap valueToRecordBitmap) {
-		kryo.writeClassAndObject(output, valueToRecordBitmap.getValue());
-		final Bitmap bitmap = valueToRecordBitmap.getRecordIds();
-		kryo.writeObject(output, bitmap);
+	public void write(Kryo kryo, Output output, ComparableLocale locale) {
+		kryo.writeObject(output, locale.getLocale());
 	}
 
-	public ValueToRecordBitmap read(Kryo kryo, Input input, Class<? extends ValueToRecordBitmap> type) {
-		final Serializable comparable = (Serializable) kryo.readClassAndObject(input);
-		final TransactionalBitmap bitmap = kryo.readObject(input, TransactionalBitmap.class);
-		return new ValueToRecordBitmap(comparable, bitmap);
+	public ComparableLocale read(Kryo kryo, Input input, Class<? extends ComparableLocale> type) {
+		return kryo.readObject(input, ComparableLocale.class);
 	}
 
 }

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/FilterIndexStoragePartSerializer_2024_5.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/FilterIndexStoragePartSerializer_2024_5.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -54,7 +54,15 @@ public class FilterIndexStoragePartSerializer_2024_5 extends Serializer<FilterIn
 		output.writeVarLong(uniquePartId, true);
 		output.writeVarInt(keyCompressor.getId(filterIndex.getAttributeKey()), true);
 
-		kryo.writeObject(output, new InvertedIndex<>(filterIndex.getHistogramPoints(), (o1, o2) -> ((Comparable)o1).compareTo(o2)));
+		//noinspection rawtypes,unchecked
+		kryo.writeObject(
+			output,
+			new InvertedIndex(
+				filterIndex.getHistogramPoints(),
+				FilterIndex.NO_NORMALIZATION,
+				(o1, o2) -> ((Comparable)o1).compareTo(o2)
+			)
+		);
 		final boolean rangeIndex = filterIndex.getRangeIndex() != null;
 		output.writeBoolean(rangeIndex);
 		if (rangeIndex) {
@@ -68,7 +76,7 @@ public class FilterIndexStoragePartSerializer_2024_5 extends Serializer<FilterIn
 		final long uniquePartId = input.readVarLong(true);
 		final AttributeKey attributeKey = keyCompressor.getKeyForId(input.readVarInt(true));
 
-		final InvertedIndex<?> invertedIndex = kryo.readObject(input, InvertedIndex.class);
+		final InvertedIndex invertedIndex = kryo.readObject(input, InvertedIndex.class);
 		final boolean hasRangeIndex = input.readBoolean();
 		if (hasRangeIndex) {
 			final RangeIndex intRangeIndex = kryo.readObject(input, RangeIndex.class);

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/InvertedIndexSerializer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/index/serializer/InvertedIndexSerializer.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.Serializer;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
+import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.invertedIndex.InvertedIndex;
 import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
 
@@ -38,7 +39,6 @@ import java.util.Comparator;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
 @Deprecated
-@SuppressWarnings("rawtypes")
 public class InvertedIndexSerializer extends Serializer<InvertedIndex> {
 
 	@Override
@@ -57,8 +57,7 @@ public class InvertedIndexSerializer extends Serializer<InvertedIndex> {
 		for (int i = 0; i < pointCount; i++) {
 			points[i] = kryo.readObject(input, ValueToRecordBitmap.class);
 		}
-		//noinspection unchecked
-		return new InvertedIndex(points, Comparator.naturalOrder());
+		return new InvertedIndex(points, FilterIndex.NO_NORMALIZATION, Comparator.naturalOrder());
 	}
 
 }

--- a/evita_test_support/src/main/java/io/evitadb/test/generator/DataGenerator.java
+++ b/evita_test_support/src/main/java/io/evitadb/test/generator/DataGenerator.java
@@ -599,7 +599,7 @@ public class DataGenerator {
 			} else {
 				throw new IllegalArgumentException("Unsupported auto-generated value type: " + type);
 			}
-			if (valueGenerator == null && attribute.isSortable()) {
+			if (valueGenerator == null && attribute.isSortable() && !(value instanceof Currency || value instanceof Locale)) {
 				value = sortableAttributesChecker.getUniqueAttribute(attributeName, value);
 			}
 		} while (value == null && sanityCheck++ < 1000);


### PR DESCRIPTION
…e attribute

There are scenarios where we want to insert currency or locale as an attribute value and be able to sort / filter by it. These values should be converted to "currencyCode" and "languageTag" respectively and these values should be used for filtering and sorting.