### PR TITLE
fix(#726): automatic rounding for attributes prices with incompatible number of decimal places

### DIFF
--- a/evita_common/src/main/java/io/evitadb/utils/NumberUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/NumberUtils.java
@@ -23,6 +23,8 @@
 
 package io.evitadb.utils;
 
+import io.evitadb.exception.EvitaInvalidUsageException;
+
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 
@@ -54,6 +56,7 @@ public class NumberUtils {
 	 * converted to the same type and applied. Method checks that there is no loss of precision during sum.
 	 */
 	@SuppressWarnings("RedundantCast")
+	@Nonnull
 	public static Number sum(@Nonnull Number a, @Nonnull Number b) {
 		if (a instanceof Byte) {
 			final long longResult = convertToLong(a) + convertToLong(b);
@@ -152,10 +155,26 @@ public class NumberUtils {
 		try {
 			return number.stripTrailingZeros().scaleByPowerOfTen(acceptDecimalPlaces).intValueExact();
 		} catch (ArithmeticException ex) {
-			throw new IllegalArgumentException(
+			throw new ArithmeticException(
 				"Cannot convert big decimal " + number +
 					" to exact integer by using " + acceptDecimalPlaces + " decimal places!"
 			);
+		}
+	}
+
+	/**
+	 * Converts passed {@link BigDecimal} number to integer value with rounding and overflow handling.
+	 *
+	 * @param number             number to convert
+	 * @param indexedPricePlaces number of decimal places to keep in the integer value
+	 * @return converted integer value
+	 * @throws EvitaInvalidUsageException if the number is too large to be converted to integer
+	 */
+	public static int convertExternalNumberToInt(@Nonnull BigDecimal number, int indexedPricePlaces) {
+		try {
+			return convertToInt(number, indexedPricePlaces);
+		} catch (ArithmeticException ex) {
+			throw new EvitaInvalidUsageException(ex.getMessage(), ex);
 		}
 	}
 
@@ -173,6 +192,7 @@ public class NumberUtils {
 	/**
 	 * Converts unknown number to {@link BigDecimal}.
 	 */
+	@Nonnull
 	public static BigDecimal convertToBigDecimal(@Nonnull Number number) {
 		if (number instanceof Byte) {
 			return new BigDecimal(number.toString());

--- a/evita_common/src/main/java/io/evitadb/utils/NumberUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/NumberUtils.java
@@ -27,6 +27,7 @@ import io.evitadb.exception.EvitaInvalidUsageException;
 
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 /**
  * String utils contains shared utility method for working with Numbers.
@@ -153,7 +154,10 @@ public class NumberUtils {
 	 */
 	public static int convertToInt(@Nonnull BigDecimal number, int acceptDecimalPlaces) {
 		try {
-			return number.stripTrailingZeros().scaleByPowerOfTen(acceptDecimalPlaces).intValueExact();
+			return number.stripTrailingZeros()
+				.scaleByPowerOfTen(acceptDecimalPlaces)
+				.setScale(0, RoundingMode.HALF_UP)
+				.intValueExact();
 		} catch (ArithmeticException ex) {
 			throw new ArithmeticException(
 				"Cannot convert big decimal " + number +

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/predicate/PricePredicate.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/predicate/PricePredicate.java
@@ -78,8 +78,8 @@ public sealed abstract class PricePredicate implements PricePredicateContract
 		int indexedPricePlaces
 	) {
 		this.queryPriceMode = queryPriceMode;
-		this.fromAsInt = from == null ? Integer.MIN_VALUE : NumberUtils.convertToInt(from, indexedPricePlaces);
-		this.toAsInt = to == null ? Integer.MAX_VALUE : NumberUtils.convertToInt(to, indexedPricePlaces);
+		this.fromAsInt = from == null ? Integer.MIN_VALUE : NumberUtils.convertExternalNumberToInt(from, indexedPricePlaces);
+		this.toAsInt = to == null ? Integer.MAX_VALUE : NumberUtils.convertExternalNumberToInt(to, indexedPricePlaces);
 		this.indexedPricePlaces = indexedPricePlaces;
 		if (queryPriceMode == null) {
 			this.description = "NO FILTER PREDICATE";
@@ -109,7 +109,7 @@ public sealed abstract class PricePredicate implements PricePredicateContract
 		this.amountPredicate = new PriceAmountPredicate(
 			queryPriceMode, from, to, indexedPricePlaces,
 			amount ->  {
-				final int amountAsInt = NumberUtils.convertToInt(amount, indexedPricePlaces);
+				final int amountAsInt = NumberUtils.convertExternalNumberToInt(amount, indexedPricePlaces);
 				return amountAsInt >= fromAsInt && amountAsInt <= toAsInt;
 			}
 		);

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/price/alternative/SellingPriceAvailableBitmapFilter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/price/alternative/SellingPriceAvailableBitmapFilter.java
@@ -127,8 +127,8 @@ public class SellingPriceAvailableBitmapFilter implements EntityToBitmapFilter, 
 								innerRecordPrice.priceId(),
 								entityPrimaryKey,
 								innerRecordPrice.innerRecordId(),
-								NumberUtils.convertToInt(innerRecordPrice.priceWithTax(), indexedPricePlaces),
-								NumberUtils.convertToInt(innerRecordPrice.priceWithoutTax(), indexedPricePlaces)
+								NumberUtils.convertExternalNumberToInt(innerRecordPrice.priceWithTax(), indexedPricePlaces),
+								NumberUtils.convertExternalNumberToInt(innerRecordPrice.priceWithoutTax(), indexedPricePlaces)
 							)
 						);
 					}
@@ -136,8 +136,8 @@ public class SellingPriceAvailableBitmapFilter implements EntityToBitmapFilter, 
 				return new CumulatedVirtualPriceRecord(
 					entityPrimaryKey,
 					priceQueryMode == QueryPriceMode.WITH_TAX ?
-						NumberUtils.convertToInt(cumulatedPrice.priceWithTax(), indexedPricePlaces) :
-						NumberUtils.convertToInt(cumulatedPrice.priceWithoutTax(), indexedPricePlaces),
+						NumberUtils.convertExternalNumberToInt(cumulatedPrice.priceWithTax(), indexedPricePlaces) :
+						NumberUtils.convertExternalNumberToInt(cumulatedPrice.priceWithoutTax(), indexedPricePlaces),
 					priceQueryMode,
 					intSetInnerRecordIds
 				);
@@ -147,8 +147,8 @@ public class SellingPriceAvailableBitmapFilter implements EntityToBitmapFilter, 
 						priceWithInternalIds.getInternalPriceId() : -1,
 						priceContract.priceId(),
 					entityPrimaryKey,
-					NumberUtils.convertToInt(priceContract.priceWithTax(), indexedPricePlaces),
-					NumberUtils.convertToInt(priceContract.priceWithoutTax(), indexedPricePlaces)
+					NumberUtils.convertExternalNumberToInt(priceContract.priceWithTax(), indexedPricePlaces),
+					NumberUtils.convertExternalNumberToInt(priceContract.priceWithoutTax(), indexedPricePlaces)
 				);
 			} else {
 				return new PriceRecordInnerRecordSpecific(
@@ -157,8 +157,8 @@ public class SellingPriceAvailableBitmapFilter implements EntityToBitmapFilter, 
 					priceContract.priceId(),
 					entityPrimaryKey,
 					priceContract.innerRecordId(),
-					NumberUtils.convertToInt(priceContract.priceWithTax(), indexedPricePlaces),
-					NumberUtils.convertToInt(priceContract.priceWithoutTax(), indexedPricePlaces)
+					NumberUtils.convertExternalNumberToInt(priceContract.priceWithTax(), indexedPricePlaces),
+					NumberUtils.convertExternalNumberToInt(priceContract.priceWithoutTax(), indexedPricePlaces)
 				);
 			}
 		};

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/index/PriceIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/index/PriceIndexMutator.java
@@ -33,6 +33,7 @@ import io.evitadb.store.entity.model.entity.PricesStoragePart;
 import io.evitadb.store.entity.model.entity.price.PriceInternalIdContainer;
 import io.evitadb.store.entity.model.entity.price.PriceWithInternalIds;
 import io.evitadb.utils.Assert;
+import io.evitadb.utils.NumberUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -40,8 +41,6 @@ import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-
-import static io.evitadb.utils.NumberUtils.convertToInt;
 
 /**
  * This interface is used to co-locate price mutating routines which are rather procedural and long to avoid excessive
@@ -108,8 +107,8 @@ public interface PriceIndexMutator {
 			final Integer formerInternalPriceId = Objects.requireNonNull(formerPrice.getInternalPriceId());
 			final Integer formerInnerRecordId = formerPrice.innerRecordId();
 			final DateTimeRange formerValidity = formerPrice.validity();
-			final int formerPriceWithoutTax = convertToInt(formerPrice.priceWithoutTax(), indexedPricePlaces);
-			final int formerPriceWithTax = convertToInt(formerPrice.priceWithTax(), indexedPricePlaces);
+			final int formerPriceWithoutTax = NumberUtils.convertExternalNumberToInt(formerPrice.priceWithoutTax(), indexedPricePlaces);
+			final int formerPriceWithTax = NumberUtils.convertExternalNumberToInt(formerPrice.priceWithTax(), indexedPricePlaces);
 			entityIndex.priceRemove(
 				entityPrimaryKey,
 				formerInternalPriceId,
@@ -135,8 +134,8 @@ public interface PriceIndexMutator {
 		if (indexed) {
 			final PriceInternalIdContainer internalPriceIds = internalIdSupplier.apply(priceKey, innerRecordId);
 			final Integer internalPriceId = internalPriceIds.getInternalPriceId();
-			final int priceWithoutTaxAsInt = convertToInt(priceWithoutTax, indexedPricePlaces);
-			final int priceWithTaxAsInt = convertToInt(priceWithTax, indexedPricePlaces);
+			final int priceWithoutTaxAsInt = NumberUtils.convertExternalNumberToInt(priceWithoutTax, indexedPricePlaces);
+			final int priceWithTaxAsInt = NumberUtils.convertExternalNumberToInt(priceWithTax, indexedPricePlaces);
 			final PriceInternalIdContainer priceId = entityIndex.addPrice(
 				entityPrimaryKey,
 				internalPriceId,
@@ -198,8 +197,8 @@ public interface PriceIndexMutator {
 				final int internalPriceId = formerPrice.getInternalPriceId();
 				final Integer innerRecordId = formerPrice.innerRecordId();
 				final DateTimeRange validity = formerPrice.validity();
-				final int priceWithoutTax = convertToInt(formerPrice.priceWithoutTax(), indexedPricePlaces);
-				final int priceWithTax = convertToInt(formerPrice.priceWithTax(), indexedPricePlaces);
+				final int priceWithoutTax = NumberUtils.convertExternalNumberToInt(formerPrice.priceWithoutTax(), indexedPricePlaces);
+				final int priceWithTax = NumberUtils.convertExternalNumberToInt(formerPrice.priceWithTax(), indexedPricePlaces);
 				entityIndex.priceRemove(
 					entityPrimaryKey,
 					internalPriceId,
@@ -244,4 +243,5 @@ public interface PriceIndexMutator {
 			return price;
 		};
 	}
+
 }

--- a/evita_functional_tests/src/test/java/io/evitadb/utils/NumberUtilsTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/utils/NumberUtilsTest.java
@@ -146,6 +146,9 @@ class NumberUtilsTest {
 		assertEquals(2, NumberUtils.convertToInt((short) 2));
 		assertEquals(2, NumberUtils.convertToInt(2));
 		assertEquals(2, NumberUtils.convertToInt((long) 2));
+		assertEquals(22314, NumberUtils.convertToInt(new BigDecimal("223.1405"), 2));
+		assertEquals(2231405, NumberUtils.convertToInt(new BigDecimal("223.1405"), 4));
+		assertEquals(223, NumberUtils.convertToInt(new BigDecimal("223.1405"), 0));
 	}
 
 	@Test

--- a/evita_functional_tests/src/test/java/io/evitadb/utils/NumberUtilsTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/utils/NumberUtilsTest.java
@@ -163,7 +163,7 @@ class NumberUtilsTest {
 		assertEquals(11020, NumberUtils.convertToInt(new BigDecimal("110.2"), 2));
 		assertEquals(11020, NumberUtils.convertToInt(new BigDecimal("110.20"), 2));
 		assertEquals(11020, NumberUtils.convertToInt(new BigDecimal("110.2000"), 2));
-		assertThrows(IllegalArgumentException.class, () -> NumberUtils.convertToInt(new BigDecimal("110.202"), 2));
+		assertThrows(ArithmeticException.class, () -> NumberUtils.convertToInt(new BigDecimal("21474836471"), 2));
 	}
 
 	@Test


### PR DESCRIPTION
Currently evitaDB fails with an exception when the client tries to index the price `243.2405` with 2 decimal places because there is a remainder `.0005`. This is rather impractical, so evitaDB should automatically round the remainder and include it in the converted integer. The original values on the entity remain in the original form - i.e. in BigDecimal without loss of precision. This rounding and conversion to int only happens when the entity is indexed for filtering/searching.