### PR TITLE
fix(#728): Referenced entity sorting doesn't work correctly if langua…

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/EntityDecorator.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/EntityDecorator.java
@@ -171,12 +171,12 @@ public class EntityDecorator implements SealedEntity {
 					final ReferenceDecorator[] filteredReferences = Arrays.stream(references, start, end)
 						.filter(it -> referenceFilter.test(entityPrimaryKey, it))
 						.toArray(ReferenceDecorator[]::new);
+					Arrays.sort(filteredReferences, referenceComparator);
 
 					for (int i = start; i < end; i++) {
 						final int filteredIndex = i - start;
 						references[i] = filteredReferences.length > filteredIndex ? filteredReferences[filteredIndex] : null;
 					}
-					Arrays.sort(references, start, end, referenceComparator);
 				}
 				nonSortedReferenceCount = referenceComparator.getNonSortedReferenceCount();
 				start = start + (end - nonSortedReferenceCount);

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/dto/SortableAttributeCompoundSchema.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/dto/SortableAttributeCompoundSchema.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2024
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ public class SortableAttributeCompoundSchema implements SortableAttributeCompoun
 	 * Part of PRIVATE API, because we need to ensure the `attributeSchemaProvider` always provide the same and correct
 	 * attribute schemas from the same entity schema version.
 	 */
-	public boolean isLocalized(@Nonnull Function<String, AttributeSchema> attributeSchemaProvider) {
+	public boolean isLocalized(@Nonnull Function<String, ? extends AttributeSchemaContract> attributeSchemaProvider) {
 		if (this.memoizedLocalized == null) {
 			this.memoizedLocalized = attributeElements
 				.stream()

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/AttributeNaturalTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/AttributeNaturalTranslator.java
@@ -30,6 +30,7 @@ import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.NamedSchemaContract;
 import io.evitadb.api.requestResponse.schema.SortableAttributeCompoundSchemaContract;
 import io.evitadb.api.requestResponse.schema.SortableAttributeCompoundSchemaContract.AttributeElement;
+import io.evitadb.api.requestResponse.schema.dto.SortableAttributeCompoundSchema;
 import io.evitadb.core.query.AttributeSchemaAccessor.AttributeTrait;
 import io.evitadb.core.query.sort.EntityComparator;
 import io.evitadb.core.query.sort.OrderByVisitor;
@@ -159,14 +160,18 @@ public class AttributeNaturalTranslator
 		) {
 			if (orderDirection == ASC) {
 				comparator = new ReferencePredecessorComparator(
-					attributeOrCompoundName, locale, orderByVisitor,
+					attributeOrCompoundName,
+					attributeSchema.isLocalized() ? locale : null,
+					orderByVisitor,
 					ChainIndex::getAscendingOrderRecordsSupplier,
 					(ref1, ref2) -> ref1.primaryKey() == ref2.primaryKey(),
 					(epk, referenceKey) -> epk
 				);
 			} else {
 				comparator = new ReferencePredecessorComparator(
-					attributeOrCompoundName, locale, orderByVisitor,
+					attributeOrCompoundName,
+					attributeSchema.isLocalized() ? locale : null,
+					orderByVisitor,
 					ChainIndex::getDescendingOrderRecordsSupplier,
 					(ref1, ref2) -> ref1.primaryKey() == ref2.primaryKey(),
 					(epk, referenceKey) -> epk
@@ -177,28 +182,36 @@ public class AttributeNaturalTranslator
 		) {
 			if (orderDirection == ASC) {
 				comparator = new ReferencePredecessorComparator(
-					attributeOrCompoundName, locale, orderByVisitor,
+					attributeOrCompoundName,
+					attributeSchema.isLocalized() ? locale : null,
+					orderByVisitor,
 					ChainIndex::getAscendingOrderRecordsSupplier,
 					(ref1, ref2) -> true,
 					(epk, referenceKey) -> referenceKey.primaryKey()
 				);
 			} else {
 				comparator = new ReferencePredecessorComparator(
-					attributeOrCompoundName, locale, orderByVisitor,
+					attributeOrCompoundName,
+					attributeSchema.isLocalized() ? locale : null,
+					orderByVisitor,
 					ChainIndex::getDescendingOrderRecordsSupplier,
 					(ref1, ref2) -> true,
 					(epk, referenceKey) -> referenceKey.primaryKey()
 				);
 			}
-		} else if (attributeOrCompoundSchema instanceof SortableAttributeCompoundSchemaContract compoundSchemaContract) {
+		} else if (attributeOrCompoundSchema instanceof SortableAttributeCompoundSchema compoundSchemaContract) {
 			comparator = new ReferenceCompoundAttributeComparator(
-				compoundSchemaContract, locale,
+				compoundSchemaContract,
+				compoundSchemaContract.isLocalized(orderByVisitor::getAttributeSchema) ? locale : null,
 				orderByVisitor::getAttributeSchema,
 				orderDirection
 			);
 		} else if (attributeOrCompoundSchema instanceof AttributeSchemaContract attributeSchema) {
 			comparator = new ReferenceAttributeComparator(
-				attributeOrCompoundName, attributeSchema.getPlainType(), locale, orderDirection
+				attributeOrCompoundName,
+				attributeSchema.getPlainType(),
+				attributeSchema.isLocalized() ? locale : null,
+				orderDirection
 			);
 		} else {
 			throw new GenericEvitaInternalError("Unsupported attribute schema type: " + attributeOrCompoundSchema);

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/ReferencePredecessorComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/ReferencePredecessorComparator.java
@@ -218,11 +218,11 @@ public class ReferencePredecessorComparator implements ReferenceComparator, Refe
 	 *         if not found in the cache.
 	 */
 	private int getRecordPosition(@Nonnull ReferenceKey referenceKey) {
-		final int pkToLookup = primaryKeyResolver.applyAsInt(this.entityPrimaryKey, referenceKey);
+		final int pkToLookup = this.primaryKeyResolver.applyAsInt(this.entityPrimaryKey, referenceKey);
 		final int position = this.pkToRecordPositionCache.getOrDefault(pkToLookup, -1);
 		if (position == -1) {
-			final ChainIndex chainIndex = this.referenceOrderByVisitor.getChainIndex(this.entityPrimaryKey, referenceKey, attributeKey).orElse(null);
-			final SortedRecordsProvider sortedRecordsSupplier = chainIndex == null ? SortedRecordsProvider.EMPTY : sortedRecordsSupplierProvider.apply(chainIndex);
+			final ChainIndex chainIndex = this.referenceOrderByVisitor.getChainIndex(this.entityPrimaryKey, referenceKey, this.attributeKey).orElse(null);
+			final SortedRecordsProvider sortedRecordsSupplier = chainIndex == null ? SortedRecordsProvider.EMPTY : this.sortedRecordsSupplierProvider.apply(chainIndex);
 			final int index = sortedRecordsSupplier.getAllRecords().indexOf(pkToLookup);
 			final int computedPosition = index < 0 ? -2 : sortedRecordsSupplier.getRecordPositions()[index];
 			this.pkToRecordPositionCache.put(pkToLookup, computedPosition);


### PR DESCRIPTION
…ge is part of the query

(cherry picked from commit 0f9cd8700f2998d935c9a67bac11d20922f3ae1c)