### PR TITLE
fix: cumulative patch

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanner.java
@@ -170,9 +170,10 @@ public class QueryPlanner {
 	 */
 	@Nonnull
 	public static QueryPlan planNestedQuery(
-		@Nonnull QueryPlanningContext context
+		@Nonnull QueryPlanningContext context,
+		@Nonnull Supplier<String> nestedQueryDescription
 	) {
-		context.pushStep(QueryPhase.PLANNING_NESTED_QUERY);
+		context.pushStep(QueryPhase.PLANNING_NESTED_QUERY, nestedQueryDescription);
 		try {
 			// determine the indexes that should be used for filtering
 			final IndexSelectionResult<?> indexSelectionResult = selectIndexes(context);

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanningContext.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanningContext.java
@@ -606,6 +606,17 @@ public class QueryPlanningContext implements LocaleProvider, PrefetchStrategyRes
 	}
 
 	/**
+	 * Method returns appropriate {@link EntityCollection} for the {@link #evitaRequest} or throws comprehensible
+	 * exception. In order exception to be comprehensible you need to provide sensible `reason` for accessing
+	 * the collection in the input parameter.
+	 */
+	@Nonnull
+	public EntityCollection getEntityCollectionOrThrowException(@Nullable String entityType, @Nonnull Supplier<String> reasonSupplier) {
+		return getEntityCollection(entityType)
+			.orElseThrow(() -> new EntityCollectionRequiredException(reasonSupplier.get()));
+	}
+
+	/**
 	 * Method creates new {@link EvitaRequest} for particular `entityType` that takes all passed `requiredConstraints`
 	 * into the account. Fabricated request is expected to be used only for passing the scope to
 	 * {@link EntityCollection#limitEntity(EntityContract, EvitaRequest, EvitaSessionContract)}  or
@@ -637,9 +648,9 @@ public class QueryPlanningContext implements LocaleProvider, PrefetchStrategyRes
 		@Nonnull Supplier<Formula> formulaSupplier,
 		long... additionalCacheKeys
 	) {
-		if (parentContext == null) {
-			if (internalCache == null) {
-				internalCache = new HashMap<>();
+		if (this.parentContext == null) {
+			if (this.internalCache == null) {
+				this.internalCache = new HashMap<>();
 			}
 			final InternalCacheKey cacheKey = new InternalCacheKey(
 				LongStream.concat(
@@ -648,17 +659,17 @@ public class QueryPlanningContext implements LocaleProvider, PrefetchStrategyRes
 				).toArray(),
 				constraint
 			);
-			final Formula cachedResult = internalCache.get(cacheKey);
+			final Formula cachedResult = this.internalCache.get(cacheKey);
 			if (cachedResult == null) {
 				final Formula computedResult = formulaSupplier.get();
 				computedResult.initialize(this.internalExecutionContext);
-				internalCache.put(cacheKey, computedResult);
+				this.internalCache.put(cacheKey, computedResult);
 				return computedResult;
 			} else {
 				return cachedResult;
 			}
 		} else {
-			return parentContext.computeOnlyOnce(
+			return this.parentContext.computeOnlyOnce(
 				entityIndexes, constraint, formulaSupplier, additionalCacheKeys
 			);
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/AbstractHierarchyTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/AbstractHierarchyTranslator.java
@@ -169,9 +169,9 @@ public abstract class AbstractHierarchyTranslator {
 			);
 			// now analyze the filter by in a nested context with exchanged primary entity index
 			final Formula theFormula = queryContext.analyse(
-				theFilterByVisitor.executeInContext(
+				theFilterByVisitor.executeInContextAndIsolatedFormulaStack(
 					indexType,
-					Collections.singletonList(entityIndex),
+					() -> Collections.singletonList(entityIndex),
 					null,
 					targetEntitySchema,
 					null,

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/producer/ParentStatisticsComputer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/producer/ParentStatisticsComputer.java
@@ -117,6 +117,10 @@ public class ParentStatisticsComputer extends AbstractHierarchyStatisticsCompute
 			);
 
 			final List<Accumulator> children = childVisitor.getAccumulators();
+			if (children.isEmpty()) {
+				return Collections.emptyList();
+			}
+
 			Assert.isPremiseValid(children.size() == 1, "Expected exactly one node but found `" + children.size() + "`!");
 			final Accumulator startNode = children.get(0);
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/FilterByVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/FilterByVisitor.java
@@ -189,7 +189,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 	 * Contemporary stack for keeping results resolved for each level of the query.
 	 */
 	@Getter(AccessLevel.PROTECTED)
-	private final Deque<ProcessingScope<? extends Index<?>>> scope = new ArrayDeque<>(16);
+	private final Deque<ProcessingScope<? extends Index<?>>> scope = new ArrayDeque<>(8);
 	/**
 	 * Contains list of registered post processors. Formula post processor is used to transform final {@link Formula}
 	 * tree constructed in {@link FilterByVisitor} before computing the result. Post processors should analyze created
@@ -197,7 +197,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 	 * as soon as possible. We may take advantage of transitivity in boolean algebra to exchange formula placement
 	 * the way it's most performant.
 	 */
-	private final LinkedHashMap<Class<? extends FormulaPostProcessor>, FormulaPostProcessor> postProcessors = new LinkedHashMap<>(16);
+	private final Deque<LinkedHashMap<Class<? extends FormulaPostProcessor>, FormulaPostProcessor>> postProcessors = new ArrayDeque<>(8);
 	/**
 	 * Reference to the query context that allows to access entity bodies, indexes, original request and much more.
 	 */
@@ -262,9 +262,9 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 			theFormula = queryContext.getGlobalEntityIndexIfExists(entityType)
 				.map(
 					entityIndex -> queryContext.analyse(
-						theFilterByVisitor.executeInContext(
+						theFilterByVisitor.executeInContextAndIsolatedFormulaStack(
 							GlobalEntityIndex.class,
-							Collections.singletonList(entityIndex),
+							() -> Collections.singletonList(entityIndex),
 							null,
 							queryContext.getSchema(entityType),
 							null,
@@ -293,6 +293,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 		@Nonnull TargetIndexes<T> indexSetToUse
 	) {
 		this.stack.push(new LinkedList<>());
+		this.postProcessors.push(new LinkedHashMap<>(16));
 		this.scope.push(processingScope);
 		this.queryContext = queryContext;
 		//I just can't get generic to work here
@@ -342,7 +343,6 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 			.map(this::constructFinalFormula)
 			.orElseGet(this::getSuperSetFormula);
 		this.computedFormula = null;
-		this.postProcessors.clear();
 		return result;
 	}
 
@@ -368,7 +368,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 	 */
 	@Nonnull
 	public Formula[] getCollectedFormulasOnCurrentLevel() {
-		return ofNullable(stack.peek())
+		return ofNullable(this.stack.peek())
 			.map(it -> it.toArray(Formula[]::new))
 			.orElse(EMPTY_INTEGER_FORMULA);
 	}
@@ -507,7 +507,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 		@Nonnull Supplier<T> formulaPostProcessorSupplier
 	) {
 		final T value = formulaPostProcessorSupplier.get();
-		this.postProcessors.put(
+		this.postProcessors.peek().put(
 			postProcessorType,
 			value
 		);
@@ -580,9 +580,9 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 			return EmptyFormula.INSTANCE;
 		}
 
-		final Formula resultFormula = executeInContext(
+		final Formula resultFormula = executeInContextAndIsolatedFormulaStack(
 			ReferencedTypeEntityIndex.class,
-			Collections.singletonList(entityIndex.get()),
+			() -> Collections.singletonList(entityIndex.get()),
 			ReferenceContent.ALL_REFERENCES,
 			entitySchema,
 			referenceSchema,
@@ -703,6 +703,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 	) {
 		try {
 			this.stack.push(new LinkedList<>());
+			this.postProcessors.push(new LinkedHashMap<>(16));
 			return executeInContext(
 				indexType,
 				targetIndexSupplier,
@@ -718,6 +719,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 			);
 		} finally {
 			this.stack.pop();
+			this.postProcessors.poll();
 		}
 	}
 
@@ -979,9 +981,10 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 	@Nonnull
 	private Formula constructFinalFormula(@Nonnull Formula constraintFormula) {
 		Formula finalFormula = constraintFormula;
-		if (!this.postProcessors.isEmpty()) {
-			final Set<FormulaPostProcessor> executedProcessors = CollectionUtils.createHashSet(postProcessors.size());
-			for (FormulaPostProcessor postProcessor : this.postProcessors.values()) {
+		final LinkedHashMap<Class<? extends FormulaPostProcessor>, FormulaPostProcessor> thePostProcessors = this.postProcessors.peek();
+		if (!thePostProcessors.isEmpty()) {
+			final Set<FormulaPostProcessor> executedProcessors = CollectionUtils.createHashSet(thePostProcessors.size());
+			for (FormulaPostProcessor postProcessor : thePostProcessors.values()) {
 				if (!executedProcessors.contains(postProcessor)) {
 					postProcessor.visit(finalFormula);
 					finalFormula = postProcessor.getPostProcessedFormula();
@@ -1180,6 +1183,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 		/**
 		 * Returns indexes that should be used for searching.
 		 */
+		@Nonnull
 		public List<T> getIndexes() {
 			if (indexes == null) {
 				this.indexes = this.indexSupplier.get();
@@ -1190,6 +1194,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 		/**
 		 * Returns stream of indexes that should be used for searching.
 		 */
+		@Nonnull
 		public Stream<T> getIndexStream() {
 			return getIndexes().stream();
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/FilteringFormulaHierarchyEntityPredicate.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/FilteringFormulaHierarchyEntityPredicate.java
@@ -127,9 +127,9 @@ public class FilteringFormulaHierarchyEntityPredicate implements HierarchyFilter
 			final Formula theFormula;
 			if (referenceSchema == null) {
 				theFormula = queryContext.analyse(
-					theFilterByVisitor.executeInContext(
+					theFilterByVisitor.executeInContextAndIsolatedFormulaStack(
 						GlobalEntityIndex.class,
-						Collections.singletonList(queryContext.getGlobalEntityIndex()),
+						() -> Collections.singletonList(queryContext.getGlobalEntityIndex()),
 						null,
 						queryContext.getSchema(),
 						null,
@@ -223,9 +223,9 @@ public class FilteringFormulaHierarchyEntityPredicate implements HierarchyFilter
 			);
 			// now analyze the filter by in a nested context with exchanged primary entity index
 			final Formula theFormula = queryContext.analyse(
-				theFilterByVisitor.executeInContext(
+				theFilterByVisitor.executeInContextAndIsolatedFormulaStack(
 					GlobalEntityIndex.class,
-					Collections.singletonList(entityIndex),
+					() -> Collections.singletonList(entityIndex),
 					null,
 					entitySchema,
 					null,


### PR DESCRIPTION
- fix(#731): When target hierarchical entity is not found, parents should return empty result instead of error
- fix(#732): EntityPrimaryKeyInSet pollutes query execution context