### PR TITLE
fix(#734): When prices are completely reset on an existing entity, removal mutation for already dropped price might be generated

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/ExistingPricesBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/ExistingPricesBuilder.java
@@ -335,6 +335,7 @@ public class ExistingPricesBuilder implements PricesBuilder {
 							}),
 						originalPrices
 							.stream()
+							.filter(Droppable::exists)
 							.filter(it -> priceMutations.get(it.priceKey()) == null)
 							.map(it -> new RemovePriceMutation(it.priceKey()))
 					)


### PR DESCRIPTION
The `io.evitadb.api.requestResponse.data.structure.ExistingPricesBuilder` in `buildChangeSet` method, when `removeAllNonModifiedPrices` is set to true doesn't filter the original prices by `Droppable::exists` which leads to creating `RemovePriceMutation` for already removed prices and results in rejecting entity upsert.

(cherry picked from commit 5a3e2e7e60871cddc3d6c143bd2fd30ac25c27bc)