### PR TITLE
feat: Make fsSync configurable

### DIFF
--- a/documentation/user/en/operate/configure.md
+++ b/documentation/user/en/operate/configure.md
@@ -41,6 +41,7 @@ storage:                                          # [see Storage configuration](
   waitOnCloseSeconds: 60
   outputBufferSize: 4MB
   maxOpenedReadHandles: 12
+  syncWrites: true
   computeCRC32C: true
   minimalActiveRecordShare: 0.5
   fileSizeCompactionThresholdBytes: 100MB
@@ -489,6 +490,14 @@ This section contains configuration options for the storage layer of the databas
             Read these articles for [Linux](https://www.baeldung.com/linux/limit-file-descriptors) or 
             [MacOS](https://gist.github.com/tombigel/d503800a282fcadbee14b537735d202c)            
         </Note>
+    </dd>
+    <dt>syncWrites</dt>
+    <dd>
+        <p>**Default:** `true`</p>
+        <p>Determines whether the storage layer forces the operating system to flush the internal buffers to disk at
+        regular "safe points" or not. The default is true, so that data is not lost in the event of a power failure. 
+        There are situations where disabling this feature can improve performance and the client can accept the risk
+        of data loss (e.g. when running automated tests, etc.).</p>
     </dd>
     <dt>computeCRC32C</dt>
     <dd>

--- a/evita_api/src/main/java/io/evitadb/api/configuration/StorageOptions.java
+++ b/evita_api/src/main/java/io/evitadb/api/configuration/StorageOptions.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -52,7 +52,13 @@ import java.util.Optional;
  *                                           purposes. The size of the buffer limits the maximum size of an individual record in the
  *                                           key/value data store.
  * @param maxOpenedReadHandles               Maximum number of simultaneously opened {@link java.io.InputStream} to file offset index file.
- * @param computeCRC32C                      Contains setting that determined whether CRC32C checksums will be computed for written
+ * @param syncWrites                         Determines whether the storage layer forces the operating system to flush
+ *                                           the internal buffers to disk at regular "safe points" or not. The default
+ *                                           is true, so that data is not lost in the event of a power failure. There
+ *                                           are situations where disabling this feature can improve performance and
+ *                                           the client can accept the risk of data loss (e.g. when running automated
+ *                                           tests, etc.).
+ * @param computeCRC32C                      Determines whether CRC32C checksums will be computed for written
  *                                           records and also whether the CRC32C checksum will be checked on record read.
  * @param minimalActiveRecordShare           Minimal share of active records in the file. If the share is lower, the file will
  *                                           be compacted.
@@ -79,6 +85,7 @@ public record StorageOptions(
 	long waitOnCloseSeconds,
 	int outputBufferSize,
 	int maxOpenedReadHandles,
+	boolean syncWrites,
 	boolean computeCRC32C,
 	double minimalActiveRecordShare,
 	long fileSizeCompactionThresholdBytes,
@@ -93,6 +100,7 @@ public record StorageOptions(
 	public static final int DEFAULT_LOCK_TIMEOUT_SECONDS = 5;
 	public static final int DEFAULT_WAIT_ON_CLOSE_SECONDS = 5;
 	public static final int DEFAULT_MAX_OPENED_READ_HANDLES = Runtime.getRuntime().availableProcessors();
+	public static final boolean DEFAULT_SYNC_WRITES = true;
 	public static final boolean DEFAULT_COMPUTE_CRC = true;
 	public static final double DEFAULT_MINIMAL_ACTIVE_RECORD_SHARE = 0.5;
 	public static final long DEFAULT_MINIMAL_FILE_SIZE_COMPACTION_THRESHOLD = 104_857_600L; // 100MB
@@ -103,12 +111,14 @@ public record StorageOptions(
 	/**
 	 * Builder method is planned to be used only in tests.
 	 */
+	@Nonnull
 	public static StorageOptions temporary() {
 		return new StorageOptions(
 			Path.of(System.getProperty("java.io.tmpdir"), "evita/data"),
 			Path.of(System.getProperty("java.io.tmpdir"), "evita/export"),
 			5, 5, DEFAULT_OUTPUT_BUFFER_SIZE,
 			Runtime.getRuntime().availableProcessors(),
+			false,
 			true,
 			DEFAULT_MINIMAL_ACTIVE_RECORD_SHARE,
 			DEFAULT_MINIMAL_FILE_SIZE_COMPACTION_THRESHOLD,
@@ -121,6 +131,7 @@ public record StorageOptions(
 	/**
 	 * Builder for the storage options. Recommended to use to avoid binary compatibility problems in the future.
 	 */
+	@Nonnull
 	public static StorageOptions.Builder builder() {
 		return new StorageOptions.Builder();
 	}
@@ -128,6 +139,7 @@ public record StorageOptions(
 	/**
 	 * Builder for the storage options. Recommended to use to avoid binary compatibility problems in the future.
 	 */
+	@Nonnull
 	public static StorageOptions.Builder builder(@Nonnull StorageOptions storageOptions) {
 		return new StorageOptions.Builder(storageOptions);
 	}
@@ -140,6 +152,7 @@ public record StorageOptions(
 			DEFAULT_WAIT_ON_CLOSE_SECONDS,
 			DEFAULT_OUTPUT_BUFFER_SIZE,
 			DEFAULT_MAX_OPENED_READ_HANDLES,
+			DEFAULT_SYNC_WRITES,
 			DEFAULT_COMPUTE_CRC,
 			DEFAULT_MINIMAL_ACTIVE_RECORD_SHARE,
 			DEFAULT_MINIMAL_FILE_SIZE_COMPACTION_THRESHOLD,
@@ -156,6 +169,7 @@ public record StorageOptions(
 		long waitOnCloseSeconds,
 		int outputBufferSize,
 		int maxOpenedReadHandles,
+		boolean syncWrites,
 		boolean computeCRC32C,
 		double minimalActiveRecordShare,
 		long fileSizeCompactionThresholdBytes,
@@ -169,6 +183,7 @@ public record StorageOptions(
 		this.waitOnCloseSeconds = waitOnCloseSeconds;
 		this.outputBufferSize = outputBufferSize;
 		this.maxOpenedReadHandles = maxOpenedReadHandles;
+		this.syncWrites = syncWrites;
 		this.computeCRC32C = computeCRC32C;
 		this.minimalActiveRecordShare = minimalActiveRecordShare;
 		this.fileSizeCompactionThresholdBytes = fileSizeCompactionThresholdBytes;
@@ -188,6 +203,7 @@ public record StorageOptions(
 		private long waitOnCloseSeconds = DEFAULT_WAIT_ON_CLOSE_SECONDS;
 		private int outputBufferSize = DEFAULT_OUTPUT_BUFFER_SIZE;
 		private int maxOpenedReadHandles = DEFAULT_MAX_OPENED_READ_HANDLES;
+		private boolean syncWrites = DEFAULT_SYNC_WRITES;
 		private boolean computeCRC32C = DEFAULT_COMPUTE_CRC;
 		private double minimalActiveRecordShare = DEFAULT_MINIMAL_ACTIVE_RECORD_SHARE;
 		private long fileSizeCompactionThresholdBytes = DEFAULT_MINIMAL_FILE_SIZE_COMPACTION_THRESHOLD;
@@ -205,6 +221,7 @@ public record StorageOptions(
 			this.waitOnCloseSeconds = storageOptions.waitOnCloseSeconds;
 			this.outputBufferSize = storageOptions.outputBufferSize;
 			this.maxOpenedReadHandles = storageOptions.maxOpenedReadHandles;
+			this.syncWrites = storageOptions.syncWrites;
 			this.computeCRC32C = storageOptions.computeCRC32C;
 			this.minimalActiveRecordShare = storageOptions.minimalActiveRecordShare;
 			this.fileSizeCompactionThresholdBytes = storageOptions.fileSizeCompactionThresholdBytes;
@@ -248,6 +265,12 @@ public record StorageOptions(
 		@Nonnull
 		public Builder maxOpenedReadHandles(int maxOpenedReadHandles) {
 			this.maxOpenedReadHandles = maxOpenedReadHandles;
+			return this;
+		}
+
+		@Nonnull
+		public Builder syncWrites(boolean syncWrites) {
+			this.syncWrites = syncWrites;
 			return this;
 		}
 
@@ -296,6 +319,7 @@ public record StorageOptions(
 				waitOnCloseSeconds,
 				outputBufferSize,
 				maxOpenedReadHandles,
+				syncWrites,
 				computeCRC32C,
 				minimalActiveRecordShare,
 				fileSizeCompactionThresholdBytes,

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTransactionalFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTransactionalFunctionalTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -1610,7 +1610,10 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 			UUID.randomUUID(),
 			KryoFactory.createKryo(WalKryoConfigurer.INSTANCE),
 			new WriteOnlyOffHeapWithFileBackupHandle(
-				isolatedWalFilePath, this.observableOutputKeeper, offHeapMemoryManager
+				isolatedWalFilePath,
+				false,
+				this.observableOutputKeeper,
+				offHeapMemoryManager
 			)
 		);
 

--- a/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DefaultCatalogPersistenceServiceTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DefaultCatalogPersistenceServiceTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -159,6 +159,7 @@ class DefaultCatalogPersistenceServiceTest implements EvitaTestSupport {
 	);
 	private final WriteOnlyOffHeapWithFileBackupHandle writeHandle = new WriteOnlyOffHeapWithFileBackupHandle(
 		getTestDirectory().resolve(transactionId.toString()),
+		false,
 		observableOutputKeeper,
 		new OffHeapMemoryManager(TEST_CATALOG, 512, 1)
 	);
@@ -248,6 +249,7 @@ class DefaultCatalogPersistenceServiceTest implements EvitaTestSupport {
 						catalogName,
 						FileType.CATALOG,
 						catalogName,
+						false,
 						catalogFilePath,
 						observableOutputKeeper
 					),
@@ -796,7 +798,7 @@ class DefaultCatalogPersistenceServiceTest implements EvitaTestSupport {
 			getTestDirectory().resolve(DIR_DEFAULT_CATALOG_PERSISTENCE_SERVICE_TEST),
 			60, 60,
 			StorageOptions.DEFAULT_OUTPUT_BUFFER_SIZE, 1,
-			true, 1.0, 0L, false,
+			false, true, 1.0, 0L, false,
 			Long.MAX_VALUE, Long.MAX_VALUE
 		);
 	}

--- a/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DefaultIsolatedWalServiceTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DefaultIsolatedWalServiceTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024
+ *   Copyright (c) 2024-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -87,6 +87,7 @@ class DefaultIsolatedWalServiceTest implements EvitaTestSupport {
 	);
 	private final WriteOnlyOffHeapWithFileBackupHandle writeHandle = new WriteOnlyOffHeapWithFileBackupHandle(
 		getTestDirectory().resolve(transactionId.toString()),
+		false,
 		observableOutputKeeper,
 		new OffHeapMemoryManager(TEST_CATALOG, 512, 1)
 	);

--- a/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexSerializationServiceTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexSerializationServiceTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class OffsetIndexSerializationServiceTest {
 	void shouldComputeExpectedRecordCountProperly() {
 		final StorageOptions testOptions = new StorageOptions(
 			Path.of(""), Path.of(""), 1, 0, 55, 1,
-			false, 1.0, 0L, false, Long.MAX_VALUE, Long.MAX_VALUE
+			false, false, 1.0, 0L, false, Long.MAX_VALUE, Long.MAX_VALUE
 		);
 		assertEquals(new OffsetIndexSerializationService.ExpectedCounts(0, 1), OffsetIndexSerializationService.computeExpectedRecordCount(testOptions, 0));
 		assertEquals(new OffsetIndexSerializationService.ExpectedCounts(1, 1), OffsetIndexSerializationService.computeExpectedRecordCount(testOptions, 1));

--- a/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.function.Supplier;
 
 import static io.evitadb.store.offsetIndex.OffsetIndexSerializationService.computeExpectedRecordCount;
 import static io.evitadb.test.TestConstants.LONG_RUNNING_TEST;
@@ -199,7 +200,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 			),
 			limitedBufferOptions,
 			offsetIndexRecordTypeRegistry,
-			new WriteOnlyFileHandle(targetFile, observableOutputKeeper),
+			new WriteOnlyFileHandle(targetFile, false, observableOutputKeeper),
 			nonFlushedBlock -> {},
 			oldestRecordTimestamp -> {}
 		);
@@ -221,7 +222,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 			),
 			limitedBufferOptions,
 			offsetIndexRecordTypeRegistry,
-			new WriteOnlyFileHandle(targetFile, observableOutputKeeper),
+			new WriteOnlyFileHandle(targetFile, false, observableOutputKeeper),
 			nonFlushedBlock -> {},
 			oldestRecordTimestamp -> {}
 		);
@@ -242,7 +243,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 				snapshotBootstrapDescriptor,
 				limitedBufferOptions,
 				offsetIndexRecordTypeRegistry,
-				new WriteOnlyFileHandle(snapshotPath, observableOutputKeeper),
+				new WriteOnlyFileHandle(snapshotPath, false, observableOutputKeeper),
 				nonFlushedBlock -> {},
 				oldestRecordTimestamp -> {}
 			);
@@ -284,7 +285,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 			),
 			options,
 			offsetIndexRecordTypeRegistry,
-			new WriteOnlyFileHandle(targetFile, observableOutputKeeper),
+			new WriteOnlyFileHandle(targetFile, false, observableOutputKeeper),
 			nonFlushedBlock -> {},
 			oldestRecordTimestamp -> {}
 		);
@@ -328,7 +329,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 			),
 			options,
 			offsetIndexRecordTypeRegistry,
-			new WriteOnlyFileHandle(targetFile, observableOutputKeeper),
+			new WriteOnlyFileHandle(targetFile, false, observableOutputKeeper),
 			nonFlushedBlock -> {},
 			oldestRecordTimestamp -> {}
 		);
@@ -384,7 +385,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 				i
 			);
 
-			final EntityBodyStoragePart entityBody = OffsetIndex.readSingleRecord(
+			final Supplier<EntityBodyStoragePart> entityBodySupplier = () -> OffsetIndex.readSingleRecord(
 				targetFile,
 				offsetIndexDescriptor.fileLocation(),
 				key,
@@ -395,8 +396,9 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 					.orElse(null)
 			);
 			if (i < recordCount * (iterationCount - 1) && i % recordCount < removedRecords && i % recordCount > 0) {
-				assertNull(entityBody);
+				assertThrows(NullPointerException.class, entityBodySupplier::get);
 			} else {
+				final EntityBodyStoragePart entityBody = entityBodySupplier.get();
 				assertNotNull(entityBody);
 				assertEquals(
 					new EntityBodyStoragePart(i),
@@ -418,7 +420,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 			),
 			options,
 			offsetIndexRecordTypeRegistry,
-			new WriteOnlyFileHandle(targetFile, observableOutputKeeper),
+			new WriteOnlyFileHandle(targetFile, false, observableOutputKeeper),
 			nonFlushedBlock -> {},
 			oldestRecordTimestamp -> {}
 		);
@@ -448,7 +450,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 				),
 				buildOptionsWithLimitedBuffer(),
 				offsetIndexRecordTypeRegistry,
-				new WriteOnlyFileHandle(targetFile, observableOutputKeeper),
+				new WriteOnlyFileHandle(targetFile, false, observableOutputKeeper),
 				nonFlushedBlock -> {},
 				oldestRecordTimestamp -> {}
 			)
@@ -522,7 +524,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 					),
 					options,
 					offsetIndexRecordTypeRegistry,
-					new WriteOnlyFileHandle(currentFilePath.get(), observableOutputKeeper),
+					new WriteOnlyFileHandle(currentFilePath.get(), false, observableOutputKeeper),
 					nonFlushedBlock -> {},
 					oldestRecordTimestamp -> {}
 				);
@@ -610,7 +612,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 						),
 						options,
 						offsetIndexRecordTypeRegistry,
-						new WriteOnlyFileHandle(newPath, observableOutputKeeper),
+						new WriteOnlyFileHandle(newPath, false, observableOutputKeeper),
 						nonFlushedBlock -> {},
 						oldestRecordTimestamp -> {}
 					);
@@ -653,7 +655,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 			),
 			storageOptions,
 			offsetIndexRecordTypeRegistry,
-			new WriteOnlyFileHandle(targetFile, observableOutputKeeper),
+			new WriteOnlyFileHandle(targetFile, false, observableOutputKeeper),
 			nonFlushedBlock -> {},
 			oldestRecordTimestamp -> {}
 		);
@@ -675,7 +677,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 			),
 			storageOptions,
 			offsetIndexRecordTypeRegistry,
-			new WriteOnlyFileHandle(targetFile, observableOutputKeeper),
+			new WriteOnlyFileHandle(targetFile, false, observableOutputKeeper),
 			nonFlushedBlock -> {},
 			oldestRecordTimestamp -> {}
 		);
@@ -718,7 +720,7 @@ class OffsetIndexTest implements TimeBoundedTestSupport {
 			),
 			options,
 			offsetIndexRecordTypeRegistry,
-			new WriteOnlyFileHandle(targetFile, observableOutputKeeper),
+			new WriteOnlyFileHandle(targetFile, false, observableOutputKeeper),
 			nonFlushedBlock -> {},
 			oldestRecordTimestamp -> {}
 		);

--- a/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/io/WriteOnlyOffHeapWithFileBackupHandleTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/io/WriteOnlyOffHeapWithFileBackupHandleTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ class WriteOnlyOffHeapWithFileBackupHandleTest implements EvitaTestSupport {
 		try (
 			final OffHeapMemoryManager memoryManager = new OffHeapMemoryManager(TEST_CATALOG, 32, 1);
 			final WriteOnlyOffHeapWithFileBackupHandle writeHandle = new WriteOnlyOffHeapWithFileBackupHandle(
-				targetDirectory.resolve(UUIDUtil.randomUUID() + ".tmp"), outputKeeper, memoryManager
+				targetDirectory.resolve(UUIDUtil.randomUUID() + ".tmp"), false, outputKeeper, memoryManager
 			)
 		) {
 			writeHandle.checkAndExecuteAndSync(
@@ -85,7 +85,7 @@ class WriteOnlyOffHeapWithFileBackupHandleTest implements EvitaTestSupport {
 		try (
 			final OffHeapMemoryManager memoryManager = new OffHeapMemoryManager(TEST_CATALOG, 32, 1);
 			final WriteOnlyOffHeapWithFileBackupHandle writeHandle = new WriteOnlyOffHeapWithFileBackupHandle(
-				targetDirectory.resolve(UUIDUtil.randomUUID() + ".tmp"), outputKeeper, memoryManager
+				targetDirectory.resolve(UUIDUtil.randomUUID() + ".tmp"), false, outputKeeper, memoryManager
 			)
 		) {
 			for (int i = 0; i < 5; i++) {
@@ -116,7 +116,7 @@ class WriteOnlyOffHeapWithFileBackupHandleTest implements EvitaTestSupport {
 		try (
 			final OffHeapMemoryManager memoryManager = new OffHeapMemoryManager(TEST_CATALOG, 32, 1);
 			final WriteOnlyOffHeapWithFileBackupHandle writeHandle = new WriteOnlyOffHeapWithFileBackupHandle(
-				targetDirectory.resolve(UUIDUtil.randomUUID() + ".tmp"), outputKeeper, memoryManager
+				targetDirectory.resolve(UUIDUtil.randomUUID() + ".tmp"), false, outputKeeper, memoryManager
 			)
 		) {
 			for (int i = 0; i < 5; i++) {
@@ -151,7 +151,7 @@ class WriteOnlyOffHeapWithFileBackupHandleTest implements EvitaTestSupport {
 		try (
 			final OffHeapMemoryManager memoryManager = new OffHeapMemoryManager(TEST_CATALOG, 32, 1);
 			final WriteOnlyOffHeapWithFileBackupHandle realMemoryHandle = new WriteOnlyOffHeapWithFileBackupHandle(
-				targetDirectory.resolve(UUIDUtil.randomUUID() + ".tmp"), outputKeeper, memoryManager
+				targetDirectory.resolve(UUIDUtil.randomUUID() + ".tmp"), false, outputKeeper, memoryManager
 			)
 		) {
 			// we need to write at least one byte to the real memory handle to force the memory manager
@@ -164,7 +164,7 @@ class WriteOnlyOffHeapWithFileBackupHandleTest implements EvitaTestSupport {
 			// because there is only one region available - this will force the handle to use the file backup immediately
 			try (
 				final WriteOnlyOffHeapWithFileBackupHandle forcedFileHandle = new WriteOnlyOffHeapWithFileBackupHandle(
-					targetDirectory.resolve(UUIDUtil.randomUUID() + ".tmp"), outputKeeper, memoryManager
+					targetDirectory.resolve(UUIDUtil.randomUUID() + ".tmp"), false, outputKeeper, memoryManager
 				)
 			) {
 				for (int i = 0; i < 5; i++) {

--- a/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogIntegrationTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogIntegrationTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024
+ *   Copyright (c) 2024-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -333,7 +333,7 @@ class CatalogWriteAheadLogIntegrationTest {
 			UUID.randomUUID(),
 			KryoFactory.createKryo(WalKryoConfigurer.INSTANCE),
 			new WriteOnlyOffHeapWithFileBackupHandle(
-				isolatedWalFilePath, observableOutputKeeper, offHeapMemoryManager
+				isolatedWalFilePath, false, observableOutputKeeper, offHeapMemoryManager
 			)
 		);
 

--- a/evita_server/src/main/resources/evita-configuration.yaml
+++ b/evita_server/src/main/resources/evita-configuration.yaml
@@ -29,6 +29,7 @@ storage:
   waitOnCloseSeconds: ${storage.waitOnCloseSeconds:60}
   outputBufferSize: ${storage.outputBufferSize:4MB}
   maxOpenedReadHandles: ${storage.maxOpenedReadHandles:12}
+  syncWrites: ${storage.syncWrites:true}
   computeCRC32C: ${storage.computeCRC32C:true}
   minimalActiveRecordShare: ${storage.minimalActiveRecordShare:0.5}
   fileSizeCompactionThresholdBytes: ${storage.fileSizeCompactionThresholdBytes:100M}

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -230,7 +230,7 @@ public class OffsetIndex {
 	 * @param <T>               The type of the storage part.
 	 * @return deserialized storage part or null if the record was not found
 	 */
-	@Nullable
+	@Nonnull
 	public static <T extends StoragePart> T readSingleRecord(
 		@Nonnull Path filePath,
 		@Nonnull FileLocation fileLocation,
@@ -251,7 +251,9 @@ public class OffsetIndex {
 				fileLocation,
 				filteringOffsetIndexBuilder
 			);
-			return storagePartReader.apply(filteringOffsetIndexBuilder, input);
+			return Objects.requireNonNull(
+				storagePartReader.apply(filteringOffsetIndexBuilder, input)
+			);
 		} catch (FileNotFoundException e) {
 			throw new UnexpectedIOException(
 				"Cannot create read offset file index from file `" + filePath + "`!",
@@ -1649,7 +1651,7 @@ public class OffsetIndex {
 			// scan non-flushed values
 			final ConcurrentHashMap<Long, NonFlushedValueSet> nvValues = this.nonFlushedValues;
 			final long[] nv = this.nonFlushedVersions;
-			if (nv != null) {
+			if (nv != null && nvValues != null) {
 				int index = Arrays.binarySearch(nv, catalogVersion);
 				if (index != -1) {
 					final int startIndex = index >= 0 ? index : -index - 1;
@@ -1673,7 +1675,7 @@ public class OffsetIndex {
 				}
 				if (hv != null) {
 					int index = Arrays.binarySearch(hv, catalogVersion);
-					if (index != -1) {
+					if (index != -1 && hvValues != null) {
 						final int startIndex = index >= 0 ? index : -index - 1;
 						for (int ix = hv.length - 1; ix > startIndex && ix >= 0; ix--) {
 							final PastMemory differenceSet = hvValues.get(hv[ix]);
@@ -1701,7 +1703,7 @@ public class OffsetIndex {
 			final long[] nv = this.nonFlushedVersions;
 			if (nv != null) {
 				int index = Arrays.binarySearch(nv, catalogVersion);
-				if (index != -1) {
+				if (index != -1 && nvValues != null) {
 					final int startIndex = index >= 0 ? index : -index - 1;
 					for (int ix = nv.length - 1; ix >= startIndex && ix >= 0; ix--) {
 						final NonFlushedValueSet nonFlushedValueSet = nvValues.get(nv[ix]);
@@ -1721,7 +1723,7 @@ public class OffsetIndex {
 				} finally {
 					this.lock.unlock();
 				}
-				if (hv != null) {
+				if (hv != null && hvValues != null) {
 					int index = Arrays.binarySearch(hv, catalogVersion);
 					if (index != -1) {
 						final int startIndex = index >= 0 ? index : -index - 1;
@@ -1747,7 +1749,7 @@ public class OffsetIndex {
 		public Optional<VersionedValue> getNonFlushedValueIfVersionMatches(long catalogVersion, @Nonnull RecordKey key) {
 			final ConcurrentHashMap<Long, NonFlushedValueSet> nvSet = this.nonFlushedValues;
 			final long[] nv = this.nonFlushedVersions;
-			if (nv != null) {
+			if (nv != null && nvSet != null) {
 				int index = Arrays.binarySearch(nv, catalogVersion);
 				final int startIndex = index >= 0 ? index : -index - 2;
 				if (startIndex >= 0) {
@@ -1784,7 +1786,8 @@ public class OffsetIndex {
 		 * @return true if there are non-flushed values, false otherwise
 		 */
 		public boolean hasValuesToFlush() {
-			return !(nonFlushedValues == null || nonFlushedValues.isEmpty());
+			final ConcurrentHashMap<Long, NonFlushedValueSet> nvSet = this.nonFlushedValues;
+			return nvSet != null && !nvSet.isEmpty();
 		}
 
 		/**
@@ -1815,6 +1818,7 @@ public class OffsetIndex {
 					final long examinedVersion = hv[ix];
 					final PastMemory pastMemory = hvValues.get(examinedVersion);
 					if (pastMemory.getRemovedKeys().contains(key)) {
+						//noinspection DataFlowIssue
 						addedInFuture = false;
 					}
 					if (pastMemory.getAddedKeys().contains(key) && examinedVersion != catalogVersion) {
@@ -1871,7 +1875,7 @@ public class OffsetIndex {
 		public Collection<NonFlushedValueSet> getNonFlushedEntriesToPromote(long catalogVersion) {
 			final ConcurrentHashMap<Long, NonFlushedValueSet> nvSet = this.nonFlushedValues;
 			final long[] nv = this.nonFlushedVersions;
-			if (nv != null) {
+			if (nv != null && nvSet != null) {
 				Assert.isPremiseValid(
 					catalogVersion >= nv[nv.length - 1],
 					"Catalog version is expected to be at least " + nv[nv.length - 1] + "!"
@@ -1912,13 +1916,14 @@ public class OffsetIndex {
 			if (versionToPurge > -1) {
 				try {
 					this.lock.lock();
-					if (this.historicalVersions != null) {
-						final long[] versionsToPurge = this.historicalVersions;
+					final long[] versionsToPurge = this.historicalVersions;
+					final ConcurrentHashMap<Long, PastMemory> theVolatileValues = this.volatileValues;
+					if (versionsToPurge != null && theVolatileValues != null) {
 						int index = Arrays.binarySearch(versionsToPurge, versionToPurge);
 						final int startIndex = index >= 0 ? index : -index - 2;
 						if (index != -1) {
 							for (int ix = startIndex; ix >= 0; ix--) {
-								this.volatileValues.remove(versionsToPurge[ix]);
+								theVolatileValues.remove(versionsToPurge[ix]);
 							}
 						}
 						this.historicalVersions = Arrays.copyOfRange(versionsToPurge, startIndex + 1, versionsToPurge.length);
@@ -1933,16 +1938,18 @@ public class OffsetIndex {
 				final long catalogVersion = valuesToPromote.getCatalogVersion();
 				try {
 					this.lock.lock();
-					if (this.historicalVersions == null) {
+					final long[] hv = this.historicalVersions;
+					final ConcurrentHashMap<Long, PastMemory> theVolatileValues = this.volatileValues;
+					if (hv == null || theVolatileValues == null) {
+						final ConcurrentHashMap<Long, PastMemory> newVolatileValues = CollectionUtils.createConcurrentHashMap(16);
+						newVolatileValues.put(catalogVersion, valuesToPromote.createFrom(keyToLocations));
 						this.historicalVersions = new long[]{catalogVersion};
-						this.volatileValues = CollectionUtils.createConcurrentHashMap(16);
-						this.volatileValues.put(catalogVersion, valuesToPromote.createFrom(keyToLocations));
+						this.volatileValues = newVolatileValues;
 					} else {
-						this.volatileValues.compute(
+						theVolatileValues.compute(
 							catalogVersion,
 							(key, value) -> {
 								if (value == null) {
-									final long[] hv = this.historicalVersions;
 									this.historicalVersions = ArrayUtils.insertLongIntoOrderedArray(catalogVersion, hv);
 									return valuesToPromote.createFrom(keyToLocations);
 								} else {
@@ -2041,14 +2048,17 @@ public class OffsetIndex {
 		 */
 		public boolean contains(@Nonnull RecordKey key) {
 			final long[] nv = this.nonFlushedVersions;
-			for (int i = nv.length - 1; i >= 0; i--) {
-				long nonFlushedVersion = nv[i];
-				final NonFlushedValueSet nfSet = this.nonFlushedValues.get(nonFlushedVersion);
-				if (nfSet != null) {
-					if (nfSet.removedKeys.contains(key)) {
-						return false;
-					} else if (nfSet.addedKeys.contains(key)) {
-						return true;
+			final ConcurrentHashMap<Long, NonFlushedValueSet> theNonVlushedValues = this.nonFlushedValues;
+			if (nv != null && theNonVlushedValues != null) {
+				for (int i = nv.length - 1; i >= 0; i--) {
+					long nonFlushedVersion = nv[i];
+					final NonFlushedValueSet nfSet = theNonVlushedValues.get(nonFlushedVersion);
+					if (nfSet != null) {
+						if (nfSet.removedKeys.contains(key)) {
+							return false;
+						} else if (nfSet.addedKeys.contains(key)) {
+							return true;
+						}
 					}
 				}
 			}
@@ -2063,17 +2073,19 @@ public class OffsetIndex {
 		 */
 		@Nonnull
 		private NonFlushedValueSet getNonFlushedValues(long catalogVersion) {
-			if (this.nonFlushedVersions == null) {
-				this.nonFlushedValues = CollectionUtils.createConcurrentHashMap(16);
+			final long[] nv = this.nonFlushedVersions;
+			final ConcurrentHashMap<Long, NonFlushedValueSet> theNonFlushedValues = this.nonFlushedValues;
+			if (nv == null || theNonFlushedValues == null) {
+				final ConcurrentHashMap<Long, NonFlushedValueSet> newNonFlushedValues = CollectionUtils.createConcurrentHashMap(16);
+				final NonFlushedValueSet nvSet = new NonFlushedValueSet(catalogVersion, this::notifySizeIncrease);
+				newNonFlushedValues.put(catalogVersion, nvSet);
+				this.nonFlushedValues = newNonFlushedValues;
 				this.nonFlushedVersions = new long[]{catalogVersion};
-				final NonFlushedValueSet nv = new NonFlushedValueSet(catalogVersion, this::notifySizeIncrease);
-				this.nonFlushedValues.put(catalogVersion, nv);
-				return nv;
+				return nvSet;
 			} else {
-				return this.nonFlushedValues.computeIfAbsent(
+				return theNonFlushedValues.computeIfAbsent(
 					catalogVersion,
 					cv -> {
-						final long[] nv = this.nonFlushedVersions;
 						final long lastCatalogVersion = nv[nv.length - 1];
 						Assert.isPremiseValid(
 							lastCatalogVersion == -1 || lastCatalogVersion <= catalogVersion,
@@ -2253,7 +2265,7 @@ public class OffsetIndex {
 	 * @param addedInFuture  true if the value was added in future versions
 	 */
 	protected record VolatileValueInformation(
-		@Nonnull VersionedValue versionedValue,
+		@Nullable VersionedValue versionedValue,
 		boolean removed,
 		boolean addedInFuture
 	) {

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/model/VersionedValue.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/model/VersionedValue.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import io.evitadb.store.model.FileLocation;
 import io.evitadb.store.offsetIndex.OffsetIndex;
 import io.evitadb.utils.MemoryMeasuringConstants;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import java.io.Serial;
 import java.io.Serializable;
 
@@ -43,7 +43,7 @@ import java.io.Serializable;
 public record VersionedValue(
 	long primaryKey,
 	byte recordType,
-	@Nullable FileLocation fileLocation
+	@Nonnull FileLocation fileLocation
 ) implements Serializable {
 	@Serial private static final long serialVersionUID = -4467999274212489366L;
 	public static final long MEMORY_SIZE = 2 * MemoryMeasuringConstants.OBJECT_HEADER_SIZE +

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -858,6 +858,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 				this.catalogName,
 				FileType.CATALOG,
 				this.catalogName,
+				storageOptions.syncWrites(),
 				this.catalogStoragePath.resolve(getCatalogBootstrapFileName(catalogName)),
 				this.observableOutputKeeper
 			)
@@ -940,6 +941,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 				this.catalogName,
 				FileType.CATALOG,
 				this.catalogName,
+				storageOptions.syncWrites(),
 				this.catalogStoragePath.resolve(getCatalogBootstrapFileName(catalogName)),
 				this.observableOutputKeeper
 			)
@@ -1442,6 +1444,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 				this.transactionOptions.transactionWorkDirectory()
 					.resolve(transactionId.toString())
 					.resolve(transactionId + ".wal"),
+				this.storageOptions.syncWrites(),
 				this.observableOutputKeeper,
 				this.offHeapMemoryManager
 			)
@@ -1614,6 +1617,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 					catalogNameToBeReplaced,
 					FileType.CATALOG,
 					catalogNameToBeReplaced,
+					storageOptions.syncWrites(),
 					newPath.resolve(getCatalogBootstrapFileName(catalogNameToBeReplaced)),
 					this.observableOutputKeeper
 				),
@@ -2221,6 +2225,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 						originalBootstrapHandle,
 						new WriteOnlyFileHandle(
 							originalBootstrapHandle.getTargetFile(),
+							storageOptions.syncWrites(),
 							this.observableOutputKeeper
 						)
 					),
@@ -2275,6 +2280,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 					originalBootstrapHandle,
 					new WriteOnlyFileHandle(
 						originalBootstrapHandle.getTargetFile(),
+						storageOptions.syncWrites(),
 						this.observableOutputKeeper
 					)
 				),
@@ -2498,6 +2504,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 			// create new file and replace the former one with it
 			return new WriteOnlyFileHandle(
 				Files.createTempFile(CatalogPersistenceService.getCatalogBootstrapFileName(newCatalogName), ".tmp"),
+				storageOptions.syncWrites(),
 				this.observableOutputKeeper
 			);
 		} catch (IOException e) {

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -763,6 +763,7 @@ public class DefaultEntityCollectionPersistenceService implements EntityCollecti
 					catalogName,
 					FileType.ENTITY_COLLECTION,
 					this.entityCollectionFileReference.entityType(),
+					storageOptions.syncWrites(),
 					this.entityCollectionFile,
 					observableOutputKeeper
 				),
@@ -817,6 +818,7 @@ public class DefaultEntityCollectionPersistenceService implements EntityCollecti
 					catalogName,
 					FileType.ENTITY_COLLECTION,
 					this.entityCollectionFileReference.entityType(),
+					storageOptions.syncWrites(),
 					this.entityCollectionFile,
 					this.observableOutputKeeper
 				),

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/TransactionalStoragePartPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/TransactionalStoragePartPersistenceService.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -107,6 +107,7 @@ public class TransactionalStoragePartPersistenceService implements StoragePartPe
 			offsetIndexRecordTypeRegistry,
 			new WriteOnlyOffHeapWithFileBackupHandle(
 				this.targetFile,
+				storageOptions.syncWrites(),
 				observableOutputKeeper,
 				offHeapMemoryManager
 			),

--- a/evita_test_support/src/main/resources/evita-configuration.yaml
+++ b/evita_test_support/src/main/resources/evita-configuration.yaml
@@ -29,6 +29,7 @@ storage:
   waitOnCloseSeconds: ${storage.waitOnCloseSeconds:60}
   outputBufferSize: ${storage.outputBufferSize:4MB}
   maxOpenedReadHandles: ${storage.maxOpenedReadHandles:12}
+  syncWrites: ${storage.syncWrites:true}
   computeCRC32C: ${storage.computeCRC32C:true}
   minimalActiveRecordShare: ${storage.minimalActiveRecordShare:0.5}
   fileSizeCompactionThresholdBytes: ${storage.fileSizeCompactionThresholdBytes:100M}


### PR DESCRIPTION
Explicit file system synchronisation (java.io.FileDescriptor#sync) is an expensive operation that is not necessary in all scenarios. It ensures that committed data is safely written to persistent storage, but in integration testing, for example, this kind of guarantee is useless.

The measured impact of this explicit synchronisation in a test integration suite of 1400 E2E tests heavily using evitaDB resulted in 25% better performance (shorter test suite duration), which is a significant improvement. So it's a good idea to make this fsync a configurable option, enabled by default, but able to be disabled.

Refs: #767