### PR TITLE
chore: set time travel to disabled by default

### DIFF
--- a/documentation/user/en/operate/configure.md
+++ b/documentation/user/en/operate/configure.md
@@ -44,7 +44,7 @@ storage:                                          # [see Storage configuration](
   computeCRC32C: true
   minimalActiveRecordShare: 0.5
   fileSizeCompactionThresholdBytes: 100MB
-  timeTravelEnabled: true
+  timeTravelEnabled: false
   exportDirectorySizeLimitBytes: 1G
   exportFileHistoryExpirationSeconds: 7d
 
@@ -497,7 +497,7 @@ This section contains configuration options for the storage layer of the databas
     </dd>
     <dt>timeTravelEnabled</dt>
     <dd>
-        <p>**Default:** `true`</p>
+        <p>**Default:** `false`</p>
         <p>When set to true, the data files are not removed immediately after compacting, but are kept on disk as long 
         as there is history available in the WAL log. This allows a snapshot of the database to be taken at any point 
         in the history covered by the WAL log. From the snapshot, the database can be restored to the exact point in 

--- a/evita_api/src/main/java/io/evitadb/api/configuration/StorageOptions.java
+++ b/evita_api/src/main/java/io/evitadb/api/configuration/StorageOptions.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ public record StorageOptions(
 	public static final boolean DEFAULT_COMPUTE_CRC = true;
 	public static final double DEFAULT_MINIMAL_ACTIVE_RECORD_SHARE = 0.5;
 	public static final long DEFAULT_MINIMAL_FILE_SIZE_COMPACTION_THRESHOLD = 104_857_600L; // 100MB
-	public static final boolean DEFAULT_TIME_TRAVEL_ENABLED = true;
+	public static final boolean DEFAULT_TIME_TRAVEL_ENABLED = false;
 	public static final long DEFAULT_EXPORT_DIRECTORY_SIZE_LIMIT_BYTES = 1_073_741_824L; // 1GB
 	public static final long DEFAULT_EXPORT_FILE_HISTORY_EXPIRATION_SECONDS = 604_800L; // 7 days
 

--- a/evita_server/src/main/resources/evita-configuration.yaml
+++ b/evita_server/src/main/resources/evita-configuration.yaml
@@ -32,7 +32,7 @@ storage:
   computeCRC32C: ${storage.computeCRC32C:true}
   minimalActiveRecordShare: ${storage.minimalActiveRecordShare:0.5}
   fileSizeCompactionThresholdBytes: ${storage.fileSizeCompactionThresholdBytes:100M}
-  timeTravelEnabled: ${storage.timeTravelEnabled:true}
+  timeTravelEnabled: ${storage.timeTravelEnabled:false}
   exportDirectorySizeLimitBytes: ${storage.exportDirectorySizeLimitBytes:1G}
   exportFileHistoryExpirationSeconds: ${storage.exportFileHistoryExpirationSeconds:7d}
 

--- a/evita_test_support/src/main/resources/evita-configuration.yaml
+++ b/evita_test_support/src/main/resources/evita-configuration.yaml
@@ -32,7 +32,7 @@ storage:
   computeCRC32C: ${storage.computeCRC32C:true}
   minimalActiveRecordShare: ${storage.minimalActiveRecordShare:0.5}
   fileSizeCompactionThresholdBytes: ${storage.fileSizeCompactionThresholdBytes:100M}
-  timeTravelEnabled: ${storage.timeTravelEnabled:true}
+  timeTravelEnabled: ${storage.timeTravelEnabled:false}
   exportDirectorySizeLimitBytes: ${storage.exportDirectorySizeLimitBytes:1G}
   exportFileHistoryExpirationSeconds: ${storage.exportFileHistoryExpirationSeconds:7d}
 


### PR DESCRIPTION
Although time travel works on its own, we've found that it's impractical to use in production because it takes up too much disk space. These issues need to be addressed first so that this feature doesn't cause problems on production systems:

- https://github.com/FgForrest/evitaDB/issues/760
- https://github.com/FgForrest/evitaDB/issues/421
- https://github.com/FgForrest/evitaDB/issues/761

That's why we temporarily disable this feature in the default settings.

Refs: #772