### PR TITLE
fix: Filtering constraint attributeStartsWith doesn't work with array…

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AbstractAttributeStringSearchTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AbstractAttributeStringSearchTranslator.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024
+ *   Copyright (c) 2024-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ class AbstractAttributeStringSearchTranslator extends AbstractAttributeTranslato
 		@Nonnull AttributeSchemaContract attributeDefinition
 	) {
 		Assert.isTrue(
-			String.class.equals(attributeDefinition.getType()),
+			String.class.equals(attributeDefinition.getPlainType()),
 			() -> attributeConstraint.getClass().getSimpleName() + " constraint can be used only on String attributes - `" + attributeDefinition.getName() + "` is `" + attributeDefinition.getType() + "`!"
 		);
 	}


### PR DESCRIPTION
… type attributes

The query:

```graphQL
query {
  queryProduct(
    filterBy: {
      entityLocaleEquals: en
      attributeUrlInactiveStartsWith: "/"
    }
  ) {
    recordPage {
      data {
        primaryKey
        attributes {
          url
        }
      }
    }
  }
}
```

Doesn't work on demo schema since the `urlInactive` is string array.

Refs: #778