### PR TITLE
Hotfixes

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/CacheableSorter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/CacheableSorter.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ package io.evitadb.core.query.sort;
 
 import io.evitadb.api.requestResponse.EvitaResponseExtraResult;
 import io.evitadb.core.cache.payload.CachePayloadHeader;
-import io.evitadb.core.query.QueryPlanningContext;
+import io.evitadb.core.query.QueryExecutionContext;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
 import io.evitadb.core.query.sort.SortedRecordsSupplierFactory.SortedRecordsProvider;
@@ -60,7 +60,7 @@ public interface CacheableSorter extends TransactionalDataRelatedStructure, Sort
 
 	/**
 	 * Returns copy of this computer with same configuration but new method handle that references callback that
-	 * will be called when {@link #sortAndSlice(QueryPlanningContext, Formula, int, int, int[], int)} method is first executed
+	 * will be called when {@link #sortAndSlice(QueryExecutionContext, Formula, int, int, int[], int)} method is first executed
 	 * and memoized result is available.
 	 */
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/DeferredSorter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/DeferredSorter.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -72,9 +72,15 @@ public class DeferredSorter implements Sorter {
 		int peak,
 		@Nullable IntConsumer skippedRecordsConsumer
 	) {
-		return executionWrapper.applyAsInt(
-			() -> ConditionalSorter.getFirstApplicableSorter(queryContext, sorter)
-				.sortAndSlice(queryContext, input, startIndex, endIndex, result, peak, skippedRecordsConsumer)
-		);
+		final Sorter firstApplicableSorter = ConditionalSorter.getFirstApplicableSorter(queryContext, sorter);
+		if (firstApplicableSorter == null) {
+			return 0;
+		} else {
+			return executionWrapper.applyAsInt(
+				() -> firstApplicableSorter.sortAndSlice(
+					queryContext, input, startIndex, endIndex, result, peak, skippedRecordsConsumer
+				)
+			);
+		}
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/PredecessorAttributeComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/PredecessorAttributeComparator.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -108,16 +108,16 @@ public class PredecessorAttributeComparator implements EntityComparator {
 				break;
 			}
 		}
-		if (!(o1Found || o2Found) && nonSortedEntities == null) {
+		if (!(o1Found && o2Found) && this.nonSortedEntities == null) {
 			// if any of the entities is not found, and we don't have the container to store them, create it
-			nonSortedEntities = new CompositeObjectArray<>(EntityContract.class);
+			this.nonSortedEntities = new CompositeObjectArray<>(EntityContract.class);
 		}
 		// if any of the entities is not found, store it in the container
 		if (!o1Found) {
-			nonSortedEntities.add(o1);
+			this.nonSortedEntities.add(o1);
 		}
 		if (!o2Found) {
-			nonSortedEntities.add(o2);
+			this.nonSortedEntities.add(o2);
 		}
 		// return the result
 		return result;


### PR DESCRIPTION
fix: NullPointerException in PredecessorAttributeComparator (https://github.com/FgForrest/evitaDB/issues/781)
fix: ArrayIndexOutOfBounds in MergedSortedRecordsSupplier (https://github.com/FgForrest/evitaDB/issues/780)