### PR TITLE
fix: Ordering referenced entities by reference attribute inside `inScope` container doesn't work

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/OrderByVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/OrderByVisitor.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -130,10 +130,6 @@ public class OrderByVisitor implements ConstraintVisitor, LocaleProvider {
 	 * Contemporary stack for auxiliary data resolved for each level of the query.
 	 */
 	private final Deque<ProcessingScope> scope = new ArrayDeque<>(16);
-	/**
-	 * Contains the created sorter from the ordering query source tree.
-	 */
-	private final Deque<Sorter> sorters = new ArrayDeque<>(16);
 
 	public OrderByVisitor(
 		@Nonnull QueryPlanningContext queryContext,
@@ -175,7 +171,7 @@ public class OrderByVisitor implements ConstraintVisitor, LocaleProvider {
 				null,
 				attributeSchemaAccessor,
 				EntityAttributeExtractor.INSTANCE,
-				this.sorters
+				new ArrayDeque<>(16)
 			)
 		);
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/translator/OrderInScopeTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/translator/OrderInScopeTranslator.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -68,7 +68,22 @@ public class OrderInScopeTranslator implements OrderingConstraintTranslator<Orde
 
 	@Override
 	public void createComparator(@Nonnull OrderInScope inScope, @Nonnull ReferenceOrderByVisitor orderByVisitor) {
-		// do nothing
+		final Set<Scope> requestedScopes = orderByVisitor.getScopes();
+		final Scope scopeToUse = inScope.getScope();
+		Assert.isTrue(
+			requestedScopes.contains(scopeToUse),
+			"Scope `" + scopeToUse + "` used in `inScope` order container was not requested by `scope` constraint!"
+		);
+
+		// process inner constraints
+		orderByVisitor.doWithScope(
+			Set.of(scopeToUse),
+			() -> {
+				for (OrderConstraint innerConstraint : inScope.getChildren()) {
+					innerConstraint.accept(orderByVisitor);
+				}
+			}
+		);
 	}
 
 }


### PR DESCRIPTION
This graphQL query:

```graphql
query productPage {
  queryProduct{
    recordStrip(limit: 1) {
      data {
        primaryKey
        categories(
          orderBy: {inScope: {scope: LIVE, ordering: {attributeCategoryPriorityNatural: ASC}}}
        ) {
          referencedPrimaryKey
          attributes {
            categoryPriority
          }
          referencedEntity {
            primaryKey
            attributes {
              code
            }
          }
        }
      }
    }
  }
}
```

... doesn't work properly. When ordering constraint is enveloped in `inScope` container it's completely skipped.

Refs: #789