### PR TITLE
feat: Allow overriding `serviceName` for OpenTelemetry in configuration

### DIFF
--- a/documentation/user/en/operate/configure.md
+++ b/documentation/user/en/operate/configure.md
@@ -155,6 +155,7 @@ api:                                              # [see API configuration](#api
       tlsMode: null
       keepAlive: null
       tracing:
+        serviceName: evitaDB
         endpoint: null
         protocol: grpc
       allowedEvents: null
@@ -1154,6 +1155,11 @@ pro scraping Prometheus metrics, OTEL trace exporter and Java Flight Recorder ev
     <dd>
         <p>**Default:** `FORCE_NO_TLS`</p>
         <p>See [default endpoint configuration](#default-endpoint-configuration)</p>
+    </dd>
+    <dt>tracing.serviceName</dt>
+    <dd>
+        <p>**Default:** `evitaDB`</p>
+        <p>Specifies the name of the service the traces should be published for.</p>
     </dd>
     <dt>tracing.endpoint</dt>
     <dd>

--- a/documentation/user/en/operate/observe.md
+++ b/documentation/user/en/operate/observe.md
@@ -436,6 +436,7 @@ Observability:
   exposeOn: ${api.endpoints.observability.exposeOn:"localhost:5555"}
   tlsMode: ${api.endpoints.observability.tlsMode:FORCE_NO_TLS}
   tracing:
+    serviceName: ${api.endpoints.observability.tracing.serviceName:evitaDB}
     endpoint: ${api.endpoints.observability.tracing.endpoint:null}
     protocol: ${api.endpoints.observability.tracing.protocol:grpc}
 ```

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/ObservabilityProviderRegistrar.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/ObservabilityProviderRegistrar.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public class ObservabilityProviderRegistrar implements ExternalApiProviderRegist
 	public ExternalApiProvider<ObservabilityConfig> register(@Nonnull Evita evita, @Nonnull ExternalApiServer externalApiServer, @Nonnull ApiOptions apiOptions, @Nonnull ObservabilityConfig observabilityConfig) {
 		final ObservabilityManager observabilityManager = new ObservabilityManager(observabilityConfig, evita);
 		final TracingConfig tracingConfig = observabilityConfig.getTracing();
-		if (tracingConfig != null && tracingConfig.getEndpoint() != null) {
+		if (tracingConfig != null && tracingConfig.endpoint() != null) {
 			OpenTelemetryTracerSetup.setTracingConfig(observabilityConfig.getTracing());
 		}
 		observabilityManager.registerPrometheusMetricHandler();

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/configuration/TracingConfig.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/configuration/TracingConfig.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024
+ *   Copyright (c) 2024-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -25,38 +25,42 @@ package io.evitadb.externalApi.observability.configuration;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
  * Tracing endpoint configuration.
  *
+ * @param serviceName name of the service. Default is `evitaDB`.
+ * @param endpoint tracing endpoint, should look like this:
+ *                 gRPC: `http://localhost:4317`
+ *                 HTTP: `http://localhost:4318/v1/traces`
+ * @param protocol protocol used for tracing - options are: HTTP,GRPC. Default is GRPC.
  * @author Tomáš Pozler, FG Forrest a.s. (c) 2024
  */
-public class TracingConfig {
-	/**
-	 * Tracing endpoint. Should look like this:
-	 *
-	 * gRPC: `http://localhost:4317`
-	 * HTTP: `http://localhost:4318/v1/traces`
-	 */
-
-	@Getter private final String endpoint;
-	/**
-	 * Protocol used for tracing - options are: HTTP,GRPC. Default is GRPC.
-	 */
-	@Getter private final String protocol;
+public record TracingConfig(
+	@Nonnull String serviceName,
+	@Nullable String endpoint,
+	@Nullable String protocol
+) {
+	public static final String DEFAULT_SERVICE_NAME = "evitaDB";
+	public static final String SPAN_HTTP_PROTOCOL = "HTTP";
+	public static final String SPAN_GRPC_PROTOCOL = "GRPC";
+	public static final String DEFAULT_PROTOCOL = SPAN_GRPC_PROTOCOL;
 
 	public TracingConfig() {
-		this.endpoint = null;
-		this.protocol = null;
+		this(DEFAULT_SERVICE_NAME, null, DEFAULT_PROTOCOL);
 	}
 
 	@JsonCreator
-	public TracingConfig(@Nullable @JsonProperty("endpoint") String endpoint,
-	                     @Nullable @JsonProperty("protocol") String protocol) {
+	public TracingConfig(
+		@Nullable @JsonProperty("serviceName") String serviceName,
+		@Nullable @JsonProperty("endpoint") String endpoint,
+		@Nullable @JsonProperty("protocol") String protocol
+	) {
+		this.serviceName = serviceName == null ? DEFAULT_SERVICE_NAME : serviceName;
 		this.endpoint = endpoint;
-		this.protocol = protocol;
+		this.protocol = protocol == null ? DEFAULT_PROTOCOL : protocol;
 	}
 }

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/trace/OpenTelemetryTracerSetup.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/trace/OpenTelemetryTracerSetup.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024
+ *   Copyright (c) 2024-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ package io.evitadb.externalApi.observability.trace;
 import io.evitadb.externalApi.observability.configuration.ObservabilityConfig;
 import io.evitadb.externalApi.observability.configuration.TracingConfig;
 import io.evitadb.externalApi.utils.ExternalApiTracingContext;
+import io.evitadb.utils.Assert;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.trace.Tracer;
@@ -61,10 +62,6 @@ public class OpenTelemetryTracerSetup {
 	 */
 	public static final ContextKey<String> CONTEXT_KEY = ContextKey.named(ExternalApiTracingContext.CLIENT_ID_CONTEXT_KEY_NAME);
 	/**
-	 * Name of the service that is used in the tracing context.
-	 */
-	private static final String SERVICE_NAME = "evitaDB";
-	/**
 	 * Observability API tracing config.
 	 */
 	private static TracingConfig TRACING_CONFIG;
@@ -77,9 +74,6 @@ public class OpenTelemetryTracerSetup {
 	 */
 	private static Tracer TRACER;
 
-	private static final String SPAN_HTTP_PROTOCOL = "HTTP";
-	private static final String SPAN_GRPC_PROTOCOL = "GRPC";
-
 	/**
 	 * Sets the {@link ObservabilityConfig} that is used to configure the OpenTelemetry. Should be set before working with
 	 * the OpenTelemetry.
@@ -87,19 +81,19 @@ public class OpenTelemetryTracerSetup {
 	public static void setTracingConfig(@Nonnull TracingConfig tracingConfig) {
 		TRACING_CONFIG = tracingConfig;
 		if (isTracingEnabled(tracingConfig)) {
-			OPEN_TELEMETRY = initializeOpenTelemetry();
+			OPEN_TELEMETRY = initializeOpenTelemetry(tracingConfig);
 		}
 	}
 
 	/**
 	 * Initializes the OpenTelemetry instance with the configured exporter and propagator.
 	 */
-	@Nullable
-	private static OpenTelemetry initializeOpenTelemetry() {
-		final Resource resource = Resource.getDefault().toBuilder().put(ResourceAttributes.SERVICE_NAME, SERVICE_NAME).build();
+	@Nonnull
+	private static OpenTelemetry initializeOpenTelemetry(@Nonnull TracingConfig tracingConfig) {
+		final Resource resource = Resource.getDefault().toBuilder().put(ResourceAttributes.SERVICE_NAME, tracingConfig.serviceName()).build();
 
 		final SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()
-			.addSpanProcessor(getSpanProcessor(TRACING_CONFIG))
+			.addSpanProcessor(getSpanProcessor(tracingConfig))
 			.setResource(resource)
 			.build();
 
@@ -116,20 +110,22 @@ public class OpenTelemetryTracerSetup {
 	 */
 	@Nonnull
 	private static SpanProcessor getSpanProcessor(@Nonnull TracingConfig tracingConfig) {
-		if (SPAN_HTTP_PROTOCOL.equalsIgnoreCase(tracingConfig.getProtocol())) {
+		Assert.isTrue(tracingConfig.endpoint() != null, "Tracing endpoint must be set.");
+		if (TracingConfig.SPAN_HTTP_PROTOCOL.equalsIgnoreCase(tracingConfig.protocol())) {
 			return BatchSpanProcessor.builder(
 				OtlpHttpSpanExporter.builder()
-					.setEndpoint(TRACING_CONFIG.getEndpoint())
+					.setEndpoint(tracingConfig.endpoint())
+					.setTimeout(Duration.ofSeconds(10))
+					.build()
+			).build();
+		} else {
+			return BatchSpanProcessor.builder(
+				OtlpGrpcSpanExporter.builder()
+					.setEndpoint(tracingConfig.endpoint())
 					.setTimeout(Duration.ofSeconds(10))
 					.build()
 			).build();
 		}
-		return BatchSpanProcessor.builder(
-			OtlpGrpcSpanExporter.builder()
-				.setEndpoint(TRACING_CONFIG.getEndpoint())
-				.setTimeout(Duration.ofSeconds(10))
-				.build()
-		).build();
 	}
 
 	/**
@@ -146,7 +142,7 @@ public class OpenTelemetryTracerSetup {
 	@Nonnull
 	public static Tracer getTracer() {
 		if (TRACER == null) {
-			TRACER = OPEN_TELEMETRY.getTracer(SERVICE_NAME);
+			TRACER = OPEN_TELEMETRY.getTracer(TRACING_CONFIG.serviceName());
 		}
 		return TRACER;
 	}
@@ -169,7 +165,7 @@ public class OpenTelemetryTracerSetup {
 		if (tracingConfig == null) {
 			return false;
 		}
-		final String endpoint = tracingConfig.getEndpoint();
+		final String endpoint = tracingConfig.endpoint();
 		if (endpoint == null) {
 			return false;
 		}

--- a/evita_server/src/main/resources/evita-configuration.yaml
+++ b/evita_server/src/main/resources/evita-configuration.yaml
@@ -142,6 +142,7 @@ api:
       tlsMode: ${api.endpoints.observability.tlsMode:FORCE_NO_TLS}
       keepAlive: ${api.endpoints.observability.keepAlive:null}
       tracing:
+        serviceName: ${api.endpoints.observability.tracing.serviceName:evitaDB}
         endpoint: ${api.endpoints.observability.tracing.endpoint:null}
         protocol: ${api.endpoints.observability.tracing.protocol:grpc}
       allowedEvents: !include ${api.endpoints.observability.allowedEvents:null}

--- a/evita_test_support/src/main/resources/evita-configuration.yaml
+++ b/evita_test_support/src/main/resources/evita-configuration.yaml
@@ -142,6 +142,7 @@ api:
       tlsMode: ${api.endpoints.observability.tlsMode:FORCE_NO_TLS}
       keepAlive: ${api.endpoints.observability.keepAlive:null}
       tracing:
+        serviceName: ${api.endpoints.observability.tracing.serviceName:evitaDB}
         endpoint: ${api.endpoints.observability.tracing.endpoint:null}
         protocol: ${api.endpoints.observability.tracing.protocol:grpc}
       allowedEvents: !include ${api.endpoints.observability.allowedEvents:null}


### PR DESCRIPTION
Currently we use constant value for `serviceName` of OpenTelemetry - `evitaDB`, but this needs to be overridable by configuration settings.

Refs: #805