### PR TITLE
feat: Allow engine start even if configuration contains unknown property

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,9 @@ ENV SYSTEM_API_PORT="5555"
 
 ## 2. Environment variables, MAY BE overriden in container ##
 
+## set to TRUE to fail on unknown properties in configuration files
+ENV EVITA_STRICT_CONFIG_FILE_CHECK="false"
+
 ## using volumes:
 
 ## folder with configuration files, all of them are applied one on top of another in alphabetical order

--- a/docker/README.MD
+++ b/docker/README.MD
@@ -26,6 +26,7 @@ docker run -i --rm --net=host \
 
 ## Environment variables
 - **EVITA_CONFIG_FILE** - Path to configuration file. Default: `/evita/conf/evita-configuration.yaml`
+- **EVITA_STRICT_CONFIG_FILE_CHECK** - Optional flag that may set configuration file validations to strict. Default: `false`
 - **EVITA_STORAGE_DIR** - Path to storage directory. Default: `/evita/data`
 - **EVITA_EXPORT_DIR** - Path to export directory (temporary storage for backup / exports). Default: `/evita/export`
 - **EVITA_CERTIFICATE_DIR** - Path to directory with automatically generated server certificates. Default: `/evita/certificates`

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -30,6 +30,7 @@ if [ "$1" = "" ]; then
         -javaagent:${EVITA_BIN_DIR}${EVITA_JAR_NAME} \
         $EVITA_JAVA_OPTS \
         -jar "${EVITA_BIN_DIR}${EVITA_JAR_NAME}" \
+        "strictConfigFileCheck=$EVITA_STRICT_CONFIG_FILE_CHECK" \
         "configDir=$EVITA_CONFIG_DIR" \
         "storage.storageDirectory=$EVITA_STORAGE_DIR" \
         "storage.exportDirectory=$EVITA_EXPORT_DIR" \

--- a/documentation/user/en/get-started/run-evitadb.md
+++ b/documentation/user/en/get-started/run-evitadb.md
@@ -70,7 +70,7 @@ To integrate evitaDB into your project, use the following steps:
 </CodeTabsBlock>
 <CodeTabsBlock>
 ```Gradle
-implementation 'io.evitadb:evita_db:2024.10.0'
+implementation 'io.evitadb:evita_db:2025.1.0'
 ```
 </CodeTabsBlock>
 </CodeTabs>
@@ -115,7 +115,7 @@ exception when you enable the corresponding API in evitaDB's configuration.
 </CodeTabsBlock>
 <CodeTabsBlock>
 ```Gradle
-implementation 'io.evitadb:evita_external_api_grpc:2024.10.0'
+implementation 'io.evitadb:evita_external_api_grpc:2025.1.0'
 ```
 </CodeTabsBlock>
 </CodeTabs>
@@ -135,7 +135,7 @@ implementation 'io.evitadb:evita_external_api_grpc:2024.10.0'
 </CodeTabsBlock>
 <CodeTabsBlock>
 ```Gradle
-implementation 'io.evitadb:evita_external_api_graphql:2024.10.0'
+implementation 'io.evitadb:evita_external_api_graphql:2025.1.0'
 ```
 </CodeTabsBlock>
 </CodeTabs>
@@ -155,7 +155,7 @@ implementation 'io.evitadb:evita_external_api_graphql:2024.10.0'
 </CodeTabsBlock>
 <CodeTabsBlock>
 ```Gradle
-implementation 'io.evitadb:evita_external_api_rest:2024.10.0'
+implementation 'io.evitadb:evita_external_api_rest:2025.1.0'
 ```
 </CodeTabsBlock>
 </CodeTabs>
@@ -225,7 +225,7 @@ When you start the evitaDB server you should see the following information in th
 |  __/\ V /| | || (_| | |_| | |_) |
  \___| \_/ |_|\__\__,_|____/|____/
 
-beta build 2024.10.0 (keep calm and report bugs 😉)
+beta build 2025.1.0 (keep calm and report bugs 😉)
 Visit us at: https://evitadb.io
 
 Log config used: META-INF/logback.xml

--- a/documentation/user/en/operate/run.md
+++ b/documentation/user/en/operate/run.md
@@ -220,15 +220,19 @@ You can take advantage of all the following variables:
     <Tbody>
         <Tr>
             <Td>**`EVITA_CONFIG_FILE`**</Td>
-            <Td>path to configuration file, default: `/evita/conf/evita-configuration.yaml`</Td>
+            <Td>Path to configuration file, default: `/evita/conf/evita-configuration.yaml`</Td>
+        </Tr>
+        <Tr>
+            <Td>**`EVITA_STRICT_CONFIG_FILE_CHECK`**</Td>
+            <Td>Optional flag that may set configuration file validations to strict. Default: `false`</Td>
         </Tr>
         <Tr>
             <Td>**`EVITA_STORAGE_DIR`**</Td>
-            <Td>path to storage directory, default: `/evita/data`</Td>
+            <Td>Path to storage directory, default: `/evita/data`</Td>
         </Tr>
         <Tr>
             <Td>**`EVITA_CERTIFICATE_DIR`**</Td>
-            <Td>path to directory with automatically generated server certificates. Default: `/evita/certificates`</Td>
+            <Td>Path to directory with automatically generated server certificates. Default: `/evita/certificates`</Td>
         </Tr>
         <Tr>
             <Td>**`EVITA_JAVA_OPTS`**</Td>

--- a/evita_functional_tests/src/test/java/io/evitadb/server/EvitaServerTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/server/EvitaServerTest.java
@@ -897,6 +897,47 @@ class EvitaServerTest implements TestConstants, EvitaTestSupport {
 		}
 	}
 
+	@Test
+	void shouldLoadConfigurationWithUnknownProperties() {
+		EvitaTestSupport.bootstrapEvitaServerConfigurationFileFrom(
+			DIR_EVITA_SERVER_TEST,
+			"/testData/evita-configuration-unknown-props.yaml",
+			"evita-configuration-unknown-props.yaml"
+		);
+
+		final EvitaServer evitaServer = new EvitaServer(
+			getPathInTargetDirectory(DIR_EVITA_SERVER_TEST),
+			constructTestArguments()
+		);
+		try {
+			evitaServer.run();
+		} catch (Exception ex) {
+			fail(ex);
+		} finally {
+			closeServerAndEvita(evitaServer);
+		}
+	}
+
+	@Test
+	void shouldFailToLoadConfigurationWithUnknownPropertiesOnStrictSettings() {
+		EvitaTestSupport.bootstrapEvitaServerConfigurationFileFrom(
+			DIR_EVITA_SERVER_TEST,
+			"/testData/evita-configuration-unknown-props.yaml",
+			"evita-configuration-unknown-props.yaml"
+		);
+
+		try {
+			new EvitaServer(
+				getPathInTargetDirectory(DIR_EVITA_SERVER_TEST),
+				true, null,
+				constructTestArguments()
+			);
+			fail("The server should have failed to start due to unknown properties in the configuration file.");
+		} catch (Exception ex) {
+			// this is okey
+		}
+	}
+
 	@Nonnull
 	private Map<String, String> constructTestArguments(
 		@Nonnull String... enabledApis

--- a/evita_functional_tests/src/test/java/io/evitadb/server/SpecialConfigInputFormatsHandlerTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/server/SpecialConfigInputFormatsHandlerTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 package io.evitadb.server;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
+import io.evitadb.server.yaml.SpecialConfigInputFormatsHandler;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 

--- a/evita_functional_tests/src/test/resources/testData/evita-configuration-unknown-props.yaml
+++ b/evita_functional_tests/src/test/resources/testData/evita-configuration-unknown-props.yaml
@@ -1,0 +1,15 @@
+api:
+  keepAlive: false
+  unknownProperty1: "hello"
+  endpoints:
+    graphQL:
+      tlsEnabled: false
+    rest:
+      tlsEnabled: false
+      anotherUnknownProperty: "world"
+    gRPC:
+      tlsEnabled: false
+    lab:
+      tlsEnabled: false
+    observability:
+      tlsEnabled: true

--- a/evita_server/src/main/java/io/evitadb/server/yaml/SpecialConfigInputFormatsHandler.java
+++ b/evita_server/src/main/java/io/evitadb/server/yaml/SpecialConfigInputFormatsHandler.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
  *   limitations under the License.
  */
 
-package io.evitadb.server;
+package io.evitadb.server.yaml;
 
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
@@ -59,7 +59,7 @@ import java.util.regex.Pattern;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
-class SpecialConfigInputFormatsHandler extends DeserializationProblemHandler {
+public class SpecialConfigInputFormatsHandler extends DeserializationProblemHandler {
 	private final Pattern SIZE_FORMAT = Pattern.compile("(\\d+(\\.\\d+)?)(KB|MB|GB|TB)");
 	private final Pattern NUMBER_FORMAT = Pattern.compile("([\\d_]+(\\.\\d+)?)([KMGT])");
 	private final Pattern TIME_FORMAT = Pattern.compile("([\\d_]+(\\.\\d+)?)([smhdwy])");

--- a/evita_server/src/main/java/io/evitadb/server/yaml/UnknownPropertyProblemHandler.java
+++ b/evita_server/src/main/java/io/evitadb/server/yaml/UnknownPropertyProblemHandler.java
@@ -1,0 +1,71 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.server.yaml;
+
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.regex.Pattern;
+
+/**
+ * This class is used to handle unknown properties in YAML configuration files.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+@Slf4j
+public class UnknownPropertyProblemHandler extends DeserializationProblemHandler implements Serializable {
+	@Serial private static final long serialVersionUID = -8541510916893219751L;
+	private static final Pattern REPLACE_PATTERN = Pattern.compile("/");
+	@Nullable @Setter private String prefix;
+
+	@Override
+	public boolean handleUnknownProperty(DeserializationContext ctxt, JsonParser jp, JsonDeserializer<?> deserializer, Object beanOrClass, String propertyName) throws IOException {
+		final String propertyPath = ctxt.getParser().getParsingContext().pathAsPointer().toString();
+		final String path = REPLACE_PATTERN.matcher((prefix == null ? "" : prefix) + propertyPath + "/" + propertyName).replaceAll(".");
+		final boolean startsWithDot = path.charAt(0) == '.';
+		final String finalPath = startsWithDot ? path.substring(1) : path;
+		log.warn("Unsupported property '{}' encountered in YAML configuration.", finalPath);
+		return true; // indicate that the problem is handled
+	}
+
+	 /**
+	 * Clears the current prefix used for constructing property paths.
+	 *
+	 * This method sets the prefix field to null, effectively removing
+	 * any previously set path prefix that may be used for handling unknown
+	 * properties in a YAML configuration file.
+	 */
+	public void clearPrefix() {
+		this.prefix = null;
+	}
+}

--- a/evita_server/src/main/java/module-info.java
+++ b/evita_server/src/main/java/module-info.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ module evita.server {
 	opens io.evitadb.server.configuration to com.fasterxml.jackson.databind;
 	exports io.evitadb.server;
 	exports io.evitadb.server.log to ch.qos.logback.core;
+	exports io.evitadb.server.yaml;
 
 	requires static lombok;
 	requires static jsr305;


### PR DESCRIPTION
Actually, evitaDB fails to start if configuration contains unknown property (settings). This brings complications for "operations" guys who manage the configuration templates and don't always control the engine version actually used (they might apply newer configuration settings for older engine version). New default mode should be that unknown properties and container objects are ignored and only a warning is printed when the engine is started. If the engine is run with special `strict` mode, the engine will fail (current behaviour).

Refs: #806