### PR TITLE
feat: Accept labels in HTTP headers

### DIFF
--- a/documentation/user/en/operate/observe.md
+++ b/documentation/user/en/operate/observe.md
@@ -555,7 +555,7 @@ a ZIP file and make it available for download. This file can be used for further
 different evitaDB instances.
 
 The recorded traffic can be browsed and filtered in evitaLab and any query can be easily executed in the corresponding 
-query console on the current dataset. Records can also be filtered by custom [labels](../query/header/header.md#label), 
+query console on the current dataset. Records can also be filtered by custom [labels](../query/header/label.md#label), 
 traceIds or protocol types. You can easily isolate sets of traffic records that relate to a single business case, such 
 as a single page rendering or a single API call.
 

--- a/documentation/user/en/query/header/label.md
+++ b/documentation/user/en/query/header/label.md
@@ -42,3 +42,20 @@ Each label is a key-value pair appended to the query header, as shown in the fol
 [Attaching labels to query](/documentation/user/en/query/header/examples/labels.evitaql)
 
 </SourceCodeTabs>
+
+<Note type="info">
+
+You can also provide labels using HTTP request headers in the form of `X-Meta-Label: <label-name>=<label-value>`.
+You may set multiple labels by providing multiple `X-Meta-Label` headers in the same request.
+
+There are also automatic labels that are added to the query by the system, such as:
+
+- `client-ip`: the IP address of the client that sent the query (real client IP address can be propagated using the
+  [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) header)
+- `client-uri`: the URI of the client that sent the query, present only if [X-Forwarded-Uri](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Uri) header is present
+- `client-id`: the identification of the client - see [clientId](../../use/connectors/java.md#configuration)
+- `trace-id`: current trace ID if [tracing](../../operate/observe.md#tracing) is enabled
+
+<LS to="g">If you use GraphQL API there is also `operation-name` label derived from the query name (if any name is defined).</LS>
+
+</Note>

--- a/evita_api/src/main/java/io/evitadb/api/observability/trace/TracingContext.java
+++ b/evita_api/src/main/java/io/evitadb/api/observability/trace/TracingContext.java
@@ -23,6 +23,8 @@
 
 package io.evitadb.api.observability.trace;
 
+
+import io.evitadb.api.query.head.Label;
 import org.slf4j.MDC;
 
 import javax.annotation.Nonnull;
@@ -49,6 +51,14 @@ public interface TracingContext {
 	 * Name of property representing the client IP address in the {@link MDC}.
 	 */
 	String MDC_CLIENT_IP_ADDRESS = "clientIp";
+	/**
+	 * Name of property representing the client URI in the {@link MDC}.
+	 */
+	String MDC_CLIENT_URI = "clientUri";
+	/**
+	 * Thread local storage for client labels.
+	 */
+	ThreadLocal<Label[]> CLIENT_LABELS = new ThreadLocal<>();
 
 	/**
 	 * Executes the provided operation within the context of the specified client IP address.
@@ -57,21 +67,77 @@ public interface TracingContext {
 	 * is removed from the MDC.
 	 *
 	 * @param clientIpAddress the IP address of the client, which will be added to the MDC for the scope of this execution
-	 * @param runnable the operation to be executed, provided as a {@code SupplierThrowingException} returning a result of type {@code T}
+	 * @param runnable        the operation to be executed, provided as a {@code SupplierThrowingException} returning a result of type {@code T}
 	 * @return the result of the operation executed by {@code runnable}
-	 * @throws Exception if the provided {@code runnable} operation throws an exception
 	 */
-	static <T> T executeWithClientIpAddress(@Nonnull String clientIpAddress, @Nonnull SupplierThrowingException<T> runnable) throws Exception {
+	static <T> T executeWithClientContext(
+		@Nullable String clientIpAddress,
+		@Nullable String clientUri,
+		@Nullable Label[] labels,
+		@Nonnull Supplier<T> runnable
+	) {
 		MDC.put(MDC_CLIENT_IP_ADDRESS, clientIpAddress);
+		MDC.put(MDC_CLIENT_URI, clientUri);
+		CLIENT_LABELS.set(labels);
 		try {
 			return runnable.get();
 		} finally {
 			MDC.remove(MDC_CLIENT_IP_ADDRESS);
+			MDC.remove(MDC_CLIENT_URI);
+			CLIENT_LABELS.remove();
 		}
 	}
 
 	/**
+	 * Executes the provided operation within the context of the specified client IP address.
+	 * The client IP address is temporarily stored in the MDC (Mapped Diagnostic Context) for tracking
+	 * or logging purposes during the execution of the operation. After execution, the client IP address
+	 * is removed from the MDC.
+	 *
+	 * @param context  the previously stored context with all necessary information
+	 * @param runnable the operation to be executed, provided as a {@code SupplierThrowingException} returning a result of type {@code T}
+	 * @return the result of the operation executed by {@code runnable}
+	 */
+	static <T> T executeWithClientContext(
+		@Nonnull CapturedContext context,
+		@Nonnull Supplier<T> runnable
+	) {
+		MDC.put(MDC_TRACE_ID_PROPERTY, context.traceId());
+		MDC.put(MDC_CLIENT_ID_PROPERTY, context.clientId());
+		MDC.put(MDC_CLIENT_IP_ADDRESS, context.clientIpAddress());
+		MDC.put(MDC_CLIENT_URI, context.clientUri());
+		CLIENT_LABELS.set(context.clientLabels());
+		try {
+			return runnable.get();
+		} finally {
+			MDC.remove(MDC_TRACE_ID_PROPERTY);
+			MDC.remove(MDC_CLIENT_ID_PROPERTY);
+			MDC.remove(MDC_CLIENT_IP_ADDRESS);
+			MDC.remove(MDC_CLIENT_URI);
+			CLIENT_LABELS.remove();
+		}
+	}
+
+	/**
+	 * Captures the current context information from the MDC (Mapped Diagnostic Context) and client-specific labels.
+	 *
+	 * @return A {@link CapturedContext} instance containing trace ID, client ID, client IP address, client URI,
+	 * and a set of client labels extracted from the MDC and thread-local storage.
+	 */
+	@Nonnull
+	static CapturedContext captureContext() {
+		return new CapturedContext(
+			MDC.get(MDC_TRACE_ID_PROPERTY),
+			MDC.get(MDC_CLIENT_ID_PROPERTY),
+			MDC.get(MDC_CLIENT_IP_ADDRESS),
+			MDC.get(MDC_CLIENT_URI),
+			CLIENT_LABELS.get()
+		);
+	}
+
+	/**
 	 * Returns the trace identifier associated with the trace.
+	 *
 	 * @return the trace identifier
 	 */
 	@Nonnull
@@ -79,6 +145,7 @@ public interface TracingContext {
 
 	/**
 	 * Returns the client identifier associated with the trace.
+	 *
 	 * @return the client identifier
 	 */
 	@Nonnull
@@ -86,11 +153,33 @@ public interface TracingContext {
 
 	/**
 	 * Returns the client IP address associated with the trace.
+	 *
 	 * @return the client IP address
 	 */
 	@Nonnull
 	default Optional<String> getClientIpAddress() {
 		return Optional.ofNullable(MDC.get(MDC_CLIENT_IP_ADDRESS));
+	}
+
+	/**
+	 * Returns the client URI associated with the trace.
+	 *
+	 * @return the client URI
+	 */
+	@Nonnull
+	default Optional<String> getClientUri() {
+		return Optional.ofNullable(MDC.get(MDC_CLIENT_URI));
+	}
+
+	/**
+	 * Returns the client labels associated with the trace.
+	 *
+	 * @return the client labels
+	 */
+	@Nonnull
+	default Label[] getClientLabels() {
+		final Label[] labels = CLIENT_LABELS.get();
+		return labels == null ? Label.EMPTY_ARRAY : labels;
 	}
 
 	/**
@@ -326,13 +415,21 @@ public interface TracingContext {
 	}
 
 	/**
-	 * Interface similar to {@link Supplier} but allows to throw checked exceptions.
+	 * Represents a captured context of this tracing context
+	 *
+	 * @param traceId         the trace identifier
+	 * @param clientId        the client identifier
+	 * @param clientIpAddress the client IP address
+	 * @param clientUri       the client URI
+	 * @param clientLabels    the client labels
 	 */
-	@FunctionalInterface
-	interface SupplierThrowingException<T> {
-
-		T get() throws Exception;
-
+	record CapturedContext(
+		@Nullable String traceId,
+		@Nullable String clientId,
+		@Nullable String clientIpAddress,
+		@Nullable String clientUri,
+		@Nullable Label[] clientLabels
+	) {
 	}
 
 }

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/utils/ExternalApiTracingContext.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/utils/ExternalApiTracingContext.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024
+ *   Copyright (c) 2024-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ public interface ExternalApiTracingContext<C> {
 	 * Format of the client ID used by the server.
 	 */
 	String SERVER_CLIENT_ID_FORMAT = "%s|%s";
+
 	/**
 	 * Default client ID used when the client does not send any.
 	 */
@@ -54,6 +55,21 @@ public interface ExternalApiTracingContext<C> {
 	 * Name of the ContextKey used by tracing library.
 	 */
 	String CLIENT_ID_CONTEXT_KEY_NAME = "client_id";
+
+	/**
+	 * Header name for meta labels that allow to set traffic recording labels via HTTP headers.
+	 */
+	String X_META_LABEL = "X-Meta-Label";
+
+	/**
+	 * Header name for the client URI.
+	 */
+	String X_FORWARDED_URI = "X-Forwarded-Uri";
+
+	/**
+	 * Header name for the client IP.
+	 */
+	String X_FORWARDED_FOR = "X-Forwarded-For";
 
 	/**
 	 * Regex identifying characters that are not allowed inside client ID.


### PR DESCRIPTION
Adding labels directly into the query might be problem in Node.js environment due to the use of query templates, but it would be quite easy to add them to the HTTP request as headers. So we should be able to optionally accept query labels in headers in the form of:

- `X-Forwarded-Uri`: as the original URI requested for the frontend facade
- `X-Meta-Label`: with arbitrary value for new labels passed in headers

These headers should be automatically accepted and incorporated in the traffic recording.

Refs: #802