### PR TITLE
fix: Data files might have been removed before backup is finished

### DIFF
--- a/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTransactionalFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTransactionalFunctionalTest.java
@@ -1397,6 +1397,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 						.exportDirectory(testDirectoryExport)
 						.minimalActiveRecordShare(0.9)
 						.fileSizeCompactionThresholdBytes(16_384)
+						.timeTravelEnabled(true)
 						.build()
 				)
 				.transaction(

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
@@ -1071,7 +1071,8 @@ public class OffsetIndex {
 		@Nonnull OffsetIndexDescriptor fileOffsetIndexDescriptor,
 		boolean close
 	) {
-		if (this.volatileValues.hasValuesToFlush()) {
+		// if there are any non-flushed values, we need to flush them to the disk (of if the offset index was not yet created)
+		if (this.volatileValues.hasValuesToFlush() || fileOffsetIndexDescriptor.fileLocation() == null) {
 			final OffsetIndexDescriptor newFileOffsetIndexDescriptor = writeHandle.checkAndExecuteAndSync(
 				"Writing mem table",
 				this::assertOperative,


### PR DESCRIPTION
OffsetIndex may have produced empty file location. Added checks, handled this situation, added tests.

Removed invalid check in ObsoleteFileMaintainer and safer handling of the backup task version reservation.

The test itself must enable time travel, because it tries to restore older backups, that may have been already removed if the time travel is not enabled.

Refs: #816