### PR TITLE
fix: formula for previous scope was not included in aggregated formula

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/ReferencedEntityFetcher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/ReferencedEntityFetcher.java
@@ -581,6 +581,7 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 								final Formula epkFormula = entityPrimaryKeyFormula.get(indexKey.scope());
 								if (epkFormula != null) {
 									lastIndexFormula = FormulaFactory.or(
+										lastIndexFormula,
 										resultFormula,
 										epkFormula
 									);


### PR DESCRIPTION
In case there are multiple scopes used in the query and references are fetched, some of them may be missing since previous formula was forgotten to be included in the aggregated result formula.

Refs: #830