### PR TITLE
feat: System endpoints return 404 with trailing slash

### DIFF
--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/utils/path/PathHandlingService.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/utils/path/PathHandlingService.java
@@ -55,7 +55,7 @@ public class PathHandlingService implements HttpService {
 	public HttpResponse serve(@Nonnull ServiceRequestContext ctx, @Nonnull HttpRequest req) throws Exception {
 		PathMatcher.PathMatch<HttpService> match = null;
 		boolean hit = false;
-		final String path = req.uri().getPath();
+		final String path = URLUtils.normalizeSlashes(req.uri().getPath());
 		if(cache != null) {
 			match = cache.get(path);
 			hit = true;

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/utils/path/routing/PathMatcher.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/utils/path/routing/PathMatcher.java
@@ -147,7 +147,7 @@ public class PathMatcher<T> {
 	}
 
 	public T getExactPath(final String path) {
-		return exactPathMatches.get(URLUtils.normalizeSlashes(path));
+		return exactPathMatches.get(path);
 	}
 
 	public T getPrefixPath(final String path) {

--- a/evita_functional_tests/src/test/java/io/evitadb/server/EvitaServerTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/server/EvitaServerTest.java
@@ -464,6 +464,19 @@ class EvitaServerTest implements TestConstants, EvitaTestSupport {
 				content -> assertTrue(content.contains("evitaDB-"), "The system API should be accessible via Lab scheme and port: " + content)
 			);
 
+			// we should be able also to access the system API with trailing slash
+			NetworkUtils.fetchContent(
+				"http://localhost:" + servicePorts.get(SystemProvider.CODE) + "/system/server-name/",
+				"GET",
+				"text/plain",
+				null,
+				TIMEOUT_IN_MILLIS,
+				error -> fail("The system API should be accessible via Lab scheme and port: " + error),
+				timeout -> assertEquals("Error fetching content from URL: http://localhost:" + servicePorts.get(ObservabilityProvider.CODE) + "/system/server-name/ HTTP status 404 - Not Found: Service not available.", timeout)
+			).ifPresent(
+				content -> assertTrue(content.contains("evitaDB-"), "The system API should be accessible via Lab scheme and port: " + content)
+			);
+
 			NetworkUtils.fetchContent(
 				"https://localhost:" + servicePorts.get(GraphQLProvider.CODE) + "/gql/system",
 				"POST",


### PR DESCRIPTION
System API endpoints such as `/system/server-name` returns 404 error when access with trailing slash like so `/system/server-name/`.

This makes the API completely inaccessible on some server which do automatic redirect to trailing slash.

Refs: #746