### PR TITLE
Sorted records offsets must not be null error when ordering by non existing attribute data (#851)

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -137,7 +137,7 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./dist.zip
-        asset_name: Dist (zip)
+        asset_name: evitaDB-${{ steps.release_version.outputs.version }}.zip
         asset_content_type: application/zip
 
     - name: Upload dist.tar.gz to release
@@ -146,7 +146,7 @@ jobs:
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./dist.tar.gz
-        asset_name: Dist (tar.gz)
+        asset_name: evitaDB-${{ steps.release_version.outputs.version }}.tar.gz
         asset_content_type: application/gzip
 
     - name: Upload evitaDB server artifact

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferencePredecessorAttributeComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferencePredecessorAttributeComparator.java
@@ -138,13 +138,13 @@ public class TraverseReferencePredecessorAttributeComparator
 			this.sortedRecordsOffsets = createSortedRecordsOffsets(this.sortedRecordsProviders);
 			//noinspection ObjectInstantiationInEqualsHashCode
 			this.cache = new IntIntMap[this.sortedRecordsProviders.length];
-			Assert.notNull(this.sortedRecordsOffsets, "Sorted records offsets must not be null!");
 		}
 		final ReferenceAttributeValue attribute1 = this.attributeValueFetcher.apply(o1);
 		final ReferenceAttributeValue attribute2 = this.attributeValueFetcher.apply(o2);
 		if (attribute1 != null && attribute2 != null) {
 			if (attribute1.referencedKey().equals(attribute2.referencedKey())) {
-				final OffsetAndLimit offsetAndLimit = this.sortedRecordsOffsets.get(attribute1.referencedKey());
+				final OffsetAndLimit offsetAndLimit = this.sortedRecordsOffsets == null ?
+					null : this.sortedRecordsOffsets.get(attribute1.referencedKey());
 				if (offsetAndLimit != null) {
 					int result = 0;
 					int o1FoundInProvider = -1;


### PR DESCRIPTION
This pull request includes a change to the `TraverseReferencePredecessorAttributeComparator` class in the `evita_engine` module. The primary change involves modifying the comparison logic to handle potential null values for `sortedRecordsOffsets`.

Key change:

* [`evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferencePredecessorAttributeComparator.java`](diffhunk://#diff-5b8cb3a1d90d8c7fd54369bc49c339b9733a659661e473f5705cba77535f1895L141-R147): Updated the comparison logic to include a null check for `sortedRecordsOffsets` before attempting to access its elements.