### PR TITLE
evitalab should prefer hostname and port of incoming request (#855)

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferencePredecessorAttributeComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferencePredecessorAttributeComparator.java
@@ -143,6 +143,7 @@ public class TraverseReferencePredecessorAttributeComparator
 		final ReferenceAttributeValue attribute2 = this.attributeValueFetcher.apply(o2);
 		if (attribute1 != null && attribute2 != null) {
 			if (attribute1.referencedKey().equals(attribute2.referencedKey())) {
+				// if the offset is null, the sorted record provider was not found for the given reference key
 				final OffsetAndLimit offsetAndLimit = this.sortedRecordsOffsets == null ?
 					null : this.sortedRecordsOffsets.get(attribute1.referencedKey());
 				if (offsetAndLimit != null) {

--- a/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/configuration/GuiConfig.java
+++ b/evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/configuration/GuiConfig.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -29,9 +29,9 @@ import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.externalApi.lab.gui.dto.EvitaDBConnection;
 import lombok.Getter;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -41,33 +41,69 @@ import java.util.stream.Collectors;
  * @author Lukáš Hornych, FG Forrest a.s. (c) 2023
  */
 public class GuiConfig {
-
+	/**
+	 * Whether the GUI is enabled.
+	 */
 	@Getter private final boolean enabled;
+	/**
+	 * Whether the GUI is in read-only mode.
+	 */
 	@Getter private final boolean readOnly;
+	/**
+	 * List of preconfigured connections to evitaDB instances.
+	 */
 	@Getter @Nullable private final List<EvitaDBConnection> preconfiguredConnections;
+	/**
+	 * Whether to prefer using the incoming request's host and port over the resolved expose URL when creating a self-connection.
+	 */
+	@Getter private final boolean preferIncomingHostAndPort;
 
+	/**
+	 * Default constructor with default values.
+	 */
 	public GuiConfig() {
 		this.enabled = true;
 		this.readOnly = false;
 		this.preconfiguredConnections = null;
+		this.preferIncomingHostAndPort = true;
 	}
 
+	/**
+	 * Constructor with custom values.
+	 *
+	 * @param enabled whether the GUI is enabled
+	 * @param readOnly whether the GUI is in read-only mode
+	 * @param preconfiguredConnections list of preconfigured connections to evitaDB instances
+	 * @param preferIncomingHostAndPort whether to prefer using the incoming request's host and port
+	 */
 	@JsonCreator
 	public GuiConfig(@Nullable @JsonProperty("enabled") Boolean enabled,
 	                 @Nullable @JsonProperty("readOnly") Boolean readOnly,
-	                 @Nullable @JsonProperty("preconfiguredConnections") List<EvitaDBConnection> preconfiguredConnections) {
+	                 @Nullable @JsonProperty("preconfiguredConnections") List<EvitaDBConnection> preconfiguredConnections,
+	                 @Nullable @JsonProperty("preferIncomingHostAndPort") Boolean preferIncomingHostAndPort) {
 		this.enabled = Optional.ofNullable(enabled).orElse(true);
 		this.readOnly = Optional.ofNullable(readOnly).orElse(false);
 		validatePreconfiguredConnections(preconfiguredConnections);
 		this.preconfiguredConnections = preconfiguredConnections;
+		this.preferIncomingHostAndPort = Optional.ofNullable(preferIncomingHostAndPort).orElse(true);
 	}
 
+	/**
+	 * Validates that there are no duplicate IDs or names in the preconfigured connections.
+	 *
+	 * @param preconfiguredConnections list of preconfigured connections to validate
+	 * @throws EvitaInvalidUsageException if there are duplicate IDs or names
+	 */
 	private static void validatePreconfiguredConnections(@Nullable List<EvitaDBConnection> preconfiguredConnections) {
 		if (preconfiguredConnections == null) {
 			return;
 		}
+
+		// Check for duplicate non-null IDs
 		preconfiguredConnections.stream()
-			.collect(Collectors.groupingBy(EvitaDBConnection::id, Collectors.counting()))
+			.map(EvitaDBConnection::id)
+			.filter(Objects::nonNull)
+			.collect(Collectors.groupingBy(id -> id, Collectors.counting()))
 			.entrySet()
 			.stream()
 			.filter(it -> it.getValue() > 1)
@@ -75,6 +111,8 @@ public class GuiConfig {
 			.ifPresent(it -> {
 				throw new EvitaInvalidUsageException("Duplicate evitaDB connection id: " + it.getKey());
 			});
+
+		// Check for duplicate names
 		preconfiguredConnections.stream()
 			.collect(Collectors.groupingBy(EvitaDBConnection::name, Collectors.counting()))
 			.entrySet()


### PR DESCRIPTION
This pull request includes several changes to the `evita_external_api_lab` module and a minor update to the `evita_engine` module. The primary focus is on enhancing the configuration and handling of GUI settings, as well as improving the asset serving and request handling in the GUI resolver.

Enhancements to GUI configuration:

* [`evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/configuration/GuiConfig.java`](diffhunk://#diff-790709c9dce0e9e0d52f1aa1989b13d30178c8d23aa39153bd2e500766afd484L44-R115): Added new fields with appropriate getters, including `preferIncomingHostAndPort`, and updated constructors to handle these fields. Also added validation for preconfigured connections to check for duplicates. [[1]](diffhunk://#diff-790709c9dce0e9e0d52f1aa1989b13d30178c8d23aa39153bd2e500766afd484L44-R115) [[2]](diffhunk://#diff-790709c9dce0e9e0d52f1aa1989b13d30178c8d23aa39153bd2e500766afd484L32-R34)

Improvements to asset serving and request handling:

* [`evita_external_api/evita_external_api_lab/src/main/java/io/evitadb/externalApi/lab/gui/resolver/GuiHandler.java`](diffhunk://#diff-25fba47254d802aa89efebe2b76262743d700c0251eff839e6d36cbd50c0cd6aR83-R165): Added methods to create resource locations with forward slashes for Windows compatibility, determine if the original request was HTTPS, and serve static assets with caching. Updated methods to handle new parameters and improve request handling. [[1]](diffhunk://#diff-25fba47254d802aa89efebe2b76262743d700c0251eff839e6d36cbd50c0cd6aR83-R165) [[2]](diffhunk://#diff-25fba47254d802aa89efebe2b76262743d700c0251eff839e6d36cbd50c0cd6aL109-R211) [[3]](diffhunk://#diff-25fba47254d802aa89efebe2b76262743d700c0251eff839e6d36cbd50c0cd6aL148-L183) [[4]](diffhunk://#diff-25fba47254d802aa89efebe2b76262743d700c0251eff839e6d36cbd50c0cd6aL212-L241)

Minor update:

* [`evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferencePredecessorAttributeComparator.java`](diffhunk://#diff-5b8cb3a1d90d8c7fd54369bc49c339b9733a659661e473f5705cba77535f1895R146): Added a comment to clarify the handling of null offsets when the sorted record provider is not found for a given reference key.