### PR TITLE
fix: Session can be created during catalog replacement

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/EvitaInternalSessionContract.java
+++ b/evita_engine/src/main/java/io/evitadb/core/EvitaInternalSessionContract.java
@@ -165,6 +165,15 @@ public interface EvitaInternalSessionContract extends EvitaSessionContract, Traf
 	boolean methodIsRunning();
 
 	/**
+	 * Invokes lambda once no method on the current object is running or immediately if there is no method running.
+	 * This method allows to execute code that needs to be executed when the session is not busy with any method.
+	 * When lambda is invoked, it is guaranteed that no other method starts running on the current object.
+	 *
+	 * @param lambda the lambda to be executed when no method is running
+	 */
+	void executeWhenMethodIsNotRunning(@Nonnull Runnable lambda);
+
+	/**
 	 * Retrieves a CompletableFuture that represents the finalization status of a session. If the catalog is in
 	 * transactional mode, the future will respect the requested {@link CommitBehavior} bound to the current transaction.
 	 *

--- a/evita_engine/src/main/java/io/evitadb/core/EvitaSession.java
+++ b/evita_engine/src/main/java/io/evitadb/core/EvitaSession.java
@@ -1525,7 +1525,14 @@ public final class EvitaSession implements EvitaInternalSessionContract {
 
 	@Override
 	public boolean methodIsRunning() {
-		return false;
+		// method invocation should be handled on session proxy level
+		throw new UnsupportedOperationException("This method is not supported in this session!");
+	}
+
+	@Override
+	public void executeWhenMethodIsNotRunning(@Nonnull Runnable lambda) {
+		// method invocation should be handled on session proxy level
+		throw new UnsupportedOperationException("This method is not supported in this session!");
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/core/SessionRegistry.java
+++ b/evita_engine/src/main/java/io/evitadb/core/SessionRegistry.java
@@ -26,12 +26,14 @@ package io.evitadb.core;
 import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.TransactionContract.CommitBehavior;
 import io.evitadb.api.exception.ConcurrentInitializationException;
+import io.evitadb.api.exception.InstanceTerminatedException;
 import io.evitadb.api.exception.TransactionException;
 import io.evitadb.api.observability.trace.RepresentsMutation;
 import io.evitadb.api.observability.trace.RepresentsQuery;
 import io.evitadb.api.observability.trace.Traced;
 import io.evitadb.api.observability.trace.TracingContext;
 import io.evitadb.api.observability.trace.TracingContext.SpanAttribute;
+import io.evitadb.core.exception.SessionBusyException;
 import io.evitadb.core.metric.event.session.ClosedEvent;
 import io.evitadb.core.metric.event.session.OpenedEvent;
 import io.evitadb.core.metric.event.transaction.TransactionFinishedEvent;
@@ -55,8 +57,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Proxy;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -66,8 +68,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -100,6 +108,10 @@ final class SessionRegistry {
 	 */
 	private final Map<UUID, EvitaSessionTuple> activeSessions = CollectionUtils.createConcurrentHashMap(512);
 	/**
+	 * This field is used to keep track of the current suspend operation (if any).
+	 */
+	private final AtomicReference<InSuspension> activeSuspendOperation = new AtomicReference<>(null);
+	/**
 	 * Keeps information about sessions sorted according to date of creation.
 	 */
 	private final ConcurrentLinkedQueue<EvitaSessionTuple> sessionsFifoQueue = new ConcurrentLinkedQueue<>();
@@ -122,39 +134,59 @@ final class SessionRegistry {
 	 * Method closes and removes all active sessions from the registry.
 	 * All changes are rolled back.
 	 */
-	public void closeAllActiveSessions() {
-		final List<CompletableFuture<Long>> futures = new LinkedList<>();
-		for (EvitaSessionTuple sessionTuple : this.activeSessions.values()) {
-			final EvitaSession activeSession = sessionTuple.plainSession();
-			if (activeSession.isActive()) {
-				if (activeSession.isTransactionOpen()) {
-					activeSession.setRollbackOnly();
+	public void closeAllActiveSessionsAndSuspend(@Nonnull SuspendOperation suspendOperation) {
+		if (this.activeSuspendOperation.compareAndSet(null, new InSuspension(suspendOperation))) {
+			final long start = System.currentTimeMillis();
+			do {
+				final List<CompletableFuture<Long>> futures = new ArrayList<>(this.activeSessions.size());
+				for (EvitaSessionTuple sessionTuple : this.activeSessions.values()) {
+					final EvitaSession plainSession = sessionTuple.plainSession();
+					final EvitaInternalSessionContract proxySession = sessionTuple.proxySession();
+					if (proxySession.isActive()) {
+						proxySession
+							// close the session once the running method is finished or immediately if there is no method running
+							.executeWhenMethodIsNotRunning(
+								() -> {
+									if (plainSession.isActive()) {
+										if (plainSession.isTransactionOpen()) {
+											plainSession.setRollbackOnly();
+										}
+										final UUID sessionId = plainSession.getId();
+										log.info("There is still active session {} - terminating.", sessionId);
+										futures.add(plainSession.closeNow(CommitBehavior.WAIT_FOR_WAL_PERSISTENCE));
+									}
+								}
+							);
+					}
 				}
-				futures.add(activeSession.closeNow(CommitBehavior.WAIT_FOR_WAL_PERSISTENCE));
-				log.info("There is still active session {} - terminating.", activeSession.getId());
-			}
-		}
-		// wait for all futures to complete
-		CompletableFuture
-			.allOf(futures.toArray(new CompletableFuture[0]))
-			.join();
+				// wait for all futures to complete
+				CompletableFuture
+					.allOf(futures.toArray(new CompletableFuture[0]))
+					.join();
+				// wait for active sessions to be empty, but at most 5 seconds
+			} while (!this.activeSessions.isEmpty() && System.currentTimeMillis() - start < 5000);
 
-		// check that all sessions were closed, and wait for concurrent operations to finish 20ms
-		final long start = System.currentTimeMillis();
-		while (!this.activeSessions.isEmpty() && System.currentTimeMillis() - start < 20) {
-			Thread.onSpinWait();
+			Assert.isPremiseValid(
+				this.activeSessions.isEmpty(),
+				"Some of the sessions didn't clean themselves (" +
+					this.activeSessions.values()
+						.stream()
+						.map(EvitaSessionTuple::plainSession)
+						.map(it -> it.getId() + ((it.isActive()) ? ": active" : ": closed"))
+						.collect(Collectors.joining(", "))
+					+ ")!"
+			);
 		}
+	}
 
-		Assert.isPremiseValid(
-			this.activeSessions.isEmpty(),
-			"Some of the sessions didn't clean themselves (" +
-				this.activeSessions.values()
-					.stream()
-					.map(EvitaSessionTuple::plainSession)
-					.map(it -> it.getId() + ((it.isActive()) ? ": active" : ": closed"))
-					.collect(Collectors.joining(", "))
-				+ ")!"
-		);
+	/**
+	 * Method resumes operations on this registry - i.e. creating new sessions.
+	 */
+	public void resumeOperations() {
+		final InSuspension inSuspension = this.activeSuspendOperation.getAndSet(null);
+		if (inSuspension != null) {
+			inSuspension.suspendFuture().complete(null);
+		}
 	}
 
 	/**
@@ -163,67 +195,78 @@ final class SessionRegistry {
 	 */
 	@Nonnull
 	public EvitaInternalSessionContract addSession(boolean transactional, @Nonnull Supplier<EvitaSession> sessionSupplier) {
-		if (!transactional && !this.activeSessions.isEmpty()) {
-			throw new ConcurrentInitializationException(this.activeSessions.keySet().iterator().next());
-		}
+		return handleSuspension(() -> {
+			if (!transactional && !this.activeSessions.isEmpty()) {
+				throw new ConcurrentInitializationException(this.activeSessions.keySet().iterator().next());
+			}
 
-		final EvitaSession newSession = sessionSupplier.get();
-		final long catalogVersion = newSession.getCatalogVersion();
-		final String catalogName = newSession.getCatalogName();
+			final EvitaSession newSession = sessionSupplier.get();
+			final long catalogVersion = newSession.getCatalogVersion();
+			final String catalogName = newSession.getCatalogName();
 
-		final EvitaInternalSessionContract newSessionProxy = (EvitaInternalSessionContract) Proxy.newProxyInstance(
-			EvitaInternalSessionContract.class.getClassLoader(),
-			new Class[]{EvitaInternalSessionContract.class, EvitaProxyFinalization.class},
-			new EvitaSessionProxy(newSession, this.tracingContext)
-		);
-		final EvitaSessionTuple sessionTuple = new EvitaSessionTuple(newSession, newSessionProxy);
-		this.activeSessions.put(newSession.getId(), sessionTuple);
-		this.sessionsFifoQueue.add(sessionTuple);
-		this.catalogConsumedVersions.computeIfAbsent(catalogName, k -> new VersionConsumingSessions())
-			.registerSessionConsumingCatalogInVersion(catalogVersion);
-		this.sharedDataStore.addSession(sessionTuple);
+			final EvitaInternalSessionContract newSessionProxy = (EvitaInternalSessionContract) Proxy.newProxyInstance(
+				EvitaInternalSessionContract.class.getClassLoader(),
+				new Class[]{EvitaInternalSessionContract.class, EvitaProxyFinalization.class},
+				new EvitaSessionProxy(newSession, this.tracingContext)
+			);
+			final EvitaSessionTuple sessionTuple = new EvitaSessionTuple(newSession, newSessionProxy);
+			sessionTuple.executeAtomically(
+				() -> {
+					this.activeSessions.put(newSession.getId(), sessionTuple);
+					this.sessionsFifoQueue.add(sessionTuple);
+					this.catalogConsumedVersions.computeIfAbsent(catalogName, k -> new VersionConsumingSessions())
+						.registerSessionConsumingCatalogInVersion(catalogVersion);
+					this.sharedDataStore.addSession(sessionTuple);
+				}
+			);
 
-		return newSessionProxy;
+			return newSessionProxy;
+		});
 	}
 
 	/**
 	 * Removes session from the registry.
 	 */
 	public void removeSession(@Nonnull EvitaSession session) {
-		final EvitaSessionTuple activeSession = this.sharedDataStore.removeSession(session.getId());
-		if (activeSession != null) {
-			Assert.isPremiseValid(
-				this.activeSessions.remove(session.getId()) == activeSession,
-				"Session instance doesn't match the information found in the registry."
+		final EvitaSessionTuple theSessionToRemove = this.activeSessions.remove(session.getId());
+		if (theSessionToRemove != null) {
+			theSessionToRemove.executeAtomically(
+				() -> {
+					final EvitaSessionTuple globallySharedSession = this.sharedDataStore.removeSession(session.getId());
+					Assert.isPremiseValid(
+						theSessionToRemove == globallySharedSession,
+						"Session not found in the globally shared data store."
+					);
+					Assert.isPremiseValid(this.sessionsFifoQueue.remove(theSessionToRemove), "Session not found in the queue.");
+
+					session.getTransaction().ifPresent(transaction -> {
+						// emit event
+						transaction.getFinalizationEvent()
+							.finishWithResolution(
+								this.sessionsFifoQueue.stream()
+									.map(EvitaSessionTuple::plainSession)
+									.filter(it -> it.getOpenedTransaction().isPresent())
+									.map(EvitaSession::getCreated)
+									.findFirst()
+									.orElse(null),
+								transaction.isRollbackOnly() ? TransactionResolution.ROLLBACK : TransactionResolution.COMMIT
+							).commit();
+					});
+
+					this.catalogConsumedVersions.get(session.getCatalogName())
+						.unregisterSessionConsumingCatalogInVersion(session.getCatalogVersion(), this.catalog);
+
+					// emit event
+					//noinspection CastToIncompatibleInterface,resource
+					((EvitaProxyFinalization) theSessionToRemove.proxySession())
+						.finish(
+							ofNullable(this.sessionsFifoQueue.peek())
+								.map(it -> it.plainSession().getCreated())
+								.orElse(null),
+							this.activeSessions.size()
+						);
+				}
 			);
-			Assert.isPremiseValid(this.sessionsFifoQueue.remove(activeSession), "Session not found in the queue.");
-
-			session.getTransaction().ifPresent(transaction -> {
-				// emit event
-				transaction.getFinalizationEvent()
-					.finishWithResolution(
-						this.sessionsFifoQueue.stream()
-							.map(EvitaSessionTuple::plainSession)
-							.filter(it -> it.getOpenedTransaction().isPresent())
-							.map(EvitaSession::getCreated)
-							.findFirst()
-							.orElse(null),
-						transaction.isRollbackOnly() ? TransactionResolution.ROLLBACK : TransactionResolution.COMMIT
-					).commit();
-			});
-
-			this.catalogConsumedVersions.get(session.getCatalogName())
-				.unregisterSessionConsumingCatalogInVersion(session.getCatalogVersion(), this.catalog);
-
-			// emit event
-			//noinspection CastToIncompatibleInterface,resource
-			((EvitaProxyFinalization) activeSession.proxySession())
-				.finish(
-					ofNullable(this.sessionsFifoQueue.peek())
-						.map(it -> it.plainSession().getCreated())
-						.orElse(null),
-					this.activeSessions.size()
-				);
 		}
 	}
 
@@ -239,6 +282,47 @@ final class SessionRegistry {
 			this.catalogConsumedVersions.computeIfAbsent(catalogName, k -> new VersionConsumingSessions()),
 			this.catalog
 		);
+	}
+
+	/**
+	 * Internal method that creates and initializes session and returns it.
+	 * @param sessionFactory the function that creates the session
+	 * @return the created session
+	 */
+	@Nonnull
+	public EvitaInternalSessionContract createSession(@Nonnull Function<SessionRegistry, EvitaInternalSessionContract> sessionFactory) {
+		return handleSuspension(() -> sessionFactory.apply(this));
+	}
+
+	/**
+	 * Handles a suspension operation based on the current state.
+	 * If there is an active suspend operation, it evaluates its behavior and
+	 * acts accordingly by either postponing the operation, awaiting completion,
+	 * or throwing an exception. If no active suspend operation is detected, it
+	 * proceeds with the supplied operation.
+	 *
+	 * @param <T> the type of the result provided by the supplier
+	 * @param supplier a non-null supplier that provides the operation to execute
+	 *                 if suspension allows it
+	 * @return the result of the supplier's operation if executed successfully
+	 * @throws SessionBusyException if the suspension operation has been postponed
+	 *                              and could not finish within the timeout period
+	 * @throws InstanceTerminatedException if the suspension operation indicates
+	 *                                     the instance termination
+	 */
+	private <T> T handleSuspension(@Nonnull Supplier<T> supplier) {
+		final InSuspension inSuspension = this.activeSuspendOperation.get();
+		if (inSuspension == null) {
+			return supplier.get();
+		} else if (inSuspension.suspendOperation() == SuspendOperation.POSTPONE) {
+			if (inSuspension.awaitFinish(500, TimeUnit.MILLISECONDS)) {
+				return supplier.get();
+			} else {
+				throw SessionBusyException.INSTANCE;
+			}
+		} else {
+			throw new InstanceTerminatedException("catalog");
+		}
 	}
 
 	/**
@@ -265,17 +349,22 @@ final class SessionRegistry {
 	 * supports JDK proxies out-of-the-box so this shouldn't be a problem in the future.
 	 */
 	private static class EvitaSessionProxy implements InvocationHandler {
+		private final static Method IS_ACTIVE;
 		private final static Method IS_METHOD_RUNNING;
+		private final static Method WHEN_METHOD_IS_NOT_RUNNING;
 		private final static Method INACTIVITY_IN_SECONDS;
 		private final EvitaSession evitaSession;
 		private final TracingContext tracingContext;
 		@Getter private final ClosedEvent sessionClosedEvent;
 		private final AtomicInteger insideInvocation = new AtomicInteger(0);
 		private final AtomicLong lastCall = new AtomicLong(System.currentTimeMillis());
+		private final AtomicReference<ClosingSequence> closeLambda = new AtomicReference<>(null);
 
 		static {
 			try {
+				IS_ACTIVE = EvitaInternalSessionContract.class.getMethod("isActive");
 				IS_METHOD_RUNNING = EvitaInternalSessionContract.class.getMethod("methodIsRunning");
+				WHEN_METHOD_IS_NOT_RUNNING = EvitaInternalSessionContract.class.getMethod("executeWhenMethodIsNotRunning", Runnable.class);
 				INACTIVITY_IN_SECONDS = EvitaInternalSessionContract.class.getMethod("getInactivityDurationInSeconds");
 			} catch (NoSuchMethodException ex) {
 				throw new GenericEvitaInternalError("Method not found.", ex);
@@ -326,119 +415,231 @@ final class SessionRegistry {
 		@Override
 		public Object invoke(Object proxy, Method method, Object[] args) {
 			if (method.getDeclaringClass().equals(EvitaProxyFinalization.class)) {
-				sessionClosedEvent
+				this.sessionClosedEvent
 					.finish((OffsetDateTime) args[0], (int) args[1])
 					.commit();
 				return null;
 			} else if (method.equals(INACTIVITY_IN_SECONDS)) {
 				return (System.currentTimeMillis() - this.lastCall.get()) / 1000;
+			} else if (method.equals(IS_ACTIVE)) {
+				// if we know that the session is being closed on proxy level
+				if (this.closeLambda.get() != null) {
+					// return eagerly false result
+					return false;
+				} else {
+					return executeDelegateMethod(method, args);
+				}
 			} else if (method.equals(IS_METHOD_RUNNING)) {
 				return this.insideInvocation.get() > 0;
+			} else if (method.equals(WHEN_METHOD_IS_NOT_RUNNING)) {
+				final ClosingSequence closingSequence = new ClosingSequence((Runnable) args[0]);
+				Assert.isPremiseValid(
+					this.closeLambda.compareAndSet(null, closingSequence),
+					"Close lambda is already set!"
+				);
+				// execute immediately
+				if (this.insideInvocation.get() == 0) {
+					executeCloseLambda(closingSequence);
+				}
+				return null;
 			} else {
 				try {
-					this.evitaSession.increaseNestLevel();
-					// invoke original method on delegate
-					return Transaction.executeInTransactionIfProvided(
-						this.evitaSession.getOpenedTransaction().orElse(null),
-						() -> {
-							final Supplier<Object> invocation = () -> {
-								try {
-									this.insideInvocation.incrementAndGet();
-									this.lastCall.set(System.currentTimeMillis());
-									return method.invoke(evitaSession, args);
-								} catch (InvocationTargetException ex) {
-									// handle the error
-									final Throwable targetException = ex.getTargetException() instanceof CompletionException completionException ?
-										completionException.getCause() : ex.getTargetException();
-									if (targetException instanceof TransactionException transactionException) {
-										// just unwrap and rethrow
-										throw transactionException;
-									} else if (targetException instanceof EvitaInvalidUsageException evitaInvalidUsageException) {
-										// just unwrap and rethrow
-										throw evitaInvalidUsageException;
-									} else if (targetException instanceof EvitaInternalError evitaInternalError) {
-										if (log.isErrorEnabled()) {
-											log.error(
-												"Internal Evita error occurred in " + evitaInternalError.getErrorCode() +
-													": " + evitaInternalError.getPrivateMessage() + "," +
-													" arguments: " + printArguments(method, args),
-												targetException
-											);
-										}
-										// unwrap and rethrow
-										throw evitaInternalError;
-									} else {
-										if (log.isErrorEnabled()) {
-											log.error(
-												"Unexpected internal Evita error occurred: " + ex.getCause().getMessage() + ", " +
-													" arguments: " + printArguments(method, args),
-												targetException == null ? ex : targetException
-											);
-										}
-										throw new GenericEvitaInternalError(
-											"Unexpected internal Evita error occurred: " + ex.getCause().getMessage(),
-											"Unexpected internal Evita error occurred.",
-											targetException == null ? ex : targetException
-										);
-									}
-								} catch (Throwable ex) {
-									if (log.isErrorEnabled()) {
-										log.error(
-											"Unexpected system error occurred: " + ex.getMessage() + "," +
-												" arguments: " + printArguments(method, args),
-											ex
-										);
-									}
-									throw new GenericEvitaInternalError(
-										"Unexpected system error occurred: " + ex.getMessage(),
-										"Unexpected system error occurred.",
-										ex
-									);
-								} finally {
-									this.insideInvocation.decrementAndGet();
-									this.lastCall.set(System.currentTimeMillis());
-								}
-							};
-							if (method.isAnnotationPresent(RepresentsQuery.class)) {
-								this.sessionClosedEvent.recordQuery();
-							}
-							if (method.isAnnotationPresent(RepresentsMutation.class)) {
-								this.sessionClosedEvent.recordMutation();
-							}
-							if (method.isAnnotationPresent(Traced.class)) {
-								return tracingContext.executeWithinBlockIfParentContextAvailable(
-									"session call - " + method.getName(),
-									invocation,
-									() -> {
-										final Parameter[] parameters = method.getParameters();
-										final SpanAttribute[] spanAttributes = new SpanAttribute[1 + parameters.length];
-										spanAttributes[0] = new SpanAttribute("session.id", this.evitaSession.getId().toString());
-										if (args == null) {
-											return spanAttributes;
-										} else {
-											int index = 1;
-											for (int i = 0; i < args.length; i++) {
-												final Object arg = args[i];
-												if (EvitaDataTypes.isSupportedType(parameters[i].getType()) && arg != null) {
-													spanAttributes[index++] = new SpanAttribute(parameters[i].getName(), arg);
-												}
-											}
-											return index < spanAttributes.length ?
-												Arrays.copyOfRange(spanAttributes, 0, index) : spanAttributes;
-										}
-									}
-								);
-							} else {
-								return invocation.get();
-							}
-						},
-						this.evitaSession.isRootLevelExecution()
-					);
+					final ClosingSequence closingSequence = this.closeLambda.get();
+					// if there's a closing sequence in place
+					if (closingSequence != null) {
+						// wait for it to finish
+						if (closingSequence.awaitFinish(500, TimeUnit.MILLISECONDS)) {
+							// and then execute the call - it probably ends up with exception that session was closed
+							return executeDelegateMethod(method, args);
+						} else {
+							throw SessionBusyException.INSTANCE;
+						}
+					} else {
+						// standard delegated execution - normal operation
+						return executeDelegateMethod(method, args);
+					}
 				} finally {
-					this.evitaSession.decreaseNestLevel();
+					final ClosingSequence closingSequence = this.closeLambda.get();
+					// if there is newly registered close lambda and there is no other method being executed
+					if (this.insideInvocation.get() == 0 && closingSequence != null) {
+						// execute close lambda
+						executeCloseLambda(closingSequence);
+					}
 				}
 			}
 		}
+
+		/**
+		 * Executes the closeLambda, a function intended to release resources or perform cleanup operations.
+		 * This method ensures safe execution of the lambda function by managing thread-synchronization
+		 * through a CountDownLatch.
+		 */
+		private void executeCloseLambda(@Nonnull ClosingSequence closingSequence) {
+			if (this.closeLambda.compareAndSet(closingSequence, null)) {
+				try {
+					closingSequence.closeLambda().run();
+				} finally {
+					closingSequence.closedFuture().complete(null);
+				}
+			} else {
+				// close lambda was already executed
+			}
+		}
+
+		/**
+		 * Executes a delegate method within the current session while handling transactions, tracing, and error logging.
+		 * This method wraps the method invocation with additional logic for transaction management,
+		 * query and mutation tracking, and tracing execution based on annotations.
+		 *
+		 * @param method the method to be invoked on the delegate object, must not be null
+		 * @param args the arguments to pass to the method being invoked, must not be null
+		 * @return the result of the method invocation or null if the method returns void or there is an error
+		 * @throws TransactionException if a transaction-related error occurs during execution
+		 * @throws EvitaInvalidUsageException if an invalid usage of the Evita API is detected
+		 * @throws EvitaInternalError if an internal Evita-specific error occurs
+		 * @throws GenericEvitaInternalError if an unexpected system error occurs during execution
+		 */
+		@Nullable
+		private Object executeDelegateMethod(@Nonnull Method method, @Nullable Object[] args) {
+			try {
+				this.evitaSession.increaseNestLevel();
+				// invoke original method on delegate
+				return Transaction.executeInTransactionIfProvided(
+					this.evitaSession.getOpenedTransaction().orElse(null),
+					() -> {
+						final Supplier<Object> invocation = () -> {
+							try {
+								this.insideInvocation.incrementAndGet();
+								this.lastCall.set(System.currentTimeMillis());
+								return method.invoke(evitaSession, args);
+							} catch (InvocationTargetException ex) {
+								// handle the error
+								final Throwable targetException = ex.getTargetException() instanceof CompletionException completionException ?
+									completionException.getCause() : ex.getTargetException();
+								if (targetException instanceof TransactionException transactionException) {
+									// just unwrap and rethrow
+									throw transactionException;
+								} else if (targetException instanceof EvitaInvalidUsageException evitaInvalidUsageException) {
+									// just unwrap and rethrow
+									throw evitaInvalidUsageException;
+								} else if (targetException instanceof EvitaInternalError evitaInternalError) {
+									if (log.isErrorEnabled()) {
+										log.error(
+											"Internal Evita error occurred in " + evitaInternalError.getErrorCode() +
+												": " + evitaInternalError.getPrivateMessage() + "," +
+												" arguments: " + printArguments(method, args),
+											targetException
+										);
+									}
+									// unwrap and rethrow
+									throw evitaInternalError;
+								} else {
+									if (log.isErrorEnabled()) {
+										log.error(
+											"Unexpected internal Evita error occurred: " + ex.getCause().getMessage() + ", " +
+												" arguments: " + printArguments(method, args),
+											targetException == null ? ex : targetException
+										);
+									}
+									throw new GenericEvitaInternalError(
+										"Unexpected internal Evita error occurred: " + ex.getCause().getMessage(),
+										"Unexpected internal Evita error occurred.",
+										targetException == null ? ex : targetException
+									);
+								}
+							} catch (Throwable ex) {
+								if (log.isErrorEnabled()) {
+									log.error(
+										"Unexpected system error occurred: " + ex.getMessage() + "," +
+											" arguments: " + printArguments(method, args),
+										ex
+									);
+								}
+								throw new GenericEvitaInternalError(
+									"Unexpected system error occurred: " + ex.getMessage(),
+									"Unexpected system error occurred.",
+									ex
+								);
+							} finally {
+								this.insideInvocation.decrementAndGet();
+								this.lastCall.set(System.currentTimeMillis());
+							}
+						};
+						if (method.isAnnotationPresent(RepresentsQuery.class)) {
+							this.sessionClosedEvent.recordQuery();
+						}
+						if (method.isAnnotationPresent(RepresentsMutation.class)) {
+							this.sessionClosedEvent.recordMutation();
+						}
+						if (method.isAnnotationPresent(Traced.class)) {
+							return tracingContext.executeWithinBlockIfParentContextAvailable(
+								"session call - " + method.getName(),
+								invocation,
+								() -> {
+									final Parameter[] parameters = method.getParameters();
+									final SpanAttribute[] spanAttributes = new SpanAttribute[1 + parameters.length];
+									spanAttributes[0] = new SpanAttribute("session.id", this.evitaSession.getId().toString());
+									if (args == null || args.length == 0) {
+										return spanAttributes;
+									} else {
+										int index = 1;
+										for (int i = 0; i < args.length; i++) {
+											final Object arg = args[i];
+											if (EvitaDataTypes.isSupportedType(parameters[i].getType()) && arg != null) {
+												spanAttributes[index++] = new SpanAttribute(parameters[i].getName(), arg);
+											}
+										}
+										return index < spanAttributes.length ?
+											Arrays.copyOfRange(spanAttributes, 0, index) : spanAttributes;
+									}
+								}
+							);
+						} else {
+							return invocation.get();
+						}
+					},
+					this.evitaSession.isRootLevelExecution()
+				);
+			} finally {
+				this.evitaSession.decreaseNestLevel();
+			}
+		}
+	}
+
+	/**
+	 * Record that provides access both to the latch and the close lambda.
+	 *
+	 * @param closeLambda the close lambda that is executed when the session is closed
+	 * @param closedFuture the future that is completed when the session is closed
+	 */
+	private record ClosingSequence(
+		@Nonnull Runnable closeLambda,
+		@Nonnull CompletableFuture<Void> closedFuture
+	) {
+
+		private ClosingSequence(@Nonnull Runnable closeLambda) {
+			this(closeLambda, new CompletableFuture<>());
+		}
+
+		/**
+		 * Waits for the session to finish closing within the specified timeout period.
+		 *
+		 * @param timeout the maximum time to wait for the session to finish, in the given time unit
+		 * @param timeUnit the time unit of the timeout parameter
+		 * @return {@code true} if the session finished closing within the timeout period, {@code false} if the timeout elapsed
+		 * @throws SessionBusyException if an InterruptedException or ExecutionException occurs while waiting
+		 */
+		public boolean awaitFinish(int timeout, @Nonnull TimeUnit timeUnit) {
+			try {
+				this.closedFuture.get(timeout, timeUnit);
+				return true;
+			} catch (TimeoutException e) {
+				return false;
+			} catch (InterruptedException | ExecutionException e) {
+				throw SessionBusyException.INSTANCE;
+			}
+		}
+
 	}
 
 	/**
@@ -450,9 +651,32 @@ final class SessionRegistry {
 	 */
 	private record EvitaSessionTuple(
 		@Nonnull EvitaSession plainSession,
-		@Nonnull EvitaInternalSessionContract proxySession
+		@Nonnull EvitaInternalSessionContract proxySession,
+		@Nonnull ReentrantLock atomicLock
 	) {
 
+		private EvitaSessionTuple(@Nonnull EvitaSession plainSession, @Nonnull EvitaInternalSessionContract proxySession) {
+			this(
+				plainSession,
+				proxySession,
+				new ReentrantLock()
+			);
+		}
+
+		/**
+		 * Method executes the given lambda in an atomic way, ensuring that no other thread can interfere with
+		 * the block execution.
+		 *
+		 * @param lambda the lambda to be executed atomically
+		 */
+		public void executeAtomically(@Nonnull Runnable lambda) {
+			this.atomicLock.lock();
+			try {
+				lambda.run();
+			} finally {
+				this.atomicLock.unlock();
+			}
+		}
 	}
 
 	/**
@@ -505,14 +729,10 @@ final class SessionRegistry {
 			if (lastReader) {
 				// notify listeners that the catalog version is no longer used
 				final Catalog theCatalog = catalog.get();
+				// in rare cases (catalog replacement) the catalog might not have been available already
 				if (theCatalog != null) {
 					final long minimalActiveVersion = minimalActiveCatalogVersion.orElse(theCatalog.getVersion());
 					theCatalog.consumersLeft(minimalActiveVersion);
-				} else {
-					log.error(
-						"Catalog is not available for the session finalization.",
-						new GenericEvitaInternalError("Catalog is not available for the session finalization.")
-					);
 				}
 			}
 		}
@@ -581,6 +801,57 @@ final class SessionRegistry {
 			this.versionConsumingSessions.unregisterSessionConsumingCatalogInVersion(version, this.catalog);
 		}
 
+	}
+
+	/**
+	 * This record is used to keep information about the current suspension period.
+	 */
+	private record InSuspension(
+		@Nonnull SuspendOperation suspendOperation,
+		@Nonnull CompletableFuture<Void> suspendFuture
+	) {
+
+		public InSuspension(@Nonnull SuspendOperation suspendOperation) {
+			this(
+				suspendOperation,
+				new CompletableFuture<>()
+			);
+		}
+
+		/**
+		 * Waits for the suspension period to finish or times out after the specified duration.
+		 *
+		 * @param timeout the maximum time to wait for the suspension to finish, in the given time unit
+		 * @param timeUnit the unit of time for the timeout parameter, must not be null
+		 * @return true if the suspension period finishes within the specified timeout, false if the timeout occurs
+		 * @throws SessionBusyException if an error occurs during the wait or the current thread is interrupted
+		 */
+		public boolean awaitFinish(int timeout, @Nonnull TimeUnit timeUnit) {
+			try {
+				this.suspendFuture.get(timeout, timeUnit);
+				return true;
+			} catch (TimeoutException e) {
+				return false;
+			} catch (InterruptedException | ExecutionException e) {
+				throw SessionBusyException.INSTANCE;
+			}
+		}
+
+	}
+
+	/**
+	 * Enum contains different levels of suspension operations for the SessionRegistry.
+	 */
+	public enum SuspendOperation {
+		/**
+		 * All incoming operations are temporarily suspended due to internal operations with the catalog - such
+		 * as rename or replace.
+		 */
+		POSTPONE,
+		/**
+		 * All incoming operations should be immediately rejected because the catalog is being terminated.
+		 */
+		REJECT
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/exception/SessionBusyException.java
+++ b/evita_engine/src/main/java/io/evitadb/core/exception/SessionBusyException.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.exception;
+
+
+import io.evitadb.exception.EvitaInvalidUsageException;
+
+import java.io.Serial;
+
+/**
+ * Exception is thrown when the session is busy handling internal operation and cannot accept new requests.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+public class SessionBusyException extends EvitaInvalidUsageException {
+	@Serial private static final long serialVersionUID = 7832387401200985161L;
+	public static final SessionBusyException INSTANCE = new SessionBusyException();
+
+	private SessionBusyException() {
+		super(
+		"Method on session was called while the session was busy handling internal operation. " +
+			"Please wait until the operation is finished and try again."
+		);
+	}
+
+}

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EvitaReplacementFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EvitaReplacementFunctionalTest.java
@@ -1,0 +1,205 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api;
+
+
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.exception.InstanceTerminatedException;
+import io.evitadb.core.Evita;
+import io.evitadb.core.exception.SessionBusyException;
+import io.evitadb.test.EvitaTestSupport;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.commons.util.ExceptionUtils;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
+import static io.evitadb.api.query.QueryConstraints.dataInLocales;
+import static io.evitadb.test.TestConstants.LONG_RUNNING_TEST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This test verifies behavior of evitaDB when catalog is replaced while there are clients trying to query it.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+@DisplayName("Evita catalog replacement under load")
+@Tag(LONG_RUNNING_TEST)
+@ExtendWith(EvitaParameterResolver.class)
+public class EvitaReplacementFunctionalTest implements EvitaTestSupport {
+	private static final String DIR_EVITA_REPLACEMENT_TEST = "evitaReplacementTest";
+	private static final String DIR_EVITA_REPLACEMENT_TEST_EXPORT = "evitaReplacementTest_export";
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() {
+		cleanTestSubDirectoryWithRethrow(DIR_EVITA_REPLACEMENT_TEST);
+		cleanTestSubDirectoryWithRethrow(DIR_EVITA_REPLACEMENT_TEST_EXPORT);
+		evita = new Evita(
+			getEvitaConfiguration()
+		);
+		evita.defineCatalog(TEST_CATALOG);
+	}
+
+	@AfterEach
+	void tearDown() {
+		evita.close();
+		cleanTestSubDirectoryWithRethrow(DIR_EVITA_REPLACEMENT_TEST);
+		cleanTestSubDirectoryWithRethrow(DIR_EVITA_REPLACEMENT_TEST_EXPORT);
+	}
+
+	@DisplayName("Replace catalog under heavy load")
+	@Test
+	void shouldReplaceCatalogUnderHeavyLoad() throws InterruptedException {
+		final String catalogWithSingleEntity = "catalogWithSingleEntity";
+		final String catalogWithHundredEntities = "catalogWithHundredEntities";
+
+		// create a catalog with a single entity
+		evita.defineCatalog(catalogWithSingleEntity)
+			.updateViaNewSession(evita);
+		evita.updateCatalog(
+			catalogWithSingleEntity,
+			session -> {
+				session.createNewEntity("Brand", 1)
+					.setAttribute("name", Locale.ENGLISH, "Lenovo")
+					.upsertVia(session);
+				session.goLiveAndClose();
+			}
+		);
+
+		// create a catalog with a single entity
+		evita.defineCatalog(catalogWithHundredEntities)
+			.updateViaNewSession(evita);
+		evita.updateCatalog(
+			catalogWithHundredEntities,
+			session -> {
+				for (int i = 1; i <= 100; i++) {
+					session.createNewEntity("Brand", i)
+						.setAttribute("name", Locale.ENGLISH, "Lenovo_" + i)
+						.upsertVia(session);
+				}
+				session.goLiveAndClose();
+			}
+		);
+
+		// now create multiple clients heavily querying the catalog with single entity
+		final AtomicLong errors = new AtomicLong(0);
+		final AtomicLong terminations = new AtomicLong(0);
+		final AtomicLong queries = new AtomicLong(0);
+
+		final int iterations = 1000;
+		final int clientCount = 100;
+		final CountDownLatch latch = new CountDownLatch(clientCount);
+		for (int i = 0; i < clientCount; i++) {
+			final int clientId = i;
+			new Thread(
+				() -> {
+					for (int j = 0; j < iterations; j++) {
+						try {
+							evita.queryCatalog(
+								catalogWithSingleEntity,
+								session -> {
+									final String brand = session.getEntity("Brand", 1, attributeContentAll(), dataInLocales(Locale.ENGLISH))
+										.orElseThrow()
+										.getAttribute("name", Locale.ENGLISH);
+									assertTrue(
+										"Lenovo".equals(brand) || "Lenovo_1".equals(brand),
+										"Client " + clientId + " expected Lenovo or Lenovo_1 but got " + brand
+									);
+								}
+							);
+							queries.incrementAndGet();
+						} catch (Exception e) {
+							final List<Throwable> nestedThrowables = ExceptionUtils.findNestedThrowables(e);
+							if (nestedThrowables.stream().anyMatch(InstanceTerminatedException.class::isInstance)) {
+								terminations.incrementAndGet();
+							} else if (nestedThrowables.stream().anyMatch(SessionBusyException.class::isInstance)) {
+								terminations.incrementAndGet();
+							} else {
+								errors.incrementAndGet();
+							}
+						}
+					}
+					latch.countDown();
+				}
+			).start();
+		}
+
+		while (queries.get() < (iterations * clientCount) / 2) {
+			Thread.sleep(10);
+		}
+
+		// now replace the catalog with a hundred entities
+		evita.replaceCatalog(
+			catalogWithHundredEntities,
+			catalogWithSingleEntity
+		);
+
+		// and wait for all clients to finish
+		latch.await();
+
+		// we must not have any errors
+		assertEquals(0, errors.get());
+
+		System.out.println("Successful queries: " + queries.get());
+		System.out.println("Terminations: " + terminations.get());
+	}
+
+	@Nonnull
+	private EvitaConfiguration getEvitaConfiguration() {
+		return getEvitaConfiguration(-1);
+	}
+
+	@Nonnull
+	private EvitaConfiguration getEvitaConfiguration(int inactivityTimeoutInSeconds) {
+		return EvitaConfiguration.builder()
+			.server(
+				ServerOptions.builder()
+					.closeSessionsAfterSecondsOfInactivity(inactivityTimeoutInSeconds)
+					.build()
+			)
+			.storage(
+				StorageOptions.builder()
+					.storageDirectory(getTestDirectory().resolve(DIR_EVITA_REPLACEMENT_TEST))
+					.exportDirectory(getTestDirectory().resolve(DIR_EVITA_REPLACEMENT_TEST_EXPORT))
+					.maxOpenedReadHandles(100)
+					.build()
+			)
+			.build();
+	}
+
+}

--- a/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/model/StorageRecordTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/model/StorageRecordTest.java
@@ -288,8 +288,7 @@ class StorageRecordTest {
 	@ParameterizedTest
 	@MethodSource("combineSettings")
 	void shouldWriteAndReadRandomlyMultipleDifferentRecordsOfVaryingSize(Crc32Check crc32Check, Compression compression) throws IOException {
-		/* TODO JNO - revert to 256 */
-		final int count = 6;
+		final int count = 256;
 		final int retrievalCount = 512;
 		final Map<FileLocation, StorageRecord<ByteChunk>> index = generateAndWriteRandomRecords(
 			count, rec -> {}, crc32Check, compression


### PR DESCRIPTION
Catalog renaming/replacing/closing does not effectively prevent a new session from being created if there is a lot of traffic on the catalogue. Method close all sessions should enable some kind of flag that will prevent new session to pop-up. This flag needs to be reseted when the catalogue leaves critical section and starts to be available again. Or it needs to be removed from the catalogue listing much earlier.

I've written an integration test that uses 100 parallel clients doing 1000 queries and when 50% queries are finished I make the catalog replacement. This test now passes with zero query failures.

Refs: #850