### PR TITLE
chore: added logs before and after compaction

### DIFF
--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -1376,7 +1376,17 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 			final OffsetIndexDescriptor newDescriptor = entityCollectionPersistenceService.flush(catalogVersion, headerInfoSupplier);
 			if (newDescriptor.getActiveRecordShare() < this.storageOptions.minimalActiveRecordShare() &&
 				newDescriptor.getFileSize() > this.storageOptions.fileSizeCompactionThresholdBytes()) {
-				final EntityCollectionHeader compactedHeader = entityCollectionPersistenceService.compact(catalogName, catalogVersion, headerInfoSupplier);
+				log.info(
+					"Compacting catalog `{}` entity collection `{}`, size exceeds threshold `{}` and active record share is `{}`%, " +
+						"entity collection files on disk consume `{}` bytes.",
+					this.catalogName,
+					entityCollectionHeader.entityType(),
+					newDescriptor.getFileSize(),
+					newDescriptor.getActiveRecordShare(),
+					entityCollectionPersistenceService.getSizeOnDiskInBytes()
+				);
+
+				final EntityCollectionHeader compactedHeader = entityCollectionPersistenceService.compact(this.catalogName, catalogVersion, headerInfoSupplier);
 				final DefaultEntityCollectionPersistenceService newPersistenceService = this.entityCollectionPersistenceServices.computeIfAbsent(
 					new CollectionFileReference(
 						entityCollectionHeader.entityType(),

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java
@@ -1281,10 +1281,19 @@ public class DefaultEntityCollectionPersistenceService implements EntityCollecti
 				e
 			);
 		}
-		final EntityCollectionHeader newCollecitonHeader = createEntityCollectionHeader(catalogVersion, catalogStoragePath, offsetIndexDescriptor, headerInfoSupplier, newReference);
+		final EntityCollectionHeader newCollectionHeader = createEntityCollectionHeader(catalogVersion, catalogStoragePath, offsetIndexDescriptor, headerInfoSupplier, newReference);
 		// emit event
 		event.finish().commit();
-		return newCollecitonHeader;
+		log.info(
+			"Compaction of catalog `{}` entity collection `{}` finished, current size is `{}` and active record share is `{}`%, " +
+				"entity collection files on disk consume `{}` bytes.",
+			catalogName,
+			this.entityCollectionFileReference.entityType(),
+			offsetIndexDescriptor.getFileSize(),
+			offsetIndexDescriptor.getActiveRecordShare(),
+			this.getSizeOnDiskInBytes()
+		);
+		return newCollectionHeader;
 	}
 
 	/**


### PR DESCRIPTION
This pull request focuses on improving logging and fixing a typo in the `evita_store` module. The most important changes include adding detailed logging for the compaction process and correcting a misspelled variable name.

Enhancements to logging:

* [`evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java`](diffhunk://#diff-3cfc78a9196f5b426470228b99c4b3448991e9c52bce692e65e41be138236dedL1379-R1389): Added detailed logging to provide information about the compaction process, including catalog name, entity collection type, file size, active record share, and disk consumption.
* [`evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java`](diffhunk://#diff-2ad86126f5e5c85ab6a6c0061f41ae9d5976c7c7f89ebb181be36a9de9709771L1284-R1296): Added logging to indicate the completion of the compaction process, including details about the catalog name, entity collection type, file size, active record share, and disk consumption.

Bug fix:

* [`evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java`](diffhunk://#diff-2ad86126f5e5c85ab6a6c0061f41ae9d5976c7c7f89ebb181be36a9de9709771L1284-R1296): Corrected the misspelled variable name `newCollecitonHeader` to `newCollectionHeader`.