### PR TITLE
fix: GraphQL query wraps facet includingChildren into and container

### DIFF
--- a/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/constraint/FilterConstraintResolverTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/constraint/FilterConstraintResolverTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -251,11 +251,12 @@ class FilterConstraintResolverTest extends AbstractConstraintResolverTest {
 								.build(),
 							map()
 								.e("priceBetween", List.of(BigDecimal.valueOf(10L), BigDecimal.valueOf(20L)))
-								.e("facetBrandHaving", List.of(
+								.e(
+									"facetBrandHaving",
 									map()
 										.e("entityPrimaryKeyInSet",  List.of(10, 20, 30))
 										.build()
-								))
+								)
 								.build()
 						))
 						.e("referenceCategoryHaving", List.of(
@@ -313,11 +314,12 @@ class FilterConstraintResolverTest extends AbstractConstraintResolverTest {
 								.build(),
 							map()
 								.e("priceBetween", null)
-								.e("facetBrandHaving", List.of(
+								.e(
+									"facetBrandHaving",
 									map()
 										.e("entityPrimaryKeyInSet",  List.of(10, 20, 30))
 										.build()
-								))
+								)
 								.build()
 						))
 						.e("referenceCategoryHaving", List.of(

--- a/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/resolver/constraint/FilterConstraintResolverTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/resolver/constraint/FilterConstraintResolverTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import io.evitadb.api.query.visitor.QueryPurifierVisitor;
 import io.evitadb.dataType.exception.UnsupportedDataTypeException;
 import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.exception.EvitaInvalidUsageException;
-import io.evitadb.externalApi.rest.api.catalog.dataApi.resolver.constraint.FilterConstraintResolver;
 import io.evitadb.test.Entities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -252,11 +251,12 @@ class FilterConstraintResolverTest extends AbstractConstraintResolverTest {
 								.build(),
 							map()
 								.e("priceBetween", List.of(BigDecimal.valueOf(10L), BigDecimal.valueOf(20L)))
-								.e("facetBrandHaving", List.of(
+								.e(
+									"facetBrandHaving",
 									map()
 										.e("entityPrimaryKeyInSet",  List.of(10, 20, 30))
 										.build()
-								))
+								)
 								.build()
 						))
 						.e("referenceCategoryHaving", List.of(
@@ -314,11 +314,12 @@ class FilterConstraintResolverTest extends AbstractConstraintResolverTest {
 								.build(),
 							map()
 								.e("priceBetween", null)
-								.e("facetBrandHaving", List.of(
+								.e(
+									"facetBrandHaving",
 									map()
 										.e("entityPrimaryKeyInSet",  List.of(10, 20, 30))
 										.build()
-								))
+								)
 								.build()
 						))
 						.e("referenceCategoryHaving", List.of(

--- a/evita_functional_tests/src/test/java/io/evitadb/test/client/query/FilterConstraintToJsonConverterTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/test/client/query/FilterConstraintToJsonConverterTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -206,15 +206,13 @@ class FilterConstraintToJsonConverterTest extends ConstraintToJsonConverterTest 
 		priceBetween.add(jsonNodeFactory.textNode("20"));
 		andWrapperContainer.putIfAbsent("priceBetween", priceBetween);
 
-		final ArrayNode facetHaving = jsonNodeFactory.arrayNode();
 		final ObjectNode facetHavingWrapperContainer = jsonNodeFactory.objectNode();
 		final ArrayNode entityPrimaryKeyInSet = jsonNodeFactory.arrayNode();
 		entityPrimaryKeyInSet.add(10);
 		entityPrimaryKeyInSet.add(20);
 		entityPrimaryKeyInSet.add(30);
 		facetHavingWrapperContainer.putIfAbsent("entityPrimaryKeyInSet", entityPrimaryKeyInSet);
-		facetHaving.add(facetHavingWrapperContainer);
-		andWrapperContainer.putIfAbsent("facetBrandHaving", facetHaving);
+		andWrapperContainer.putIfAbsent("facetBrandHaving", facetHavingWrapperContainer);
 
 		and.add(andWrapperContainer);
 		orWrapperContainer2.putIfAbsent("and", and);

--- a/evita_query/src/main/java/io/evitadb/api/query/filter/FacetHaving.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/filter/FacetHaving.java
@@ -85,7 +85,7 @@ public class FacetHaving extends AbstractFilterConstraintContainer implements Fa
 
 	@Creator
 	public FacetHaving(@Nonnull @Classifier String referenceName,
-	                   @Nonnull FilterConstraint... filter) {
+	                   @Nonnull @Child(uniqueChildren = true) FilterConstraint... filter) {
 		super(new Serializable[]{referenceName}, filter);
 	}
 


### PR DESCRIPTION
Unfortunatelly the [`includingChildren`](https://evitadb.io/documentation/query/filtering/references?lang=graphql#including-children) is wrapped into an and container by GraphQL API and is not evaluated correctly by the engine.

Refs: #862