### PR TITLE
fix: Comparison method violates its general contract inTimSort (#867)

### DIFF
--- a/documentation/user/en/query/filtering/examples/behavioral/archived-entities-filtering.java
+++ b/documentation/user/en/query/filtering/examples/behavioral/archived-entities-filtering.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2024
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/filtering/examples/behavioral/archived-entities-listing.java
+++ b/documentation/user/en/query/filtering/examples/behavioral/archived-entities-listing.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2024
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/filtering/examples/behavioral/user-filter.graphql
+++ b/documentation/user/en/query/filtering/examples/behavioral/user-filter.graphql
@@ -8,15 +8,13 @@
       },
       userFilter: [
         {
-          facetBrandHaving: [
-            {
-              entityHaving: {
-                attributeCodeInSet: [
-                  "amazon"
-                ]
-              }
+          facetBrandHaving: {
+            entityHaving: {
+              attributeCodeInSet: [
+                "amazon"
+              ]
             }
-          ]
+          }
         }
       ]
     }

--- a/documentation/user/en/query/filtering/examples/behavioral/user-filter.rest
+++ b/documentation/user/en/query/filtering/examples/behavioral/user-filter.rest
@@ -9,15 +9,13 @@ POST /rest/evita/Product/query
     },
     "userFilter" : [
       {
-        "facetBrandHaving" : [
-          {
-            "entityHaving" : {
-              "attributeCodeInSet" : [
-                "amazon"
-              ]
-            }
+        "facetBrandHaving" : {
+          "entityHaving" : {
+            "attributeCodeInSet" : [
+              "amazon"
+            ]
           }
-        ]
+        }
       }
     ]
   },

--- a/documentation/user/en/query/filtering/examples/references/facet-having.graphql
+++ b/documentation/user/en/query/filtering/examples/references/facet-having.graphql
@@ -8,15 +8,13 @@
       },
       userFilter: [
         {
-          facetBrandHaving: [
-            {
-              entityHaving: {
-                attributeCodeInSet: [
-                  "amazon"
-                ]
-              }
+          facetBrandHaving: {
+            entityHaving: {
+              attributeCodeInSet: [
+                "amazon"
+              ]
             }
-          ]
+          }
         }
       ]
     }

--- a/documentation/user/en/query/filtering/examples/references/facet-having.rest
+++ b/documentation/user/en/query/filtering/examples/references/facet-having.rest
@@ -9,15 +9,13 @@ POST /rest/evita/Product/query
     },
     "userFilter" : [
       {
-        "facetBrandHaving" : [
-          {
-            "entityHaving" : {
-              "attributeCodeInSet" : [
-                "amazon"
-              ]
-            }
+        "facetBrandHaving" : {
+          "entityHaving" : {
+            "attributeCodeInSet" : [
+              "amazon"
+            ]
           }
-        ]
+        }
       }
     ]
   },

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children-except.graphql
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children-except.graphql
@@ -10,16 +10,14 @@
       ],
       userFilter: [
         {
-          facetCategoriesHaving: [
-            {
-              entityHaving: {
-                attributeCodeEquals: "laptops"
-              },
-              includingChildrenExcept: {
-                attributeCodeContains: "books"
-              }
+          facetCategoriesHaving: {
+            entityHaving: {
+              attributeCodeEquals: "laptops"
+            },
+            includingChildrenExcept: {
+              attributeCodeContains: "books"
             }
-          ]
+          }
         }
       ]
     }

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children-except.graphql.json.md
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children-except.graphql.json.md
@@ -8,7 +8,7 @@
         "count" : 56,
         "impact" : {
           "difference" : 0,
-          "matchCount" : 56,
+          "matchCount" : 191,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -23,7 +23,7 @@
         "count" : 31,
         "impact" : {
           "difference" : 31,
-          "matchCount" : 87,
+          "matchCount" : 222,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -38,7 +38,7 @@
         "count" : 5,
         "impact" : {
           "difference" : 5,
-          "matchCount" : 61,
+          "matchCount" : 196,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -53,7 +53,7 @@
         "count" : 56,
         "impact" : {
           "difference" : 56,
-          "matchCount" : 112,
+          "matchCount" : 247,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -64,11 +64,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 89,
         "impact" : {
-          "difference" : 89,
-          "matchCount" : 145,
+          "difference" : 0,
+          "matchCount" : 191,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -79,11 +79,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 20,
         "impact" : {
-          "difference" : 20,
-          "matchCount" : 76,
+          "difference" : 0,
+          "matchCount" : 191,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -94,11 +94,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 26,
         "impact" : {
-          "difference" : 26,
-          "matchCount" : 82,
+          "difference" : 0,
+          "matchCount" : 191,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -113,7 +113,7 @@
         "count" : 9,
         "impact" : {
           "difference" : 9,
-          "matchCount" : 65,
+          "matchCount" : 200,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -128,7 +128,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 192,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -143,7 +143,7 @@
         "count" : 2,
         "impact" : {
           "difference" : 2,
-          "matchCount" : 58,
+          "matchCount" : 193,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -158,7 +158,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 192,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -173,7 +173,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 194,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -188,7 +188,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 194,
           "hasSense" : true
         },
         "facetEntity" : {

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children-except.java
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children-except.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children-except.rest
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children-except.rest
@@ -11,16 +11,14 @@ POST /rest/evita/Product/query
     ],
     "userFilter" : [
       {
-        "facetCategoriesHaving" : [
-          {
-            "entityHaving" : {
-              "attributeCodeEquals" : "laptops"
-            },
-            "includingChildrenExcept" : {
-              "attributeCodeContains" : "books"
-            }
+        "facetCategoriesHaving" : {
+          "entityHaving" : {
+            "attributeCodeEquals" : "laptops"
+          },
+          "includingChildrenExcept" : {
+            "attributeCodeContains" : "books"
           }
-        ]
+        }
       }
     ]
   },

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children-except.rest.json.md
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children-except.rest.json.md
@@ -8,7 +8,7 @@
         "count" : 56,
         "impact" : {
           "difference" : 0,
-          "matchCount" : 56,
+          "matchCount" : 191,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -31,7 +31,7 @@
         "count" : 31,
         "impact" : {
           "difference" : 31,
-          "matchCount" : 87,
+          "matchCount" : 222,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -54,7 +54,7 @@
         "count" : 5,
         "impact" : {
           "difference" : 5,
-          "matchCount" : 61,
+          "matchCount" : 196,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -77,7 +77,7 @@
         "count" : 56,
         "impact" : {
           "difference" : 56,
-          "matchCount" : 112,
+          "matchCount" : 247,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -96,11 +96,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 89,
         "impact" : {
-          "difference" : 89,
-          "matchCount" : 145,
+          "difference" : 0,
+          "matchCount" : 191,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -119,11 +119,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 20,
         "impact" : {
-          "difference" : 20,
-          "matchCount" : 76,
+          "difference" : 0,
+          "matchCount" : 191,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -142,11 +142,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 26,
         "impact" : {
-          "difference" : 26,
-          "matchCount" : 82,
+          "difference" : 0,
+          "matchCount" : 191,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -169,7 +169,7 @@
         "count" : 9,
         "impact" : {
           "difference" : 9,
-          "matchCount" : 65,
+          "matchCount" : 200,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -192,7 +192,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 192,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -215,7 +215,7 @@
         "count" : 2,
         "impact" : {
           "difference" : 2,
-          "matchCount" : 58,
+          "matchCount" : 193,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -238,7 +238,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 192,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -261,7 +261,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 194,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -284,7 +284,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 194,
           "hasSense" : true
         },
         "facetEntity" : {

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children-having.graphql
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children-having.graphql
@@ -10,16 +10,14 @@
       ],
       userFilter: [
         {
-          facetCategoriesHaving: [
-            {
-              entityHaving: {
-                attributeCodeEquals: "laptops"
-              },
-              includingChildrenHaving: {
-                attributeCodeContains: "books"
-              }
+          facetCategoriesHaving: {
+            entityHaving: {
+              attributeCodeEquals: "laptops"
+            },
+            includingChildrenHaving: {
+              attributeCodeContains: "books"
             }
-          ]
+          }
         }
       ]
     }

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children-having.graphql.json.md
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children-having.graphql.json.md
@@ -8,7 +8,7 @@
         "count" : 56,
         "impact" : {
           "difference" : 0,
-          "matchCount" : 56,
+          "matchCount" : 117,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -23,7 +23,7 @@
         "count" : 31,
         "impact" : {
           "difference" : 31,
-          "matchCount" : 87,
+          "matchCount" : 148,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -34,11 +34,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 5,
         "impact" : {
-          "difference" : 5,
-          "matchCount" : 61,
+          "difference" : 0,
+          "matchCount" : 117,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -49,11 +49,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 56,
         "impact" : {
-          "difference" : 56,
-          "matchCount" : 112,
+          "difference" : 0,
+          "matchCount" : 117,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -68,7 +68,7 @@
         "count" : 89,
         "impact" : {
           "difference" : 89,
-          "matchCount" : 145,
+          "matchCount" : 206,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -83,7 +83,7 @@
         "count" : 20,
         "impact" : {
           "difference" : 20,
-          "matchCount" : 76,
+          "matchCount" : 137,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -98,7 +98,7 @@
         "count" : 26,
         "impact" : {
           "difference" : 26,
-          "matchCount" : 82,
+          "matchCount" : 143,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -113,7 +113,7 @@
         "count" : 9,
         "impact" : {
           "difference" : 9,
-          "matchCount" : 65,
+          "matchCount" : 126,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -128,7 +128,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 118,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -143,7 +143,7 @@
         "count" : 2,
         "impact" : {
           "difference" : 2,
-          "matchCount" : 58,
+          "matchCount" : 119,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -158,7 +158,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 118,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -173,7 +173,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 120,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -188,7 +188,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 120,
           "hasSense" : true
         },
         "facetEntity" : {

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children-having.java
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children-having.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children-having.rest
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children-having.rest
@@ -11,16 +11,14 @@ POST /rest/evita/Product/query
     ],
     "userFilter" : [
       {
-        "facetCategoriesHaving" : [
-          {
-            "entityHaving" : {
-              "attributeCodeEquals" : "laptops"
-            },
-            "includingChildrenHaving" : {
-              "attributeCodeContains" : "books"
-            }
+        "facetCategoriesHaving" : {
+          "entityHaving" : {
+            "attributeCodeEquals" : "laptops"
+          },
+          "includingChildrenHaving" : {
+            "attributeCodeContains" : "books"
           }
-        ]
+        }
       }
     ]
   },

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children-having.rest.json.md
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children-having.rest.json.md
@@ -8,7 +8,7 @@
         "count" : 56,
         "impact" : {
           "difference" : 0,
-          "matchCount" : 56,
+          "matchCount" : 117,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -31,7 +31,7 @@
         "count" : 31,
         "impact" : {
           "difference" : 31,
-          "matchCount" : 87,
+          "matchCount" : 148,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -50,11 +50,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 5,
         "impact" : {
-          "difference" : 5,
-          "matchCount" : 61,
+          "difference" : 0,
+          "matchCount" : 117,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -73,11 +73,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 56,
         "impact" : {
-          "difference" : 56,
-          "matchCount" : 112,
+          "difference" : 0,
+          "matchCount" : 117,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -100,7 +100,7 @@
         "count" : 89,
         "impact" : {
           "difference" : 89,
-          "matchCount" : 145,
+          "matchCount" : 206,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -123,7 +123,7 @@
         "count" : 20,
         "impact" : {
           "difference" : 20,
-          "matchCount" : 76,
+          "matchCount" : 137,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -146,7 +146,7 @@
         "count" : 26,
         "impact" : {
           "difference" : 26,
-          "matchCount" : 82,
+          "matchCount" : 143,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -169,7 +169,7 @@
         "count" : 9,
         "impact" : {
           "difference" : 9,
-          "matchCount" : 65,
+          "matchCount" : 126,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -192,7 +192,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 118,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -215,7 +215,7 @@
         "count" : 2,
         "impact" : {
           "difference" : 2,
-          "matchCount" : 58,
+          "matchCount" : 119,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -238,7 +238,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 118,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -261,7 +261,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 120,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -284,7 +284,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 120,
           "hasSense" : true
         },
         "facetEntity" : {

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children.graphql
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children.graphql
@@ -10,14 +10,12 @@
       ],
       userFilter: [
         {
-          facetCategoriesHaving: [
-            {
-              entityHaving: {
-                attributeCodeEquals: "laptops"
-              },
-              includingChildren: true
-            }
-          ]
+          facetCategoriesHaving: {
+            entityHaving: {
+              attributeCodeEquals: "laptops"
+            },
+            includingChildren: true
+          }
         }
       ]
     }

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children.graphql.json.md
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children.graphql.json.md
@@ -8,7 +8,7 @@
         "count" : 56,
         "impact" : {
           "difference" : 0,
-          "matchCount" : 56,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -23,7 +23,7 @@
         "count" : 31,
         "impact" : {
           "difference" : 31,
-          "matchCount" : 87,
+          "matchCount" : 283,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -34,11 +34,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 5,
         "impact" : {
-          "difference" : 5,
-          "matchCount" : 61,
+          "difference" : 0,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -49,11 +49,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 56,
         "impact" : {
-          "difference" : 56,
-          "matchCount" : 112,
+          "difference" : 0,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -64,11 +64,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 89,
         "impact" : {
-          "difference" : 89,
-          "matchCount" : 145,
+          "difference" : 0,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -79,11 +79,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 20,
         "impact" : {
-          "difference" : 20,
-          "matchCount" : 76,
+          "difference" : 0,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -94,11 +94,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 26,
         "impact" : {
-          "difference" : 26,
-          "matchCount" : 82,
+          "difference" : 0,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -113,7 +113,7 @@
         "count" : 9,
         "impact" : {
           "difference" : 9,
-          "matchCount" : 65,
+          "matchCount" : 261,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -128,7 +128,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 253,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -143,7 +143,7 @@
         "count" : 2,
         "impact" : {
           "difference" : 2,
-          "matchCount" : 58,
+          "matchCount" : 254,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -158,7 +158,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 253,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -173,7 +173,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 255,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -188,7 +188,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 255,
           "hasSense" : true
         },
         "facetEntity" : {

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children.java
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children.rest
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children.rest
@@ -11,14 +11,12 @@ POST /rest/evita/Product/query
     ],
     "userFilter" : [
       {
-        "facetCategoriesHaving" : [
-          {
-            "entityHaving" : {
-              "attributeCodeEquals" : "laptops"
-            },
-            "includingChildren" : true
-          }
-        ]
+        "facetCategoriesHaving" : {
+          "entityHaving" : {
+            "attributeCodeEquals" : "laptops"
+          },
+          "includingChildren" : true
+        }
       }
     ]
   },

--- a/documentation/user/en/query/filtering/examples/references/facet-including-children.rest.json.md
+++ b/documentation/user/en/query/filtering/examples/references/facet-including-children.rest.json.md
@@ -8,7 +8,7 @@
         "count" : 56,
         "impact" : {
           "difference" : 0,
-          "matchCount" : 56,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -31,7 +31,7 @@
         "count" : 31,
         "impact" : {
           "difference" : 31,
-          "matchCount" : 87,
+          "matchCount" : 283,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -50,11 +50,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 5,
         "impact" : {
-          "difference" : 5,
-          "matchCount" : 61,
+          "difference" : 0,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -73,11 +73,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 56,
         "impact" : {
-          "difference" : 56,
-          "matchCount" : 112,
+          "difference" : 0,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -96,11 +96,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 89,
         "impact" : {
-          "difference" : 89,
-          "matchCount" : 145,
+          "difference" : 0,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -119,11 +119,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 20,
         "impact" : {
-          "difference" : 20,
-          "matchCount" : 76,
+          "difference" : 0,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -142,11 +142,11 @@
         }
       },
       {
-        "requested" : false,
+        "requested" : true,
         "count" : 26,
         "impact" : {
-          "difference" : 26,
-          "matchCount" : 82,
+          "difference" : 0,
+          "matchCount" : 252,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -169,7 +169,7 @@
         "count" : 9,
         "impact" : {
           "difference" : 9,
-          "matchCount" : 65,
+          "matchCount" : 261,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -192,7 +192,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 253,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -215,7 +215,7 @@
         "count" : 2,
         "impact" : {
           "difference" : 2,
-          "matchCount" : 58,
+          "matchCount" : 254,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -238,7 +238,7 @@
         "count" : 1,
         "impact" : {
           "difference" : 1,
-          "matchCount" : 57,
+          "matchCount" : 253,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -261,7 +261,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 255,
           "hasSense" : true
         },
         "facetEntity" : {
@@ -284,7 +284,7 @@
         "count" : 3,
         "impact" : {
           "difference" : 3,
-          "matchCount" : 59,
+          "matchCount" : 255,
           "hasSense" : true
         },
         "facetEntity" : {

--- a/documentation/user/en/query/ordering/examples/reference/reference-attribute-natural-hierarchy.java
+++ b/documentation/user/en/query/ordering/examples/reference/reference-attribute-natural-hierarchy.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/ordering/examples/reference/reference-attribute-natural-multiple-explicit.java
+++ b/documentation/user/en/query/ordering/examples/reference/reference-attribute-natural-multiple-explicit.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/ordering/examples/reference/reference-traverse-by.evitaql.json.md
+++ b/documentation/user/en/query/ordering/examples/reference/reference-traverse-by.evitaql.json.md
@@ -1,13 +1,13 @@
 ```json
 {
-  "primaryKey" : 107891,
+  "primaryKey" : 113705,
   "attributes" : {
-    "code" : "amazfit-bip-3"
+    "code" : "emos-cold-base-set-for-interconnecting-chains"
   },
   "references" : {
     "categories" : [
       {
-        "referencedKey" : 66486,
+        "referencedKey" : 66480,
         "attributes" : {
           "orderInCategory" : "Predecessor[predecessorPk=-1]"
         }

--- a/documentation/user/en/query/ordering/examples/reference/reference-traverse-by.graphql.json.md
+++ b/documentation/user/en/query/ordering/examples/reference/reference-traverse-by.graphql.json.md
@@ -5,13 +5,13 @@
       "recordPage" : {
         "data" : [
           {
-            "primaryKey" : 107891,
+            "primaryKey" : 113705,
             "attributes" : {
-              "code" : "amazfit-bip-3"
+              "code" : "emos-cold-base-set-for-interconnecting-chains"
             },
             "categories" : [
               {
-                "referencedPrimaryKey" : 66486,
+                "referencedPrimaryKey" : 66480,
                 "attributes" : {
                   "orderInCategory" : -1
                 }
@@ -19,13 +19,139 @@
             ]
           },
           {
-            "primaryKey" : 107893,
+            "primaryKey" : 113709,
             "attributes" : {
-              "code" : "amazfit-bip-3-1"
+              "code" : "emos-warm-base-set-for-interconnecting-chains"
             },
             "categories" : [
               {
-                "referencedPrimaryKey" : 66486,
+                "referencedPrimaryKey" : 66480,
+                "attributes" : {
+                  "orderInCategory" : 113705
+                }
+              }
+            ]
+          },
+          {
+            "primaryKey" : 113713,
+            "attributes" : {
+              "code" : "emos-nativity-set"
+            },
+            "categories" : [
+              {
+                "referencedPrimaryKey" : 66480,
+                "attributes" : {
+                  "orderInCategory" : 113709
+                }
+              }
+            ]
+          },
+          {
+            "primaryKey" : 113714,
+            "attributes" : {
+              "code" : "emos-candlestick"
+            },
+            "categories" : [
+              {
+                "referencedPrimaryKey" : 66480,
+                "attributes" : {
+                  "orderInCategory" : 113713
+                }
+              }
+            ]
+          },
+          {
+            "primaryKey" : 113716,
+            "attributes" : {
+              "code" : "retlux-warm-white-christmas-lightning"
+            },
+            "categories" : [
+              {
+                "referencedPrimaryKey" : 66480,
+                "attributes" : {
+                  "orderInCategory" : 113714
+                }
+              }
+            ]
+          },
+          {
+            "primaryKey" : 113718,
+            "attributes" : {
+              "code" : "retlux-blue-christmas-lightning"
+            },
+            "categories" : [
+              {
+                "referencedPrimaryKey" : 66480,
+                "attributes" : {
+                  "orderInCategory" : 113716
+                }
+              }
+            ]
+          },
+          {
+            "primaryKey" : 113720,
+            "attributes" : {
+              "code" : "retlux-cottage-acrylic-ornament"
+            },
+            "categories" : [
+              {
+                "referencedPrimaryKey" : 66480,
+                "attributes" : {
+                  "orderInCategory" : 113718
+                }
+              }
+            ]
+          },
+          {
+            "primaryKey" : 113721,
+            "attributes" : {
+              "code" : "immax-neo-lite-smart-chain"
+            },
+            "categories" : [
+              {
+                "referencedPrimaryKey" : 66480,
+                "attributes" : {
+                  "orderInCategory" : 113720
+                }
+              }
+            ]
+          },
+          {
+            "primaryKey" : 113725,
+            "attributes" : {
+              "code" : "immax-neo-lite-smart-christmas-led-tree"
+            },
+            "categories" : [
+              {
+                "referencedPrimaryKey" : 66480,
+                "attributes" : {
+                  "orderInCategory" : 113721
+                }
+              }
+            ]
+          },
+          {
+            "primaryKey" : 113727,
+            "attributes" : {
+              "code" : "immax-neo-lite-smart-christmas-led-strip"
+            },
+            "categories" : [
+              {
+                "referencedPrimaryKey" : 66480,
+                "attributes" : {
+                  "orderInCategory" : 113725
+                }
+              }
+            ]
+          },
+          {
+            "primaryKey" : 113221,
+            "attributes" : {
+              "code" : "24p3qw"
+            },
+            "categories" : [
+              {
+                "referencedPrimaryKey" : 66483,
                 "attributes" : {
                   "orderInCategory" : -1
                 }
@@ -33,253 +159,127 @@
             ]
           },
           {
-            "primaryKey" : 107894,
+            "primaryKey" : 113230,
             "attributes" : {
-              "code" : "amazfit-bip-3-2"
+              "code" : "q27p3qw"
             },
             "categories" : [
               {
-                "referencedPrimaryKey" : 66486,
+                "referencedPrimaryKey" : 66483,
                 "attributes" : {
-                  "orderInCategory" : -1
+                  "orderInCategory" : 113221
                 }
               }
             ]
           },
           {
-            "primaryKey" : 107895,
+            "primaryKey" : 113237,
             "attributes" : {
-              "code" : "amazfit-bip-3-3"
+              "code" : "27e3um-bk"
             },
             "categories" : [
               {
-                "referencedPrimaryKey" : 66486,
+                "referencedPrimaryKey" : 66483,
                 "attributes" : {
-                  "orderInCategory" : -1
+                  "orderInCategory" : 113230
                 }
               }
             ]
           },
           {
-            "primaryKey" : 107899,
+            "primaryKey" : 113242,
             "attributes" : {
-              "code" : "amazfit-bip-3-pro"
+              "code" : "24e3um-bk"
             },
             "categories" : [
               {
-                "referencedPrimaryKey" : 66486,
+                "referencedPrimaryKey" : 66483,
                 "attributes" : {
-                  "orderInCategory" : 107891
+                  "orderInCategory" : 113237
                 }
               }
             ]
           },
           {
-            "primaryKey" : 107900,
+            "primaryKey" : 113248,
             "attributes" : {
-              "code" : "amazfit-bip-3-pro-1"
+              "code" : "24p2qm"
             },
             "categories" : [
               {
-                "referencedPrimaryKey" : 66486,
+                "referencedPrimaryKey" : 66483,
                 "attributes" : {
-                  "orderInCategory" : -1
+                  "orderInCategory" : 113242
                 }
               }
             ]
           },
           {
-            "primaryKey" : 107901,
+            "primaryKey" : 113258,
             "attributes" : {
-              "code" : "amazfit-bip-3-pro-2"
+              "code" : "u34e2m-bk"
             },
             "categories" : [
               {
-                "referencedPrimaryKey" : 66486,
+                "referencedPrimaryKey" : 66483,
                 "attributes" : {
-                  "orderInCategory" : -1
+                  "orderInCategory" : 113248
                 }
               }
             ]
           },
           {
-            "primaryKey" : 107902,
+            "primaryKey" : 113265,
             "attributes" : {
-              "code" : "amazfit-bip-3-pro-3"
+              "code" : "q27b3ma"
             },
             "categories" : [
               {
-                "referencedPrimaryKey" : 66486,
+                "referencedPrimaryKey" : 66483,
                 "attributes" : {
-                  "orderInCategory" : -1
+                  "orderInCategory" : 113258
                 }
               }
             ]
           },
           {
-            "primaryKey" : 107911,
+            "primaryKey" : 113271,
             "attributes" : {
-              "code" : "amazfit-bip-s"
+              "code" : "cu34v5cw"
             },
             "categories" : [
               {
-                "referencedPrimaryKey" : 66486,
+                "referencedPrimaryKey" : 66483,
                 "attributes" : {
-                  "orderInCategory" : 107899
+                  "orderInCategory" : 113265
                 }
               }
             ]
           },
           {
-            "primaryKey" : 107913,
+            "primaryKey" : 113276,
             "attributes" : {
-              "code" : "amazfit-bip-s-1"
+              "code" : "24v5cw"
             },
             "categories" : [
               {
-                "referencedPrimaryKey" : 66486,
+                "referencedPrimaryKey" : 66483,
                 "attributes" : {
-                  "orderInCategory" : -1
+                  "orderInCategory" : 113271
                 }
               }
             ]
           },
           {
-            "primaryKey" : 107915,
+            "primaryKey" : 113279,
             "attributes" : {
-              "code" : "amazfit-bip-s-2"
+              "code" : "q27v5cw"
             },
             "categories" : [
               {
-                "referencedPrimaryKey" : 66486,
+                "referencedPrimaryKey" : 66483,
                 "attributes" : {
-                  "orderInCategory" : -1
-                }
-              }
-            ]
-          },
-          {
-            "primaryKey" : 107917,
-            "attributes" : {
-              "code" : "amazfit-bip-s-3"
-            },
-            "categories" : [
-              {
-                "referencedPrimaryKey" : 66486,
-                "attributes" : {
-                  "orderInCategory" : -1
-                }
-              }
-            ]
-          },
-          {
-            "primaryKey" : 107919,
-            "attributes" : {
-              "code" : "amazfit-bip-s-4"
-            },
-            "categories" : [
-              {
-                "referencedPrimaryKey" : 66486,
-                "attributes" : {
-                  "orderInCategory" : -1
-                }
-              }
-            ]
-          },
-          {
-            "primaryKey" : 107923,
-            "attributes" : {
-              "code" : "amazfit-bip-s-lite"
-            },
-            "categories" : [
-              {
-                "referencedPrimaryKey" : 66486,
-                "attributes" : {
-                  "orderInCategory" : 107911
-                }
-              }
-            ]
-          },
-          {
-            "primaryKey" : 107924,
-            "attributes" : {
-              "code" : "amazfit-bip-s-lite-1"
-            },
-            "categories" : [
-              {
-                "referencedPrimaryKey" : 66486,
-                "attributes" : {
-                  "orderInCategory" : -1
-                }
-              }
-            ]
-          },
-          {
-            "primaryKey" : 107925,
-            "attributes" : {
-              "code" : "amazfit-bip-s-lite-2"
-            },
-            "categories" : [
-              {
-                "referencedPrimaryKey" : 66486,
-                "attributes" : {
-                  "orderInCategory" : -1
-                }
-              }
-            ]
-          },
-          {
-            "primaryKey" : 107926,
-            "attributes" : {
-              "code" : "amazfit-bip-s-lite-3"
-            },
-            "categories" : [
-              {
-                "referencedPrimaryKey" : 66486,
-                "attributes" : {
-                  "orderInCategory" : -1
-                }
-              }
-            ]
-          },
-          {
-            "primaryKey" : 107933,
-            "attributes" : {
-              "code" : "amazfit-bip-u"
-            },
-            "categories" : [
-              {
-                "referencedPrimaryKey" : 66486,
-                "attributes" : {
-                  "orderInCategory" : 107923
-                }
-              }
-            ]
-          },
-          {
-            "primaryKey" : 107934,
-            "attributes" : {
-              "code" : "amazfit-bip-u-1"
-            },
-            "categories" : [
-              {
-                "referencedPrimaryKey" : 66486,
-                "attributes" : {
-                  "orderInCategory" : -1
-                }
-              }
-            ]
-          },
-          {
-            "primaryKey" : 107935,
-            "attributes" : {
-              "code" : "amazfit-bip-u-2"
-            },
-            "categories" : [
-              {
-                "referencedPrimaryKey" : 66486,
-                "attributes" : {
-                  "orderInCategory" : -1
+                  "orderInCategory" : 113276
                 }
               }
             ]

--- a/documentation/user/en/query/ordering/examples/reference/reference-traverse-by.java
+++ b/documentation/user/en/query/ordering/examples/reference/reference-traverse-by.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/ordering/examples/reference/reference-traverse-by.rest.json.md
+++ b/documentation/user/en/query/ordering/examples/reference/reference-traverse-by.rest.json.md
@@ -3,31 +3,7 @@
   "recordPage" : {
     "data" : [
       {
-        "primaryKey" : 107891,
-        "type" : "Product",
-        "version" : 2,
-        "scope" : "LIVE",
-        "allLocales" : [
-          "en"
-        ],
-        "attributes" : {
-          "global" : {
-            "code" : "amazfit-bip-3"
-          }
-        },
-        "categories" : [
-          {
-            "referencedPrimaryKey" : 66486,
-            "attributes" : {
-              "global" : {
-                "orderInCategory" : -1
-              }
-            }
-          }
-        ]
-      },
-      {
-        "primaryKey" : 107893,
+        "primaryKey" : 113705,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -36,12 +12,12 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-3-1"
+            "code" : "emos-cold-base-set-for-interconnecting-chains"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66480,
             "attributes" : {
               "global" : {
                 "orderInCategory" : -1
@@ -51,7 +27,7 @@
         ]
       },
       {
-        "primaryKey" : 107894,
+        "primaryKey" : 113709,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -60,22 +36,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-3-2"
+            "code" : "emos-warm-base-set-for-interconnecting-chains"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66480,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113705
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107895,
+        "primaryKey" : 113713,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -84,46 +60,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-3-3"
+            "code" : "emos-nativity-set"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66480,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113709
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107899,
-        "type" : "Product",
-        "version" : 2,
-        "scope" : "LIVE",
-        "allLocales" : [
-          "en"
-        ],
-        "attributes" : {
-          "global" : {
-            "code" : "amazfit-bip-3-pro"
-          }
-        },
-        "categories" : [
-          {
-            "referencedPrimaryKey" : 66486,
-            "attributes" : {
-              "global" : {
-                "orderInCategory" : 107891
-              }
-            }
-          }
-        ]
-      },
-      {
-        "primaryKey" : 107900,
+        "primaryKey" : 113714,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -132,22 +84,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-3-pro-1"
+            "code" : "emos-candlestick"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66480,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113713
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107901,
+        "primaryKey" : 113716,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -156,22 +108,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-3-pro-2"
+            "code" : "retlux-warm-white-christmas-lightning"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66480,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113714
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107902,
+        "primaryKey" : 113718,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -180,46 +132,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-3-pro-3"
+            "code" : "retlux-blue-christmas-lightning"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66480,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113716
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107911,
-        "type" : "Product",
-        "version" : 2,
-        "scope" : "LIVE",
-        "allLocales" : [
-          "en"
-        ],
-        "attributes" : {
-          "global" : {
-            "code" : "amazfit-bip-s"
-          }
-        },
-        "categories" : [
-          {
-            "referencedPrimaryKey" : 66486,
-            "attributes" : {
-              "global" : {
-                "orderInCategory" : 107899
-              }
-            }
-          }
-        ]
-      },
-      {
-        "primaryKey" : 107913,
+        "primaryKey" : 113720,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -228,22 +156,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-s-1"
+            "code" : "retlux-cottage-acrylic-ornament"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66480,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113718
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107915,
+        "primaryKey" : 113721,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -252,22 +180,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-s-2"
+            "code" : "immax-neo-lite-smart-chain"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66480,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113720
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107917,
+        "primaryKey" : 113725,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -276,22 +204,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-s-3"
+            "code" : "immax-neo-lite-smart-christmas-led-tree"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66480,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113721
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107919,
+        "primaryKey" : 113727,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -300,46 +228,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-s-4"
+            "code" : "immax-neo-lite-smart-christmas-led-strip"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66480,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113725
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107923,
-        "type" : "Product",
-        "version" : 2,
-        "scope" : "LIVE",
-        "allLocales" : [
-          "en"
-        ],
-        "attributes" : {
-          "global" : {
-            "code" : "amazfit-bip-s-lite"
-          }
-        },
-        "categories" : [
-          {
-            "referencedPrimaryKey" : 66486,
-            "attributes" : {
-              "global" : {
-                "orderInCategory" : 107911
-              }
-            }
-          }
-        ]
-      },
-      {
-        "primaryKey" : 107924,
+        "primaryKey" : 113221,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -348,12 +252,12 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-s-lite-1"
+            "code" : "24p3qw"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66483,
             "attributes" : {
               "global" : {
                 "orderInCategory" : -1
@@ -363,7 +267,7 @@
         ]
       },
       {
-        "primaryKey" : 107925,
+        "primaryKey" : 113230,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -372,22 +276,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-s-lite-2"
+            "code" : "q27p3qw"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66483,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113221
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107926,
+        "primaryKey" : 113237,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -396,46 +300,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-s-lite-3"
+            "code" : "27e3um-bk"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66483,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113230
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107933,
-        "type" : "Product",
-        "version" : 2,
-        "scope" : "LIVE",
-        "allLocales" : [
-          "en"
-        ],
-        "attributes" : {
-          "global" : {
-            "code" : "amazfit-bip-u"
-          }
-        },
-        "categories" : [
-          {
-            "referencedPrimaryKey" : 66486,
-            "attributes" : {
-              "global" : {
-                "orderInCategory" : 107923
-              }
-            }
-          }
-        ]
-      },
-      {
-        "primaryKey" : 107934,
+        "primaryKey" : 113242,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -444,22 +324,22 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-u-1"
+            "code" : "24e3um-bk"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66483,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113237
               }
             }
           }
         ]
       },
       {
-        "primaryKey" : 107935,
+        "primaryKey" : 113248,
         "type" : "Product",
         "version" : 1,
         "scope" : "LIVE",
@@ -468,15 +348,135 @@
         ],
         "attributes" : {
           "global" : {
-            "code" : "amazfit-bip-u-2"
+            "code" : "24p2qm"
           }
         },
         "categories" : [
           {
-            "referencedPrimaryKey" : 66486,
+            "referencedPrimaryKey" : 66483,
             "attributes" : {
               "global" : {
-                "orderInCategory" : -1
+                "orderInCategory" : 113242
+              }
+            }
+          }
+        ]
+      },
+      {
+        "primaryKey" : 113258,
+        "type" : "Product",
+        "version" : 1,
+        "scope" : "LIVE",
+        "allLocales" : [
+          "en"
+        ],
+        "attributes" : {
+          "global" : {
+            "code" : "u34e2m-bk"
+          }
+        },
+        "categories" : [
+          {
+            "referencedPrimaryKey" : 66483,
+            "attributes" : {
+              "global" : {
+                "orderInCategory" : 113248
+              }
+            }
+          }
+        ]
+      },
+      {
+        "primaryKey" : 113265,
+        "type" : "Product",
+        "version" : 1,
+        "scope" : "LIVE",
+        "allLocales" : [
+          "en"
+        ],
+        "attributes" : {
+          "global" : {
+            "code" : "q27b3ma"
+          }
+        },
+        "categories" : [
+          {
+            "referencedPrimaryKey" : 66483,
+            "attributes" : {
+              "global" : {
+                "orderInCategory" : 113258
+              }
+            }
+          }
+        ]
+      },
+      {
+        "primaryKey" : 113271,
+        "type" : "Product",
+        "version" : 1,
+        "scope" : "LIVE",
+        "allLocales" : [
+          "en"
+        ],
+        "attributes" : {
+          "global" : {
+            "code" : "cu34v5cw"
+          }
+        },
+        "categories" : [
+          {
+            "referencedPrimaryKey" : 66483,
+            "attributes" : {
+              "global" : {
+                "orderInCategory" : 113265
+              }
+            }
+          }
+        ]
+      },
+      {
+        "primaryKey" : 113276,
+        "type" : "Product",
+        "version" : 1,
+        "scope" : "LIVE",
+        "allLocales" : [
+          "en"
+        ],
+        "attributes" : {
+          "global" : {
+            "code" : "24v5cw"
+          }
+        },
+        "categories" : [
+          {
+            "referencedPrimaryKey" : 66483,
+            "attributes" : {
+              "global" : {
+                "orderInCategory" : 113271
+              }
+            }
+          }
+        ]
+      },
+      {
+        "primaryKey" : 113279,
+        "type" : "Product",
+        "version" : 1,
+        "scope" : "LIVE",
+        "allLocales" : [
+          "en"
+        ],
+        "attributes" : {
+          "global" : {
+            "code" : "q27v5cw"
+          }
+        },
+        "categories" : [
+          {
+            "referencedPrimaryKey" : 66483,
+            "attributes" : {
+              "global" : {
+                "orderInCategory" : 113276
               }
             }
           }

--- a/documentation/user/en/query/requirements/examples/facet/change-default-calculation-rules.java
+++ b/documentation/user/en/query/requirements/examples/facet/change-default-calculation-rules.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-groups-conjunction.graphql
+++ b/documentation/user/en/query/requirements/examples/facet/facet-groups-conjunction.graphql
@@ -3,15 +3,13 @@
     filterBy: {
       userFilter: [
         {
-          facetGroupsHaving: [
-            {
-              entityHaving: {
-                attributeCodeInSet: [
-                  "sale"
-                ]
-              }
+          facetGroupsHaving: {
+            entityHaving: {
+              attributeCodeInSet: [
+                "sale"
+              ]
             }
-          ]
+          }
         }
       ]
     },

--- a/documentation/user/en/query/requirements/examples/facet/facet-groups-conjunction.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-groups-conjunction.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-groups-conjunction.rest
+++ b/documentation/user/en/query/requirements/examples/facet/facet-groups-conjunction.rest
@@ -4,15 +4,13 @@ POST /rest/evita/Product/query
   "filterBy" : {
     "userFilter" : [
       {
-        "facetGroupsHaving" : [
-          {
-            "entityHaving" : {
-              "attributeCodeInSet" : [
-                "sale"
-              ]
-            }
+        "facetGroupsHaving" : {
+          "entityHaving" : {
+            "attributeCodeInSet" : [
+              "sale"
+            ]
           }
-        ]
+        }
       }
     ]
   },

--- a/documentation/user/en/query/requirements/examples/facet/facet-groups-disjunction.graphql
+++ b/documentation/user/en/query/requirements/examples/facet/facet-groups-disjunction.graphql
@@ -3,15 +3,13 @@
     filterBy: {
       userFilter: [
         {
-          facetParameterValuesHaving: [
-            {
-              entityHaving: {
-                attributeCodeInSet: [
-                  "ram-memory-64"
-                ]
-              }
+          facetParameterValuesHaving: {
+            entityHaving: {
+              attributeCodeInSet: [
+                "ram-memory-64"
+              ]
             }
-          ]
+          }
         }
       ]
     },

--- a/documentation/user/en/query/requirements/examples/facet/facet-groups-disjunction.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-groups-disjunction.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-groups-disjunction.rest
+++ b/documentation/user/en/query/requirements/examples/facet/facet-groups-disjunction.rest
@@ -4,15 +4,13 @@ POST /rest/evita/Product/query
   "filterBy" : {
     "userFilter" : [
       {
-        "facetParameterValuesHaving" : [
-          {
-            "entityHaving" : {
-              "attributeCodeInSet" : [
-                "ram-memory-64"
-              ]
-            }
+        "facetParameterValuesHaving" : {
+          "entityHaving" : {
+            "attributeCodeInSet" : [
+              "ram-memory-64"
+            ]
           }
-        ]
+        }
       }
     ]
   },

--- a/documentation/user/en/query/requirements/examples/facet/facet-groups-exclusivity.graphql
+++ b/documentation/user/en/query/requirements/examples/facet/facet-groups-exclusivity.graphql
@@ -3,15 +3,13 @@
     filterBy: {
       userFilter: [
         {
-          facetParameterValuesHaving: [
-            {
-              entityHaving: {
-                attributeCodeInSet: [
-                  "ram-memory-24"
-                ]
-              }
+          facetParameterValuesHaving: {
+            entityHaving: {
+              attributeCodeInSet: [
+                "ram-memory-24"
+              ]
             }
-          ]
+          }
         }
       ]
     },

--- a/documentation/user/en/query/requirements/examples/facet/facet-groups-exclusivity.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-groups-exclusivity.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-groups-exclusivity.rest
+++ b/documentation/user/en/query/requirements/examples/facet/facet-groups-exclusivity.rest
@@ -4,15 +4,13 @@ POST /rest/evita/Product/query
   "filterBy" : {
     "userFilter" : [
       {
-        "facetParameterValuesHaving" : [
-          {
-            "entityHaving" : {
-              "attributeCodeInSet" : [
-                "ram-memory-24"
-              ]
-            }
+        "facetParameterValuesHaving" : {
+          "entityHaving" : {
+            "attributeCodeInSet" : [
+              "ram-memory-24"
+            ]
           }
-        ]
+        }
       }
     ]
   },

--- a/documentation/user/en/query/requirements/examples/facet/facet-summary-bodies.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-summary-bodies.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-summary-filtering.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-summary-filtering.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-summary-localized-bodies.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-summary-localized-bodies.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-summary-of-reference-bodies.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-summary-of-reference-bodies.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-summary-of-reference-filtering.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-summary-of-reference-filtering.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-summary-of-reference-localized-bodies.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-summary-of-reference-localized-bodies.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-summary-of-reference-ordering.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-summary-of-reference-ordering.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-summary-of-reference.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-summary-of-reference.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/query/requirements/examples/facet/facet-summary-ordering.java
+++ b/documentation/user/en/query/requirements/examples/facet/facet-summary-ordering.java
@@ -1,26 +1,3 @@
-/*
- *
- *                         _ _        ____  ____
- *               _____   _(_) |_ __ _|  _ \| __ )
- *              / _ \ \ / / | __/ _` | | | |  _ \
- *             |  __/\ V /| | || (_| | |_| | |_) |
- *              \___| \_/ |_|\__\__,_|____/|____/
- *
- *   Copyright (c) 2025
- *
- *   Licensed under the Business Source License, Version 1.1 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
- */
-
 final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 	"evita",
 	session -> {

--- a/documentation/user/en/solve/examples/filtering-products-in-category/faceted-search-brand.graphql
+++ b/documentation/user/en/solve/examples/filtering-products-in-category/faceted-search-brand.graphql
@@ -9,13 +9,11 @@
       },
       userFilter: [
         {
-          facetBrandHaving: [
-            {
-              entityPrimaryKeyInSet: [
-                66465
-              ]
-            }
-          ]
+          facetBrandHaving: {
+            entityPrimaryKeyInSet: [
+              66465
+            ]
+          }
         }
       ]
     }

--- a/documentation/user/en/solve/examples/filtering-products-in-category/faceted-search-brand.rest
+++ b/documentation/user/en/solve/examples/filtering-products-in-category/faceted-search-brand.rest
@@ -10,13 +10,11 @@ POST /rest/evita/Product/query
     },
     "userFilter" : [
       {
-        "facetBrandHaving" : [
-          {
-            "entityPrimaryKeyInSet" : [
-              66465
-            ]
-          }
-        ]
+        "facetBrandHaving" : {
+          "entityPrimaryKeyInSet" : [
+            66465
+          ]
+        }
       }
     ]
   },

--- a/documentation/user/en/solve/examples/filtering-products-in-category/price-filter.rest
+++ b/documentation/user/en/solve/examples/filtering-products-in-category/price-filter.rest
@@ -24,8 +24,7 @@ POST /rest/evita/Product/query
   },
   "require" : {
     "priceHistogram" : {
-      "requestedBucketCount" : 10,
-      "behavior" : "STANDARD"
+      "requestedBucketCount" : 10
     }
   }
 }

--- a/documentation/user/en/solve/examples/filtering-products-in-category/product-listing-with-facets-and-sorting.graphql
+++ b/documentation/user/en/solve/examples/filtering-products-in-category/product-listing-with-facets-and-sorting.graphql
@@ -28,13 +28,11 @@
       priceValidInNow: true,
       userFilter: [
         {
-          facetBrandHaving: [
-            {
-              entityPrimaryKeyInSet: [
-                66465
-              ]
-            }
-          ],
+          facetBrandHaving: {
+            entityPrimaryKeyInSet: [
+              66465
+            ]
+          },
           priceBetween: [
             "50",
             "400"
@@ -48,10 +46,7 @@
       }
     ]
   ) {
-    recordPage(
-      number: 1
-      size: 16
-    ) {
+    recordPage(size: 16) {
       data {
         primaryKey
         attributes {

--- a/documentation/user/en/solve/examples/filtering-products-in-category/product-listing-with-facets-and-sorting.rest
+++ b/documentation/user/en/solve/examples/filtering-products-in-category/product-listing-with-facets-and-sorting.rest
@@ -29,13 +29,11 @@ POST /rest/evita/Product/query
     "priceValidInNow" : true,
     "userFilter" : [
       {
-        "facetBrandHaving" : [
-          {
-            "entityPrimaryKeyInSet" : [
-              66465
-            ]
-          }
-        ],
+        "facetBrandHaving" : {
+          "entityPrimaryKeyInSet" : [
+            66465
+          ]
+        },
         "priceBetween" : [
           "50",
           "400"
@@ -106,8 +104,7 @@ POST /rest/evita/Product/query
       ]
     },
     "priceHistogram" : {
-      "requestedBucketCount" : 10,
-      "behavior" : "STANDARD"
+      "requestedBucketCount" : 10
     },
     "page" : {
       "number" : 1,

--- a/documentation/user/en/use/api/example/evita-query-example.graphql
+++ b/documentation/user/en/use/api/example/evita-query-example.graphql
@@ -18,16 +18,14 @@
           ],
           userFilter: [
             {
-              facetParameterValuesHaving: [
-                {
-                  entityHaving: {
-                    attributeCodeInSet: [
-                      "gluten-free",
-                      "original-recipe"
-                    ]
-                  }
+              facetParameterValuesHaving: {
+                entityHaving: {
+                  attributeCodeInSet: [
+                    "gluten-free",
+                    "original-recipe"
+                  ]
                 }
-              ],
+              },
               priceBetween: [
                 "600",
                 "1600"

--- a/documentation/user/en/use/api/example/evita-query-example.java
+++ b/documentation/user/en/use/api/example/evita-query-example.java
@@ -29,7 +29,7 @@ final EvitaResponse<SealedEntity> entities = evita.queryCatalog(
 					page(1, 20),
 					facetSummary(IMPACT),
 					priceType(WITH_TAX),
-					priceHistogram(30)
+					priceHistogram(30, STANDARD)
 				)
 			)
 		);

--- a/documentation/user/en/use/api/example/evita-query-example.rest
+++ b/documentation/user/en/use/api/example/evita-query-example.rest
@@ -19,16 +19,14 @@ POST /rest/evita/Product/query
         ],
         "userFilter" : [
           {
-            "facetParameterValuesHaving" : [
-              {
-                "entityHaving" : {
-                  "attributeCodeInSet" : [
-                    "gluten-free",
-                    "original-recipe"
-                  ]
-                }
+            "facetParameterValuesHaving" : {
+              "entityHaving" : {
+                "attributeCodeInSet" : [
+                  "gluten-free",
+                  "original-recipe"
+                ]
               }
-            ],
+            },
             "priceBetween" : [
               "600",
               "1600"
@@ -48,8 +46,7 @@ POST /rest/evita/Product/query
     },
     "priceType" : "WITH_TAX",
     "priceHistogram" : {
-      "requestedBucketCount" : 30,
-      "behavior" : "STANDARD"
+      "requestedBucketCount" : 30
     }
   }
 }

--- a/documentation/user/en/use/api/example/rest-full-query-example.rest
+++ b/documentation/user/en/use/api/example/rest-full-query-example.rest
@@ -12,11 +12,11 @@ POST /rest/evita/Product/query
     "priceInCurrency": "CZK",
     "priceInPriceLists": ["vip", "loyal-customer", "regular-prices"],
     "userFilter": [{
-      "facetParameterValuesHaving": [{
+      "facetParameterValuesHaving": {
         "entityHaving": {
           "attributeCodeInSet": ["gluten-free", "original-recipe"]
         }
-      }],
+      },
       "priceBetween": ["600", "1600"]
     }]
   },

--- a/documentation/user/en/use/api/example/rest-list-query-example.rest
+++ b/documentation/user/en/use/api/example/rest-list-query-example.rest
@@ -12,11 +12,11 @@ POST /rest/evita/Product/list
     "priceInCurrency": "CZK",
     "priceInPriceLists": ["vip", "loyal-customer", "regular-prices"],
     "userFilter": [{
-      "facetParameterValuesHaving": [{
+      "facetParameterValuesHaving": {
         "entityHaving": {
           "attributeCodeInSet": ["gluten-free", "original-recipe"]
         }
-      }],
+      },
       "priceBetween": ["600", "1600"]
     }]
   },

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/AttributeSetExactTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/AttributeSetExactTranslator.java
@@ -65,7 +65,6 @@ public class AttributeSetExactTranslator implements OrderingConstraintTranslator
 			"Expected exactly one index for sorting, but " + indexForSort.length + " were found."
 		);
 
-		//noinspection SuspiciousToArrayCall
 		return Stream.of(
 			new AttributeExactSorter(
 				attributeName,

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/ReferenceAttributeReferenceComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/ReferenceAttributeReferenceComparator.java
@@ -113,18 +113,18 @@ public class ReferenceAttributeReferenceComparator implements ReferenceComparato
 	@Nonnull
 	@Override
 	public ReferenceComparator andThen(@Nonnull ReferenceComparator comparatorForUnknownRecords) {
-		return new ReferenceAttributeReferenceComparator(comparatorForUnknownRecords, attributeValueFetcher, comparator);
+		return new ReferenceAttributeReferenceComparator(comparatorForUnknownRecords, this.attributeValueFetcher, this.comparator);
 	}
 
 	@Nullable
 	@Override
 	public ReferenceComparator getNextComparator() {
-		return nextComparator;
+		return this.nextComparator;
 	}
 
 	@Override
 	public int getNonSortedReferenceCount() {
-		return ofNullable(nonSortedReferences)
+		return ofNullable(this.nonSortedReferences)
 			.map(IntHashSet::size)
 			.orElse(0);
 	}
@@ -134,7 +134,7 @@ public class ReferenceAttributeReferenceComparator implements ReferenceComparato
 		final Serializable attribute1 = o1 == null ? null : this.attributeValueFetcher.apply(o1);
 		final Serializable attribute2 = o2 == null ? null : this.attributeValueFetcher.apply(o2);
 		if (attribute1 != null && attribute2 != null) {
-			return comparator.compare(attribute1, attribute2);
+			return this.comparator.compare(attribute1, attribute2);
 		} else if (attribute1 == null && attribute2 != null) {
 			this.nonSortedReferences = ofNullable(this.nonSortedReferences)
 				.orElseGet(IntHashSet::new);

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/ReferenceCompoundAttributeReferenceComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/ReferenceCompoundAttributeReferenceComparator.java
@@ -103,9 +103,9 @@ public class ReferenceCompoundAttributeReferenceComparator implements ReferenceC
 			.toArray(ComparatorSource[]::new);
 
 		// initialize normalizers
-		this.normalizer = createNormalizerFor(comparatorSource);
+		this.normalizer = createNormalizerFor(this.comparatorSource);
 		//noinspection rawtypes
-		final Comparator baseComparator = createCombinedComparatorFor(locale, comparatorSource);
+		final Comparator baseComparator = createCombinedComparatorFor(locale, this.comparatorSource);
 		//noinspection unchecked
 		this.comparator = orderDirection == OrderDirection.ASC ?
 			baseComparator : (o1, o2) -> baseComparator.compare(o2, o1);
@@ -141,7 +141,7 @@ public class ReferenceCompoundAttributeReferenceComparator implements ReferenceC
 	public int compare(ReferenceContract o1, ReferenceContract o2) {
 		final ComparableArray valueToCompare1 = getAndMemoizeValue(o1);
 		final ComparableArray valueToCompare2 = getAndMemoizeValue(o2);
-		return comparator.compare(valueToCompare1, valueToCompare2);
+		return this.comparator.compare(valueToCompare1, valueToCompare2);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferenceAttributeComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferenceAttributeComparator.java
@@ -100,13 +100,18 @@ public class TraverseReferenceAttributeComparator
 	public int compare(EntityContract o1, EntityContract o2) {
 		final ReferenceAttributeValue attribute1 = this.attributeValueFetcher.apply(o1);
 		final ReferenceAttributeValue attribute2 = this.attributeValueFetcher.apply(o2);
-		if (attribute1 != null && attribute2 != null) {
+		// to correctly compare the references we need to compare only attributes on the same reference
+		final boolean bothAttributesSpecified = attribute1 != null && attribute2 != null;
+		final boolean attributesExistOnSameReference = bothAttributesSpecified && attribute1.referencedKey().equals(attribute2.referencedKey());
+		if (attributesExistOnSameReference) {
 			final int result = attribute1.compareTo(attribute2);
 			if (result == 0) {
 				return this.pkComparator.compare(o1, o2);
 			} else {
 				return result;
 			}
+		} else if (bothAttributesSpecified) {
+			return attribute1.referencedKey().compareTo(attribute2.referencedKey());
 		} else if (attribute1 == null && attribute2 != null) {
 			return 1;
 		} else if (attribute1 != null) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferenceCompoundAttributeComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferenceCompoundAttributeComparator.java
@@ -102,14 +102,19 @@ public class TraverseReferenceCompoundAttributeComparator
 
 	@Override
 	public int compare(EntityContract o1, EntityContract o2) {
-		final ReferenceAttributeValue valueToCompare1 = getAndMemoizeValue(o1);
-		final ReferenceAttributeValue valueToCompare2 = getAndMemoizeValue(o2);
-		if (valueToCompare1 != ReferenceAttributeValue.MISSING && valueToCompare2 != ReferenceAttributeValue.MISSING) {
-			return valueToCompare1.compareTo(valueToCompare2);
+		final ReferenceAttributeValue attribute1 = getAndMemoizeValue(o1);
+		final ReferenceAttributeValue attribute2 = getAndMemoizeValue(o2);
+		// to correctly compare the references we need to compare only attributes on the same reference
+		final boolean bothAttributesSpecified = attribute1 != ReferenceAttributeValue.MISSING && attribute2 != ReferenceAttributeValue.MISSING;
+		final boolean attributesExistOnSameReference = bothAttributesSpecified && attribute1.referencedEntityPrimaryKey() == attribute2.referencedEntityPrimaryKey();
+		if (attributesExistOnSameReference) {
+			return attribute1.compareTo(attribute2);
+		} else if (bothAttributesSpecified) {
+			return Integer.compare(attribute1.referencedEntityPrimaryKey(), attribute2.referencedEntityPrimaryKey());
 		} else {
-			if (valueToCompare1 != ReferenceAttributeValue.MISSING) {
+			if (attribute1 != ReferenceAttributeValue.MISSING) {
 				return -1;
-			} else if (valueToCompare2 != ReferenceAttributeValue.MISSING) {
+			} else if (attribute2 != ReferenceAttributeValue.MISSING) {
 				return 1;
 			} else {
 				return 0;

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferencePredecessorAttributeComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferencePredecessorAttributeComparator.java
@@ -141,7 +141,10 @@ public class TraverseReferencePredecessorAttributeComparator
 		}
 		final ReferenceAttributeValue attribute1 = this.attributeValueFetcher.apply(o1);
 		final ReferenceAttributeValue attribute2 = this.attributeValueFetcher.apply(o2);
-		if (attribute1 != null && attribute2 != null) {
+		// to correctly compare the references we need to compare only attributes on the same reference
+		final boolean bothAttributesSpecified = attribute1 != null && attribute2 != null;
+		final boolean attributesExistOnSameReference = bothAttributesSpecified && attribute1.referencedKey().equals(attribute2.referencedKey());
+		if (attributesExistOnSameReference) {
 			if (attribute1.referencedKey().equals(attribute2.referencedKey())) {
 				// if the offset is null, the sorted record provider was not found for the given reference key
 				final OffsetAndLimit offsetAndLimit = this.sortedRecordsOffsets == null ?
@@ -213,6 +216,8 @@ public class TraverseReferencePredecessorAttributeComparator
 				}
 			}
 			return 0;
+		} else if (bothAttributesSpecified) {
+			return attribute1.referencedKey().compareTo(attribute2.referencedKey());
 		} else if (attribute1 == null && attribute2 != null) {
 			return 1;
 		} else if (attribute1 != null) {

--- a/evita_functional_tests/src/test/java/io/evitadb/documentation/UserDocumentationTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/documentation/UserDocumentationTest.java
@@ -473,8 +473,8 @@ public class UserDocumentationTest implements EvitaTestSupport {
 	@Disabled
 	Stream<DynamicTest> testSingleFileDocumentationAndCreateOtherLanguageSnippets() {
 		return this.createTests(
-			Environment.LOCALHOST,
-			getRootDirectory().resolve("documentation/user/en/query/ordering/reference.md"),
+			Environment.DEMO_SERVER,
+			getRootDirectory().resolve("documentation/user/en/use/api/query-data.md"),
 			new ExampleFilter[]{
 				/*ExampleFilter.CSHARP,*/
 				ExampleFilter.JAVA,


### PR DESCRIPTION
When pick by first entit is used over predecessor attribute on reference TimSort, IllegalArgumentException `Comparison method violates its general contract!` may be thrown. This can happen when two entities pick their predecessor attribute from different reference chains and other comparisons use different chains, resulting in conflicting sort indicators.

If we are sorting by predecessors, we need to ensure that only predecessors from the same reference are used for comparison. This is currently not enforced. This behaviour should be the same for other entity traversal comparators.

Refs: https://github.com/FgForrest/evitaDB/issues/867