### PR TITLE
fix: Commit behavior passed as last argument of updateCatalog method is not respected

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/EvitaSessionContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/EvitaSessionContract.java
@@ -195,7 +195,7 @@ public interface EvitaSessionContract extends Comparable<EvitaSessionContract>, 
 	 */
 	@Override
 	default void close() {
-		closeWhen(CommitBehavior.defaultBehaviour());
+		closeWhen(getCommitBehavior());
 	}
 
 	/**
@@ -1260,6 +1260,15 @@ public interface EvitaSessionContract extends Comparable<EvitaSessionContract>, 
 	 * @see io.evitadb.api.SessionTraits.SessionFlags#READ_WRITE
 	 */
 	boolean isReadOnly();
+
+	/**
+	 * Method returns {@link CommitBehavior} set when the session was created. This behavior can be changed when
+	 * the session is {@link #closeWhen(CommitBehavior) closed}, but is used when implicit {@link #close()} is called.
+	 *
+	 * @return commit behavior
+	 */
+	@Nonnull
+	CommitBehavior getCommitBehavior();
 
 	/**
 	 * Returns true if session is switched to binary format output.

--- a/evita_engine/src/main/java/io/evitadb/core/EvitaSession.java
+++ b/evita_engine/src/main/java/io/evitadb/core/EvitaSession.java
@@ -1426,6 +1426,12 @@ public final class EvitaSession implements EvitaInternalSessionContract {
 		return !this.sessionTraits.isReadWrite();
 	}
 
+	@Nonnull
+	@Override
+	public CommitBehavior getCommitBehavior() {
+		return this.commitBehaviour;
+	}
+
 	@Override
 	public boolean isBinaryFormat() {
 		return this.sessionTraits.isBinary();


### PR DESCRIPTION
When the commit behavior is used in following call:

```java
evita.updateCatalog(
        "whatever",
        session -> {
            session.getEntity(...)
                    .orElseThrow()
                    .openForWrite()
                    .setAttribute("changed", OffsetDateTime.now())
                    .upsertVia(session);
        },
        TransactionContract.CommitBehavior.WAIT_FOR_WAL_PERSISTENCE
);
```

The default commit behavior WAIT_FOR_INDEX_PROPAGATION is still used.

Refs: #871