### PR TITLE
fix: Old WAL files might not contain statistic tail written

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/Catalog.java
@@ -877,6 +877,8 @@ public final class Catalog implements CatalogContract, CatalogConsumersListener,
 				},
 				() -> updatedCatalogConsumer.accept(this)
 			);
+
+		this.persistenceService.verifyIntegrity();
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/core/Evita.java
+++ b/evita_engine/src/main/java/io/evitadb/core/Evita.java
@@ -722,7 +722,12 @@ public final class Evita implements EvitaContract {
 				// this will be one day used in more clever way, when entire catalog loading will be split into
 				// multiple smaller tasks and done asynchronously after the startup (along with catalog loading / unloading feature)
 				theCatalog.processWriteAheadLog(
-					updatedCatalog -> this.catalogs.put(catalogName, updatedCatalog)
+					updatedCatalog -> {
+						this.catalogs.put(catalogName, updatedCatalog);
+						if (updatedCatalog instanceof Catalog theUpdatedCatalog) {
+							theUpdatedCatalog.notifyCatalogPresentInLiveView();
+						}
+					}
 				);
 				this.emitCatalogStatistics(catalogName);
 			},

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
@@ -534,10 +534,11 @@ public class TransactionManager {
 	) {
 		try {
 			if (this.walAppendingLock.tryLock(0, TimeUnit.MILLISECONDS)) {
+				final long theLastWrittenCatalogVersion = this.lastWrittenCatalogVersion.get();
 				Assert.isPremiseValid(
-					this.lastWrittenCatalogVersion.get() + 1 == transactionMutation.getCatalogVersion(),
+					theLastWrittenCatalogVersion <= 0 || theLastWrittenCatalogVersion + 1 == transactionMutation.getCatalogVersion(),
 					"Transaction cannot be written to the WAL out of order. " +
-						"Expected version " + (this.lastWrittenCatalogVersion.get() + 1) + ", got " + transactionMutation.getCatalogVersion() + "."
+						"Expected version " + (theLastWrittenCatalogVersion + 1) + ", got " + transactionMutation.getCatalogVersion() + "."
 				);
 				return getLivingCatalog()
 					.appendWalAndDiscard(

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/stage/WalAppendingTransactionStage.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/stage/WalAppendingTransactionStage.java
@@ -88,7 +88,7 @@ public final class WalAppendingTransactionStage
 
 		final long lastWrittenCatalogVersion = this.transactionManager.getLastWrittenCatalogVersion();
 		Assert.isPremiseValid(
-			lastWrittenCatalogVersion == -1 || lastWrittenCatalogVersion == task.catalogVersion() - 1,
+			lastWrittenCatalogVersion <= 0 || lastWrittenCatalogVersion == task.catalogVersion() - 1,
 			"Transaction cannot be written to the WAL out of order. " +
 				"Expected version " + (lastWrittenCatalogVersion + 1) + ", got " + task.catalogVersion() + "."
 		);

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/stage/WalAppendingTransactionStage.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/stage/WalAppendingTransactionStage.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024
+ *   Copyright (c) 2024-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -67,8 +67,11 @@ public final class WalAppendingTransactionStage
 
 	@Override
 	protected void handleException(@Nonnull WalAppendingTransactionTask task, @Nonnull Throwable ex) {
-		this.transactionManager.notifyCatalogVersionDropped(this.droppedCatalogVersions);
-		super.handleException(task, ex);
+		try {
+			this.transactionManager.notifyCatalogVersionDropped(this.droppedCatalogVersions);
+		} finally {
+			super.handleException(task, ex);
+		}
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/store/spi/CatalogPersistenceService.java
+++ b/evita_engine/src/main/java/io/evitadb/store/spi/CatalogPersistenceService.java
@@ -520,6 +520,24 @@ public non-sealed interface CatalogPersistenceService extends PersistenceService
 	) throws TemporalDataNotAvailableException;
 
 	/**
+	 * Verifies the integrity of a system, component, or data structure.
+	 * This method performs an internal check to ensure that the state
+	 * or configuration adheres to expected standards or rules.
+	 *
+	 * The specific implementation of the integrity verification depends
+	 * on the context in which this method is used. It may include tasks
+	 * such as validating data consistency, ensuring correct initialization,
+	 * or detecting anomalies that could indicate corruption or unexpected
+	 * modifications.
+	 *
+	 * No inputs or return values are required. The method performs its
+	 * operations as a void execution.
+	 *
+	 * Potential exceptions may be thrown if integrity violations are detected.
+	 */
+	void verifyIntegrity();
+
+	/**
 	 * Returns size taken by all catalog data structures in bytes.
 	 *
 	 * @return size taken by all catalog data structures in bytes

--- a/evita_store/evita_store_common/src/main/java/io/evitadb/store/exception/WriteAheadLogCorruptedException.java
+++ b/evita_store/evita_store_common/src/main/java/io/evitadb/store/exception/WriteAheadLogCorruptedException.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024
+ *   Copyright (c) 2024-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import io.evitadb.exception.EvitaInternalError;
 
 import javax.annotation.Nonnull;
 import java.io.Serial;
+import java.util.function.BiFunction;
 
 /**
  * Exception indicating that a Write Ahead Log (WAL) has been corrupted.
@@ -44,5 +45,20 @@ public class WriteAheadLogCorruptedException extends EvitaInternalError {
 
 	public WriteAheadLogCorruptedException(@Nonnull String privateMessage, @Nonnull String publicMessage, @Nonnull Throwable cause) {
 		super(privateMessage, publicMessage, cause);
+	}
+
+	public WriteAheadLogCorruptedException(
+		@Nonnull String catalogName,
+		int walIndex,
+		long lastVersion,
+		long firstVersion,
+		@Nonnull BiFunction<String, Integer, String> getWalFileName
+	) {
+		super(
+			"First version of the WAL file `" + getWalFileName.apply(catalogName, walIndex) + "` doesn't follow up to the last version of the" +
+				" previous WAL file `" + getWalFileName.apply(catalogName, walIndex - 1) + "`! Last version found: `" +
+				lastVersion + "`, first version of the next WAL file : `" + firstVersion + "`! ",
+			"First version of the WAL file doesn't follow up to the last version of the previous WAL file!"
+		);
 	}
 }

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -2236,6 +2236,20 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	}
 
 	@Override
+	public void verifyIntegrity() {
+		Assert.isPremiseValid(
+			getCatalogHeader(this.bootstrapUsed.catalogVersion()).version() == this.bootstrapUsed.catalogVersion(),
+			"Catalog version mismatch! Expected `" + this.bootstrapUsed.catalogVersion() + "` but found `" + getCatalogHeader(this.bootstrapUsed.catalogVersion()).version() + "`!"
+		);
+		if (this.catalogWal != null) {
+			Assert.isPremiseValid(
+				this.catalogWal.getLastWrittenCatalogVersion() == this.bootstrapUsed.catalogVersion(),
+				"Catalog WAL version mismatch! Expected `" + this.bootstrapUsed.catalogVersion() + "` but found `" + this.catalogWal.getLastWrittenCatalogVersion() + "`!"
+			);
+		}
+	}
+
+	@Override
 	public long getSizeOnDiskInBytes() {
 		return FileUtils.getDirectorySize(this.catalogStoragePath);
 	}


### PR DESCRIPTION
Under certain conditions (we are not yet sure which ones), the old WAL files, which are not written to, lack the tail statistics information in them. These statistics are used to locate transactions in them for the sake of the CDC, and also for replay in case evitaDB is restarted or transaction processing lags behind transaction commits.

The current handling is not secure enough and needs to be updated:

- when the catalogue is loaded, old WAL files need to be checked too (not just the current WAL file)
- if old WAL files lack tail information, they need to be checked, trimmed and the statistics appended to the tail
- all WAL files need to be checked to see if they contain consecutive monotonic rows of transactions
- Catalogue needs to be checked that the catalogue versions in: bootstrap record, catalogue header and WAL file match after all transactions from the WAL files have been applied.

This may reveal why / when the statistical information is missing from the old files. And if such a situation happens, it could be recovered automatically.

Refs: https://github.com/FgForrest/evitaDB/issues/873