### PR TITLE
feat!: Propagate catalog schema version to client

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -20,6 +20,8 @@
       </list>
     </option>
     <JavaCodeStyleSettings>
+      <option name="GENERATE_FINAL_LOCALS" value="true" />
+      <option name="REPLACE_INSTANCEOF_AND_CAST" value="true" />
       <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
       <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="10" />

--- a/.idea/inspectionProfiles/Evita_DB_Defaults.xml
+++ b/.idea/inspectionProfiles/Evita_DB_Defaults.xml
@@ -168,6 +168,7 @@
     <inspection_tool class="SuspiciousArrayCast" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TransientFieldInNonSerializableClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TransientFieldNotInitialized" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="UnqualifiedFieldAccess" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnusedReturnValue" enabled="true" level="TEXT ATTRIBUTES" enabled_by_default="true" editorAttributes="CONSIDERATION_ATTRIBUTES" />
     <inspection_tool class="UseOfPropertiesAsHashtable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="VariableNotUsedInsideIf" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />

--- a/evita_api/src/main/java/io/evitadb/api/CommitProgress.java
+++ b/evita_api/src/main/java/io/evitadb/api/CommitProgress.java
@@ -1,0 +1,126 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api;
+
+
+import io.evitadb.api.TransactionContract.CommitBehavior;
+import io.evitadb.exception.EvitaInvalidUsageException;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * CommitProgress is an interface that represents the progress of a transaction commit operation in a database. It contains
+ * multiple CompletableFuture objects that allow tracking the status of various stages of the commit process. It provides
+ * the following guarantees:
+ *
+ * 1. later stage is not completed before the earlier stage is completed
+ * 2. when a stage completes with an exception, all later stages are completed with the same exception immediately after
+ * 3. all stages must eventually complete
+ * 4. if WAL appending stage completes successfully, the changes are guaranteed to be visible to all readers later;
+ * if onChangesVisible completes with exception afterwards, the system will replay the changes or mark a catalog
+ * as corrupted (changes might be applied after evita server restart, or the error just might signalize lost connection
+ * between the server and client and the server side already applied the changed, but the client couldn't receive
+ * acknowledgment)
+ * 5. if a session was read-only or didn't make any changes, all stages are completed before the record is created
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+public interface CommitProgress {
+
+	/**
+	 * Returns a {@link CompletionStage} that completes when the system verifies changes are not in conflict with
+	 * changes from other transactions committed in the meantime.
+	 *
+	 * @return the {@link CompletionStage} for conflict resolution
+	 */
+	@Nonnull
+	CompletionStage<CommitVersions> onConflictResolved();
+
+	/**
+	 * Returns a {@link CompletionStage} that completes when the changes are appended to the Write Ahead Log (WAL).
+	 *
+	 * @return the {@link CompletionStage} for WAL appending
+	 */
+	@Nonnull
+	CompletionStage<CommitVersions> onWalAppended();
+
+	/**
+	 * Returns a {@link CompletionStage} that completes when the changes are visible to all readers.
+	 *
+	 * @return the {@link CompletionStage} for changes visibility
+	 */
+	@Nonnull
+	CompletionStage<CommitVersions> onChangesVisible();
+
+	/**
+	 * Returns a {@link CompletionStage} that represents a specific stage in the transaction commit process,
+	 * based on the provided {@link CommitBehavior}.
+	 *
+	 * @param commitBehavior the behavior defining the desired stage in the transaction commit process.
+	 *
+	 * @return the {@link CompletionStage} corresponding to the specified commit behavior.
+	 * @throws EvitaInvalidUsageException if an unsupported commit behavior is provided.
+	 */
+	default CompletionStage<CommitVersions> on(@Nonnull CommitBehavior commitBehavior) {
+		switch (commitBehavior) {
+			case WAIT_FOR_CONFLICT_RESOLUTION -> {
+				return onConflictResolved();
+			}
+			case WAIT_FOR_WAL_PERSISTENCE -> {
+				return onWalAppended();
+			}
+			case WAIT_FOR_INDEX_PROPAGATION -> {
+				return onChangesVisible();
+			}
+			default -> throw new EvitaInvalidUsageException("Unsupported commit behavior: " + commitBehavior);
+		}
+	}
+
+	/**
+	 * Returns true if all the commit stages are completed successfully.
+	 * @return true if all stages are completed successfully, false otherwise.
+	 */
+	boolean isCompletedSuccessfully();
+
+	/**
+	 * Returns true if either of the stages is completed exceptionally.
+	 * @return true if any of the stages is completed exceptionally, false otherwise.
+	 */
+	boolean isCompletedExceptionally();
+
+	/**
+	 * CommitVersions is a record that contains the catalog and catalog schema versions that were assigned during
+	 * the commit process. They guarantee to contain all changes made during the transaction, when the catalog
+	 * of this particular version is visible to the reader.
+	 *
+	 * @param catalogVersion       the version of the catalog after the operation is completed
+	 * @param catalogSchemaVersion the schema version of the catalog after the operation is completed
+	 */
+	record CommitVersions(
+		long catalogVersion,
+		int catalogSchemaVersion
+	) {
+	}
+}

--- a/evita_api/src/main/java/io/evitadb/api/CommitProgressRecord.java
+++ b/evita_api/src/main/java/io/evitadb/api/CommitProgressRecord.java
@@ -1,0 +1,135 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * CommitProgressRecord is an implementation of {@link CommitProgress} that represents the progress of a transaction
+ * commit operation in a database. It contains multiple CompletableFuture objects that allow tracking the status of
+ * various stages of the commit process.
+ *
+ * This implementation provides methods to complete all futures either successfully or exceptionally.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+public class CommitProgressRecord implements CommitProgress {
+
+    /**
+     * CompletableFuture that completes when the system verifies changes are not in conflict with
+     * changes from other transactions committed in the meantime.
+     */
+    private final CompletableFuture<CommitVersions> onConflictResolved;
+
+    /**
+     * CompletableFuture that completes when the changes are appended to the Write Ahead Log (WAL).
+     */
+    private final CompletableFuture<CommitVersions> onWalAppended;
+
+    /**
+     * CompletableFuture that completes when the changes are visible to all readers.
+     */
+    private final CompletableFuture<CommitVersions> onChangesVisible;
+
+    /**
+     * Creates a new instance of CommitProgressRecord with the specified CompletableFuture objects.
+     */
+    public CommitProgressRecord() {
+        this.onConflictResolved = new CompletableFuture<>();
+        this.onWalAppended = new CompletableFuture<>();
+        this.onChangesVisible = new CompletableFuture<>();
+    }
+
+    @Override
+    @Nonnull
+    public CompletableFuture<CommitVersions> onConflictResolved() {
+        return this.onConflictResolved;
+    }
+
+    @Override
+    @Nonnull
+    public CompletableFuture<CommitVersions> onWalAppended() {
+        return this.onWalAppended;
+    }
+
+    @Override
+    @Nonnull
+    public CompletableFuture<CommitVersions> onChangesVisible() {
+        return this.onChangesVisible;
+    }
+
+    @Override
+    public boolean isCompletedSuccessfully() {
+        return this.onConflictResolved.isDone() &&
+                this.onWalAppended.isDone() &&
+                this.onChangesVisible.isDone() &&
+                !this.onConflictResolved.isCompletedExceptionally() &&
+                !this.onWalAppended.isCompletedExceptionally() &&
+                !this.onChangesVisible.isCompletedExceptionally();
+    }
+
+    @Override
+    public boolean isCompletedExceptionally() {
+        return this.onConflictResolved.isCompletedExceptionally() ||
+                this.onWalAppended.isCompletedExceptionally() ||
+                this.onChangesVisible.isCompletedExceptionally();
+    }
+
+    /**
+     * Completes all non-finished futures exceptionally with the specified exception.
+     *
+     * @param exception the exception to complete the futures with
+     */
+    public void completeExceptionally(@Nonnull Throwable exception) {
+        if (!this.onConflictResolved.isDone()) {
+            this.onConflictResolved.completeExceptionally(exception);
+        }
+        if (!this.onWalAppended.isDone()) {
+            this.onWalAppended.completeExceptionally(exception);
+        }
+        if (!this.onChangesVisible.isDone()) {
+            this.onChangesVisible.completeExceptionally(exception);
+        }
+    }
+
+    /**
+     * Completes all non-finished futures successfully.
+     * For onConflictResolved, it completes with null.
+     * For onWalAppended and onChangesVisible, it completes with the specified CommitVersions.
+     *
+     * @param durableResult the result to complete the futures with
+     */
+    public void complete(@Nonnull CommitVersions durableResult) {
+        if (!this.onConflictResolved.isDone()) {
+            this.onConflictResolved.complete(durableResult);
+        }
+        if (!this.onWalAppended.isDone()) {
+            this.onWalAppended.complete(durableResult);
+        }
+        if (!this.onChangesVisible.isDone()) {
+            this.onChangesVisible.complete(durableResult);
+        }
+    }
+}

--- a/evita_api/src/main/java/io/evitadb/api/EvitaContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/EvitaContract.java
@@ -40,7 +40,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -232,7 +232,7 @@ public interface EvitaContract extends AutoCloseable {
 	 * @return future that is completed when the query finishes
 	 */
 	@Nonnull
-	<T> CompletableFuture<T> queryCatalogAsync(
+	<T> CompletionStage<T> queryCatalogAsync(
 		@Nonnull String catalogName,
 		@Nonnull Function<EvitaSessionContract, T> queryLogic,
 		@Nullable SessionFlags... flags
@@ -287,7 +287,7 @@ public interface EvitaContract extends AutoCloseable {
 		@Nullable SessionFlags... flags
 	) {
 		try {
-			return updateCatalogAsync(catalogName, updater, commitBehaviour, flags).join();
+			return updateCatalogAsync(catalogName, updater, commitBehaviour, flags).toCompletableFuture().join();
 		} catch (EvitaInvalidUsageException | EvitaInternalError e) {
 			throw e;
 		} catch (Exception e) {
@@ -317,7 +317,7 @@ public interface EvitaContract extends AutoCloseable {
 	 * @return future that is completed when the transaction reaches the processing stage defined by the `commitBehaviour`
 	 */
 	@Nonnull
-	<T> CompletableFuture<T> updateCatalogAsync(
+	<T> CompletionStage<T> updateCatalogAsync(
 		@Nonnull String catalogName,
 		@Nonnull Function<EvitaSessionContract, T> updater,
 		@Nonnull CommitBehavior commitBehaviour,
@@ -339,7 +339,10 @@ public interface EvitaContract extends AutoCloseable {
 		@Nullable SessionFlags... flags
 	) {
 		try {
-			updateCatalogAsync(catalogName, updater, commitBehaviour, flags).join();
+			updateCatalogAsync(catalogName, updater, commitBehaviour, flags)
+				.on(commitBehaviour)
+				.toCompletableFuture()
+				.join();
 		} catch (EvitaInvalidUsageException | EvitaInternalError e) {
 			throw e;
 		} catch (Exception e) {
@@ -355,22 +358,45 @@ public interface EvitaContract extends AutoCloseable {
 
 	/**
 	 * Overloaded method {@link #updateCatalogAsync(String, Function, CommitBehavior, SessionFlags...)} that returns
-	 * future that is completed when the transaction reaches the processing stage defined by the `commitBehaviour`
-	 * argument.
+	 * object containing futures that refer to all transaction processing phases that are completed when the transaction
+	 * processing finishes the particular processing stage.
 	 *
-	 * @return future that is completed when the transaction reaches the processing stage defined by the `commitBehaviour`
-	 * argument. Long represents catalog version where the transaction changes will be visible.
+	 * @param catalogName     name of the catalog
+	 * @param updater         application logic that reads and writes data
+	 * @param flags           optional flags that can be passed to the session and affect its behavior
+	 * @return object containing futures that refer to all transaction processing phases
 	 * @throws TransactionException when transaction fails
 	 * @see #updateCatalog(String, Function, CommitBehavior, SessionFlags[])
 	 */
 	@Nonnull
-	CompletableFuture<Long> updateCatalogAsync(
+	default CommitProgress updateCatalogAsync(
+		@Nonnull String catalogName,
+		@Nonnull Consumer<EvitaSessionContract> updater,
+		@Nullable SessionFlags... flags
+	) throws TransactionException {
+		return updateCatalogAsync(catalogName, updater, CommitBehavior.defaultBehaviour(), flags);
+	}
+
+	/**
+	 * Overloaded method {@link #updateCatalogAsync(String, Function, CommitBehavior, SessionFlags...)} that returns
+	 * object containing futures that refer to all transaction processing phases that are completed when the transaction
+	 * processing finishes the particular processing stage.
+	 *
+	 * @param catalogName     name of the catalog
+	 * @param updater         application logic that reads and writes data
+	 * @param commitBehaviour defines the commit processing stage at which the session is considered to be finished
+	 * @param flags           optional flags that can be passed to the session and affect its behavior
+	 * @return object containing futures that refer to all transaction processing phases
+	 * @throws TransactionException when transaction fails
+	 * @see #updateCatalog(String, Function, CommitBehavior, SessionFlags[])
+	 */
+	@Nonnull
+	CommitProgress updateCatalogAsync(
 		@Nonnull String catalogName,
 		@Nonnull Consumer<EvitaSessionContract> updater,
 		@Nonnull CommitBehavior commitBehaviour,
 		@Nullable SessionFlags... flags
-	)
-		throws TransactionException;
+	) throws TransactionException;
 
 	/**
 	 * Returns management service that allows to execute various management tasks on the Evita instance and retrieve

--- a/evita_api/src/main/java/io/evitadb/api/EvitaSessionContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/EvitaSessionContract.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.api;
 
+import io.evitadb.api.CommitProgress.CommitVersions;
 import io.evitadb.api.TransactionContract.CommitBehavior;
 import io.evitadb.api.exception.CollectionNotFoundException;
 import io.evitadb.api.exception.EntityAlreadyRemovedException;
@@ -86,7 +87,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
 import static io.evitadb.api.query.QueryConstraints.entityFetch;
@@ -207,14 +208,15 @@ public interface EvitaSessionContract extends Comparable<EvitaSessionContract>, 
 	 * This method is idempotent and may be called multiple times. Only first call is really processed and others are
 	 * ignored.
 	 */
-	default long closeWhen(@Nonnull CommitBehavior commitBehaviour) {
-		return closeNow(commitBehaviour).join();
+	@Nonnull
+	default CommitVersions closeWhen(@Nonnull CommitBehavior commitBehaviour) {
+		return closeNow(commitBehaviour).toCompletableFuture().join();
 	}
 
 	/**
 	 * Method terminates Evita session and releases all used resources. This method renders the session unusable and
 	 * any further calls to this session should end up with {@link InstanceTerminatedException}. Method finishes
-	 * immediately returning a {@link CompletableFuture} that will be completed when:
+	 * immediately returning a {@link CompletionStage} that will be completed when:
 	 *
 	 * 1. catalog is in warm-up mode: immediately
 	 * 2. catalog is in transactional mode and no changes were made: immediately
@@ -223,7 +225,22 @@ public interface EvitaSessionContract extends Comparable<EvitaSessionContract>, 
 	 * This method is idempotent and may be called multiple times, it always returns the same future.
 	 */
 	@Nonnull
-	CompletableFuture<Long> closeNow(@Nonnull CommitBehavior commitBehaviour);
+	CompletionStage<CommitVersions> closeNow(@Nonnull CommitBehavior commitBehaviour);
+
+	/**
+	 * Terminates the session and releases all resources, returning a {@link CommitProgress} object.
+	 * This object exposes {@link CompletionStage}s for each significant transaction commit milestone,
+	 * allowing callers to react asynchronously as the commit progresses (e.g. after conflict resolution,
+	 * WAL persistence, index updates, and global visibility). Method finishes immediately returning
+	 * an object with futures for each significant transaction commit milestone that a client might be
+	 * interested in.
+	 *
+	 * This method is idempotent; repeated calls return the same progress object.
+	 *
+	 * @return a {@link CommitProgress} for observing commit milestones
+	 */
+	@Nonnull
+	CommitProgress closeNowWithProgress();
 
 	/**
 	 * Method creates new a new entity schema and collection for it in the catalog this session is tied to. It returns

--- a/evita_api/src/main/java/io/evitadb/api/TransactionContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/TransactionContract.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -107,6 +107,7 @@ public interface TransactionContract extends AutoCloseable {
 		 * Returns default commit behaviour.
 		 * @return default commit behaviour
 		 */
+		@Nonnull
 		public static CommitBehavior defaultBehaviour() {
 			return WAIT_FOR_INDEX_PROPAGATION;
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/EvitaInternalSessionContract.java
+++ b/evita_engine/src/main/java/io/evitadb/core/EvitaInternalSessionContract.java
@@ -24,6 +24,7 @@
 package io.evitadb.core;
 
 import io.evitadb.api.CatalogContract;
+import io.evitadb.api.CommitProgressRecord;
 import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.TrafficRecordingReader;
 import io.evitadb.api.TransactionContract.CommitBehavior;
@@ -52,7 +53,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -180,7 +180,7 @@ public interface EvitaInternalSessionContract extends EvitaSessionContract, Traf
 	 * @return completable future returning new catalog version introduced by this session
 	 */
 	@Nonnull
-	CompletableFuture<Long> getFinalizationFuture();
+	CommitProgressRecord getCommitProgress();
 
 	/**
 	 * Method registers RAW input query and assigns a unique identifier to it. All queries in this session that are

--- a/evita_engine/src/main/java/io/evitadb/core/Transaction.java
+++ b/evita_engine/src/main/java/io/evitadb/core/Transaction.java
@@ -401,14 +401,14 @@ public final class Transaction implements TransactionContract {
 
 		try {
 			if (isRollbackOnly()) {
-				if (rollbackCause != null) {
-					log.debug("Rolling back transaction `" + transactionId + "` with exception.", rollbackCause);
+				if (this.rollbackCause != null) {
+					log.debug("Rolling back transaction `" + this.transactionId + "` with exception.", this.rollbackCause);
 				} else {
-					log.debug("Rolling back transaction `{}`.", transactionId);
+					log.debug("Rolling back transaction `{}`.", this.transactionId);
 				}
-				this.transactionalMemory.rollback(rollbackCause);
+				this.transactionalMemory.rollback(this.rollbackCause);
 			} else {
-				log.debug("Committing transaction `{}`.", transactionId);
+				log.debug("Committing transaction `{}`.", this.transactionId);
 				this.transactionalMemory.commit();
 			}
 		} finally {
@@ -472,7 +472,7 @@ public final class Transaction implements TransactionContract {
 
 	@Override
 	public String toString() {
-		return transactionId + " (replay=" + replay + ", rollbackOnly=" + rollbackOnly + '}';
+		return this.transactionId + " (replay=" + this.replay + ", rollbackOnly=" + this.rollbackOnly + '}';
 	}
 
 	/**
@@ -502,7 +502,7 @@ public final class Transaction implements TransactionContract {
 
 		@Override
 		public void commit(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-			this.committed = transactionalLayer.getStateCopyWithCommittedChanges(txRoot);
+			this.committed = transactionalLayer.getStateCopyWithCommittedChanges(this.txRoot);
 		}
 
 		@Override

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/stage/CatalogSnapshotPropagationTransactionStage.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/stage/CatalogSnapshotPropagationTransactionStage.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024
+ *   Copyright (c) 2024-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,12 +23,11 @@
 
 package io.evitadb.core.transaction.stage;
 
-import io.evitadb.api.TransactionContract.CommitBehavior;
+import io.evitadb.api.CommitProgress.CommitVersions;
 import io.evitadb.core.metric.event.transaction.NewCatalogVersionPropagatedEvent;
 import io.evitadb.core.metric.event.transaction.TransactionProcessedEvent;
 import io.evitadb.core.transaction.TransactionManager;
 import io.evitadb.core.transaction.stage.TrunkIncorporationTransactionStage.UpdatedCatalogTransactionTask;
-import io.evitadb.utils.Assert;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -92,20 +91,11 @@ public class CatalogSnapshotPropagationTransactionStage implements Flow.Subscrib
 		try {
 			this.catalogName = task.catalogName();
 			this.transactionManager.propagateCatalogSnapshot(task.catalog());
-			if (task.future() != null) {
-				log.debug("Snapshot propagating task for catalog `" + catalogName + "` completed (" + task.catalog().getEntityTypes() + ")!");
-				task.future().complete(task.catalogVersion());
-			} else {
-				Assert.isPremiseValid(
-					task.commitBehaviour() != CommitBehavior.WAIT_FOR_INDEX_PROPAGATION,
-					"Future is unexpectedly null and commit behaviour is WAIT_FOR_INDEX_PROPAGATION!"
-				);
-			}
+			log.debug("Snapshot propagating task for catalog `" + this.catalogName + "` completed (" + task.catalog().getEntityTypes() + ")!");
+			task.commitProgress().onChangesVisible().complete(new CommitVersions(task.catalogVersion(), task.catalogSchemaVersion()));
 		} catch (Throwable ex) {
-			log.error("Error while processing snapshot propagating task for catalog `" + catalogName + "`!", ex);
-			if (task.future() != null) {
-				task.future().completeExceptionally(ex);
-			}
+			log.error("Error while processing snapshot propagating task for catalog `" + this.catalogName + "`!", ex);
+			task.commitProgress().completeExceptionally(ex);
 		}
 
 		// emit the event
@@ -114,7 +104,7 @@ public class CatalogSnapshotPropagationTransactionStage implements Flow.Subscrib
 		// emit transaction processed events
 		final OffsetDateTime now = OffsetDateTime.now();
 		for (OffsetDateTime commitTime : task.commitTimestamps()) {
-			new TransactionProcessedEvent(catalogName, Duration.between(commitTime, now)).commit();
+			new TransactionProcessedEvent(this.catalogName, Duration.between(commitTime, now)).commit();
 		}
 
 		this.subscription.request(1);
@@ -123,7 +113,7 @@ public class CatalogSnapshotPropagationTransactionStage implements Flow.Subscrib
 	@Override
 	public final void onError(Throwable throwable) {
 		log.error(
-			"Fatal error! Error propagated outside catalog `" + catalogName + "` snapshot propagation task! " +
+			"Fatal error! Error propagated outside catalog `" + this.catalogName + "` snapshot propagation task! " +
 				"This is unexpected and effectively stops transaction processing!",
 			throwable
 		);
@@ -131,7 +121,7 @@ public class CatalogSnapshotPropagationTransactionStage implements Flow.Subscrib
 
 	@Override
 	public final void onComplete() {
-		log.debug("Conflict snapshot propagation stage completed for catalog `" + catalogName + "`!");
+		log.debug("Conflict snapshot propagation stage completed for catalog `" + this.catalogName + "`!");
 		this.completed = true;
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/stage/TransactionTask.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/stage/TransactionTask.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024
+ *   Copyright (c) 2024-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,13 +23,11 @@
 
 package io.evitadb.core.transaction.stage;
 
-import io.evitadb.api.TransactionContract.CommitBehavior;
+import io.evitadb.api.CommitProgressRecord;
 import io.evitadb.core.metric.event.transaction.TransactionQueuedEvent;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * This interface represents a transaction task, which is a unit of work performed within a transaction. It provides
@@ -52,11 +50,20 @@ public interface TransactionTask {
 	String catalogName();
 
 	/**
-	 * Returns the version of the catalog the transaction is bound to.
+	 * Returns the version of the catalog that will be valid in the catalog after the transaction is
+	 * committed.
 	 *
 	 * @return The catalog version assigned to the transaction task
 	 */
 	long catalogVersion();
+
+	/**
+	 * Returns the version of the catalog schema that will be valid in the catalog after the transaction is
+	 * committed.
+	 *
+	 * @return The catalog schema version assigned to the transaction task
+	 */
+	int catalogSchemaVersion();
 
 	/**
 	 * Retrieves the unique ID of the transaction that carries the changes to the database.
@@ -67,23 +74,14 @@ public interface TransactionTask {
 	UUID transactionId();
 
 	/**
-	 * Retrieves the commit behavior of the transaction task. Commit behavior defines the moment the transaction is
-	 * considered as committed from the client point of view.
-	 *
-	 * @return The commit behavior of the transaction task
-	 */
-	@Nonnull
-	CommitBehavior commitBehaviour();
-
-	/**
-	 * Retrieves the future associated with this transaction task. The future represents the completion of the task
-	 * execution and returns a new catalog version when completed. It's non-null ony if the client still waits for
-	 * the transaction to reach the requested processing stage.
+	 * Retrieves the {@link CommitProgressRecord} associated with this transaction task. The this record contains
+	 * future objects that represents the completion of the task execution and returns a new catalog version when
+	 * completed.
 	 *
 	 * @return The future associated with the transaction task
 	 */
-	@Nullable
-	CompletableFuture<Long> future();
+	@Nonnull
+	CommitProgressRecord commitProgress();
 
 	/**
 	 * Contains the event generated when the task was created.

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/stage/WalAppendingTransactionStage.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/stage/WalAppendingTransactionStage.java
@@ -23,7 +23,8 @@
 
 package io.evitadb.core.transaction.stage;
 
-import io.evitadb.api.TransactionContract.CommitBehavior;
+import io.evitadb.api.CommitProgress.CommitVersions;
+import io.evitadb.api.CommitProgressRecord;
 import io.evitadb.api.requestResponse.transaction.TransactionMutation;
 import io.evitadb.core.metric.event.transaction.TransactionAppendedToWalEvent;
 import io.evitadb.core.metric.event.transaction.TransactionQueuedEvent;
@@ -36,11 +37,9 @@ import io.evitadb.utils.Assert;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.time.OffsetDateTime;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 
@@ -55,6 +54,7 @@ import java.util.function.BiConsumer;
 public final class WalAppendingTransactionStage
 	extends AbstractTransactionStage<WalAppendingTransactionTask, TrunkIncorporationTransactionTask> {
 	private int droppedCatalogVersions;
+	private int droppedCatalogSchemaVersionDelta;
 
 	public WalAppendingTransactionStage(
 		@Nonnull Executor executor,
@@ -68,7 +68,10 @@ public final class WalAppendingTransactionStage
 	@Override
 	protected void handleException(@Nonnull WalAppendingTransactionTask task, @Nonnull Throwable ex) {
 		try {
-			this.transactionManager.notifyCatalogVersionDropped(this.droppedCatalogVersions);
+			this.transactionManager.notifyCatalogVersionDropped(
+				this.droppedCatalogVersions,
+				this.droppedCatalogSchemaVersionDelta
+			);
 		} finally {
 			super.handleException(task, ex);
 		}
@@ -82,6 +85,7 @@ public final class WalAppendingTransactionStage
 	@Override
 	protected void handleNext(@Nonnull WalAppendingTransactionTask task) {
 		this.droppedCatalogVersions = 1;
+		this.droppedCatalogSchemaVersionDelta = task.catalogSchemaVersionDelta();
 
 		// emit queue event
 		task.transactionQueuedEvent().finish().commit();
@@ -115,11 +119,11 @@ public final class WalAppendingTransactionStage
 			log.error(
 				"Transaction mismatch between transaction manager and WAL {} vs. {} in catalog {}.",
 				ex.getCurrentTransactionVersion(),
-				transactionManager.getLastWrittenCatalogVersion(),
+				this.transactionManager.getLastWrittenCatalogVersion(),
 				task.catalogName(),
 				ex
 			);
-			this.droppedCatalogVersions = Math.toIntExact(ex.getCurrentTransactionVersion() - transactionManager.getLastWrittenCatalogVersion());
+			this.droppedCatalogVersions = Math.toIntExact(ex.getCurrentTransactionVersion() - this.transactionManager.getLastWrittenCatalogVersion());
 			throw ex;
 		}
 
@@ -132,9 +136,9 @@ public final class WalAppendingTransactionStage
 			new TrunkIncorporationTransactionTask(
 				task.catalogName(),
 				task.catalogVersion(),
+				task.catalogSchemaVersion(),
 				task.transactionId(),
-				task.commitBehaviour(),
-				task.commitBehaviour() != CommitBehavior.WAIT_FOR_WAL_PERSISTENCE ? task.future() : null
+				task.commitProgress()
 			)
 		);
 
@@ -147,44 +151,54 @@ public final class WalAppendingTransactionStage
 		this.transactionManager.updateLastWrittenCatalogVersion(task.catalogVersion());
 	}
 
+	@Override
+	protected void complete(@Nonnull CommitProgressRecord commitProgress, @Nonnull WalAppendingTransactionTask sourceTask, @Nonnull TrunkIncorporationTransactionTask targetTask) {
+		commitProgress.onWalAppended().complete(new CommitVersions(targetTask.catalogVersion(), targetTask.catalogSchemaVersion()));
+	}
+
 	/**
 	 * Represents a task for resolving conflicts during a transaction.
 	 *
 	 * @param catalogName     the name of the catalog the transaction is bound to
 	 * @param catalogVersion  assigned catalog version (the sequence number of the next catalog version)
+	 * @param catalogSchemaVersion  assigned catalog schema version (the sequence number of the next catalog schema version)
+	 * @param catalogSchemaVersionDelta  used delta to estimate catalog schema version
 	 * @param transactionId   the ID of the transaction
 	 * @param mutationCount   the number of mutations in the transaction (excluding the leading mutation)
 	 * @param walSizeInBytes  the size of the WAL file in bytes (size of the mutations excluding the leading mutation)
 	 * @param walReference    the reference to the WAL file
-	 * @param commitBehaviour requested stage to wait for during commit
-	 * @param future          the future to complete when the transaction propagates to requested stage
+	 * @param commitProgress the commit progress record for the transaction
+	 * @param transactionQueuedEvent the event to track the transaction
 	 */
 	@NonRepeatableTask
 	public record WalAppendingTransactionTask(
 		@Nonnull String catalogName,
 		long catalogVersion,
+		int catalogSchemaVersion,
+		int catalogSchemaVersionDelta,
 		@Nonnull UUID transactionId,
 		int mutationCount,
 		long walSizeInBytes,
 		@Nonnull OffHeapWithFileBackupReference walReference,
-		@Nonnull CommitBehavior commitBehaviour,
-		@Nullable CompletableFuture<Long> future,
+		@Nonnull CommitProgressRecord commitProgress,
 		@Nonnull TransactionQueuedEvent transactionQueuedEvent
 	) implements TransactionTask {
 
 		public WalAppendingTransactionTask(
 			@Nonnull String catalogName,
 			long catalogVersion,
+			int catalogSchemaVersion,
+			int catalogSchemaVersionDelta,
 			@Nonnull UUID transactionId,
 			int mutationCount,
 			long walSizeInBytes,
 			@Nonnull OffHeapWithFileBackupReference walReference,
-			@Nonnull CommitBehavior commitBehaviour,
-			@Nullable CompletableFuture<Long> future
+			@Nonnull CommitProgressRecord commitProgress
 		) {
 			this(
-				catalogName, catalogVersion, transactionId, mutationCount, walSizeInBytes, walReference,
-				commitBehaviour, future, new TransactionQueuedEvent(catalogName, "wal_appending")
+				catalogName, catalogVersion, catalogSchemaVersion, catalogSchemaVersionDelta,
+				transactionId, mutationCount, walSizeInBytes, walReference,
+				commitProgress, new TransactionQueuedEvent(catalogName, "wal_appending")
 			);
 		}
 	}

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
@@ -31,6 +31,8 @@ import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
 import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import io.evitadb.api.CatalogState;
+import io.evitadb.api.CommitProgress;
+import io.evitadb.api.CommitProgress.CommitVersions;
 import io.evitadb.api.EvitaContract;
 import io.evitadb.api.EvitaManagementContract;
 import io.evitadb.api.EvitaSessionContract;
@@ -89,6 +91,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -384,7 +387,7 @@ public class EvitaClient implements EvitaContract {
 
 	@Override
 	public boolean isActive() {
-		return active.get();
+		return this.active.get();
 	}
 
 	@Nonnull
@@ -638,7 +641,7 @@ public class EvitaClient implements EvitaContract {
 
 	@Nonnull
 	@Override
-	public <T> CompletableFuture<T> updateCatalogAsync(
+	public <T> CompletionStage<T> updateCatalogAsync(
 		@Nonnull String catalogName,
 		@Nonnull Function<EvitaSessionContract, T> updater,
 		@Nonnull CommitBehavior commitBehaviour,
@@ -653,7 +656,7 @@ public class EvitaClient implements EvitaContract {
 				ArrayUtils.insertRecordIntoArrayOnIndex(SessionFlags.READ_WRITE, flags, flags.length)
 		);
 		final EvitaSessionContract session = this.createSession(traits);
-		final CompletableFuture<Long> closeFuture;
+		final CompletionStage<CommitVersions> closeFuture;
 		final T resultValue;
 		try {
 			resultValue = updater.apply(session);
@@ -690,7 +693,7 @@ public class EvitaClient implements EvitaContract {
 
 	@Nonnull
 	@Override
-	public CompletableFuture<Long> updateCatalogAsync(
+	public CommitProgress updateCatalogAsync(
 		@Nonnull String catalogName,
 		@Nonnull Consumer<EvitaSessionContract> updater,
 		@Nonnull CommitBehavior commitBehaviour,
@@ -705,14 +708,14 @@ public class EvitaClient implements EvitaContract {
 				ArrayUtils.insertRecordIntoArrayOnIndex(SessionFlags.READ_WRITE, flags, flags.length)
 		);
 		final EvitaSessionContract session = this.createSession(traits);
-		final CompletableFuture<Long> closeFuture;
+		final CommitProgress commitProgress;
 		try {
 			updater.accept(session);
 		} finally {
-			closeFuture = session.closeNow(commitBehaviour);
+			commitProgress = session.closeNowWithProgress();
 		}
 
-		return closeFuture;
+		return commitProgress;
 	}
 
 	@Nonnull
@@ -723,7 +726,7 @@ public class EvitaClient implements EvitaContract {
 
 	@Override
 	public void close() {
-		if (active.compareAndSet(true, false)) {
+		if (this.active.compareAndSet(true, false)) {
 			this.activeSessions.values().forEach(EvitaSessionContract::close);
 			this.activeSessions.clear();
 			this.management.close();
@@ -785,7 +788,7 @@ public class EvitaClient implements EvitaContract {
 	 * Verifies this instance is still active.
 	 */
 	protected void assertActive() {
-		if (!active.get()) {
+		if (!this.active.get()) {
 			throw new InstanceTerminatedException("client instance");
 		}
 	}

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaService.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaService.java
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static io.evitadb.externalApi.grpc.requestResponse.EvitaEnumConverter.toGrpcCatalogState;
+import static io.evitadb.externalApi.grpc.requestResponse.EvitaEnumConverter.toGrpcCommitBehavior;
 
 /**
  * This service contains methods that could be called by gRPC clients on {@link EvitaContract}.
@@ -212,9 +213,9 @@ public class EvitaService extends EvitaServiceGrpc.EvitaServiceImplBase {
 	public void terminateSession(GrpcEvitaSessionTerminationRequest request, StreamObserver<GrpcEvitaSessionTerminationResponse> responseObserver) {
 		executeWithClientContext(
 			() -> {
-				final boolean terminated = evita.getSessionById(UUIDUtil.uuid(request.getSessionId()))
+				final boolean terminated = this.evita.getSessionById(UUIDUtil.uuid(request.getSessionId()))
 					.map(session -> {
-						evita.terminateSession(session);
+						this.evita.terminateSession(session);
 						return true;
 					})
 					.orElse(false);
@@ -242,7 +243,7 @@ public class EvitaService extends EvitaServiceGrpc.EvitaServiceImplBase {
 		executeWithClientContext(
 			() -> {
 				responseObserver.onNext(GrpcCatalogNamesResponse.newBuilder()
-					.addAllCatalogNames(evita.getCatalogNames())
+					.addAllCatalogNames(this.evita.getCatalogNames())
 					.build());
 				responseObserver.onCompleted();
 			},
@@ -263,7 +264,7 @@ public class EvitaService extends EvitaServiceGrpc.EvitaServiceImplBase {
 		executeWithClientContext(
 			() -> {
 				final Builder builder = GrpcGetCatalogStateResponse.newBuilder();
-				evita.getCatalogState(request.getCatalogName())
+				this.evita.getCatalogState(request.getCatalogName())
 					.ifPresent(catalogState -> builder.setCatalogState(toGrpcCatalogState(catalogState)));
 				responseObserver.onNext(builder.build());
 				responseObserver.onCompleted();
@@ -307,7 +308,7 @@ public class EvitaService extends EvitaServiceGrpc.EvitaServiceImplBase {
 		                                  request, StreamObserver<GrpcDeleteCatalogIfExistsResponse> responseObserver) {
 		executeWithClientContext(
 			() -> {
-				boolean success = evita.deleteCatalogIfExists(request.getCatalogName());
+				boolean success = this.evita.deleteCatalogIfExists(request.getCatalogName());
 				responseObserver.onNext(GrpcDeleteCatalogIfExistsResponse.newBuilder().setSuccess(success).build());
 				responseObserver.onCompleted();
 			},
@@ -398,11 +399,12 @@ public class EvitaService extends EvitaServiceGrpc.EvitaServiceImplBase {
 		executeWithClientContext(
 			() -> {
 				final SessionFlags[] flags = getSessionFlags(sessionType, rollbackTransactions);
-				final EvitaSessionContract session = evita.createSession(new SessionTraits(catalogName, flags));
+				final EvitaSessionContract session = this.evita.createSession(new SessionTraits(catalogName, flags));
 				responseObserver.onNext(GrpcEvitaSessionResponse.newBuilder()
 					.setCatalogId(session.getCatalogId().toString())
 					.setSessionId(session.getId().toString())
 					.setCatalogState(toGrpcCatalogState(session.getCatalogState()))
+					.setCommitBehaviour(toGrpcCommitBehavior(session.getCommitBehavior()))
 					.setSessionType(sessionType)
 					.build());
 				responseObserver.onCompleted();

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaSessionService.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/EvitaSessionService.java
@@ -27,7 +27,10 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.GeneratedMessageV3;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import io.evitadb.api.CatalogState;
+import io.evitadb.api.CommitProgress;
+import io.evitadb.api.CommitProgress.CommitVersions;
 import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.TransactionContract.CommitBehavior;
 import io.evitadb.api.exception.SessionNotFoundException;
 import io.evitadb.api.file.FileForFetch;
 import io.evitadb.api.query.Constraint;
@@ -109,7 +112,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
@@ -684,7 +686,15 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 			session -> {
 				final Builder responseBuilder = GrpcEntitySchemaResponse.newBuilder();
 				session.getEntitySchema(request.getEntityType())
-					.ifPresent(it -> responseBuilder.setEntitySchema(EntitySchemaConverter.convert(it, request.getNameVariants())));
+					.ifPresent(
+						entitySchema -> responseBuilder.setEntitySchema(
+							EntitySchemaConverter.convert(
+								session.getCatalogSchema(),
+								entitySchema,
+								request.getNameVariants()
+							)
+						)
+					);
 
 				responseObserver.onNext(
 					responseBuilder.build()
@@ -793,15 +803,25 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 		executeWithClientContext(
 			session -> {
 				if (session != null) {
-					final CompletableFuture<Long> future = session.closeNow(toCommitBehavior(request.getCommitBehaviour()));
-					future.whenComplete((version, throwable) -> {
-						if (throwable != null) {
-							GlobalExceptionHandlerInterceptor.sendErrorToClient(throwable, responseObserver);
-						} else {
-							responseObserver.onNext(GrpcCloseResponse.newBuilder().setCatalogVersion(version).build());
-						}
-						responseObserver.onCompleted();
-					});
+					final CommitProgress commitProgress = session.closeNowWithProgress();
+					final CommitBehavior commitBehavior = toCommitBehavior(request.getCommitBehaviour());
+					commitProgress
+						.on(commitBehavior)
+						.whenComplete(
+							(result, throwable) -> {
+								if (throwable != null) {
+									GlobalExceptionHandlerInterceptor.sendErrorToClient(throwable, responseObserver);
+								} else {
+									responseObserver.onNext(
+										GrpcCloseResponse.newBuilder()
+										.setCatalogVersion(result.catalogVersion())
+										.setCatalogSchemaVersion(result.catalogSchemaVersion())
+										.build()
+									);
+								}
+								responseObserver.onCompleted();
+							}
+						);
 				} else {
 					// no session to close, we couldn't return the catalog version, return error
 					responseObserver.onError(
@@ -813,6 +833,83 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 			responseObserver,
 			this.tracingContext
 		);
+	}
+
+	/**
+	 * Method used to close currently used session by calling {@link EvitaSessionContract#close()} and return a stream
+	 * that is updated with progress of the commit.
+	 *
+	 * @param request          empty request
+	 * @param responseObserver observer on which errors might be thrown and result returned
+	 */
+	@Override
+	public void closeWithProgress(Empty request, StreamObserver<GrpcCloseWithProgressResponse> responseObserver) {
+		executeWithClientContext(
+			session -> {
+				if (session != null) {
+					final CommitProgress commitProgress = session.closeNowWithProgress();
+					commitProgress.onConflictResolved()
+						.whenComplete(
+							(result, throwable) -> sendTransactionUpdate(
+								responseObserver, result, throwable, CommitBehavior.WAIT_FOR_CONFLICT_RESOLUTION
+							)
+						);
+					commitProgress.onWalAppended()
+						.whenComplete(
+							(result, throwable) -> sendTransactionUpdate(
+								responseObserver, result, throwable, CommitBehavior.WAIT_FOR_WAL_PERSISTENCE
+							)
+						);
+					commitProgress.onChangesVisible()
+						.whenComplete(
+							(result, throwable) -> {
+								sendTransactionUpdate(
+									responseObserver, result, throwable, CommitBehavior.WAIT_FOR_INDEX_PROPAGATION
+								);
+								// transaction reached the final phase, we can close the stream
+								responseObserver.onCompleted();
+							}
+						);
+				} else {
+					// no session to close, we couldn't return the catalog version, return error
+					responseObserver.onError(
+						new SessionNotFoundException("No session for closing found!")
+					);
+				}
+			},
+			this.evita.getRequestExecutor(),
+			responseObserver,
+			this.tracingContext
+		);
+	}
+
+	/**
+	 * Sends a transaction update to the client by responding to the provided {@link StreamObserver}.
+	 * If a {@link Throwable} is provided, it sends the corresponding error to the client.
+	 * Otherwise, it sends a response containing commit version details and phase status.
+	 *
+	 * @param responseObserver the response observer through which the update is sent to the client
+	 * @param result the commit version result containing the catalog version and schema version
+	 * @param throwable the throwable instance in case an error occurred during transaction processing
+	 * @param phase the commit behavior phase to reflect the current state of the transaction
+	 */
+	private static void sendTransactionUpdate(
+		@Nonnull StreamObserver<GrpcCloseWithProgressResponse> responseObserver,
+		@Nonnull CommitVersions result,
+		@Nonnull Throwable throwable,
+		@Nonnull CommitBehavior phase
+	) {
+		if (throwable != null) {
+			GlobalExceptionHandlerInterceptor.sendErrorToClient(throwable, responseObserver);
+		} else {
+			responseObserver.onNext(
+				GrpcCloseWithProgressResponse.newBuilder()
+					.setCatalogVersion(result.catalogVersion())
+					.setCatalogSchemaVersion(result.catalogSchemaVersion())
+					.setFinishedPhase(EvitaEnumConverter.toGrpcCommitPhase(phase))
+					.build()
+			);
+		}
 	}
 
 	/**
@@ -1109,7 +1206,13 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 				final EntitySchemaBuilder entitySchemaBuilder = session.defineEntitySchema(request.getEntityType());
 
 				final GrpcDefineEntitySchemaResponse response = GrpcDefineEntitySchemaResponse.newBuilder()
-					.setEntitySchema(EntitySchemaConverter.convert(entitySchemaBuilder.toInstance(), false))
+					.setEntitySchema(
+						EntitySchemaConverter.convert(
+							session.getCatalogSchema(),
+							entitySchemaBuilder.toInstance(),
+							false
+						)
+					)
 					.build();
 				responseObserver.onNext(response);
 				responseObserver.onCompleted();
@@ -1147,7 +1250,7 @@ public class EvitaSessionService extends EvitaSessionServiceGrpc.EvitaSessionSer
 				final SealedEntitySchema newEntitySchema = session.updateAndFetchEntitySchema(schemaMutation);
 
 				final GrpcUpdateAndFetchEntitySchemaResponse response = GrpcUpdateAndFetchEntitySchemaResponse.newBuilder()
-					.setEntitySchema(EntitySchemaConverter.convert(newEntitySchema, false))
+					.setEntitySchema(EntitySchemaConverter.convert(session.getCatalogSchema(), newEntitySchema, false))
 					.build();
 				responseObserver.onNext(response);
 				responseObserver.onCompleted();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/EvitaSessionServiceGrpc.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/EvitaSessionServiceGrpc.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -352,6 +352,37 @@ public final class EvitaSessionServiceGrpc {
       }
     }
     return getCloseMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<com.google.protobuf.Empty,
+      io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse> getCloseWithProgressMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CloseWithProgress",
+      requestType = com.google.protobuf.Empty.class,
+      responseType = io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+  public static io.grpc.MethodDescriptor<com.google.protobuf.Empty,
+      io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse> getCloseWithProgressMethod() {
+    io.grpc.MethodDescriptor<com.google.protobuf.Empty, io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse> getCloseWithProgressMethod;
+    if ((getCloseWithProgressMethod = EvitaSessionServiceGrpc.getCloseWithProgressMethod) == null) {
+      synchronized (EvitaSessionServiceGrpc.class) {
+        if ((getCloseWithProgressMethod = EvitaSessionServiceGrpc.getCloseWithProgressMethod) == null) {
+          EvitaSessionServiceGrpc.getCloseWithProgressMethod = getCloseWithProgressMethod =
+              io.grpc.MethodDescriptor.<com.google.protobuf.Empty, io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CloseWithProgress"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.google.protobuf.Empty.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new EvitaSessionServiceMethodDescriptorSupplier("CloseWithProgress"))
+              .build();
+        }
+      }
+    }
+    return getCloseWithProgressMethod;
   }
 
   private static volatile io.grpc.MethodDescriptor<io.evitadb.externalApi.grpc.generated.GrpcQueryRequest,
@@ -1240,6 +1271,16 @@ public final class EvitaSessionServiceGrpc {
 
     /**
      * <pre>
+     * Procedure that closes the session opening a stream that listens to transaction processing phases.
+     * </pre>
+     */
+    default void closeWithProgress(com.google.protobuf.Empty request,
+        io.grpc.stub.StreamObserver<io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getCloseWithProgressMethod(), responseObserver);
+    }
+
+    /**
+     * <pre>
      * Procedure that executes passed parametrised query and returns zero or one entity.
      * </pre>
      */
@@ -1627,6 +1668,17 @@ public final class EvitaSessionServiceGrpc {
 
     /**
      * <pre>
+     * Procedure that closes the session opening a stream that listens to transaction processing phases.
+     * </pre>
+     */
+    public void closeWithProgress(com.google.protobuf.Empty request,
+        io.grpc.stub.StreamObserver<io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncServerStreamingCall(
+          getChannel().newCall(getCloseWithProgressMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
      * Procedure that executes passed parametrised query and returns zero or one entity.
      * </pre>
      */
@@ -2010,6 +2062,18 @@ public final class EvitaSessionServiceGrpc {
 
     /**
      * <pre>
+     * Procedure that closes the session opening a stream that listens to transaction processing phases.
+     * </pre>
+     */
+    @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/10918")
+    public io.grpc.stub.BlockingClientCall<?, io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse>
+        closeWithProgress(com.google.protobuf.Empty request) {
+      return io.grpc.stub.ClientCalls.blockingV2ServerStreamingCall(
+          getChannel(), getCloseWithProgressMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * Procedure that executes passed parametrised query and returns zero or one entity.
      * </pre>
      */
@@ -2365,6 +2429,17 @@ public final class EvitaSessionServiceGrpc {
     public io.evitadb.externalApi.grpc.generated.GrpcCloseResponse close(io.evitadb.externalApi.grpc.generated.GrpcCloseRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getCloseMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Procedure that closes the session opening a stream that listens to transaction processing phases.
+     * </pre>
+     */
+    public java.util.Iterator<io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse> closeWithProgress(
+        com.google.protobuf.Empty request) {
+      return io.grpc.stub.ClientCalls.blockingServerStreamingCall(
+          getChannel(), getCloseWithProgressMethod(), getCallOptions(), request);
     }
 
     /**
@@ -2991,29 +3066,30 @@ public final class EvitaSessionServiceGrpc {
   private static final int METHODID_GO_LIVE_AND_CLOSE = 7;
   private static final int METHODID_BACKUP_CATALOG = 8;
   private static final int METHODID_CLOSE = 9;
-  private static final int METHODID_QUERY_ONE = 10;
-  private static final int METHODID_QUERY_LIST = 11;
-  private static final int METHODID_QUERY = 12;
-  private static final int METHODID_QUERY_ONE_UNSAFE = 13;
-  private static final int METHODID_QUERY_LIST_UNSAFE = 14;
-  private static final int METHODID_QUERY_UNSAFE = 15;
-  private static final int METHODID_GET_ENTITY = 16;
-  private static final int METHODID_UPDATE_CATALOG_SCHEMA = 17;
-  private static final int METHODID_UPDATE_AND_FETCH_CATALOG_SCHEMA = 18;
-  private static final int METHODID_DEFINE_ENTITY_SCHEMA = 19;
-  private static final int METHODID_UPDATE_ENTITY_SCHEMA = 20;
-  private static final int METHODID_UPDATE_AND_FETCH_ENTITY_SCHEMA = 21;
-  private static final int METHODID_DELETE_COLLECTION = 22;
-  private static final int METHODID_RENAME_COLLECTION = 23;
-  private static final int METHODID_REPLACE_COLLECTION = 24;
-  private static final int METHODID_GET_ENTITY_COLLECTION_SIZE = 25;
-  private static final int METHODID_UPSERT_ENTITY = 26;
-  private static final int METHODID_DELETE_ENTITY = 27;
-  private static final int METHODID_DELETE_ENTITY_AND_ITS_HIERARCHY = 28;
-  private static final int METHODID_DELETE_ENTITIES = 29;
-  private static final int METHODID_ARCHIVE_ENTITY = 30;
-  private static final int METHODID_RESTORE_ENTITY = 31;
-  private static final int METHODID_GET_TRANSACTION_ID = 32;
+  private static final int METHODID_CLOSE_WITH_PROGRESS = 10;
+  private static final int METHODID_QUERY_ONE = 11;
+  private static final int METHODID_QUERY_LIST = 12;
+  private static final int METHODID_QUERY = 13;
+  private static final int METHODID_QUERY_ONE_UNSAFE = 14;
+  private static final int METHODID_QUERY_LIST_UNSAFE = 15;
+  private static final int METHODID_QUERY_UNSAFE = 16;
+  private static final int METHODID_GET_ENTITY = 17;
+  private static final int METHODID_UPDATE_CATALOG_SCHEMA = 18;
+  private static final int METHODID_UPDATE_AND_FETCH_CATALOG_SCHEMA = 19;
+  private static final int METHODID_DEFINE_ENTITY_SCHEMA = 20;
+  private static final int METHODID_UPDATE_ENTITY_SCHEMA = 21;
+  private static final int METHODID_UPDATE_AND_FETCH_ENTITY_SCHEMA = 22;
+  private static final int METHODID_DELETE_COLLECTION = 23;
+  private static final int METHODID_RENAME_COLLECTION = 24;
+  private static final int METHODID_REPLACE_COLLECTION = 25;
+  private static final int METHODID_GET_ENTITY_COLLECTION_SIZE = 26;
+  private static final int METHODID_UPSERT_ENTITY = 27;
+  private static final int METHODID_DELETE_ENTITY = 28;
+  private static final int METHODID_DELETE_ENTITY_AND_ITS_HIERARCHY = 29;
+  private static final int METHODID_DELETE_ENTITIES = 30;
+  private static final int METHODID_ARCHIVE_ENTITY = 31;
+  private static final int METHODID_RESTORE_ENTITY = 32;
+  private static final int METHODID_GET_TRANSACTION_ID = 33;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -3071,6 +3147,10 @@ public final class EvitaSessionServiceGrpc {
         case METHODID_CLOSE:
           serviceImpl.close((io.evitadb.externalApi.grpc.generated.GrpcCloseRequest) request,
               (io.grpc.stub.StreamObserver<io.evitadb.externalApi.grpc.generated.GrpcCloseResponse>) responseObserver);
+          break;
+        case METHODID_CLOSE_WITH_PROGRESS:
+          serviceImpl.closeWithProgress((com.google.protobuf.Empty) request,
+              (io.grpc.stub.StreamObserver<io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse>) responseObserver);
           break;
         case METHODID_QUERY_ONE:
           serviceImpl.queryOne((io.evitadb.externalApi.grpc.generated.GrpcQueryRequest) request,
@@ -3252,6 +3332,13 @@ public final class EvitaSessionServiceGrpc {
               io.evitadb.externalApi.grpc.generated.GrpcCloseRequest,
               io.evitadb.externalApi.grpc.generated.GrpcCloseResponse>(
                 service, METHODID_CLOSE)))
+        .addMethod(
+          getCloseWithProgressMethod(),
+          io.grpc.stub.ServerCalls.asyncServerStreamingCall(
+            new MethodHandlers<
+              com.google.protobuf.Empty,
+              io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse>(
+                service, METHODID_CLOSE_WITH_PROGRESS)))
         .addMethod(
           getQueryOneMethod(),
           io.grpc.stub.ServerCalls.asyncUnaryCall(
@@ -3471,6 +3558,7 @@ public final class EvitaSessionServiceGrpc {
               .addMethod(getGoLiveAndCloseMethod())
               .addMethod(getBackupCatalogMethod())
               .addMethod(getCloseMethod())
+              .addMethod(getCloseWithProgressMethod())
               .addMethod(getQueryOneMethod())
               .addMethod(getQueryListMethod())
               .addMethod(getQueryMethod())

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeInheritanceBehavior.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcAttributeInheritanceBehavior.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ public enum GrpcAttributeInheritanceBehavior
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(28);
+    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(29);
   }
 
   private static final GrpcAttributeInheritanceBehavior[] VALUES = values();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcClassifierType.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcClassifierType.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -227,7 +227,7 @@ public enum GrpcClassifierType
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(30);
+    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(31);
   }
 
   private static final GrpcClassifierType[] VALUES = values();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCloseResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCloseResponse.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -80,6 +80,11 @@ private static final long serialVersionUID = 0L;
             catalogVersion_ = input.readInt64();
             break;
           }
+          case 16: {
+
+            catalogSchemaVersion_ = input.readInt32();
+            break;
+          }
           default: {
             if (!parseUnknownField(
                 input, unknownFields, extensionRegistry, tag)) {
@@ -127,6 +132,23 @@ private static final long serialVersionUID = 0L;
     return catalogVersion_;
   }
 
+  public static final int CATALOGSCHEMAVERSION_FIELD_NUMBER = 2;
+  private int catalogSchemaVersion_;
+  /**
+   * <pre>
+   * Contains the version of the catalog schema that will be valid at the moment of closing the session.
+   * If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
+   * version (i.e. the one that is returned in the response) becomes visible.
+   * </pre>
+   *
+   * <code>int32 catalogSchemaVersion = 2;</code>
+   * @return The catalogSchemaVersion.
+   */
+  @java.lang.Override
+  public int getCatalogSchemaVersion() {
+    return catalogSchemaVersion_;
+  }
+
   private byte memoizedIsInitialized = -1;
   @java.lang.Override
   public final boolean isInitialized() {
@@ -144,6 +166,9 @@ private static final long serialVersionUID = 0L;
     if (catalogVersion_ != 0L) {
       output.writeInt64(1, catalogVersion_);
     }
+    if (catalogSchemaVersion_ != 0) {
+      output.writeInt32(2, catalogSchemaVersion_);
+    }
     unknownFields.writeTo(output);
   }
 
@@ -156,6 +181,10 @@ private static final long serialVersionUID = 0L;
     if (catalogVersion_ != 0L) {
       size += com.google.protobuf.CodedOutputStream
         .computeInt64Size(1, catalogVersion_);
+    }
+    if (catalogSchemaVersion_ != 0) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt32Size(2, catalogSchemaVersion_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -174,6 +203,8 @@ private static final long serialVersionUID = 0L;
 
     if (getCatalogVersion()
         != other.getCatalogVersion()) return false;
+    if (getCatalogSchemaVersion()
+        != other.getCatalogSchemaVersion()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -188,6 +219,8 @@ private static final long serialVersionUID = 0L;
     hash = (37 * hash) + CATALOGVERSION_FIELD_NUMBER;
     hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
         getCatalogVersion());
+    hash = (37 * hash) + CATALOGSCHEMAVERSION_FIELD_NUMBER;
+    hash = (53 * hash) + getCatalogSchemaVersion();
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -327,6 +360,8 @@ private static final long serialVersionUID = 0L;
       super.clear();
       catalogVersion_ = 0L;
 
+      catalogSchemaVersion_ = 0;
+
       return this;
     }
 
@@ -354,6 +389,7 @@ private static final long serialVersionUID = 0L;
     public io.evitadb.externalApi.grpc.generated.GrpcCloseResponse buildPartial() {
       io.evitadb.externalApi.grpc.generated.GrpcCloseResponse result = new io.evitadb.externalApi.grpc.generated.GrpcCloseResponse(this);
       result.catalogVersion_ = catalogVersion_;
+      result.catalogSchemaVersion_ = catalogSchemaVersion_;
       onBuilt();
       return result;
     }
@@ -404,6 +440,9 @@ private static final long serialVersionUID = 0L;
       if (other == io.evitadb.externalApi.grpc.generated.GrpcCloseResponse.getDefaultInstance()) return this;
       if (other.getCatalogVersion() != 0L) {
         setCatalogVersion(other.getCatalogVersion());
+      }
+      if (other.getCatalogSchemaVersion() != 0) {
+        setCatalogSchemaVersion(other.getCatalogSchemaVersion());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -457,7 +496,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setCatalogVersion(long value) {
-      
+
       catalogVersion_ = value;
       onChanged();
       return this;
@@ -471,8 +510,57 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearCatalogVersion() {
-      
+
       catalogVersion_ = 0L;
+      onChanged();
+      return this;
+    }
+
+    private int catalogSchemaVersion_ ;
+    /**
+     * <pre>
+     * Contains the version of the catalog schema that will be valid at the moment of closing the session.
+     * If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
+     * version (i.e. the one that is returned in the response) becomes visible.
+     * </pre>
+     *
+     * <code>int32 catalogSchemaVersion = 2;</code>
+     * @return The catalogSchemaVersion.
+     */
+    @java.lang.Override
+    public int getCatalogSchemaVersion() {
+      return catalogSchemaVersion_;
+    }
+    /**
+     * <pre>
+     * Contains the version of the catalog schema that will be valid at the moment of closing the session.
+     * If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
+     * version (i.e. the one that is returned in the response) becomes visible.
+     * </pre>
+     *
+     * <code>int32 catalogSchemaVersion = 2;</code>
+     * @param value The catalogSchemaVersion to set.
+     * @return This builder for chaining.
+     */
+    public Builder setCatalogSchemaVersion(int value) {
+
+      catalogSchemaVersion_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Contains the version of the catalog schema that will be valid at the moment of closing the session.
+     * If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
+     * version (i.e. the one that is returned in the response) becomes visible.
+     * </pre>
+     *
+     * <code>int32 catalogSchemaVersion = 2;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearCatalogSchemaVersion() {
+
+      catalogSchemaVersion_ = 0;
       onChanged();
       return this;
     }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCloseWithProgressResponse.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCloseWithProgressResponse.java
@@ -27,29 +27,26 @@
 package io.evitadb.externalApi.grpc.generated;
 
 /**
- * <pre>
- * Response for GoLiveAndClose request that switches the catalog to ALIVE state and closes the session.
- * </pre>
- *
- * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse}
+ * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse}
  */
-public final class GrpcGoLiveAndCloseResponse extends
+public final class GrpcCloseWithProgressResponse extends
     com.google.protobuf.GeneratedMessageV3 implements
-    // @@protoc_insertion_point(message_implements:io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse)
-    GrpcGoLiveAndCloseResponseOrBuilder {
+    // @@protoc_insertion_point(message_implements:io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse)
+    GrpcCloseWithProgressResponseOrBuilder {
 private static final long serialVersionUID = 0L;
-  // Use GrpcGoLiveAndCloseResponse.newBuilder() to construct.
-  private GrpcGoLiveAndCloseResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+  // Use GrpcCloseWithProgressResponse.newBuilder() to construct.
+  private GrpcCloseWithProgressResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
     super(builder);
   }
-  private GrpcGoLiveAndCloseResponse() {
+  private GrpcCloseWithProgressResponse() {
+    finishedPhase_ = 0;
   }
 
   @java.lang.Override
   @SuppressWarnings({"unused"})
   protected java.lang.Object newInstance(
       UnusedPrivateParameter unused) {
-    return new GrpcGoLiveAndCloseResponse();
+    return new GrpcCloseWithProgressResponse();
   }
 
   @java.lang.Override
@@ -57,7 +54,7 @@ private static final long serialVersionUID = 0L;
   getUnknownFields() {
     return this.unknownFields;
   }
-  private GrpcGoLiveAndCloseResponse(
+  private GrpcCloseWithProgressResponse(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
@@ -77,17 +74,18 @@ private static final long serialVersionUID = 0L;
             break;
           case 8: {
 
-            success_ = input.readBool();
+            catalogVersion_ = input.readInt64();
             break;
           }
           case 16: {
 
-            catalogVersion_ = input.readInt64();
+            catalogSchemaVersion_ = input.readInt32();
             break;
           }
           case 24: {
+            int rawValue = input.readEnum();
 
-            catalogSchemaVersion_ = input.readInt32();
+            finishedPhase_ = rawValue;
             break;
           }
           default: {
@@ -111,40 +109,25 @@ private static final long serialVersionUID = 0L;
   }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEvitaSessionAPI.internal_static_io_evitadb_externalApi_grpc_generated_GrpcGoLiveAndCloseResponse_descriptor;
+    return io.evitadb.externalApi.grpc.generated.GrpcEvitaSessionAPI.internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseWithProgressResponse_descriptor;
   }
 
   @java.lang.Override
   protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internalGetFieldAccessorTable() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEvitaSessionAPI.internal_static_io_evitadb_externalApi_grpc_generated_GrpcGoLiveAndCloseResponse_fieldAccessorTable
+    return io.evitadb.externalApi.grpc.generated.GrpcEvitaSessionAPI.internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseWithProgressResponse_fieldAccessorTable
         .ensureFieldAccessorsInitialized(
-            io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse.class, io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse.Builder.class);
+            io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse.class, io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse.Builder.class);
   }
 
-  public static final int SUCCESS_FIELD_NUMBER = 1;
-  private boolean success_;
-  /**
-   * <pre>
-   * True, if the catalog was switched to ALIVE state.
-   * </pre>
-   *
-   * <code>bool success = 1;</code>
-   * @return The success.
-   */
-  @java.lang.Override
-  public boolean getSuccess() {
-    return success_;
-  }
-
-  public static final int CATALOGVERSION_FIELD_NUMBER = 2;
+  public static final int CATALOGVERSION_FIELD_NUMBER = 1;
   private long catalogVersion_;
   /**
    * <pre>
    * Contains next catalog version
    * </pre>
    *
-   * <code>int64 catalogVersion = 2;</code>
+   * <code>int64 catalogVersion = 1;</code>
    * @return The catalogVersion.
    */
   @java.lang.Override
@@ -152,7 +135,7 @@ private static final long serialVersionUID = 0L;
     return catalogVersion_;
   }
 
-  public static final int CATALOGSCHEMAVERSION_FIELD_NUMBER = 3;
+  public static final int CATALOGSCHEMAVERSION_FIELD_NUMBER = 2;
   private int catalogSchemaVersion_;
   /**
    * <pre>
@@ -161,12 +144,39 @@ private static final long serialVersionUID = 0L;
    * version (i.e. the one that is returned in the response) becomes visible.
    * </pre>
    *
-   * <code>int32 catalogSchemaVersion = 3;</code>
+   * <code>int32 catalogSchemaVersion = 2;</code>
    * @return The catalogSchemaVersion.
    */
   @java.lang.Override
   public int getCatalogSchemaVersion() {
     return catalogSchemaVersion_;
+  }
+
+  public static final int FINISHEDPHASE_FIELD_NUMBER = 3;
+  private int finishedPhase_;
+  /**
+   * <pre>
+   * The successfully finished phase of the transaction.
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase finishedPhase = 3;</code>
+   * @return The enum numeric value on the wire for finishedPhase.
+   */
+  @java.lang.Override public int getFinishedPhaseValue() {
+    return finishedPhase_;
+  }
+  /**
+   * <pre>
+   * The successfully finished phase of the transaction.
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase finishedPhase = 3;</code>
+   * @return The finishedPhase.
+   */
+  @java.lang.Override public io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase getFinishedPhase() {
+    @SuppressWarnings("deprecation")
+    io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase result = io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase.valueOf(finishedPhase_);
+    return result == null ? io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase.UNRECOGNIZED : result;
   }
 
   private byte memoizedIsInitialized = -1;
@@ -183,14 +193,14 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (success_ != false) {
-      output.writeBool(1, success_);
-    }
     if (catalogVersion_ != 0L) {
-      output.writeInt64(2, catalogVersion_);
+      output.writeInt64(1, catalogVersion_);
     }
     if (catalogSchemaVersion_ != 0) {
-      output.writeInt32(3, catalogSchemaVersion_);
+      output.writeInt32(2, catalogSchemaVersion_);
+    }
+    if (finishedPhase_ != io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase.CONFLICTS_RESOLVED.getNumber()) {
+      output.writeEnum(3, finishedPhase_);
     }
     unknownFields.writeTo(output);
   }
@@ -201,17 +211,17 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (success_ != false) {
-      size += com.google.protobuf.CodedOutputStream
-        .computeBoolSize(1, success_);
-    }
     if (catalogVersion_ != 0L) {
       size += com.google.protobuf.CodedOutputStream
-        .computeInt64Size(2, catalogVersion_);
+        .computeInt64Size(1, catalogVersion_);
     }
     if (catalogSchemaVersion_ != 0) {
       size += com.google.protobuf.CodedOutputStream
-        .computeInt32Size(3, catalogSchemaVersion_);
+        .computeInt32Size(2, catalogSchemaVersion_);
+    }
+    if (finishedPhase_ != io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase.CONFLICTS_RESOLVED.getNumber()) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeEnumSize(3, finishedPhase_);
     }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
@@ -223,17 +233,16 @@ private static final long serialVersionUID = 0L;
     if (obj == this) {
      return true;
     }
-    if (!(obj instanceof io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse)) {
+    if (!(obj instanceof io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse)) {
       return super.equals(obj);
     }
-    io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse other = (io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse) obj;
+    io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse other = (io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse) obj;
 
-    if (getSuccess()
-        != other.getSuccess()) return false;
     if (getCatalogVersion()
         != other.getCatalogVersion()) return false;
     if (getCatalogSchemaVersion()
         != other.getCatalogSchemaVersion()) return false;
+    if (finishedPhase_ != other.finishedPhase_) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -245,82 +254,81 @@ private static final long serialVersionUID = 0L;
     }
     int hash = 41;
     hash = (19 * hash) + getDescriptor().hashCode();
-    hash = (37 * hash) + SUCCESS_FIELD_NUMBER;
-    hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
-        getSuccess());
     hash = (37 * hash) + CATALOGVERSION_FIELD_NUMBER;
     hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
         getCatalogVersion());
     hash = (37 * hash) + CATALOGSCHEMAVERSION_FIELD_NUMBER;
     hash = (53 * hash) + getCatalogSchemaVersion();
+    hash = (37 * hash) + FINISHEDPHASE_FIELD_NUMBER;
+    hash = (53 * hash) + finishedPhase_;
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
   }
 
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseFrom(
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseFrom(
       java.nio.ByteBuffer data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseFrom(
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseFrom(
       java.nio.ByteBuffer data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseFrom(
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseFrom(
       com.google.protobuf.ByteString data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseFrom(
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseFrom(
       com.google.protobuf.ByteString data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseFrom(byte[] data)
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseFrom(byte[] data)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data);
   }
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseFrom(
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseFrom(
       byte[] data,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws com.google.protobuf.InvalidProtocolBufferException {
     return PARSER.parseFrom(data, extensionRegistry);
   }
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseFrom(java.io.InputStream input)
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseFrom(
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input, extensionRegistry);
   }
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseDelimitedFrom(java.io.InputStream input)
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseDelimitedFrom(java.io.InputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input);
   }
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseDelimitedFrom(
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseDelimitedFrom(
       java.io.InputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
   }
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseFrom(
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseFrom(
       com.google.protobuf.CodedInputStream input)
       throws java.io.IOException {
     return com.google.protobuf.GeneratedMessageV3
         .parseWithIOException(PARSER, input);
   }
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parseFrom(
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parseFrom(
       com.google.protobuf.CodedInputStream input,
       com.google.protobuf.ExtensionRegistryLite extensionRegistry)
       throws java.io.IOException {
@@ -333,7 +341,7 @@ private static final long serialVersionUID = 0L;
   public static Builder newBuilder() {
     return DEFAULT_INSTANCE.toBuilder();
   }
-  public static Builder newBuilder(io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse prototype) {
+  public static Builder newBuilder(io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse prototype) {
     return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
   }
   @java.lang.Override
@@ -349,30 +357,26 @@ private static final long serialVersionUID = 0L;
     return builder;
   }
   /**
-   * <pre>
-   * Response for GoLiveAndClose request that switches the catalog to ALIVE state and closes the session.
-   * </pre>
-   *
-   * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse}
+   * Protobuf type {@code io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse}
    */
   public static final class Builder extends
       com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-      // @@protoc_insertion_point(builder_implements:io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse)
-      io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponseOrBuilder {
+      // @@protoc_insertion_point(builder_implements:io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse)
+      io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponseOrBuilder {
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return io.evitadb.externalApi.grpc.generated.GrpcEvitaSessionAPI.internal_static_io_evitadb_externalApi_grpc_generated_GrpcGoLiveAndCloseResponse_descriptor;
+      return io.evitadb.externalApi.grpc.generated.GrpcEvitaSessionAPI.internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseWithProgressResponse_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return io.evitadb.externalApi.grpc.generated.GrpcEvitaSessionAPI.internal_static_io_evitadb_externalApi_grpc_generated_GrpcGoLiveAndCloseResponse_fieldAccessorTable
+      return io.evitadb.externalApi.grpc.generated.GrpcEvitaSessionAPI.internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseWithProgressResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse.class, io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse.Builder.class);
+              io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse.class, io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse.Builder.class);
     }
 
-    // Construct using io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse.newBuilder()
+    // Construct using io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse.newBuilder()
     private Builder() {
       maybeForceBuilderInitialization();
     }
@@ -390,11 +394,11 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public Builder clear() {
       super.clear();
-      success_ = false;
-
       catalogVersion_ = 0L;
 
       catalogSchemaVersion_ = 0;
+
+      finishedPhase_ = 0;
 
       return this;
     }
@@ -402,17 +406,17 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.google.protobuf.Descriptors.Descriptor
         getDescriptorForType() {
-      return io.evitadb.externalApi.grpc.generated.GrpcEvitaSessionAPI.internal_static_io_evitadb_externalApi_grpc_generated_GrpcGoLiveAndCloseResponse_descriptor;
+      return io.evitadb.externalApi.grpc.generated.GrpcEvitaSessionAPI.internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseWithProgressResponse_descriptor;
     }
 
     @java.lang.Override
-    public io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse getDefaultInstanceForType() {
-      return io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse.getDefaultInstance();
+    public io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse getDefaultInstanceForType() {
+      return io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse.getDefaultInstance();
     }
 
     @java.lang.Override
-    public io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse build() {
-      io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse result = buildPartial();
+    public io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse build() {
+      io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse result = buildPartial();
       if (!result.isInitialized()) {
         throw newUninitializedMessageException(result);
       }
@@ -420,11 +424,11 @@ private static final long serialVersionUID = 0L;
     }
 
     @java.lang.Override
-    public io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse buildPartial() {
-      io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse result = new io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse(this);
-      result.success_ = success_;
+    public io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse buildPartial() {
+      io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse result = new io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse(this);
       result.catalogVersion_ = catalogVersion_;
       result.catalogSchemaVersion_ = catalogSchemaVersion_;
+      result.finishedPhase_ = finishedPhase_;
       onBuilt();
       return result;
     }
@@ -463,24 +467,24 @@ private static final long serialVersionUID = 0L;
     }
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse) {
-        return mergeFrom((io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse)other);
+      if (other instanceof io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse) {
+        return mergeFrom((io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse)other);
       } else {
         super.mergeFrom(other);
         return this;
       }
     }
 
-    public Builder mergeFrom(io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse other) {
-      if (other == io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse.getDefaultInstance()) return this;
-      if (other.getSuccess() != false) {
-        setSuccess(other.getSuccess());
-      }
+    public Builder mergeFrom(io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse other) {
+      if (other == io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse.getDefaultInstance()) return this;
       if (other.getCatalogVersion() != 0L) {
         setCatalogVersion(other.getCatalogVersion());
       }
       if (other.getCatalogSchemaVersion() != 0) {
         setCatalogSchemaVersion(other.getCatalogSchemaVersion());
+      }
+      if (other.finishedPhase_ != 0) {
+        setFinishedPhaseValue(other.getFinishedPhaseValue());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -497,11 +501,11 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse parsedMessage = null;
+      io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse parsedMessage = null;
       try {
         parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse) e.getUnfinishedMessage();
+        parsedMessage = (io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
         if (parsedMessage != null) {
@@ -511,56 +515,13 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private boolean success_ ;
-    /**
-     * <pre>
-     * True, if the catalog was switched to ALIVE state.
-     * </pre>
-     *
-     * <code>bool success = 1;</code>
-     * @return The success.
-     */
-    @java.lang.Override
-    public boolean getSuccess() {
-      return success_;
-    }
-    /**
-     * <pre>
-     * True, if the catalog was switched to ALIVE state.
-     * </pre>
-     *
-     * <code>bool success = 1;</code>
-     * @param value The success to set.
-     * @return This builder for chaining.
-     */
-    public Builder setSuccess(boolean value) {
-
-      success_ = value;
-      onChanged();
-      return this;
-    }
-    /**
-     * <pre>
-     * True, if the catalog was switched to ALIVE state.
-     * </pre>
-     *
-     * <code>bool success = 1;</code>
-     * @return This builder for chaining.
-     */
-    public Builder clearSuccess() {
-
-      success_ = false;
-      onChanged();
-      return this;
-    }
-
     private long catalogVersion_ ;
     /**
      * <pre>
      * Contains next catalog version
      * </pre>
      *
-     * <code>int64 catalogVersion = 2;</code>
+     * <code>int64 catalogVersion = 1;</code>
      * @return The catalogVersion.
      */
     @java.lang.Override
@@ -572,7 +533,7 @@ private static final long serialVersionUID = 0L;
      * Contains next catalog version
      * </pre>
      *
-     * <code>int64 catalogVersion = 2;</code>
+     * <code>int64 catalogVersion = 1;</code>
      * @param value The catalogVersion to set.
      * @return This builder for chaining.
      */
@@ -587,7 +548,7 @@ private static final long serialVersionUID = 0L;
      * Contains next catalog version
      * </pre>
      *
-     * <code>int64 catalogVersion = 2;</code>
+     * <code>int64 catalogVersion = 1;</code>
      * @return This builder for chaining.
      */
     public Builder clearCatalogVersion() {
@@ -605,7 +566,7 @@ private static final long serialVersionUID = 0L;
      * version (i.e. the one that is returned in the response) becomes visible.
      * </pre>
      *
-     * <code>int32 catalogSchemaVersion = 3;</code>
+     * <code>int32 catalogSchemaVersion = 2;</code>
      * @return The catalogSchemaVersion.
      */
     @java.lang.Override
@@ -619,7 +580,7 @@ private static final long serialVersionUID = 0L;
      * version (i.e. the one that is returned in the response) becomes visible.
      * </pre>
      *
-     * <code>int32 catalogSchemaVersion = 3;</code>
+     * <code>int32 catalogSchemaVersion = 2;</code>
      * @param value The catalogSchemaVersion to set.
      * @return This builder for chaining.
      */
@@ -636,12 +597,86 @@ private static final long serialVersionUID = 0L;
      * version (i.e. the one that is returned in the response) becomes visible.
      * </pre>
      *
-     * <code>int32 catalogSchemaVersion = 3;</code>
+     * <code>int32 catalogSchemaVersion = 2;</code>
      * @return This builder for chaining.
      */
     public Builder clearCatalogSchemaVersion() {
 
       catalogSchemaVersion_ = 0;
+      onChanged();
+      return this;
+    }
+
+    private int finishedPhase_ = 0;
+    /**
+     * <pre>
+     * The successfully finished phase of the transaction.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase finishedPhase = 3;</code>
+     * @return The enum numeric value on the wire for finishedPhase.
+     */
+    @java.lang.Override public int getFinishedPhaseValue() {
+      return finishedPhase_;
+    }
+    /**
+     * <pre>
+     * The successfully finished phase of the transaction.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase finishedPhase = 3;</code>
+     * @param value The enum numeric value on the wire for finishedPhase to set.
+     * @return This builder for chaining.
+     */
+    public Builder setFinishedPhaseValue(int value) {
+
+      finishedPhase_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * The successfully finished phase of the transaction.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase finishedPhase = 3;</code>
+     * @return The finishedPhase.
+     */
+    @java.lang.Override
+    public io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase getFinishedPhase() {
+      @SuppressWarnings("deprecation")
+      io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase result = io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase.valueOf(finishedPhase_);
+      return result == null ? io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase.UNRECOGNIZED : result;
+    }
+    /**
+     * <pre>
+     * The successfully finished phase of the transaction.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase finishedPhase = 3;</code>
+     * @param value The finishedPhase to set.
+     * @return This builder for chaining.
+     */
+    public Builder setFinishedPhase(io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase value) {
+      if (value == null) {
+        throw new NullPointerException();
+      }
+
+      finishedPhase_ = value.getNumber();
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * The successfully finished phase of the transaction.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase finishedPhase = 3;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearFinishedPhase() {
+
+      finishedPhase_ = 0;
       onChanged();
       return this;
     }
@@ -658,41 +693,41 @@ private static final long serialVersionUID = 0L;
     }
 
 
-    // @@protoc_insertion_point(builder_scope:io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse)
+    // @@protoc_insertion_point(builder_scope:io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse)
   }
 
-  // @@protoc_insertion_point(class_scope:io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse)
-  private static final io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse DEFAULT_INSTANCE;
+  // @@protoc_insertion_point(class_scope:io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse)
+  private static final io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse DEFAULT_INSTANCE;
   static {
-    DEFAULT_INSTANCE = new io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse();
+    DEFAULT_INSTANCE = new io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse();
   }
 
-  public static io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse getDefaultInstance() {
+  public static io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse getDefaultInstance() {
     return DEFAULT_INSTANCE;
   }
 
-  private static final com.google.protobuf.Parser<GrpcGoLiveAndCloseResponse>
-      PARSER = new com.google.protobuf.AbstractParser<GrpcGoLiveAndCloseResponse>() {
+  private static final com.google.protobuf.Parser<GrpcCloseWithProgressResponse>
+      PARSER = new com.google.protobuf.AbstractParser<GrpcCloseWithProgressResponse>() {
     @java.lang.Override
-    public GrpcGoLiveAndCloseResponse parsePartialFrom(
+    public GrpcCloseWithProgressResponse parsePartialFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return new GrpcGoLiveAndCloseResponse(input, extensionRegistry);
+      return new GrpcCloseWithProgressResponse(input, extensionRegistry);
     }
   };
 
-  public static com.google.protobuf.Parser<GrpcGoLiveAndCloseResponse> parser() {
+  public static com.google.protobuf.Parser<GrpcCloseWithProgressResponse> parser() {
     return PARSER;
   }
 
   @java.lang.Override
-  public com.google.protobuf.Parser<GrpcGoLiveAndCloseResponse> getParserForType() {
+  public com.google.protobuf.Parser<GrpcCloseWithProgressResponse> getParserForType() {
     return PARSER;
   }
 
   @java.lang.Override
-  public io.evitadb.externalApi.grpc.generated.GrpcGoLiveAndCloseResponse getDefaultInstanceForType() {
+  public io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse getDefaultInstanceForType() {
     return DEFAULT_INSTANCE;
   }
 

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCloseWithProgressResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcCloseWithProgressResponseOrBuilder.java
@@ -26,8 +26,8 @@
 
 package io.evitadb.externalApi.grpc.generated;
 
-public interface GrpcCloseResponseOrBuilder extends
-    // @@protoc_insertion_point(interface_extends:io.evitadb.externalApi.grpc.generated.GrpcCloseResponse)
+public interface GrpcCloseWithProgressResponseOrBuilder extends
+    // @@protoc_insertion_point(interface_extends:io.evitadb.externalApi.grpc.generated.GrpcCloseWithProgressResponse)
     com.google.protobuf.MessageOrBuilder {
 
   /**
@@ -51,4 +51,23 @@ public interface GrpcCloseResponseOrBuilder extends
    * @return The catalogSchemaVersion.
    */
   int getCatalogSchemaVersion();
+
+  /**
+   * <pre>
+   * The successfully finished phase of the transaction.
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase finishedPhase = 3;</code>
+   * @return The enum numeric value on the wire for finishedPhase.
+   */
+  int getFinishedPhaseValue();
+  /**
+   * <pre>
+   * The successfully finished phase of the transaction.
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase finishedPhase = 3;</code>
+   * @return The finishedPhase.
+   */
+  io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase getFinishedPhase();
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntitySchema.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntitySchema.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -296,6 +296,11 @@ private static final long serialVersionUID = 0L;
             input.popLimit(oldLimit);
             break;
           }
+          case 152: {
+
+            catalogSchemaVersion_ = input.readInt64();
+            break;
+          }
           default: {
             if (!parseUnknownField(
                 input, unknownFields, extensionRegistry, tag)) {
@@ -381,7 +386,7 @@ private static final long serialVersionUID = 0L;
     if (ref instanceof java.lang.String) {
       return (java.lang.String) ref;
     } else {
-      com.google.protobuf.ByteString bs = 
+      com.google.protobuf.ByteString bs =
           (com.google.protobuf.ByteString) ref;
       java.lang.String s = bs.toStringUtf8();
       name_ = s;
@@ -402,7 +407,7 @@ private static final long serialVersionUID = 0L;
       getNameBytes() {
     java.lang.Object ref = name_;
     if (ref instanceof java.lang.String) {
-      com.google.protobuf.ByteString b = 
+      com.google.protobuf.ByteString b =
           com.google.protobuf.ByteString.copyFromUtf8(
               (java.lang.String) ref);
       name_ = b;
@@ -617,7 +622,7 @@ private static final long serialVersionUID = 0L;
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale locales = 9;</code>
    */
   @java.lang.Override
-  public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcLocaleOrBuilder> 
+  public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcLocaleOrBuilder>
       getLocalesOrBuilderList() {
     return locales_;
   }
@@ -680,7 +685,7 @@ private static final long serialVersionUID = 0L;
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency currencies = 10;</code>
    */
   @java.lang.Override
-  public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcCurrencyOrBuilder> 
+  public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcCurrencyOrBuilder>
       getCurrenciesOrBuilderList() {
     return currencies_;
   }
@@ -725,7 +730,7 @@ private static final long serialVersionUID = 0L;
         java.lang.String, io.evitadb.externalApi.grpc.generated.GrpcAttributeSchema> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, io.evitadb.externalApi.grpc.generated.GrpcAttributeSchema>newDefaultInstance(
-                io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaOuterClass.internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_AttributesEntry_descriptor, 
+                io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaOuterClass.internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_AttributesEntry_descriptor,
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.MESSAGE,
@@ -858,7 +863,7 @@ private static final long serialVersionUID = 0L;
         java.lang.String, io.evitadb.externalApi.grpc.generated.GrpcAssociatedDataSchema> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, io.evitadb.externalApi.grpc.generated.GrpcAssociatedDataSchema>newDefaultInstance(
-                io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaOuterClass.internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_AssociatedDataEntry_descriptor, 
+                io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaOuterClass.internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_AssociatedDataEntry_descriptor,
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.MESSAGE,
@@ -979,7 +984,7 @@ private static final long serialVersionUID = 0L;
         java.lang.String, io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, io.evitadb.externalApi.grpc.generated.GrpcReferenceSchema>newDefaultInstance(
-                io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaOuterClass.internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_ReferencesEntry_descriptor, 
+                io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaOuterClass.internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_ReferencesEntry_descriptor,
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.MESSAGE,
@@ -1216,7 +1221,7 @@ private static final long serialVersionUID = 0L;
         java.lang.String, io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema> defaultEntry =
             com.google.protobuf.MapEntry
             .<java.lang.String, io.evitadb.externalApi.grpc.generated.GrpcSortableAttributeCompoundSchema>newDefaultInstance(
-                io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaOuterClass.internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_SortableAttributeCompoundsEntry_descriptor, 
+                io.evitadb.externalApi.grpc.generated.GrpcEntitySchemaOuterClass.internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_SortableAttributeCompoundsEntry_descriptor,
                 com.google.protobuf.WireFormat.FieldType.STRING,
                 "",
                 com.google.protobuf.WireFormat.FieldType.MESSAGE,
@@ -1328,7 +1333,7 @@ private static final long serialVersionUID = 0L;
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcNameVariant nameVariant = 16;</code>
    */
   @java.lang.Override
-  public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcNameVariantOrBuilder> 
+  public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcNameVariantOrBuilder>
       getNameVariantOrBuilderList() {
     return nameVariant_;
   }
@@ -1558,6 +1563,21 @@ private static final long serialVersionUID = 0L;
   }
   private int priceIndexedInScopesMemoizedSerializedSize;
 
+  public static final int CATALOGSCHEMAVERSION_FIELD_NUMBER = 19;
+  private long catalogSchemaVersion_;
+  /**
+   * <pre>
+   * Contains current version of the catalog schema this entity schema belongs to.
+   * </pre>
+   *
+   * <code>int64 catalogSchemaVersion = 19;</code>
+   * @return The catalogSchemaVersion.
+   */
+  @java.lang.Override
+  public long getCatalogSchemaVersion() {
+    return catalogSchemaVersion_;
+  }
+
   private byte memoizedIsInitialized = -1;
   @java.lang.Override
   public final boolean isInitialized() {
@@ -1650,6 +1670,9 @@ private static final long serialVersionUID = 0L;
     }
     for (int i = 0; i < priceIndexedInScopes_.size(); i++) {
       output.writeEnumNoTag(priceIndexedInScopes_.get(i));
+    }
+    if (catalogSchemaVersion_ != 0L) {
+      output.writeInt64(19, catalogSchemaVersion_);
     }
     unknownFields.writeTo(output);
   }
@@ -1779,6 +1802,10 @@ private static final long serialVersionUID = 0L;
           .computeUInt32SizeNoTag(dataSize);
       }priceIndexedInScopesMemoizedSerializedSize = dataSize;
     }
+    if (catalogSchemaVersion_ != 0L) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeInt64Size(19, catalogSchemaVersion_);
+    }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
@@ -1833,6 +1860,8 @@ private static final long serialVersionUID = 0L;
         .equals(other.getNameVariantList())) return false;
     if (!hierarchyIndexedInScopes_.equals(other.hierarchyIndexedInScopes_)) return false;
     if (!priceIndexedInScopes_.equals(other.priceIndexedInScopes_)) return false;
+    if (getCatalogSchemaVersion()
+        != other.getCatalogSchemaVersion()) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -1907,6 +1936,9 @@ private static final long serialVersionUID = 0L;
       hash = (37 * hash) + PRICEINDEXEDINSCOPES_FIELD_NUMBER;
       hash = (53 * hash) + priceIndexedInScopes_.hashCode();
     }
+    hash = (37 * hash) + CATALOGSCHEMAVERSION_FIELD_NUMBER;
+    hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+        getCatalogSchemaVersion());
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -2141,6 +2173,8 @@ private static final long serialVersionUID = 0L;
       bitField0_ = (bitField0_ & ~0x00000100);
       priceIndexedInScopes_ = java.util.Collections.emptyList();
       bitField0_ = (bitField0_ & ~0x00000200);
+      catalogSchemaVersion_ = 0L;
+
       return this;
     }
 
@@ -2234,6 +2268,7 @@ private static final long serialVersionUID = 0L;
         bitField0_ = (bitField0_ & ~0x00000200);
       }
       result.priceIndexedInScopes_ = priceIndexedInScopes_;
+      result.catalogSchemaVersion_ = catalogSchemaVersion_;
       onBuilt();
       return result;
     }
@@ -2325,7 +2360,7 @@ private static final long serialVersionUID = 0L;
             localesBuilder_ = null;
             locales_ = other.locales_;
             bitField0_ = (bitField0_ & ~0x00000001);
-            localesBuilder_ = 
+            localesBuilder_ =
               com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getLocalesFieldBuilder() : null;
           } else {
@@ -2351,7 +2386,7 @@ private static final long serialVersionUID = 0L;
             currenciesBuilder_ = null;
             currencies_ = other.currencies_;
             bitField0_ = (bitField0_ & ~0x00000002);
-            currenciesBuilder_ = 
+            currenciesBuilder_ =
               com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getCurrenciesFieldBuilder() : null;
           } else {
@@ -2395,7 +2430,7 @@ private static final long serialVersionUID = 0L;
             nameVariantBuilder_ = null;
             nameVariant_ = other.nameVariant_;
             bitField0_ = (bitField0_ & ~0x00000080);
-            nameVariantBuilder_ = 
+            nameVariantBuilder_ =
               com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
                  getNameVariantFieldBuilder() : null;
           } else {
@@ -2422,6 +2457,9 @@ private static final long serialVersionUID = 0L;
           priceIndexedInScopes_.addAll(other.priceIndexedInScopes_);
         }
         onChanged();
+      }
+      if (other.getCatalogSchemaVersion() != 0L) {
+        setCatalogSchemaVersion(other.getCatalogSchemaVersion());
       }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
@@ -2488,7 +2526,7 @@ private static final long serialVersionUID = 0L;
         getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof String) {
-        com.google.protobuf.ByteString b = 
+        com.google.protobuf.ByteString b =
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         name_ = b;
@@ -2512,7 +2550,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) {
     throw new NullPointerException();
   }
-  
+
       name_ = value;
       onChanged();
       return this;
@@ -2527,7 +2565,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearName() {
-      
+
       name_ = getDefaultInstance().getName();
       onChanged();
       return this;
@@ -2548,7 +2586,7 @@ private static final long serialVersionUID = 0L;
     throw new NullPointerException();
   }
   checkByteStringIsUtf8(value);
-      
+
       name_ = value;
       onChanged();
       return this;
@@ -2579,7 +2617,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setVersion(int value) {
-      
+
       version_ = value;
       onChanged();
       return this;
@@ -2594,7 +2632,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearVersion() {
-      
+
       version_ = 0;
       onChanged();
       return this;
@@ -2722,7 +2760,7 @@ private static final long serialVersionUID = 0L;
      * <code>.google.protobuf.StringValue description = 3;</code>
      */
     public com.google.protobuf.StringValue.Builder getDescriptionBuilder() {
-      
+
       onChanged();
       return getDescriptionFieldBuilder().getBuilder();
     }
@@ -2751,7 +2789,7 @@ private static final long serialVersionUID = 0L;
      * <code>.google.protobuf.StringValue description = 3;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
+        com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>
         getDescriptionFieldBuilder() {
       if (descriptionBuilder_ == null) {
         descriptionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
@@ -2893,7 +2931,7 @@ private static final long serialVersionUID = 0L;
      * <code>.google.protobuf.StringValue deprecationNotice = 4;</code>
      */
     public com.google.protobuf.StringValue.Builder getDeprecationNoticeBuilder() {
-      
+
       onChanged();
       return getDeprecationNoticeFieldBuilder().getBuilder();
     }
@@ -2924,7 +2962,7 @@ private static final long serialVersionUID = 0L;
      * <code>.google.protobuf.StringValue deprecationNotice = 4;</code>
      */
     private com.google.protobuf.SingleFieldBuilderV3<
-        com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
+        com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>
         getDeprecationNoticeFieldBuilder() {
       if (deprecationNoticeBuilder_ == null) {
         deprecationNoticeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
@@ -2966,7 +3004,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setWithGeneratedPrimaryKey(boolean value) {
-      
+
       withGeneratedPrimaryKey_ = value;
       onChanged();
       return this;
@@ -2983,7 +3021,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearWithGeneratedPrimaryKey() {
-      
+
       withGeneratedPrimaryKey_ = false;
       onChanged();
       return this;
@@ -3026,7 +3064,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setWithHierarchy(boolean value) {
-      
+
       withHierarchy_ = value;
       onChanged();
       return this;
@@ -3047,7 +3085,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearWithHierarchy() {
-      
+
       withHierarchy_ = false;
       onChanged();
       return this;
@@ -3092,7 +3130,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setWithPrice(boolean value) {
-      
+
       withPrice_ = value;
       onChanged();
       return this;
@@ -3114,7 +3152,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearWithPrice() {
-      
+
       withPrice_ = false;
       onChanged();
       return this;
@@ -3149,7 +3187,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder setIndexedPricePlaces(int value) {
-      
+
       indexedPricePlaces_ = value;
       onChanged();
       return this;
@@ -3166,7 +3204,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearIndexedPricePlaces() {
-      
+
       indexedPricePlaces_ = 0;
       onChanged();
       return this;
@@ -3442,7 +3480,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale locales = 9;</code>
      */
-    public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcLocaleOrBuilder> 
+    public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcLocaleOrBuilder>
          getLocalesOrBuilderList() {
       if (localesBuilder_ != null) {
         return localesBuilder_.getMessageOrBuilderList();
@@ -3483,12 +3521,12 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale locales = 9;</code>
      */
-    public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcLocale.Builder> 
+    public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcLocale.Builder>
          getLocalesBuilderList() {
       return getLocalesFieldBuilder().getBuilderList();
     }
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        io.evitadb.externalApi.grpc.generated.GrpcLocale, io.evitadb.externalApi.grpc.generated.GrpcLocale.Builder, io.evitadb.externalApi.grpc.generated.GrpcLocaleOrBuilder> 
+        io.evitadb.externalApi.grpc.generated.GrpcLocale, io.evitadb.externalApi.grpc.generated.GrpcLocale.Builder, io.evitadb.externalApi.grpc.generated.GrpcLocaleOrBuilder>
         getLocalesFieldBuilder() {
       if (localesBuilder_ == null) {
         localesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
@@ -3757,7 +3795,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency currencies = 10;</code>
      */
-    public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcCurrencyOrBuilder> 
+    public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcCurrencyOrBuilder>
          getCurrenciesOrBuilderList() {
       if (currenciesBuilder_ != null) {
         return currenciesBuilder_.getMessageOrBuilderList();
@@ -3795,12 +3833,12 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency currencies = 10;</code>
      */
-    public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcCurrency.Builder> 
+    public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcCurrency.Builder>
          getCurrenciesBuilderList() {
       return getCurrenciesFieldBuilder().getBuilderList();
     }
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        io.evitadb.externalApi.grpc.generated.GrpcCurrency, io.evitadb.externalApi.grpc.generated.GrpcCurrency.Builder, io.evitadb.externalApi.grpc.generated.GrpcCurrencyOrBuilder> 
+        io.evitadb.externalApi.grpc.generated.GrpcCurrency, io.evitadb.externalApi.grpc.generated.GrpcCurrency.Builder, io.evitadb.externalApi.grpc.generated.GrpcCurrencyOrBuilder>
         getCurrenciesFieldBuilder() {
       if (currenciesBuilder_ == null) {
         currenciesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
@@ -5113,7 +5151,7 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcNameVariant nameVariant = 16;</code>
      */
-    public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcNameVariantOrBuilder> 
+    public java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcNameVariantOrBuilder>
          getNameVariantOrBuilderList() {
       if (nameVariantBuilder_ != null) {
         return nameVariantBuilder_.getMessageOrBuilderList();
@@ -5151,12 +5189,12 @@ private static final long serialVersionUID = 0L;
      *
      * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcNameVariant nameVariant = 16;</code>
      */
-    public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcNameVariant.Builder> 
+    public java.util.List<io.evitadb.externalApi.grpc.generated.GrpcNameVariant.Builder>
          getNameVariantBuilderList() {
       return getNameVariantFieldBuilder().getBuilderList();
     }
     private com.google.protobuf.RepeatedFieldBuilderV3<
-        io.evitadb.externalApi.grpc.generated.GrpcNameVariant, io.evitadb.externalApi.grpc.generated.GrpcNameVariant.Builder, io.evitadb.externalApi.grpc.generated.GrpcNameVariantOrBuilder> 
+        io.evitadb.externalApi.grpc.generated.GrpcNameVariant, io.evitadb.externalApi.grpc.generated.GrpcNameVariant.Builder, io.evitadb.externalApi.grpc.generated.GrpcNameVariantOrBuilder>
         getNameVariantFieldBuilder() {
       if (nameVariantBuilder_ == null) {
         nameVariantBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
@@ -5626,6 +5664,49 @@ private static final long serialVersionUID = 0L;
       for (int value : values) {
         priceIndexedInScopes_.add(value);
       }
+      onChanged();
+      return this;
+    }
+
+    private long catalogSchemaVersion_ ;
+    /**
+     * <pre>
+     * Contains current version of the catalog schema this entity schema belongs to.
+     * </pre>
+     *
+     * <code>int64 catalogSchemaVersion = 19;</code>
+     * @return The catalogSchemaVersion.
+     */
+    @java.lang.Override
+    public long getCatalogSchemaVersion() {
+      return catalogSchemaVersion_;
+    }
+    /**
+     * <pre>
+     * Contains current version of the catalog schema this entity schema belongs to.
+     * </pre>
+     *
+     * <code>int64 catalogSchemaVersion = 19;</code>
+     * @param value The catalogSchemaVersion to set.
+     * @return This builder for chaining.
+     */
+    public Builder setCatalogSchemaVersion(long value) {
+
+      catalogSchemaVersion_ = value;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Contains current version of the catalog schema this entity schema belongs to.
+     * </pre>
+     *
+     * <code>int64 catalogSchemaVersion = 19;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearCatalogSchemaVersion() {
+
+      catalogSchemaVersion_ = 0L;
       onChanged();
       return this;
     }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntitySchemaOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntitySchemaOrBuilder.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -195,7 +195,7 @@ public interface GrpcEntitySchemaOrBuilder extends
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale locales = 9;</code>
    */
-  java.util.List<io.evitadb.externalApi.grpc.generated.GrpcLocale> 
+  java.util.List<io.evitadb.externalApi.grpc.generated.GrpcLocale>
       getLocalesList();
   /**
    * <pre>
@@ -223,7 +223,7 @@ public interface GrpcEntitySchemaOrBuilder extends
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcLocale locales = 9;</code>
    */
-  java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcLocaleOrBuilder> 
+  java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcLocaleOrBuilder>
       getLocalesOrBuilderList();
   /**
    * <pre>
@@ -243,7 +243,7 @@ public interface GrpcEntitySchemaOrBuilder extends
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency currencies = 10;</code>
    */
-  java.util.List<io.evitadb.externalApi.grpc.generated.GrpcCurrency> 
+  java.util.List<io.evitadb.externalApi.grpc.generated.GrpcCurrency>
       getCurrenciesList();
   /**
    * <pre>
@@ -268,7 +268,7 @@ public interface GrpcEntitySchemaOrBuilder extends
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcCurrency currencies = 10;</code>
    */
-  java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcCurrencyOrBuilder> 
+  java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcCurrencyOrBuilder>
       getCurrenciesOrBuilderList();
   /**
    * <pre>
@@ -702,7 +702,7 @@ public interface GrpcEntitySchemaOrBuilder extends
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcNameVariant nameVariant = 16;</code>
    */
-  java.util.List<io.evitadb.externalApi.grpc.generated.GrpcNameVariant> 
+  java.util.List<io.evitadb.externalApi.grpc.generated.GrpcNameVariant>
       getNameVariantList();
   /**
    * <pre>
@@ -727,7 +727,7 @@ public interface GrpcEntitySchemaOrBuilder extends
    *
    * <code>repeated .io.evitadb.externalApi.grpc.generated.GrpcNameVariant nameVariant = 16;</code>
    */
-  java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcNameVariantOrBuilder> 
+  java.util.List<? extends io.evitadb.externalApi.grpc.generated.GrpcNameVariantOrBuilder>
       getNameVariantOrBuilderList();
   /**
    * <pre>
@@ -871,4 +871,14 @@ public interface GrpcEntitySchemaOrBuilder extends
    * @return The enum numeric value on the wire of priceIndexedInScopes at the given index.
    */
   int getPriceIndexedInScopesValue(int index);
+
+  /**
+   * <pre>
+   * Contains current version of the catalog schema this entity schema belongs to.
+   * </pre>
+   *
+   * <code>int64 catalogSchemaVersion = 19;</code>
+   * @return The catalogSchemaVersion.
+   */
+  long getCatalogSchemaVersion();
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntitySchemaOuterClass.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntitySchemaOuterClass.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -39,62 +39,62 @@ public final class GrpcEntitySchemaOuterClass {
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_AttributesEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_AttributesEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_AssociatedDataEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_AssociatedDataEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_ReferencesEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_ReferencesEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_SortableAttributeCompoundsEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_SortableAttributeCompoundsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcAttributeSchema_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcAttributeSchema_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcAssociatedDataSchema_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcAssociatedDataSchema_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcReferenceSchema_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcReferenceSchema_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcReferenceSchema_AttributesEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcReferenceSchema_AttributesEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcReferenceSchema_SortableAttributeCompoundsEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcReferenceSchema_SortableAttributeCompoundsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcSortableAttributeCompoundSchema_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcSortableAttributeCompoundSchema_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcAttributeElement_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcAttributeElement_fieldAccessorTable;
 
@@ -109,7 +109,7 @@ public final class GrpcEntitySchemaOuterClass {
       "\n\026GrpcEntitySchema.proto\022%io.evitadb.ext" +
       "ernalApi.grpc.generated\032\030GrpcEvitaDataTy" +
       "pes.proto\032\017GrpcEnums.proto\032\036google/proto" +
-      "buf/wrappers.proto\"\341\014\n\020GrpcEntitySchema\022" +
+      "buf/wrappers.proto\"\377\014\n\020GrpcEntitySchema\022" +
       "\014\n\004name\030\001 \001(\t\022\017\n\007version\030\002 \001(\005\0221\n\013descri" +
       "ption\030\003 \001(\0132\034.google.protobuf.StringValu" +
       "e\0227\n\021deprecationNotice\030\004 \001(\0132\034.google.pr" +
@@ -138,117 +138,118 @@ public final class GrpcEntitySchemaOuterClass {
       "externalApi.grpc.generated.GrpcEntitySco" +
       "pe\022T\n\024priceIndexedInScopes\030\022 \003(\01626.io.ev" +
       "itadb.externalApi.grpc.generated.GrpcEnt" +
-      "ityScope\032m\n\017AttributesEntry\022\013\n\003key\030\001 \001(\t" +
-      "\022I\n\005value\030\002 \001(\0132:.io.evitadb.externalApi" +
-      ".grpc.generated.GrpcAttributeSchema:\0028\001\032" +
-      "v\n\023AssociatedDataEntry\022\013\n\003key\030\001 \001(\t\022N\n\005v" +
-      "alue\030\002 \001(\0132?.io.evitadb.externalApi.grpc" +
-      ".generated.GrpcAssociatedDataSchema:\0028\001\032" +
-      "m\n\017ReferencesEntry\022\013\n\003key\030\001 \001(\t\022I\n\005value" +
-      "\030\002 \001(\0132:.io.evitadb.externalApi.grpc.gen" +
-      "erated.GrpcReferenceSchema:\0028\001\032\215\001\n\037Sorta" +
-      "bleAttributeCompoundsEntry\022\013\n\003key\030\001 \001(\t\022" +
-      "Y\n\005value\030\002 \001(\0132J.io.evitadb.externalApi." +
-      "grpc.generated.GrpcSortableAttributeComp" +
-      "oundSchema:\0028\001\"\227\t\n\023GrpcAttributeSchema\022\014" +
-      "\n\004name\030\001 \001(\t\022R\n\nschemaType\030\002 \001(\0162>.io.ev" +
-      "itadb.externalApi.grpc.generated.GrpcAtt" +
-      "ributeSchemaType\0221\n\013description\030\003 \001(\0132\034." +
-      "google.protobuf.StringValue\0227\n\021deprecati" +
-      "onNotice\030\004 \001(\0132\034.google.protobuf.StringV" +
-      "alue\022V\n\006unique\030\005 \001(\0162B.io.evitadb.extern" +
-      "alApi.grpc.generated.GrpcAttributeUnique" +
-      "nessTypeB\002\030\001\022d\n\016uniqueGlobally\030\006 \001(\0162H.i" +
-      "o.evitadb.externalApi.grpc.generated.Grp" +
-      "cGlobalAttributeUniquenessTypeB\002\030\001\022\026\n\nfi" +
-      "lterable\030\007 \001(\010B\002\030\001\022\024\n\010sortable\030\010 \001(\010B\002\030\001" +
-      "\022\021\n\tlocalized\030\t \001(\010\022\020\n\010nullable\030\n \001(\010\022\026\n" +
-      "\016representative\030\013 \001(\010\022F\n\004type\030\014 \001(\01628.io" +
-      ".evitadb.externalApi.grpc.generated.Grpc" +
-      "EvitaDataType\022K\n\014defaultValue\030\r \001(\01325.io" +
-      ".evitadb.externalApi.grpc.generated.Grpc" +
-      "EvitaValue\022\034\n\024indexedDecimalPlaces\030\016 \001(\005" +
-      "\022K\n\013nameVariant\030\017 \003(\01326.io.evitadb.exter" +
-      "nalApi.grpc.generated.GrpcNameVariant\022\021\n" +
-      "\tinherited\030\020 \001(\010\022`\n\016uniqueInScopes\030\021 \003(\013" +
-      "2H.io.evitadb.externalApi.grpc.generated" +
-      ".GrpcScopedAttributeUniquenessType\022n\n\026un" +
-      "iqueGloballyInScopes\030\022 \003(\0132N.io.evitadb." +
-      "externalApi.grpc.generated.GrpcScopedGlo" +
-      "balAttributeUniquenessType\022R\n\022filterable" +
-      "InScopes\030\023 \003(\01626.io.evitadb.externalApi." +
-      "grpc.generated.GrpcEntityScope\022P\n\020sortab" +
-      "leInScopes\030\024 \003(\01626.io.evitadb.externalAp" +
-      "i.grpc.generated.GrpcEntityScope\"\356\002\n\030Grp" +
-      "cAssociatedDataSchema\022\014\n\004name\030\001 \001(\t\0221\n\013d" +
-      "escription\030\002 \001(\0132\034.google.protobuf.Strin" +
-      "gValue\0227\n\021deprecationNotice\030\003 \001(\0132\034.goog" +
-      "le.protobuf.StringValue\022f\n\004type\030\004 \001(\0162X." +
-      "io.evitadb.externalApi.grpc.generated.Gr" +
-      "pcEvitaAssociatedDataDataType.GrpcEvitaD" +
-      "ataType\022\021\n\tlocalized\030\005 \001(\010\022\020\n\010nullable\030\006" +
-      " \001(\010\022K\n\013nameVariant\030\007 \003(\01326.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcNameVarian" +
-      "t\"\301\r\n\023GrpcReferenceSchema\022\014\n\004name\030\001 \001(\t\022" +
-      "1\n\013description\030\002 \001(\0132\034.google.protobuf.S" +
-      "tringValue\0227\n\021deprecationNotice\030\003 \001(\0132\034." +
-      "google.protobuf.StringValue\022K\n\013cardinali" +
-      "ty\030\004 \001(\01626.io.evitadb.externalApi.grpc.g" +
-      "enerated.GrpcCardinality\022\022\n\nentityType\030\005" +
-      " \001(\t\022%\n\031entityTypeRelatesToEntity\030\006 \001(\010B" +
-      "\002\030\001\022/\n\tgroupType\030\007 \001(\0132\034.google.protobuf" +
-      ".StringValue\022$\n\030groupTypeRelatesToEntity" +
-      "\030\010 \001(\010B\002\030\001\022\023\n\007indexed\030\t \001(\010B\002\030\001\022\023\n\007facet" +
-      "ed\030\n \001(\010B\002\030\001\022^\n\nattributes\030\013 \003(\0132J.io.ev" +
-      "itadb.externalApi.grpc.generated.GrpcRef" +
-      "erenceSchema.AttributesEntry\022~\n\032sortable" +
-      "AttributeCompounds\030\014 \003(\0132Z.io.evitadb.ex" +
-      "ternalApi.grpc.generated.GrpcReferenceSc" +
-      "hema.SortableAttributeCompoundsEntry\022K\n\013" +
-      "nameVariant\030\r \003(\01326.io.evitadb.externalA" +
-      "pi.grpc.generated.GrpcNameVariant\022U\n\025ent" +
-      "ityTypeNameVariant\030\016 \003(\01326.io.evitadb.ex" +
-      "ternalApi.grpc.generated.GrpcNameVariant" +
-      "\022T\n\024groupTypeNameVariant\030\017 \003(\01326.io.evit" +
-      "adb.externalApi.grpc.generated.GrpcNameV" +
-      "ariant\022#\n\033referencedEntityTypeManaged\030\020 " +
-      "\001(\010\022\"\n\032referencedGroupTypeManaged\030\021 \001(\010\022" +
-      "<\n\026reflectedReferenceName\030\022 \001(\0132\034.google" +
-      ".protobuf.StringValue\022\034\n\024descriptionInhe" +
-      "rited\030\023 \001(\010\022\"\n\032deprecationNoticeInherite" +
-      "d\030\024 \001(\010\022\034\n\024cardinalityInherited\030\025 \001(\010\022\030\n" +
-      "\020facetedInherited\030\026 \001(\010\022m\n\034attributeInhe" +
-      "ritanceBehavior\030\027 \001(\0162G.io.evitadb.exter" +
-      "nalApi.grpc.generated.GrpcAttributeInher" +
-      "itanceBehavior\022\"\n\032attributeInheritanceFi" +
-      "lter\030\030 \003(\t\022\030\n\020indexedInherited\030\031 \001(\010\022O\n\017" +
-      "indexedInScopes\030\032 \003(\01626.io.evitadb.exter" +
-      "nalApi.grpc.generated.GrpcEntityScope\022O\n" +
-      "\017facetedInScopes\030\033 \003(\01626.io.evitadb.exte" +
-      "rnalApi.grpc.generated.GrpcEntityScope\032m" +
+      "ityScope\022\034\n\024catalogSchemaVersion\030\023 \001(\003\032m" +
       "\n\017AttributesEntry\022\013\n\003key\030\001 \001(\t\022I\n\005value\030" +
       "\002 \001(\0132:.io.evitadb.externalApi.grpc.gene" +
-      "rated.GrpcAttributeSchema:\0028\001\032\215\001\n\037Sortab" +
-      "leAttributeCompoundsEntry\022\013\n\003key\030\001 \001(\t\022Y" +
-      "\n\005value\030\002 \001(\0132J.io.evitadb.externalApi.g" +
-      "rpc.generated.GrpcSortableAttributeCompo" +
-      "undSchema:\0028\001\"\250\003\n#GrpcSortableAttributeC" +
-      "ompoundSchema\022\014\n\004name\030\001 \001(\t\0221\n\013descripti" +
-      "on\030\002 \001(\0132\034.google.protobuf.StringValue\0227" +
-      "\n\021deprecationNotice\030\003 \001(\0132\034.google.proto" +
-      "buf.StringValue\022V\n\021attributeElements\030\004 \003" +
-      "(\0132;.io.evitadb.externalApi.grpc.generat" +
-      "ed.GrpcAttributeElement\022K\n\013nameVariant\030\005" +
-      " \003(\01326.io.evitadb.externalApi.grpc.gener" +
-      "ated.GrpcNameVariant\022\021\n\tinherited\030\006 \001(\010\022" +
-      "O\n\017indexedInScopes\030\007 \003(\01626.io.evitadb.ex" +
-      "ternalApi.grpc.generated.GrpcEntityScope" +
-      "\"\311\001\n\024GrpcAttributeElement\022\025\n\rattributeNa" +
-      "me\030\001 \001(\t\022L\n\tdirection\030\002 \001(\01629.io.evitadb" +
-      ".externalApi.grpc.generated.GrpcOrderDir" +
-      "ection\022L\n\tbehaviour\030\003 \001(\01629.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcOrderBehav" +
-      "iourB\014P\001\252\002\007EvitaDBb\006proto3"
+      "rated.GrpcAttributeSchema:\0028\001\032v\n\023Associa" +
+      "tedDataEntry\022\013\n\003key\030\001 \001(\t\022N\n\005value\030\002 \001(\013" +
+      "2?.io.evitadb.externalApi.grpc.generated" +
+      ".GrpcAssociatedDataSchema:\0028\001\032m\n\017Referen" +
+      "cesEntry\022\013\n\003key\030\001 \001(\t\022I\n\005value\030\002 \001(\0132:.i" +
+      "o.evitadb.externalApi.grpc.generated.Grp" +
+      "cReferenceSchema:\0028\001\032\215\001\n\037SortableAttribu" +
+      "teCompoundsEntry\022\013\n\003key\030\001 \001(\t\022Y\n\005value\030\002" +
+      " \001(\0132J.io.evitadb.externalApi.grpc.gener" +
+      "ated.GrpcSortableAttributeCompoundSchema" +
+      ":\0028\001\"\227\t\n\023GrpcAttributeSchema\022\014\n\004name\030\001 \001" +
+      "(\t\022R\n\nschemaType\030\002 \001(\0162>.io.evitadb.exte" +
+      "rnalApi.grpc.generated.GrpcAttributeSche" +
+      "maType\0221\n\013description\030\003 \001(\0132\034.google.pro" +
+      "tobuf.StringValue\0227\n\021deprecationNotice\030\004" +
+      " \001(\0132\034.google.protobuf.StringValue\022V\n\006un" +
+      "ique\030\005 \001(\0162B.io.evitadb.externalApi.grpc" +
+      ".generated.GrpcAttributeUniquenessTypeB\002" +
+      "\030\001\022d\n\016uniqueGlobally\030\006 \001(\0162H.io.evitadb." +
+      "externalApi.grpc.generated.GrpcGlobalAtt" +
+      "ributeUniquenessTypeB\002\030\001\022\026\n\nfilterable\030\007" +
+      " \001(\010B\002\030\001\022\024\n\010sortable\030\010 \001(\010B\002\030\001\022\021\n\tlocali" +
+      "zed\030\t \001(\010\022\020\n\010nullable\030\n \001(\010\022\026\n\016represent" +
+      "ative\030\013 \001(\010\022F\n\004type\030\014 \001(\01628.io.evitadb.e" +
+      "xternalApi.grpc.generated.GrpcEvitaDataT" +
+      "ype\022K\n\014defaultValue\030\r \001(\01325.io.evitadb.e" +
+      "xternalApi.grpc.generated.GrpcEvitaValue" +
+      "\022\034\n\024indexedDecimalPlaces\030\016 \001(\005\022K\n\013nameVa" +
+      "riant\030\017 \003(\01326.io.evitadb.externalApi.grp" +
+      "c.generated.GrpcNameVariant\022\021\n\tinherited" +
+      "\030\020 \001(\010\022`\n\016uniqueInScopes\030\021 \003(\0132H.io.evit" +
+      "adb.externalApi.grpc.generated.GrpcScope" +
+      "dAttributeUniquenessType\022n\n\026uniqueGlobal" +
+      "lyInScopes\030\022 \003(\0132N.io.evitadb.externalAp" +
+      "i.grpc.generated.GrpcScopedGlobalAttribu" +
+      "teUniquenessType\022R\n\022filterableInScopes\030\023" +
+      " \003(\01626.io.evitadb.externalApi.grpc.gener" +
+      "ated.GrpcEntityScope\022P\n\020sortableInScopes" +
+      "\030\024 \003(\01626.io.evitadb.externalApi.grpc.gen" +
+      "erated.GrpcEntityScope\"\356\002\n\030GrpcAssociate" +
+      "dDataSchema\022\014\n\004name\030\001 \001(\t\0221\n\013description" +
+      "\030\002 \001(\0132\034.google.protobuf.StringValue\0227\n\021" +
+      "deprecationNotice\030\003 \001(\0132\034.google.protobu" +
+      "f.StringValue\022f\n\004type\030\004 \001(\0162X.io.evitadb" +
+      ".externalApi.grpc.generated.GrpcEvitaAss" +
+      "ociatedDataDataType.GrpcEvitaDataType\022\021\n" +
+      "\tlocalized\030\005 \001(\010\022\020\n\010nullable\030\006 \001(\010\022K\n\013na" +
+      "meVariant\030\007 \003(\01326.io.evitadb.externalApi" +
+      ".grpc.generated.GrpcNameVariant\"\301\r\n\023Grpc" +
+      "ReferenceSchema\022\014\n\004name\030\001 \001(\t\0221\n\013descrip" +
+      "tion\030\002 \001(\0132\034.google.protobuf.StringValue" +
+      "\0227\n\021deprecationNotice\030\003 \001(\0132\034.google.pro" +
+      "tobuf.StringValue\022K\n\013cardinality\030\004 \001(\01626" +
+      ".io.evitadb.externalApi.grpc.generated.G" +
+      "rpcCardinality\022\022\n\nentityType\030\005 \001(\t\022%\n\031en" +
+      "tityTypeRelatesToEntity\030\006 \001(\010B\002\030\001\022/\n\tgro" +
+      "upType\030\007 \001(\0132\034.google.protobuf.StringVal" +
+      "ue\022$\n\030groupTypeRelatesToEntity\030\010 \001(\010B\002\030\001" +
+      "\022\023\n\007indexed\030\t \001(\010B\002\030\001\022\023\n\007faceted\030\n \001(\010B\002" +
+      "\030\001\022^\n\nattributes\030\013 \003(\0132J.io.evitadb.exte" +
+      "rnalApi.grpc.generated.GrpcReferenceSche" +
+      "ma.AttributesEntry\022~\n\032sortableAttributeC" +
+      "ompounds\030\014 \003(\0132Z.io.evitadb.externalApi." +
+      "grpc.generated.GrpcReferenceSchema.Sorta" +
+      "bleAttributeCompoundsEntry\022K\n\013nameVarian" +
+      "t\030\r \003(\01326.io.evitadb.externalApi.grpc.ge" +
+      "nerated.GrpcNameVariant\022U\n\025entityTypeNam" +
+      "eVariant\030\016 \003(\01326.io.evitadb.externalApi." +
+      "grpc.generated.GrpcNameVariant\022T\n\024groupT" +
+      "ypeNameVariant\030\017 \003(\01326.io.evitadb.extern" +
+      "alApi.grpc.generated.GrpcNameVariant\022#\n\033" +
+      "referencedEntityTypeManaged\030\020 \001(\010\022\"\n\032ref" +
+      "erencedGroupTypeManaged\030\021 \001(\010\022<\n\026reflect" +
+      "edReferenceName\030\022 \001(\0132\034.google.protobuf." +
+      "StringValue\022\034\n\024descriptionInherited\030\023 \001(" +
+      "\010\022\"\n\032deprecationNoticeInherited\030\024 \001(\010\022\034\n" +
+      "\024cardinalityInherited\030\025 \001(\010\022\030\n\020facetedIn" +
+      "herited\030\026 \001(\010\022m\n\034attributeInheritanceBeh" +
+      "avior\030\027 \001(\0162G.io.evitadb.externalApi.grp" +
+      "c.generated.GrpcAttributeInheritanceBeha" +
+      "vior\022\"\n\032attributeInheritanceFilter\030\030 \003(\t" +
+      "\022\030\n\020indexedInherited\030\031 \001(\010\022O\n\017indexedInS" +
+      "copes\030\032 \003(\01626.io.evitadb.externalApi.grp" +
+      "c.generated.GrpcEntityScope\022O\n\017facetedIn" +
+      "Scopes\030\033 \003(\01626.io.evitadb.externalApi.gr" +
+      "pc.generated.GrpcEntityScope\032m\n\017Attribut" +
+      "esEntry\022\013\n\003key\030\001 \001(\t\022I\n\005value\030\002 \001(\0132:.io" +
+      ".evitadb.externalApi.grpc.generated.Grpc" +
+      "AttributeSchema:\0028\001\032\215\001\n\037SortableAttribut" +
+      "eCompoundsEntry\022\013\n\003key\030\001 \001(\t\022Y\n\005value\030\002 " +
+      "\001(\0132J.io.evitadb.externalApi.grpc.genera" +
+      "ted.GrpcSortableAttributeCompoundSchema:" +
+      "\0028\001\"\250\003\n#GrpcSortableAttributeCompoundSch" +
+      "ema\022\014\n\004name\030\001 \001(\t\0221\n\013description\030\002 \001(\0132\034" +
+      ".google.protobuf.StringValue\0227\n\021deprecat" +
+      "ionNotice\030\003 \001(\0132\034.google.protobuf.String" +
+      "Value\022V\n\021attributeElements\030\004 \003(\0132;.io.ev" +
+      "itadb.externalApi.grpc.generated.GrpcAtt" +
+      "ributeElement\022K\n\013nameVariant\030\005 \003(\01326.io." +
+      "evitadb.externalApi.grpc.generated.GrpcN" +
+      "ameVariant\022\021\n\tinherited\030\006 \001(\010\022O\n\017indexed" +
+      "InScopes\030\007 \003(\01626.io.evitadb.externalApi." +
+      "grpc.generated.GrpcEntityScope\"\311\001\n\024GrpcA" +
+      "ttributeElement\022\025\n\rattributeName\030\001 \001(\t\022L" +
+      "\n\tdirection\030\002 \001(\01629.io.evitadb.externalA" +
+      "pi.grpc.generated.GrpcOrderDirection\022L\n\t" +
+      "behaviour\030\003 \001(\01629.io.evitadb.externalApi" +
+      ".grpc.generated.GrpcOrderBehaviourB\014P\001\252\002" +
+      "\007EvitaDBb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -262,7 +263,7 @@ public final class GrpcEntitySchemaOuterClass {
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_descriptor,
-        new java.lang.String[] { "Name", "Version", "Description", "DeprecationNotice", "WithGeneratedPrimaryKey", "WithHierarchy", "WithPrice", "IndexedPricePlaces", "Locales", "Currencies", "Attributes", "AssociatedData", "References", "EvolutionMode", "SortableAttributeCompounds", "NameVariant", "HierarchyIndexedInScopes", "PriceIndexedInScopes", });
+        new java.lang.String[] { "Name", "Version", "Description", "DeprecationNotice", "WithGeneratedPrimaryKey", "WithHierarchy", "WithPrice", "IndexedPricePlaces", "Locales", "Currencies", "Attributes", "AssociatedData", "References", "EvolutionMode", "SortableAttributeCompounds", "NameVariant", "HierarchyIndexedInScopes", "PriceIndexedInScopes", "CatalogSchemaVersion", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_AttributesEntry_descriptor =
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_descriptor.getNestedTypes().get(0);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchema_AttributesEntry_fieldAccessorTable = new

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityScope.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntityScope.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -128,7 +128,7 @@ public enum GrpcEntityScope
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(31);
+    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(32);
   }
 
   private static final GrpcEntityScope[] VALUES = values();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEnums.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEnums.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public final class GrpcEnums {
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEvitaAssociatedDataDataType_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEvitaAssociatedDataDataType_fieldAccessorTable;
 
@@ -157,37 +157,40 @@ public final class GrpcEnums {
       "EXIST\020\002*t\n\022GrpcCommitBehavior\022 \n\034WAIT_FO" +
       "R_CONFLICT_RESOLUTION\020\000\022\034\n\030WAIT_FOR_LOG_" +
       "PERSISTENCE\020\001\022\036\n\032WAIT_FOR_INDEX_PROPAGAT" +
-      "ION\020\002*m\n\024GrpcNamingConvention\022\016\n\nCAMEL_C" +
-      "ASE\020\000\022\017\n\013PASCAL_CASE\020\001\022\016\n\nSNAKE_CASE\020\002\022\024" +
-      "\n\020UPPER_SNAKE_CASE\020\003\022\016\n\nKEBAB_CASE\020\004*}\n\021" +
-      "GrpcHealthProblem\022\023\n\017MEMORY_SHORTAGE\020\000\022\034" +
-      "\n\030EXTERNAL_API_UNAVAILABLE\020\001\022\033\n\027INPUT_QU" +
-      "EUES_OVERLOADED\020\002\022\030\n\024JAVA_INTERNAL_ERROR" +
-      "S\020\003*e\n\rGrpcReadiness\022\020\n\014API_STARTING\020\000\022\r" +
-      "\n\tAPI_READY\020\001\022\020\n\014API_STALLING\020\002\022\020\n\014API_S" +
-      "HUTDOWN\020\003\022\017\n\013API_UNKNOWN\020\004*\203\001\n\027GrpcTaskS" +
-      "implifiedState\022\017\n\013TASK_QUEUED\020\000\022\020\n\014TASK_" +
-      "RUNNING\020\001\022\021\n\rTASK_FINISHED\020\002\022\017\n\013TASK_FAI" +
-      "LED\020\003\022!\n\035TASK_WAITING_FOR_PRECONDITION\020\004" +
-      "*V\n GrpcAttributeInheritanceBehavior\022\026\n\022" +
-      "INHERIT_ALL_EXCEPT\020\000\022\032\n\026INHERIT_ONLY_SPE" +
-      "CIFIED\020\001*a\n\rGrpcTaskTrait\022\027\n\023TASK_CAN_BE" +
-      "_STARTED\020\000\022\031\n\025TASK_CAN_BE_CANCELLED\020\001\022\034\n" +
-      "\030TASK_NEEDS_TO_BE_STOPPED\020\002*\372\001\n\022GrpcClas" +
-      "sifierType\022\037\n\033CLASSIFIER_TYPE_SERVER_NAM" +
-      "E\020\000\022\033\n\027CLASSIFIER_TYPE_CATALOG\020\001\022\032\n\026CLAS" +
-      "SIFIER_TYPE_ENTITY\020\002\022\035\n\031CLASSIFIER_TYPE_" +
-      "ATTRIBUTE\020\003\022#\n\037CLASSIFIER_TYPE_ASSOCIATE" +
-      "D_DATA\020\004\022\035\n\031CLASSIFIER_TYPE_REFERENCE\020\005\022" +
-      "\'\n#CLASSIFIER_TYPE_REFERENCE_ATTRIBUTE\020\006" +
-      "*5\n\017GrpcEntityScope\022\016\n\nSCOPE_LIVE\020\000\022\022\n\016S" +
-      "COPE_ARCHIVED\020\001*X\n\025GrpcFacetRelationType" +
-      "\022\017\n\013DISJUNCTION\020\000\022\017\n\013CONJUNCTION\020\001\022\014\n\010NE" +
-      "GATION\020\002\022\017\n\013EXCLUSIVITY\020\003*\\\n\033GrpcFacetGr" +
-      "oupRelationLevel\022\"\n\036WITH_DIFFERENT_FACET" +
-      "S_IN_GROUP\020\000\022\031\n\025WITH_DIFFERENT_GROUPS\020\001*" +
-      "7\n\021GrpcTraversalMode\022\017\n\013DEPTH_FIRST\020\000\022\021\n" +
-      "\rBREADTH_FIRST\020\001B\014P\001\252\002\007EvitaDBb\006proto3"
+      "ION\020\002*V\n\024GrpcTransactionPhase\022\026\n\022CONFLIC" +
+      "TS_RESOLVED\020\000\022\021\n\rWAL_PERSISTED\020\001\022\023\n\017CHAN" +
+      "GES_VISIBLE\020\002*m\n\024GrpcNamingConvention\022\016\n" +
+      "\nCAMEL_CASE\020\000\022\017\n\013PASCAL_CASE\020\001\022\016\n\nSNAKE_" +
+      "CASE\020\002\022\024\n\020UPPER_SNAKE_CASE\020\003\022\016\n\nKEBAB_CA" +
+      "SE\020\004*}\n\021GrpcHealthProblem\022\023\n\017MEMORY_SHOR" +
+      "TAGE\020\000\022\034\n\030EXTERNAL_API_UNAVAILABLE\020\001\022\033\n\027" +
+      "INPUT_QUEUES_OVERLOADED\020\002\022\030\n\024JAVA_INTERN" +
+      "AL_ERRORS\020\003*e\n\rGrpcReadiness\022\020\n\014API_STAR" +
+      "TING\020\000\022\r\n\tAPI_READY\020\001\022\020\n\014API_STALLING\020\002\022" +
+      "\020\n\014API_SHUTDOWN\020\003\022\017\n\013API_UNKNOWN\020\004*\203\001\n\027G" +
+      "rpcTaskSimplifiedState\022\017\n\013TASK_QUEUED\020\000\022" +
+      "\020\n\014TASK_RUNNING\020\001\022\021\n\rTASK_FINISHED\020\002\022\017\n\013" +
+      "TASK_FAILED\020\003\022!\n\035TASK_WAITING_FOR_PRECON" +
+      "DITION\020\004*V\n GrpcAttributeInheritanceBeha" +
+      "vior\022\026\n\022INHERIT_ALL_EXCEPT\020\000\022\032\n\026INHERIT_" +
+      "ONLY_SPECIFIED\020\001*a\n\rGrpcTaskTrait\022\027\n\023TAS" +
+      "K_CAN_BE_STARTED\020\000\022\031\n\025TASK_CAN_BE_CANCEL" +
+      "LED\020\001\022\034\n\030TASK_NEEDS_TO_BE_STOPPED\020\002*\372\001\n\022" +
+      "GrpcClassifierType\022\037\n\033CLASSIFIER_TYPE_SE" +
+      "RVER_NAME\020\000\022\033\n\027CLASSIFIER_TYPE_CATALOG\020\001" +
+      "\022\032\n\026CLASSIFIER_TYPE_ENTITY\020\002\022\035\n\031CLASSIFI" +
+      "ER_TYPE_ATTRIBUTE\020\003\022#\n\037CLASSIFIER_TYPE_A" +
+      "SSOCIATED_DATA\020\004\022\035\n\031CLASSIFIER_TYPE_REFE" +
+      "RENCE\020\005\022\'\n#CLASSIFIER_TYPE_REFERENCE_ATT" +
+      "RIBUTE\020\006*5\n\017GrpcEntityScope\022\016\n\nSCOPE_LIV" +
+      "E\020\000\022\022\n\016SCOPE_ARCHIVED\020\001*X\n\025GrpcFacetRela" +
+      "tionType\022\017\n\013DISJUNCTION\020\000\022\017\n\013CONJUNCTION" +
+      "\020\001\022\014\n\010NEGATION\020\002\022\017\n\013EXCLUSIVITY\020\003*\\\n\033Grp" +
+      "cFacetGroupRelationLevel\022\"\n\036WITH_DIFFERE" +
+      "NT_FACETS_IN_GROUP\020\000\022\031\n\025WITH_DIFFERENT_G" +
+      "ROUPS\020\001*7\n\021GrpcTraversalMode\022\017\n\013DEPTH_FI" +
+      "RST\020\000\022\021\n\rBREADTH_FIRST\020\001B\014P\001\252\002\007EvitaDBb\006" +
+      "proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionAPI.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEvitaSessionAPI.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -39,312 +39,317 @@ public final class GrpcEvitaSessionAPI {
   }
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcCatalogStateResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcCatalogStateResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcCatalogVersionAtRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcCatalogVersionAtRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcCatalogVersionAtResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcCatalogVersionAtResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GetMutationsHistoryPageRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GetMutationsHistoryPageRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GetMutationsHistoryPageResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GetMutationsHistoryPageResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GetMutationsHistoryRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GetMutationsHistoryRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GetMutationsHistoryResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GetMutationsHistoryResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcGetCatalogSchemaRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcGetCatalogSchemaRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcCatalogSchemaResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcCatalogSchemaResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchemaRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchemaRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchemaResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntitySchemaResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateCatalogSchemaRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateCatalogSchemaRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateCatalogSchemaResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateCatalogSchemaResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateAndFetchCatalogSchemaResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateAndFetchCatalogSchemaResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDefineEntitySchemaRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDefineEntitySchemaRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDefineEntitySchemaResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDefineEntitySchemaResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateEntitySchemaRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateEntitySchemaRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateEntitySchemaResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateEntitySchemaResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateAndFetchEntitySchemaResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpdateAndFetchEntitySchemaResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityRequest_NamedQueryParamsEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityRequest_NamedQueryParamsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcPaginatedList_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcPaginatedList_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcStripList_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcStripList_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDataChunk_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDataChunk_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteCollectionRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteCollectionRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteCollectionResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteCollectionResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcRenameCollectionRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcRenameCollectionRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcRenameCollectionResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcRenameCollectionResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcReplaceCollectionRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcReplaceCollectionRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcReplaceCollectionResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcReplaceCollectionResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityCollectionSizeRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityCollectionSizeRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityCollectionSizeResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityCollectionSizeResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseWithProgressResponse_descriptor;
+  static final
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseWithProgressResponse_fieldAccessorTable;
+  static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcGoLiveAndCloseResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcGoLiveAndCloseResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcBackupCatalogRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcBackupCatalogRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcBackupCatalogResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcBackupCatalogResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityTypesResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityTypesResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryRequest_NamedQueryParamsEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryRequest_NamedQueryParamsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryUnsafeRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryUnsafeRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryOneResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryOneResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryListResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryListResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityRequest_NamedQueryParamsEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityRequest_NamedQueryParamsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityRequest_NamedQueryParamsEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityRequest_NamedQueryParamsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityRequest_NamedQueryParamsEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityRequest_NamedQueryParamsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityRequest_NamedQueryParamsEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityRequest_NamedQueryParamsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesRequest_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesRequest_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesRequest_NamedQueryParamsEntry_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesRequest_NamedQueryParamsEntry_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityAndItsHierarchyResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityAndItsHierarchyResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesResponse_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcTransactionResponse_descriptor;
-  static final 
+  static final
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcTransactionResponse_fieldAccessorTable;
 
@@ -468,255 +473,263 @@ public final class GrpcEvitaSessionAPI {
       "tionSizeResponse\022\014\n\004size\030\001 \001(\005\"f\n\020GrpcCl" +
       "oseRequest\022R\n\017commitBehaviour\030\001 \001(\01629.io" +
       ".evitadb.externalApi.grpc.generated.Grpc" +
-      "CommitBehavior\"+\n\021GrpcCloseResponse\022\026\n\016c" +
-      "atalogVersion\030\001 \001(\003\"E\n\032GrpcGoLiveAndClos" +
-      "eResponse\022\017\n\007success\030\001 \001(\010\022\026\n\016catalogVer" +
-      "sion\030\002 \001(\003\"\264\001\n\030GrpcBackupCatalogRequest\022" +
-      "M\n\npastMoment\030\001 \001(\01329.io.evitadb.externa" +
-      "lApi.grpc.generated.GrpcOffsetDateTime\022\024" +
-      "\n\014includingWAL\030\002 \001(\010\0223\n\016catalogVersion\030\003" +
-      " \001(\0132\033.google.protobuf.Int64Value\"f\n\031Grp" +
-      "cBackupCatalogResponse\022I\n\ntaskStatus\030\001 \001" +
-      "(\01325.io.evitadb.externalApi.grpc.generat" +
-      "ed.GrpcTaskStatus\".\n\027GrpcEntityTypesResp" +
-      "onse\022\023\n\013entityTypes\030\001 \003(\t\"\320\002\n\020GrpcQueryR" +
-      "equest\022\r\n\005query\030\001 \001(\t\022T\n\025positionalQuery" +
-      "Params\030\002 \003(\01325.io.evitadb.externalApi.gr" +
-      "pc.generated.GrpcQueryParam\022g\n\020namedQuer" +
-      "yParams\030\003 \003(\0132M.io.evitadb.externalApi.g" +
-      "rpc.generated.GrpcQueryRequest.NamedQuer" +
-      "yParamsEntry\032n\n\025NamedQueryParamsEntry\022\013\n" +
-      "\003key\030\001 \001(\t\022D\n\005value\030\002 \001(\01325.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcQueryParam" +
-      ":\0028\001\"\'\n\026GrpcQueryUnsafeRequest\022\r\n\005query\030" +
-      "\001 \001(\t\"\254\001\n\021GrpcQueryResponse\022H\n\nrecordPag" +
-      "e\030\001 \001(\01324.io.evitadb.externalApi.grpc.ge" +
-      "nerated.GrpcDataChunk\022M\n\014extraResults\030\002 " +
-      "\001(\01327.io.evitadb.externalApi.grpc.genera" +
-      "ted.GrpcExtraResults\"\211\002\n\024GrpcQueryOneRes" +
-      "ponse\022S\n\017entityReference\030\001 \001(\0132:.io.evit" +
-      "adb.externalApi.grpc.generated.GrpcEntit" +
-      "yReference\022M\n\014sealedEntity\030\002 \001(\01327.io.ev" +
-      "itadb.externalApi.grpc.generated.GrpcSea" +
-      "ledEntity\022M\n\014binaryEntity\030\003 \001(\01327.io.evi" +
-      "tadb.externalApi.grpc.generated.GrpcBina" +
-      "ryEntity\"\217\002\n\025GrpcQueryListResponse\022T\n\020en" +
-      "tityReferences\030\001 \003(\0132:.io.evitadb.extern" +
-      "alApi.grpc.generated.GrpcEntityReference" +
-      "\022O\n\016sealedEntities\030\002 \003(\01327.io.evitadb.ex" +
-      "ternalApi.grpc.generated.GrpcSealedEntit" +
-      "y\022O\n\016binaryEntities\030\003 \003(\01327.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcBinaryEnti" +
-      "ty\"\263\003\n\027GrpcUpsertEntityRequest\022Q\n\016entity" +
-      "Mutation\030\001 \001(\01329.io.evitadb.externalApi." +
-      "grpc.generated.GrpcEntityMutation\022\017\n\007req" +
-      "uire\030\002 \001(\t\022T\n\025positionalQueryParams\030\003 \003(" +
-      "\01325.io.evitadb.externalApi.grpc.generate" +
-      "d.GrpcQueryParam\022n\n\020namedQueryParams\030\004 \003" +
-      "(\0132T.io.evitadb.externalApi.grpc.generat" +
-      "ed.GrpcUpsertEntityRequest.NamedQueryPar" +
-      "amsEntry\032n\n\025NamedQueryParamsEntry\022\013\n\003key" +
-      "\030\001 \001(\t\022D\n\005value\030\002 \001(\01325.io.evitadb.exter" +
-      "nalApi.grpc.generated.GrpcQueryParam:\0028\001" +
-      "\"\245\003\n\027GrpcDeleteEntityRequest\022\022\n\nentityTy" +
-      "pe\030\001 \001(\t\022/\n\nprimaryKey\030\002 \001(\0132\033.google.pr" +
-      "otobuf.Int32Value\022\017\n\007require\030\003 \001(\t\022T\n\025po" +
-      "sitionalQueryParams\030\004 \003(\01325.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcQueryParam" +
-      "\022n\n\020namedQueryParams\030\005 \003(\0132T.io.evitadb." +
-      "externalApi.grpc.generated.GrpcDeleteEnt" +
-      "ityRequest.NamedQueryParamsEntry\032n\n\025Name" +
-      "dQueryParamsEntry\022\013\n\003key\030\001 \001(\t\022D\n\005value\030" +
-      "\002 \001(\01325.io.evitadb.externalApi.grpc.gene" +
-      "rated.GrpcQueryParam:\0028\001\"\247\003\n\030GrpcArchive" +
-      "EntityRequest\022\022\n\nentityType\030\001 \001(\t\022/\n\npri" +
-      "maryKey\030\002 \001(\0132\033.google.protobuf.Int32Val" +
-      "ue\022\017\n\007require\030\003 \001(\t\022T\n\025positionalQueryPa" +
-      "rams\030\004 \003(\01325.io.evitadb.externalApi.grpc" +
-      ".generated.GrpcQueryParam\022o\n\020namedQueryP" +
-      "arams\030\005 \003(\0132U.io.evitadb.externalApi.grp" +
-      "c.generated.GrpcArchiveEntityRequest.Nam" +
-      "edQueryParamsEntry\032n\n\025NamedQueryParamsEn" +
-      "try\022\013\n\003key\030\001 \001(\t\022D\n\005value\030\002 \001(\01325.io.evi" +
-      "tadb.externalApi.grpc.generated.GrpcQuer" +
-      "yParam:\0028\001\"\247\003\n\030GrpcRestoreEntityRequest\022" +
-      "\022\n\nentityType\030\001 \001(\t\022/\n\nprimaryKey\030\002 \001(\0132" +
-      "\033.google.protobuf.Int32Value\022\017\n\007require\030" +
-      "\003 \001(\t\022T\n\025positionalQueryParams\030\004 \003(\01325.i" +
-      "o.evitadb.externalApi.grpc.generated.Grp" +
-      "cQueryParam\022o\n\020namedQueryParams\030\005 \003(\0132U." +
-      "io.evitadb.externalApi.grpc.generated.Gr" +
-      "pcRestoreEntityRequest.NamedQueryParamsE" +
+      "CommitBehavior\"I\n\021GrpcCloseResponse\022\026\n\016c" +
+      "atalogVersion\030\001 \001(\003\022\034\n\024catalogSchemaVers" +
+      "ion\030\002 \001(\005\"\251\001\n\035GrpcCloseWithProgressRespo" +
+      "nse\022\026\n\016catalogVersion\030\001 \001(\003\022\034\n\024catalogSc" +
+      "hemaVersion\030\002 \001(\005\022R\n\rfinishedPhase\030\003 \001(\016" +
+      "2;.io.evitadb.externalApi.grpc.generated" +
+      ".GrpcTransactionPhase\"c\n\032GrpcGoLiveAndCl" +
+      "oseResponse\022\017\n\007success\030\001 \001(\010\022\026\n\016catalogV" +
+      "ersion\030\002 \001(\003\022\034\n\024catalogSchemaVersion\030\003 \001" +
+      "(\005\"\264\001\n\030GrpcBackupCatalogRequest\022M\n\npastM" +
+      "oment\030\001 \001(\01329.io.evitadb.externalApi.grp" +
+      "c.generated.GrpcOffsetDateTime\022\024\n\014includ" +
+      "ingWAL\030\002 \001(\010\0223\n\016catalogVersion\030\003 \001(\0132\033.g" +
+      "oogle.protobuf.Int64Value\"f\n\031GrpcBackupC" +
+      "atalogResponse\022I\n\ntaskStatus\030\001 \001(\01325.io." +
+      "evitadb.externalApi.grpc.generated.GrpcT" +
+      "askStatus\".\n\027GrpcEntityTypesResponse\022\023\n\013" +
+      "entityTypes\030\001 \003(\t\"\320\002\n\020GrpcQueryRequest\022\r" +
+      "\n\005query\030\001 \001(\t\022T\n\025positionalQueryParams\030\002" +
+      " \003(\01325.io.evitadb.externalApi.grpc.gener" +
+      "ated.GrpcQueryParam\022g\n\020namedQueryParams\030" +
+      "\003 \003(\0132M.io.evitadb.externalApi.grpc.gene" +
+      "rated.GrpcQueryRequest.NamedQueryParamsE" +
       "ntry\032n\n\025NamedQueryParamsEntry\022\013\n\003key\030\001 \001" +
       "(\t\022D\n\005value\030\002 \001(\01325.io.evitadb.externalA" +
-      "pi.grpc.generated.GrpcQueryParam:\0028\001\"\342\002\n" +
-      "\031GrpcDeleteEntitiesRequest\022\r\n\005query\030\001 \001(" +
-      "\t\022T\n\025positionalQueryParams\030\002 \003(\01325.io.ev" +
-      "itadb.externalApi.grpc.generated.GrpcQue" +
-      "ryParam\022p\n\020namedQueryParams\030\003 \003(\0132V.io.e" +
-      "vitadb.externalApi.grpc.generated.GrpcDe" +
-      "leteEntitiesRequest.NamedQueryParamsEntr" +
-      "y\032n\n\025NamedQueryParamsEntry\022\013\n\003key\030\001 \001(\t\022" +
-      "D\n\005value\030\002 \001(\01325.io.evitadb.externalApi." +
-      "grpc.generated.GrpcQueryParam:\0028\001\"\310\001\n\030Gr" +
-      "pcUpsertEntityResponse\022U\n\017entityReferenc" +
-      "e\030\001 \001(\0132:.io.evitadb.externalApi.grpc.ge" +
-      "nerated.GrpcEntityReferenceH\000\022I\n\006entity\030" +
-      "\002 \001(\01327.io.evitadb.externalApi.grpc.gene" +
-      "rated.GrpcSealedEntityH\000B\n\n\010response\"\310\001\n" +
-      "\030GrpcDeleteEntityResponse\022U\n\017entityRefer" +
+      "pi.grpc.generated.GrpcQueryParam:\0028\001\"\'\n\026" +
+      "GrpcQueryUnsafeRequest\022\r\n\005query\030\001 \001(\t\"\254\001" +
+      "\n\021GrpcQueryResponse\022H\n\nrecordPage\030\001 \001(\0132" +
+      "4.io.evitadb.externalApi.grpc.generated." +
+      "GrpcDataChunk\022M\n\014extraResults\030\002 \001(\01327.io" +
+      ".evitadb.externalApi.grpc.generated.Grpc" +
+      "ExtraResults\"\211\002\n\024GrpcQueryOneResponse\022S\n" +
+      "\017entityReference\030\001 \001(\0132:.io.evitadb.exte" +
+      "rnalApi.grpc.generated.GrpcEntityReferen" +
+      "ce\022M\n\014sealedEntity\030\002 \001(\01327.io.evitadb.ex" +
+      "ternalApi.grpc.generated.GrpcSealedEntit" +
+      "y\022M\n\014binaryEntity\030\003 \001(\01327.io.evitadb.ext" +
+      "ernalApi.grpc.generated.GrpcBinaryEntity" +
+      "\"\217\002\n\025GrpcQueryListResponse\022T\n\020entityRefe" +
+      "rences\030\001 \003(\0132:.io.evitadb.externalApi.gr" +
+      "pc.generated.GrpcEntityReference\022O\n\016seal" +
+      "edEntities\030\002 \003(\01327.io.evitadb.externalAp" +
+      "i.grpc.generated.GrpcSealedEntity\022O\n\016bin" +
+      "aryEntities\030\003 \003(\01327.io.evitadb.externalA" +
+      "pi.grpc.generated.GrpcBinaryEntity\"\263\003\n\027G" +
+      "rpcUpsertEntityRequest\022Q\n\016entityMutation" +
+      "\030\001 \001(\01329.io.evitadb.externalApi.grpc.gen" +
+      "erated.GrpcEntityMutation\022\017\n\007require\030\002 \001" +
+      "(\t\022T\n\025positionalQueryParams\030\003 \003(\01325.io.e" +
+      "vitadb.externalApi.grpc.generated.GrpcQu" +
+      "eryParam\022n\n\020namedQueryParams\030\004 \003(\0132T.io." +
+      "evitadb.externalApi.grpc.generated.GrpcU" +
+      "psertEntityRequest.NamedQueryParamsEntry" +
+      "\032n\n\025NamedQueryParamsEntry\022\013\n\003key\030\001 \001(\t\022D" +
+      "\n\005value\030\002 \001(\01325.io.evitadb.externalApi.g" +
+      "rpc.generated.GrpcQueryParam:\0028\001\"\245\003\n\027Grp" +
+      "cDeleteEntityRequest\022\022\n\nentityType\030\001 \001(\t" +
+      "\022/\n\nprimaryKey\030\002 \001(\0132\033.google.protobuf.I" +
+      "nt32Value\022\017\n\007require\030\003 \001(\t\022T\n\025positional" +
+      "QueryParams\030\004 \003(\01325.io.evitadb.externalA" +
+      "pi.grpc.generated.GrpcQueryParam\022n\n\020name" +
+      "dQueryParams\030\005 \003(\0132T.io.evitadb.external" +
+      "Api.grpc.generated.GrpcDeleteEntityReque" +
+      "st.NamedQueryParamsEntry\032n\n\025NamedQueryPa" +
+      "ramsEntry\022\013\n\003key\030\001 \001(\t\022D\n\005value\030\002 \001(\01325." +
+      "io.evitadb.externalApi.grpc.generated.Gr" +
+      "pcQueryParam:\0028\001\"\247\003\n\030GrpcArchiveEntityRe" +
+      "quest\022\022\n\nentityType\030\001 \001(\t\022/\n\nprimaryKey\030" +
+      "\002 \001(\0132\033.google.protobuf.Int32Value\022\017\n\007re" +
+      "quire\030\003 \001(\t\022T\n\025positionalQueryParams\030\004 \003" +
+      "(\01325.io.evitadb.externalApi.grpc.generat" +
+      "ed.GrpcQueryParam\022o\n\020namedQueryParams\030\005 " +
+      "\003(\0132U.io.evitadb.externalApi.grpc.genera" +
+      "ted.GrpcArchiveEntityRequest.NamedQueryP" +
+      "aramsEntry\032n\n\025NamedQueryParamsEntry\022\013\n\003k" +
+      "ey\030\001 \001(\t\022D\n\005value\030\002 \001(\01325.io.evitadb.ext" +
+      "ernalApi.grpc.generated.GrpcQueryParam:\002" +
+      "8\001\"\247\003\n\030GrpcRestoreEntityRequest\022\022\n\nentit" +
+      "yType\030\001 \001(\t\022/\n\nprimaryKey\030\002 \001(\0132\033.google" +
+      ".protobuf.Int32Value\022\017\n\007require\030\003 \001(\t\022T\n" +
+      "\025positionalQueryParams\030\004 \003(\01325.io.evitad" +
+      "b.externalApi.grpc.generated.GrpcQueryPa" +
+      "ram\022o\n\020namedQueryParams\030\005 \003(\0132U.io.evita" +
+      "db.externalApi.grpc.generated.GrpcRestor" +
+      "eEntityRequest.NamedQueryParamsEntry\032n\n\025" +
+      "NamedQueryParamsEntry\022\013\n\003key\030\001 \001(\t\022D\n\005va" +
+      "lue\030\002 \001(\01325.io.evitadb.externalApi.grpc." +
+      "generated.GrpcQueryParam:\0028\001\"\342\002\n\031GrpcDel" +
+      "eteEntitiesRequest\022\r\n\005query\030\001 \001(\t\022T\n\025pos" +
+      "itionalQueryParams\030\002 \003(\01325.io.evitadb.ex" +
+      "ternalApi.grpc.generated.GrpcQueryParam\022" +
+      "p\n\020namedQueryParams\030\003 \003(\0132V.io.evitadb.e" +
+      "xternalApi.grpc.generated.GrpcDeleteEnti" +
+      "tiesRequest.NamedQueryParamsEntry\032n\n\025Nam" +
+      "edQueryParamsEntry\022\013\n\003key\030\001 \001(\t\022D\n\005value" +
+      "\030\002 \001(\01325.io.evitadb.externalApi.grpc.gen" +
+      "erated.GrpcQueryParam:\0028\001\"\310\001\n\030GrpcUpsert" +
+      "EntityResponse\022U\n\017entityReference\030\001 \001(\0132" +
+      ":.io.evitadb.externalApi.grpc.generated." +
+      "GrpcEntityReferenceH\000\022I\n\006entity\030\002 \001(\01327." +
+      "io.evitadb.externalApi.grpc.generated.Gr" +
+      "pcSealedEntityH\000B\n\n\010response\"\310\001\n\030GrpcDel" +
+      "eteEntityResponse\022U\n\017entityReference\030\001 \001" +
+      "(\0132:.io.evitadb.externalApi.grpc.generat" +
+      "ed.GrpcEntityReferenceH\000\022I\n\006entity\030\002 \001(\013" +
+      "27.io.evitadb.externalApi.grpc.generated" +
+      ".GrpcSealedEntityH\000B\n\n\010response\"\311\001\n\031Grpc" +
+      "ArchiveEntityResponse\022U\n\017entityReference" +
+      "\030\001 \001(\0132:.io.evitadb.externalApi.grpc.gen" +
+      "erated.GrpcEntityReferenceH\000\022I\n\006entity\030\002" +
+      " \001(\01327.io.evitadb.externalApi.grpc.gener" +
+      "ated.GrpcSealedEntityH\000B\n\n\010response\"\311\001\n\031" +
+      "GrpcRestoreEntityResponse\022U\n\017entityRefer" +
       "ence\030\001 \001(\0132:.io.evitadb.externalApi.grpc" +
       ".generated.GrpcEntityReferenceH\000\022I\n\006enti" +
       "ty\030\002 \001(\01327.io.evitadb.externalApi.grpc.g" +
       "enerated.GrpcSealedEntityH\000B\n\n\010response\"" +
-      "\311\001\n\031GrpcArchiveEntityResponse\022U\n\017entityR" +
-      "eference\030\001 \001(\0132:.io.evitadb.externalApi." +
-      "grpc.generated.GrpcEntityReferenceH\000\022I\n\006" +
-      "entity\030\002 \001(\01327.io.evitadb.externalApi.gr" +
-      "pc.generated.GrpcSealedEntityH\000B\n\n\010respo" +
-      "nse\"\311\001\n\031GrpcRestoreEntityResponse\022U\n\017ent" +
-      "ityReference\030\001 \001(\0132:.io.evitadb.external" +
-      "Api.grpc.generated.GrpcEntityReferenceH\000" +
-      "\022I\n\006entity\030\002 \001(\01327.io.evitadb.externalAp" +
-      "i.grpc.generated.GrpcSealedEntityH\000B\n\n\010r" +
-      "esponse\"\250\002\n\'GrpcDeleteEntityAndItsHierar" +
-      "chyResponse\022\027\n\017deletedEntities\030\001 \001(\005\022`\n\032" +
-      "deletedRootEntityReference\030\002 \001(\0132:.io.ev" +
-      "itadb.externalApi.grpc.generated.GrpcEnt" +
-      "ityReferenceH\000\022T\n\021deletedRootEntity\030\003 \001(" +
-      "\01327.io.evitadb.externalApi.grpc.generate" +
-      "d.GrpcSealedEntityH\000\022 \n\030deletedEntityPri" +
-      "maryKeys\030\004 \003(\005B\n\n\010response\"\213\001\n\032GrpcDelet" +
-      "eEntitiesResponse\022\027\n\017deletedEntities\030\001 \001" +
-      "(\005\022T\n\023deletedEntityBodies\030\002 \003(\01327.io.evi" +
-      "tadb.externalApi.grpc.generated.GrpcSeal" +
-      "edEntity\"y\n\027GrpcTransactionResponse\022\026\n\016c" +
-      "atalogVersion\030\001 \001(\003\022F\n\rtransactionId\030\002 \001" +
-      "(\0132/.io.evitadb.externalApi.grpc.generat" +
-      "ed.GrpcUuid2\237&\n\023EvitaSessionService\022\230\001\n\020" +
-      "GetCatalogSchema\022B.io.evitadb.externalAp" +
-      "i.grpc.generated.GrpcGetCatalogSchemaReq" +
-      "uest\032@.io.evitadb.externalApi.grpc.gener" +
-      "ated.GrpcCatalogSchemaResponse\022j\n\017GetCat" +
-      "alogState\022\026.google.protobuf.Empty\032?.io.e" +
-      "vitadb.externalApi.grpc.generated.GrpcCa" +
-      "talogStateResponse\022\236\001\n\023GetCatalogVersion" +
-      "At\022B.io.evitadb.externalApi.grpc.generat" +
-      "ed.GrpcCatalogVersionAtRequest\032C.io.evit" +
-      "adb.externalApi.grpc.generated.GrpcCatal" +
-      "ogVersionAtResponse\022\250\001\n\027GetMutationsHist" +
-      "oryPage\022E.io.evitadb.externalApi.grpc.ge" +
-      "nerated.GetMutationsHistoryPageRequest\032F" +
-      ".io.evitadb.externalApi.grpc.generated.G" +
-      "etMutationsHistoryPageResponse\022\236\001\n\023GetMu" +
-      "tationsHistory\022A.io.evitadb.externalApi." +
-      "grpc.generated.GetMutationsHistoryReques" +
-      "t\032B.io.evitadb.externalApi.grpc.generate" +
-      "d.GetMutationsHistoryResponse0\001\022\222\001\n\017GetE" +
-      "ntitySchema\022>.io.evitadb.externalApi.grp" +
-      "c.generated.GrpcEntitySchemaRequest\032?.io" +
-      ".evitadb.externalApi.grpc.generated.Grpc" +
-      "EntitySchemaResponse\022k\n\021GetAllEntityType" +
-      "s\022\026.google.protobuf.Empty\032>.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcEntityType" +
-      "sResponse\022k\n\016GoLiveAndClose\022\026.google.pro" +
-      "tobuf.Empty\032A.io.evitadb.externalApi.grp" +
-      "c.generated.GrpcGoLiveAndCloseResponse\022\222" +
-      "\001\n\rBackupCatalog\022?.io.evitadb.externalAp" +
-      "i.grpc.generated.GrpcBackupCatalogReques" +
-      "t\032@.io.evitadb.externalApi.grpc.generate" +
-      "d.GrpcBackupCatalogResponse\022z\n\005Close\0227.i" +
-      "o.evitadb.externalApi.grpc.generated.Grp" +
-      "cCloseRequest\0328.io.evitadb.externalApi.g" +
-      "rpc.generated.GrpcCloseResponse\022\200\001\n\010Quer" +
-      "yOne\0227.io.evitadb.externalApi.grpc.gener" +
-      "ated.GrpcQueryRequest\032;.io.evitadb.exter" +
-      "nalApi.grpc.generated.GrpcQueryOneRespon" +
-      "se\022\202\001\n\tQueryList\0227.io.evitadb.externalAp" +
-      "i.grpc.generated.GrpcQueryRequest\032<.io.e" +
-      "vitadb.externalApi.grpc.generated.GrpcQu" +
-      "eryListResponse\022z\n\005Query\0227.io.evitadb.ex" +
-      "ternalApi.grpc.generated.GrpcQueryReques" +
-      "t\0328.io.evitadb.externalApi.grpc.generate" +
-      "d.GrpcQueryResponse\022\214\001\n\016QueryOneUnsafe\022=" +
-      ".io.evitadb.externalApi.grpc.generated.G" +
-      "rpcQueryUnsafeRequest\032;.io.evitadb.exter" +
-      "nalApi.grpc.generated.GrpcQueryOneRespon" +
-      "se\022\216\001\n\017QueryListUnsafe\022=.io.evitadb.exte" +
-      "rnalApi.grpc.generated.GrpcQueryUnsafeRe" +
-      "quest\032<.io.evitadb.externalApi.grpc.gene" +
-      "rated.GrpcQueryListResponse\022\206\001\n\013QueryUns" +
-      "afe\022=.io.evitadb.externalApi.grpc.genera" +
-      "ted.GrpcQueryUnsafeRequest\0328.io.evitadb." +
-      "externalApi.grpc.generated.GrpcQueryResp" +
-      "onse\022\200\001\n\tGetEntity\0228.io.evitadb.external" +
-      "Api.grpc.generated.GrpcEntityRequest\0329.i" +
-      "o.evitadb.externalApi.grpc.generated.Grp" +
-      "cEntityResponse\022\244\001\n\023UpdateCatalogSchema\022" +
-      "E.io.evitadb.externalApi.grpc.generated." +
-      "GrpcUpdateCatalogSchemaRequest\032F.io.evit" +
-      "adb.externalApi.grpc.generated.GrpcUpdat" +
-      "eCatalogSchemaResponse\022\264\001\n\033UpdateAndFetc" +
-      "hCatalogSchema\022E.io.evitadb.externalApi." +
-      "grpc.generated.GrpcUpdateCatalogSchemaRe" +
-      "quest\032N.io.evitadb.externalApi.grpc.gene" +
-      "rated.GrpcUpdateAndFetchCatalogSchemaRes" +
-      "ponse\022\241\001\n\022DefineEntitySchema\022D.io.evitad" +
-      "b.externalApi.grpc.generated.GrpcDefineE" +
-      "ntitySchemaRequest\032E.io.evitadb.external" +
-      "Api.grpc.generated.GrpcDefineEntitySchem" +
-      "aResponse\022\241\001\n\022UpdateEntitySchema\022D.io.ev" +
-      "itadb.externalApi.grpc.generated.GrpcUpd" +
-      "ateEntitySchemaRequest\032E.io.evitadb.exte" +
-      "rnalApi.grpc.generated.GrpcUpdateEntityS" +
-      "chemaResponse\022\261\001\n\032UpdateAndFetchEntitySc" +
-      "hema\022D.io.evitadb.externalApi.grpc.gener" +
-      "ated.GrpcUpdateEntitySchemaRequest\032M.io." +
+      "\250\002\n\'GrpcDeleteEntityAndItsHierarchyRespo" +
+      "nse\022\027\n\017deletedEntities\030\001 \001(\005\022`\n\032deletedR" +
+      "ootEntityReference\030\002 \001(\0132:.io.evitadb.ex" +
+      "ternalApi.grpc.generated.GrpcEntityRefer" +
+      "enceH\000\022T\n\021deletedRootEntity\030\003 \001(\01327.io.e" +
+      "vitadb.externalApi.grpc.generated.GrpcSe" +
+      "aledEntityH\000\022 \n\030deletedEntityPrimaryKeys" +
+      "\030\004 \003(\005B\n\n\010response\"\213\001\n\032GrpcDeleteEntitie" +
+      "sResponse\022\027\n\017deletedEntities\030\001 \001(\005\022T\n\023de" +
+      "letedEntityBodies\030\002 \003(\01327.io.evitadb.ext" +
+      "ernalApi.grpc.generated.GrpcSealedEntity" +
+      "\"y\n\027GrpcTransactionResponse\022\026\n\016catalogVe" +
+      "rsion\030\001 \001(\003\022F\n\rtransactionId\030\002 \001(\0132/.io." +
       "evitadb.externalApi.grpc.generated.GrpcU" +
-      "pdateAndFetchEntitySchemaResponse\022\233\001\n\020De" +
-      "leteCollection\022B.io.evitadb.externalApi." +
-      "grpc.generated.GrpcDeleteCollectionReque" +
-      "st\032C.io.evitadb.externalApi.grpc.generat" +
-      "ed.GrpcDeleteCollectionResponse\022\233\001\n\020Rena" +
-      "meCollection\022B.io.evitadb.externalApi.gr" +
-      "pc.generated.GrpcRenameCollectionRequest" +
-      "\032C.io.evitadb.externalApi.grpc.generated" +
-      ".GrpcRenameCollectionResponse\022\236\001\n\021Replac" +
-      "eCollection\022C.io.evitadb.externalApi.grp" +
-      "c.generated.GrpcReplaceCollectionRequest" +
-      "\032D.io.evitadb.externalApi.grpc.generated" +
-      ".GrpcReplaceCollectionResponse\022\252\001\n\027GetEn" +
-      "tityCollectionSize\022F.io.evitadb.external" +
-      "Api.grpc.generated.GrpcEntityCollectionS" +
-      "izeRequest\032G.io.evitadb.externalApi.grpc" +
-      ".generated.GrpcEntityCollectionSizeRespo" +
-      "nse\022\217\001\n\014UpsertEntity\022>.io.evitadb.extern" +
-      "alApi.grpc.generated.GrpcUpsertEntityReq" +
-      "uest\032?.io.evitadb.externalApi.grpc.gener" +
-      "ated.GrpcUpsertEntityResponse\022\217\001\n\014Delete" +
-      "Entity\022>.io.evitadb.externalApi.grpc.gen" +
-      "erated.GrpcDeleteEntityRequest\032?.io.evit" +
-      "adb.externalApi.grpc.generated.GrpcDelet" +
-      "eEntityResponse\022\255\001\n\033DeleteEntityAndItsHi" +
-      "erarchy\022>.io.evitadb.externalApi.grpc.ge" +
-      "nerated.GrpcDeleteEntityRequest\032N.io.evi" +
-      "tadb.externalApi.grpc.generated.GrpcDele" +
-      "teEntityAndItsHierarchyResponse\022\225\001\n\016Dele" +
-      "teEntities\022@.io.evitadb.externalApi.grpc" +
-      ".generated.GrpcDeleteEntitiesRequest\032A.i" +
+      "uid2\224\'\n\023EvitaSessionService\022\230\001\n\020GetCatal" +
+      "ogSchema\022B.io.evitadb.externalApi.grpc.g" +
+      "enerated.GrpcGetCatalogSchemaRequest\032@.i" +
       "o.evitadb.externalApi.grpc.generated.Grp" +
-      "cDeleteEntitiesResponse\022\222\001\n\rArchiveEntit" +
-      "y\022?.io.evitadb.externalApi.grpc.generate" +
-      "d.GrpcArchiveEntityRequest\032@.io.evitadb." +
-      "externalApi.grpc.generated.GrpcArchiveEn" +
-      "tityResponse\022\222\001\n\rRestoreEntity\022?.io.evit" +
-      "adb.externalApi.grpc.generated.GrpcResto" +
-      "reEntityRequest\032@.io.evitadb.externalApi" +
-      ".grpc.generated.GrpcRestoreEntityRespons" +
-      "e\022j\n\020GetTransactionId\022\026.google.protobuf." +
-      "Empty\032>.io.evitadb.externalApi.grpc.gene" +
-      "rated.GrpcTransactionResponseB\014P\001\252\002\007Evit" +
-      "aDBb\006proto3"
+      "cCatalogSchemaResponse\022j\n\017GetCatalogStat" +
+      "e\022\026.google.protobuf.Empty\032?.io.evitadb.e" +
+      "xternalApi.grpc.generated.GrpcCatalogSta" +
+      "teResponse\022\236\001\n\023GetCatalogVersionAt\022B.io." +
+      "evitadb.externalApi.grpc.generated.GrpcC" +
+      "atalogVersionAtRequest\032C.io.evitadb.exte" +
+      "rnalApi.grpc.generated.GrpcCatalogVersio" +
+      "nAtResponse\022\250\001\n\027GetMutationsHistoryPage\022" +
+      "E.io.evitadb.externalApi.grpc.generated." +
+      "GetMutationsHistoryPageRequest\032F.io.evit" +
+      "adb.externalApi.grpc.generated.GetMutati" +
+      "onsHistoryPageResponse\022\236\001\n\023GetMutationsH" +
+      "istory\022A.io.evitadb.externalApi.grpc.gen" +
+      "erated.GetMutationsHistoryRequest\032B.io.e" +
+      "vitadb.externalApi.grpc.generated.GetMut" +
+      "ationsHistoryResponse0\001\022\222\001\n\017GetEntitySch" +
+      "ema\022>.io.evitadb.externalApi.grpc.genera" +
+      "ted.GrpcEntitySchemaRequest\032?.io.evitadb" +
+      ".externalApi.grpc.generated.GrpcEntitySc" +
+      "hemaResponse\022k\n\021GetAllEntityTypes\022\026.goog" +
+      "le.protobuf.Empty\032>.io.evitadb.externalA" +
+      "pi.grpc.generated.GrpcEntityTypesRespons" +
+      "e\022k\n\016GoLiveAndClose\022\026.google.protobuf.Em" +
+      "pty\032A.io.evitadb.externalApi.grpc.genera" +
+      "ted.GrpcGoLiveAndCloseResponse\022\222\001\n\rBacku" +
+      "pCatalog\022?.io.evitadb.externalApi.grpc.g" +
+      "enerated.GrpcBackupCatalogRequest\032@.io.e" +
+      "vitadb.externalApi.grpc.generated.GrpcBa" +
+      "ckupCatalogResponse\022z\n\005Close\0227.io.evitad" +
+      "b.externalApi.grpc.generated.GrpcCloseRe" +
+      "quest\0328.io.evitadb.externalApi.grpc.gene" +
+      "rated.GrpcCloseResponse\022s\n\021CloseWithProg" +
+      "ress\022\026.google.protobuf.Empty\032D.io.evitad" +
+      "b.externalApi.grpc.generated.GrpcCloseWi" +
+      "thProgressResponse0\001\022\200\001\n\010QueryOne\0227.io.e" +
+      "vitadb.externalApi.grpc.generated.GrpcQu" +
+      "eryRequest\032;.io.evitadb.externalApi.grpc" +
+      ".generated.GrpcQueryOneResponse\022\202\001\n\tQuer" +
+      "yList\0227.io.evitadb.externalApi.grpc.gene" +
+      "rated.GrpcQueryRequest\032<.io.evitadb.exte" +
+      "rnalApi.grpc.generated.GrpcQueryListResp" +
+      "onse\022z\n\005Query\0227.io.evitadb.externalApi.g" +
+      "rpc.generated.GrpcQueryRequest\0328.io.evit" +
+      "adb.externalApi.grpc.generated.GrpcQuery" +
+      "Response\022\214\001\n\016QueryOneUnsafe\022=.io.evitadb" +
+      ".externalApi.grpc.generated.GrpcQueryUns" +
+      "afeRequest\032;.io.evitadb.externalApi.grpc" +
+      ".generated.GrpcQueryOneResponse\022\216\001\n\017Quer" +
+      "yListUnsafe\022=.io.evitadb.externalApi.grp" +
+      "c.generated.GrpcQueryUnsafeRequest\032<.io." +
+      "evitadb.externalApi.grpc.generated.GrpcQ" +
+      "ueryListResponse\022\206\001\n\013QueryUnsafe\022=.io.ev" +
+      "itadb.externalApi.grpc.generated.GrpcQue" +
+      "ryUnsafeRequest\0328.io.evitadb.externalApi" +
+      ".grpc.generated.GrpcQueryResponse\022\200\001\n\tGe" +
+      "tEntity\0228.io.evitadb.externalApi.grpc.ge" +
+      "nerated.GrpcEntityRequest\0329.io.evitadb.e" +
+      "xternalApi.grpc.generated.GrpcEntityResp" +
+      "onse\022\244\001\n\023UpdateCatalogSchema\022E.io.evitad" +
+      "b.externalApi.grpc.generated.GrpcUpdateC" +
+      "atalogSchemaRequest\032F.io.evitadb.externa" +
+      "lApi.grpc.generated.GrpcUpdateCatalogSch" +
+      "emaResponse\022\264\001\n\033UpdateAndFetchCatalogSch" +
+      "ema\022E.io.evitadb.externalApi.grpc.genera" +
+      "ted.GrpcUpdateCatalogSchemaRequest\032N.io." +
+      "evitadb.externalApi.grpc.generated.GrpcU" +
+      "pdateAndFetchCatalogSchemaResponse\022\241\001\n\022D" +
+      "efineEntitySchema\022D.io.evitadb.externalA" +
+      "pi.grpc.generated.GrpcDefineEntitySchema" +
+      "Request\032E.io.evitadb.externalApi.grpc.ge" +
+      "nerated.GrpcDefineEntitySchemaResponse\022\241" +
+      "\001\n\022UpdateEntitySchema\022D.io.evitadb.exter" +
+      "nalApi.grpc.generated.GrpcUpdateEntitySc" +
+      "hemaRequest\032E.io.evitadb.externalApi.grp" +
+      "c.generated.GrpcUpdateEntitySchemaRespon" +
+      "se\022\261\001\n\032UpdateAndFetchEntitySchema\022D.io.e" +
+      "vitadb.externalApi.grpc.generated.GrpcUp" +
+      "dateEntitySchemaRequest\032M.io.evitadb.ext" +
+      "ernalApi.grpc.generated.GrpcUpdateAndFet" +
+      "chEntitySchemaResponse\022\233\001\n\020DeleteCollect" +
+      "ion\022B.io.evitadb.externalApi.grpc.genera" +
+      "ted.GrpcDeleteCollectionRequest\032C.io.evi" +
+      "tadb.externalApi.grpc.generated.GrpcDele" +
+      "teCollectionResponse\022\233\001\n\020RenameCollectio" +
+      "n\022B.io.evitadb.externalApi.grpc.generate" +
+      "d.GrpcRenameCollectionRequest\032C.io.evita" +
+      "db.externalApi.grpc.generated.GrpcRename" +
+      "CollectionResponse\022\236\001\n\021ReplaceCollection" +
+      "\022C.io.evitadb.externalApi.grpc.generated" +
+      ".GrpcReplaceCollectionRequest\032D.io.evita" +
+      "db.externalApi.grpc.generated.GrpcReplac" +
+      "eCollectionResponse\022\252\001\n\027GetEntityCollect" +
+      "ionSize\022F.io.evitadb.externalApi.grpc.ge" +
+      "nerated.GrpcEntityCollectionSizeRequest\032" +
+      "G.io.evitadb.externalApi.grpc.generated." +
+      "GrpcEntityCollectionSizeResponse\022\217\001\n\014Ups" +
+      "ertEntity\022>.io.evitadb.externalApi.grpc." +
+      "generated.GrpcUpsertEntityRequest\032?.io.e" +
+      "vitadb.externalApi.grpc.generated.GrpcUp" +
+      "sertEntityResponse\022\217\001\n\014DeleteEntity\022>.io" +
+      ".evitadb.externalApi.grpc.generated.Grpc" +
+      "DeleteEntityRequest\032?.io.evitadb.externa" +
+      "lApi.grpc.generated.GrpcDeleteEntityResp" +
+      "onse\022\255\001\n\033DeleteEntityAndItsHierarchy\022>.i" +
+      "o.evitadb.externalApi.grpc.generated.Grp" +
+      "cDeleteEntityRequest\032N.io.evitadb.extern" +
+      "alApi.grpc.generated.GrpcDeleteEntityAnd" +
+      "ItsHierarchyResponse\022\225\001\n\016DeleteEntities\022" +
+      "@.io.evitadb.externalApi.grpc.generated." +
+      "GrpcDeleteEntitiesRequest\032A.io.evitadb.e" +
+      "xternalApi.grpc.generated.GrpcDeleteEnti" +
+      "tiesResponse\022\222\001\n\rArchiveEntity\022?.io.evit" +
+      "adb.externalApi.grpc.generated.GrpcArchi" +
+      "veEntityRequest\032@.io.evitadb.externalApi" +
+      ".grpc.generated.GrpcArchiveEntityRespons" +
+      "e\022\222\001\n\rRestoreEntity\022?.io.evitadb.externa" +
+      "lApi.grpc.generated.GrpcRestoreEntityReq" +
+      "uest\032@.io.evitadb.externalApi.grpc.gener" +
+      "ated.GrpcRestoreEntityResponse\022j\n\020GetTra" +
+      "nsactionId\022\026.google.protobuf.Empty\032>.io." +
+      "evitadb.externalApi.grpc.generated.GrpcT" +
+      "ransactionResponseB\014P\001\252\002\007EvitaDBb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -944,33 +957,39 @@ public final class GrpcEvitaSessionAPI {
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseResponse_descriptor,
-        new java.lang.String[] { "CatalogVersion", });
-    internal_static_io_evitadb_externalApi_grpc_generated_GrpcGoLiveAndCloseResponse_descriptor =
+        new java.lang.String[] { "CatalogVersion", "CatalogSchemaVersion", });
+    internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseWithProgressResponse_descriptor =
       getDescriptor().getMessageTypes().get(34);
+    internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseWithProgressResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_io_evitadb_externalApi_grpc_generated_GrpcCloseWithProgressResponse_descriptor,
+        new java.lang.String[] { "CatalogVersion", "CatalogSchemaVersion", "FinishedPhase", });
+    internal_static_io_evitadb_externalApi_grpc_generated_GrpcGoLiveAndCloseResponse_descriptor =
+      getDescriptor().getMessageTypes().get(35);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcGoLiveAndCloseResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcGoLiveAndCloseResponse_descriptor,
-        new java.lang.String[] { "Success", "CatalogVersion", });
+        new java.lang.String[] { "Success", "CatalogVersion", "CatalogSchemaVersion", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcBackupCatalogRequest_descriptor =
-      getDescriptor().getMessageTypes().get(35);
+      getDescriptor().getMessageTypes().get(36);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcBackupCatalogRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcBackupCatalogRequest_descriptor,
         new java.lang.String[] { "PastMoment", "IncludingWAL", "CatalogVersion", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcBackupCatalogResponse_descriptor =
-      getDescriptor().getMessageTypes().get(36);
+      getDescriptor().getMessageTypes().get(37);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcBackupCatalogResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcBackupCatalogResponse_descriptor,
         new java.lang.String[] { "TaskStatus", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityTypesResponse_descriptor =
-      getDescriptor().getMessageTypes().get(37);
+      getDescriptor().getMessageTypes().get(38);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityTypesResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcEntityTypesResponse_descriptor,
         new java.lang.String[] { "EntityTypes", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryRequest_descriptor =
-      getDescriptor().getMessageTypes().get(38);
+      getDescriptor().getMessageTypes().get(39);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryRequest_descriptor,
@@ -982,31 +1001,31 @@ public final class GrpcEvitaSessionAPI {
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryRequest_NamedQueryParamsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryUnsafeRequest_descriptor =
-      getDescriptor().getMessageTypes().get(39);
+      getDescriptor().getMessageTypes().get(40);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryUnsafeRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryUnsafeRequest_descriptor,
         new java.lang.String[] { "Query", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryResponse_descriptor =
-      getDescriptor().getMessageTypes().get(40);
+      getDescriptor().getMessageTypes().get(41);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryResponse_descriptor,
         new java.lang.String[] { "RecordPage", "ExtraResults", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryOneResponse_descriptor =
-      getDescriptor().getMessageTypes().get(41);
+      getDescriptor().getMessageTypes().get(42);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryOneResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryOneResponse_descriptor,
         new java.lang.String[] { "EntityReference", "SealedEntity", "BinaryEntity", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryListResponse_descriptor =
-      getDescriptor().getMessageTypes().get(42);
+      getDescriptor().getMessageTypes().get(43);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryListResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryListResponse_descriptor,
         new java.lang.String[] { "EntityReferences", "SealedEntities", "BinaryEntities", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityRequest_descriptor =
-      getDescriptor().getMessageTypes().get(43);
+      getDescriptor().getMessageTypes().get(44);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityRequest_descriptor,
@@ -1018,7 +1037,7 @@ public final class GrpcEvitaSessionAPI {
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityRequest_NamedQueryParamsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityRequest_descriptor =
-      getDescriptor().getMessageTypes().get(44);
+      getDescriptor().getMessageTypes().get(45);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityRequest_descriptor,
@@ -1030,7 +1049,7 @@ public final class GrpcEvitaSessionAPI {
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityRequest_NamedQueryParamsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityRequest_descriptor =
-      getDescriptor().getMessageTypes().get(45);
+      getDescriptor().getMessageTypes().get(46);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityRequest_descriptor,
@@ -1042,7 +1061,7 @@ public final class GrpcEvitaSessionAPI {
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityRequest_NamedQueryParamsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityRequest_descriptor =
-      getDescriptor().getMessageTypes().get(46);
+      getDescriptor().getMessageTypes().get(47);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityRequest_descriptor,
@@ -1054,7 +1073,7 @@ public final class GrpcEvitaSessionAPI {
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityRequest_NamedQueryParamsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesRequest_descriptor =
-      getDescriptor().getMessageTypes().get(47);
+      getDescriptor().getMessageTypes().get(48);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesRequest_descriptor,
@@ -1066,43 +1085,43 @@ public final class GrpcEvitaSessionAPI {
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesRequest_NamedQueryParamsEntry_descriptor,
         new java.lang.String[] { "Key", "Value", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityResponse_descriptor =
-      getDescriptor().getMessageTypes().get(48);
+      getDescriptor().getMessageTypes().get(49);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcUpsertEntityResponse_descriptor,
         new java.lang.String[] { "EntityReference", "Entity", "Response", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityResponse_descriptor =
-      getDescriptor().getMessageTypes().get(49);
+      getDescriptor().getMessageTypes().get(50);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityResponse_descriptor,
         new java.lang.String[] { "EntityReference", "Entity", "Response", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityResponse_descriptor =
-      getDescriptor().getMessageTypes().get(50);
+      getDescriptor().getMessageTypes().get(51);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcArchiveEntityResponse_descriptor,
         new java.lang.String[] { "EntityReference", "Entity", "Response", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityResponse_descriptor =
-      getDescriptor().getMessageTypes().get(51);
+      getDescriptor().getMessageTypes().get(52);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcRestoreEntityResponse_descriptor,
         new java.lang.String[] { "EntityReference", "Entity", "Response", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityAndItsHierarchyResponse_descriptor =
-      getDescriptor().getMessageTypes().get(52);
+      getDescriptor().getMessageTypes().get(53);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityAndItsHierarchyResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntityAndItsHierarchyResponse_descriptor,
         new java.lang.String[] { "DeletedEntities", "DeletedRootEntityReference", "DeletedRootEntity", "DeletedEntityPrimaryKeys", "Response", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesResponse_descriptor =
-      getDescriptor().getMessageTypes().get(53);
+      getDescriptor().getMessageTypes().get(54);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcDeleteEntitiesResponse_descriptor,
         new java.lang.String[] { "DeletedEntities", "DeletedEntityBodies", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcTransactionResponse_descriptor =
-      getDescriptor().getMessageTypes().get(54);
+      getDescriptor().getMessageTypes().get(55);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcTransactionResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcTransactionResponse_descriptor,

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetGroupRelationLevel.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetGroupRelationLevel.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -128,7 +128,7 @@ public enum GrpcFacetGroupRelationLevel
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(33);
+    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(34);
   }
 
   private static final GrpcFacetGroupRelationLevel[] VALUES = values();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetRelationType.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcFacetRelationType.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -162,7 +162,7 @@ public enum GrpcFacetRelationType
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(32);
+    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(33);
   }
 
   private static final GrpcFacetRelationType[] VALUES = values();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGoLiveAndCloseResponseOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcGoLiveAndCloseResponseOrBuilder.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -49,4 +49,16 @@ public interface GrpcGoLiveAndCloseResponseOrBuilder extends
    * @return The catalogVersion.
    */
   long getCatalogVersion();
+
+  /**
+   * <pre>
+   * Contains the version of the catalog schema that will be valid at the moment of closing the session.
+   * If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
+   * version (i.e. the one that is returned in the response) becomes visible.
+   * </pre>
+   *
+   * <code>int32 catalogSchemaVersion = 3;</code>
+   * @return The catalogSchemaVersion.
+   */
+  int getCatalogSchemaVersion();
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcHealthProblem.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcHealthProblem.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -184,7 +184,7 @@ public enum GrpcHealthProblem
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(25);
+    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(26);
   }
 
   private static final GrpcHealthProblem[] VALUES = values();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcNamingConvention.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcNamingConvention.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -179,7 +179,7 @@ public enum GrpcNamingConvention
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(24);
+    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(25);
   }
 
   private static final GrpcNamingConvention[] VALUES = values();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskSimplifiedState.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskSimplifiedState.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -189,7 +189,7 @@ public enum GrpcTaskSimplifiedState
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(27);
+    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(28);
   }
 
   private static final GrpcTaskSimplifiedState[] VALUES = values();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskTrait.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTaskTrait.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ public enum GrpcTaskTrait
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(29);
+    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(30);
   }
 
   private static final GrpcTaskTrait[] VALUES = values();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTransactionPhase.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTransactionPhase.java
@@ -28,106 +28,66 @@ package io.evitadb.externalApi.grpc.generated;
 
 /**
  * <pre>
- * Enum representing overall readiness state of the server API.
+ * Contains set of all possible transaction phases each transaction goes through.
  * </pre>
  *
- * Protobuf enum {@code io.evitadb.externalApi.grpc.generated.GrpcReadiness}
+ * Protobuf enum {@code io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase}
  */
-public enum GrpcReadiness
+public enum GrpcTransactionPhase
     implements com.google.protobuf.ProtocolMessageEnum {
   /**
    * <pre>
-   **
-   * At least one API is not ready.
+   * All changes passed conflict resolution steps and are not in conflict with other transactions.
    * </pre>
    *
-   * <code>API_STARTING = 0;</code>
+   * <code>CONFLICTS_RESOLVED = 0;</code>
    */
-  API_STARTING(0),
+  CONFLICTS_RESOLVED(0),
   /**
    * <pre>
-   **
-   * All APIs are ready.
+   * Changes are written to Write Ahead Log (WAL) and are safely persisted on disk. Client might rely on the fact
+   * that the changes will eventually be visible in the database.
    * </pre>
    *
-   * <code>API_READY = 1;</code>
+   * <code>WAL_PERSISTED = 1;</code>
    */
-  API_READY(1),
+  WAL_PERSISTED(1),
   /**
    * <pre>
-   **
-   * At least one API that was ready is not ready anymore.
+   * Changes are visible in shared state of the database and are available to all newly created sessions.
    * </pre>
    *
-   * <code>API_STALLING = 2;</code>
+   * <code>CHANGES_VISIBLE = 2;</code>
    */
-  API_STALLING(2),
-  /**
-   * <pre>
-   **
-   * Server is shutting down. None of the APIs are ready.
-   * </pre>
-   *
-   * <code>API_SHUTDOWN = 3;</code>
-   */
-  API_SHUTDOWN(3),
-  /**
-   * <pre>
-   **
-   * Unknown state - cannot determine the state of the APIs (should not happen).
-   * </pre>
-   *
-   * <code>API_UNKNOWN = 4;</code>
-   */
-  API_UNKNOWN(4),
+  CHANGES_VISIBLE(2),
   UNRECOGNIZED(-1),
   ;
 
   /**
    * <pre>
-   **
-   * At least one API is not ready.
+   * All changes passed conflict resolution steps and are not in conflict with other transactions.
    * </pre>
    *
-   * <code>API_STARTING = 0;</code>
+   * <code>CONFLICTS_RESOLVED = 0;</code>
    */
-  public static final int API_STARTING_VALUE = 0;
+  public static final int CONFLICTS_RESOLVED_VALUE = 0;
   /**
    * <pre>
-   **
-   * All APIs are ready.
+   * Changes are written to Write Ahead Log (WAL) and are safely persisted on disk. Client might rely on the fact
+   * that the changes will eventually be visible in the database.
    * </pre>
    *
-   * <code>API_READY = 1;</code>
+   * <code>WAL_PERSISTED = 1;</code>
    */
-  public static final int API_READY_VALUE = 1;
+  public static final int WAL_PERSISTED_VALUE = 1;
   /**
    * <pre>
-   **
-   * At least one API that was ready is not ready anymore.
+   * Changes are visible in shared state of the database and are available to all newly created sessions.
    * </pre>
    *
-   * <code>API_STALLING = 2;</code>
+   * <code>CHANGES_VISIBLE = 2;</code>
    */
-  public static final int API_STALLING_VALUE = 2;
-  /**
-   * <pre>
-   **
-   * Server is shutting down. None of the APIs are ready.
-   * </pre>
-   *
-   * <code>API_SHUTDOWN = 3;</code>
-   */
-  public static final int API_SHUTDOWN_VALUE = 3;
-  /**
-   * <pre>
-   **
-   * Unknown state - cannot determine the state of the APIs (should not happen).
-   * </pre>
-   *
-   * <code>API_UNKNOWN = 4;</code>
-   */
-  public static final int API_UNKNOWN_VALUE = 4;
+  public static final int CHANGES_VISIBLE_VALUE = 2;
 
 
   public final int getNumber() {
@@ -144,7 +104,7 @@ public enum GrpcReadiness
    * @deprecated Use {@link #forNumber(int)} instead.
    */
   @java.lang.Deprecated
-  public static GrpcReadiness valueOf(int value) {
+  public static GrpcTransactionPhase valueOf(int value) {
     return forNumber(value);
   }
 
@@ -152,26 +112,24 @@ public enum GrpcReadiness
    * @param value The numeric wire value of the corresponding enum entry.
    * @return The enum associated with the given numeric wire value.
    */
-  public static GrpcReadiness forNumber(int value) {
+  public static GrpcTransactionPhase forNumber(int value) {
     switch (value) {
-      case 0: return API_STARTING;
-      case 1: return API_READY;
-      case 2: return API_STALLING;
-      case 3: return API_SHUTDOWN;
-      case 4: return API_UNKNOWN;
+      case 0: return CONFLICTS_RESOLVED;
+      case 1: return WAL_PERSISTED;
+      case 2: return CHANGES_VISIBLE;
       default: return null;
     }
   }
 
-  public static com.google.protobuf.Internal.EnumLiteMap<GrpcReadiness>
+  public static com.google.protobuf.Internal.EnumLiteMap<GrpcTransactionPhase>
       internalGetValueMap() {
     return internalValueMap;
   }
   private static final com.google.protobuf.Internal.EnumLiteMap<
-      GrpcReadiness> internalValueMap =
-        new com.google.protobuf.Internal.EnumLiteMap<GrpcReadiness>() {
-          public GrpcReadiness findValueByNumber(int number) {
-            return GrpcReadiness.forNumber(number);
+      GrpcTransactionPhase> internalValueMap =
+        new com.google.protobuf.Internal.EnumLiteMap<GrpcTransactionPhase>() {
+          public GrpcTransactionPhase findValueByNumber(int number) {
+            return GrpcTransactionPhase.forNumber(number);
           }
         };
 
@@ -189,12 +147,12 @@ public enum GrpcReadiness
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(27);
+    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(24);
   }
 
-  private static final GrpcReadiness[] VALUES = values();
+  private static final GrpcTransactionPhase[] VALUES = values();
 
-  public static GrpcReadiness valueOf(
+  public static GrpcTransactionPhase valueOf(
       com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
     if (desc.getType() != getDescriptor()) {
       throw new java.lang.IllegalArgumentException(
@@ -208,10 +166,10 @@ public enum GrpcReadiness
 
   private final int value;
 
-  private GrpcReadiness(int value) {
+  private GrpcTransactionPhase(int value) {
     this.value = value;
   }
 
-  // @@protoc_insertion_point(enum_scope:io.evitadb.externalApi.grpc.generated.GrpcReadiness)
+  // @@protoc_insertion_point(enum_scope:io.evitadb.externalApi.grpc.generated.GrpcTransactionPhase)
 }
 

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTraversalMode.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcTraversalMode.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ public enum GrpcTraversalMode
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(34);
+    return io.evitadb.externalApi.grpc.generated.GrpcEnums.getDescriptor().getEnumTypes().get(35);
   }
 
   private static final GrpcTraversalMode[] VALUES = values();

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/EvitaEnumConverter.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/EvitaEnumConverter.java
@@ -1318,4 +1318,18 @@ public class EvitaEnumConverter {
 		};
 	}
 
+	/**
+	 * Converts a given CommitBehavior to its corresponding GrpcTransactionPhase.
+	 *
+	 * @param commitBehavior the commit behavior to be converted, must not be null
+	 * @return the corresponding GrpcTransactionPhase based on the provided commit behavior
+	 */
+	@Nonnull
+	public static GrpcTransactionPhase toGrpcCommitPhase(@Nonnull CommitBehavior commitBehavior) {
+		return switch (commitBehavior) {
+			case WAIT_FOR_CONFLICT_RESOLUTION -> GrpcTransactionPhase.CONFLICTS_RESOLVED;
+			case WAIT_FOR_WAL_PERSISTENCE -> GrpcTransactionPhase.WAL_PERSISTED;
+			case WAIT_FOR_INDEX_PROPAGATION -> GrpcTransactionPhase.CHANGES_VISIBLE;
+		};
+	}
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/schema/EntitySchemaConverter.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/schema/EntitySchemaConverter.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -74,9 +74,14 @@ public class EntitySchemaConverter {
 	 * @param includeNameVariants whether to include name variants
 	 */
 	@Nonnull
-	public static GrpcEntitySchema convert(@Nonnull EntitySchemaContract entitySchema, boolean includeNameVariants) {
+	public static GrpcEntitySchema convert(
+		@Nonnull CatalogSchemaContract catalogSchema,
+		@Nonnull EntitySchemaContract entitySchema,
+		boolean includeNameVariants
+	) {
 		final GrpcEntitySchema.Builder builder = GrpcEntitySchema.newBuilder()
 			.setName(entitySchema.getName())
+			.setCatalogSchemaVersion(catalogSchema.version())
 			.setWithGeneratedPrimaryKey(entitySchema.isWithGeneratedPrimaryKey())
 			.setWithHierarchy(entitySchema.isWithHierarchy())
 			.addAllHierarchyIndexedInScopes(

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEntitySchema.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEntitySchema.proto
@@ -136,6 +136,8 @@ message GrpcEntitySchema {
 	//
 	// Prices can be also set as non-indexed individually by setting {@link PriceContract#indexed()} to false.
   repeated GrpcEntityScope priceIndexedInScopes = 18;
+  // Contains current version of the catalog schema this entity schema belongs to.
+  int64 catalogSchemaVersion = 19;
 }
 
 // This is the definition object for attributes that are stored along with

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEnums.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEnums.proto
@@ -525,6 +525,17 @@ enum GrpcCommitBehavior {
 
 }
 
+// Contains set of all possible transaction phases each transaction goes through.
+enum GrpcTransactionPhase {
+  // All changes passed conflict resolution steps and are not in conflict with other transactions.
+  CONFLICTS_RESOLVED = 0;
+  // Changes are written to Write Ahead Log (WAL) and are safely persisted on disk. Client might rely on the fact
+  // that the changes will eventually be visible in the database.
+  WAL_PERSISTED = 1;
+  // Changes are visible in shared state of the database and are available to all newly created sessions.
+  CHANGES_VISIBLE = 2;
+}
+
 // Contains set of all supported/used naming conventions in evitaDB APIs.
 enum GrpcNamingConvention {
 

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaSessionAPI.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEvitaSessionAPI.proto
@@ -287,6 +287,21 @@ message GrpcCloseRequest {
 message GrpcCloseResponse {
   // Contains next catalog version
   int64 catalogVersion = 1;
+  // Contains the version of the catalog schema that will be valid at the moment of closing the session.
+  // If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
+  // version (i.e. the one that is returned in the response) becomes visible.
+  int32 catalogSchemaVersion = 2;
+}
+
+message GrpcCloseWithProgressResponse {
+  // Contains next catalog version
+  int64 catalogVersion = 1;
+  // Contains the version of the catalog schema that will be valid at the moment of closing the session.
+  // If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
+  // version (i.e. the one that is returned in the response) becomes visible.
+  int32 catalogSchemaVersion = 2;
+  // The successfully finished phase of the transaction.
+  GrpcTransactionPhase finishedPhase = 3;
 }
 
 // Response for GoLiveAndClose request that switches the catalog to ALIVE state and closes the session.
@@ -295,6 +310,10 @@ message GrpcGoLiveAndCloseResponse {
   bool success = 1;
   // Contains next catalog version
   int64 catalogVersion = 2;
+  // Contains the version of the catalog schema that will be valid at the moment of closing the session.
+  // If session relates to a writable transaction, this schema version becomes valid at the moment the next catalog
+  // version (i.e. the one that is returned in the response) becomes visible.
+  int32 catalogSchemaVersion = 3;
 }
 
 // Response to a catalog backup request.
@@ -528,6 +547,8 @@ service EvitaSessionService {
   rpc BackupCatalog(GrpcBackupCatalogRequest) returns (GrpcBackupCatalogResponse);
   // Procedure that closes the session.
   rpc Close(GrpcCloseRequest) returns (GrpcCloseResponse);
+  // Procedure that closes the session opening a stream that listens to transaction processing phases.
+  rpc CloseWithProgress(google.protobuf.Empty) returns (stream GrpcCloseWithProgressResponse);
 
   // Procedure that executes passed parametrised query and returns zero or one entity.
   rpc QueryOne(GrpcQueryRequest) returns (GrpcQueryOneResponse);

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTest.java
@@ -24,6 +24,8 @@
 package io.evitadb.api;
 
 import io.evitadb.api.CatalogStatistics.EntityCollectionStatistics;
+import io.evitadb.api.CommitProgress.CommitVersions;
+import io.evitadb.api.SessionTraits.SessionFlags;
 import io.evitadb.api.configuration.EvitaConfiguration;
 import io.evitadb.api.configuration.ServerOptions;
 import io.evitadb.api.configuration.StorageOptions;
@@ -108,6 +110,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -148,16 +151,16 @@ class EvitaTest implements EvitaTestSupport {
 	void setUp() {
 		cleanTestSubDirectoryWithRethrow(DIR_EVITA_TEST);
 		cleanTestSubDirectoryWithRethrow(DIR_EVITA_TEST_EXPORT);
-		evita = new Evita(
+		this.evita = new Evita(
 			getEvitaConfiguration()
 		);
-		evita.defineCatalog(TEST_CATALOG);
-		evitaInstanceId = evita.management().getSystemStatus().instanceId();
+		this.evita.defineCatalog(TEST_CATALOG);
+		this.evitaInstanceId = this.evita.management().getSystemStatus().instanceId();
 	}
 
 	@AfterEach
 	void tearDown() {
-		evita.close();
+		this.evita.close();
 		cleanTestSubDirectoryWithRethrow(DIR_EVITA_TEST);
 		cleanTestSubDirectoryWithRethrow(DIR_EVITA_TEST_EXPORT);
 	}
@@ -167,8 +170,8 @@ class EvitaTest implements EvitaTestSupport {
 		assertThrows(
 			ConcurrentInitializationException.class,
 			() -> {
-				try (final EvitaSessionContract theSession = evita.createReadOnlySession(TEST_CATALOG)) {
-					evita.updateCatalog(
+				try (final EvitaSessionContract theSession = this.evita.createReadOnlySession(TEST_CATALOG)) {
+					this.evita.updateCatalog(
 						TEST_CATALOG,
 						session -> {
 							session.defineEntitySchema(Entities.CATEGORY);
@@ -181,22 +184,22 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldAutomaticallyCreateTransactionIfNoneExists() {
-		try (final EvitaSessionContract writeSession = evita.createReadWriteSession(TEST_CATALOG)) {
+		try (final EvitaSessionContract writeSession = this.evita.createReadWriteSession(TEST_CATALOG)) {
 			writeSession.goLiveAndClose();
 		}
 
-		try (final EvitaSessionContract writeSession = evita.createReadWriteSession(TEST_CATALOG)) {
+		try (final EvitaSessionContract writeSession = this.evita.createReadWriteSession(TEST_CATALOG)) {
 			writeSession.defineEntitySchema(Entities.CATEGORY).updateVia(writeSession);
 		}
 
-		try (final EvitaSessionContract readSession = evita.createReadOnlySession(TEST_CATALOG)) {
+		try (final EvitaSessionContract readSession = this.evita.createReadOnlySession(TEST_CATALOG)) {
 			assertNotNull(readSession.getEntitySchema(Entities.CATEGORY));
 		}
 	}
 
 	@Test
 	void shouldFailGracefullyWhenTryingToFilterByNonIndexedReference() {
-		try (final EvitaSessionContract session = evita.createReadWriteSession(TEST_CATALOG)) {
+		try (final EvitaSessionContract session = this.evita.createReadWriteSession(TEST_CATALOG)) {
 			session.defineEntitySchema(Entities.PRODUCT)
 				.withoutGeneratedPrimaryKey()
 				.withReferenceTo(Entities.BRAND, Entities.BRAND, Cardinality.ZERO_OR_ONE)
@@ -229,7 +232,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldFailGracefullyWhenTryingToSummarizeByNonFacetedReference() {
-		try (final EvitaSessionContract session = evita.createReadWriteSession(TEST_CATALOG)) {
+		try (final EvitaSessionContract session = this.evita.createReadWriteSession(TEST_CATALOG)) {
 			session.defineEntitySchema(Entities.PRODUCT)
 				.withoutGeneratedPrimaryKey()
 				.withReferenceTo(Entities.BRAND, Entities.BRAND, Cardinality.ZERO_OR_ONE)
@@ -265,7 +268,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldFailGracefullyWhenTryingToAddIndexingRequiredReferenceAttributeOnNonIndexedReference() {
-		try (final EvitaSessionContract session = evita.createReadWriteSession(TEST_CATALOG)) {
+		try (final EvitaSessionContract session = this.evita.createReadWriteSession(TEST_CATALOG)) {
 			assertThrows(
 				InvalidSchemaMutationException.class,
 				() -> {
@@ -309,7 +312,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldFailGracefullyWhenTryingToFilterByNonFilterableAttribute() {
-		try (final EvitaSessionContract session = evita.createReadWriteSession(TEST_CATALOG)) {
+		try (final EvitaSessionContract session = this.evita.createReadWriteSession(TEST_CATALOG)) {
 			session.defineEntitySchema(Entities.PRODUCT)
 				.withoutGeneratedPrimaryKey()
 				.withAttribute(ATTRIBUTE_NAME, String.class)
@@ -342,7 +345,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldFailGracefullyWhenTryingToFilterByNonFilterableReferenceAttribute() {
-		try (final EvitaSessionContract session = evita.createReadWriteSession(TEST_CATALOG)) {
+		try (final EvitaSessionContract session = this.evita.createReadWriteSession(TEST_CATALOG)) {
 			session.defineEntitySchema(Entities.PRODUCT)
 				.withoutGeneratedPrimaryKey()
 				.withReferenceTo(
@@ -381,7 +384,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldFailGracefullyWhenTryingToOrderByNonSortableAttribute() {
-		try (final EvitaSessionContract session = evita.createReadWriteSession(TEST_CATALOG)) {
+		try (final EvitaSessionContract session = this.evita.createReadWriteSession(TEST_CATALOG)) {
 			session.defineEntitySchema(Entities.PRODUCT)
 				.withoutGeneratedPrimaryKey()
 				.withAttribute(ATTRIBUTE_NAME, String.class)
@@ -414,7 +417,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldFailGracefullyWhenTryingToOrderByNonSortableReferenceAttribute() {
-		try (final EvitaSessionContract session = evita.createReadWriteSession(TEST_CATALOG)) {
+		try (final EvitaSessionContract session = this.evita.createReadWriteSession(TEST_CATALOG)) {
 			session.defineEntitySchema(Entities.PRODUCT)
 				.withoutGeneratedPrimaryKey()
 				.withReferenceTo(
@@ -453,7 +456,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldHandleQueryingEmptyCollection() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -475,7 +478,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldReturnZeroOrExactlyOne() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -508,7 +511,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldReturnMultipleResults() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -557,32 +560,32 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldCreateAndLoadCatalog() {
-		evita.close();
-		evita = new Evita(
+		this.evita.close();
+		this.evita = new Evita(
 			getEvitaConfiguration()
 		);
 
-		assertTrue(evita.getCatalogNames().contains(TEST_CATALOG));
+		assertTrue(this.evita.getCatalogNames().contains(TEST_CATALOG));
 	}
 
 	@Test
 	void shouldKillInactiveSessionsAutomatically() throws NoSuchFieldException, IllegalAccessException {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			it -> {
 				it.goLiveAndClose();
 			}
 		);
-		evita.close();
+		this.evita.close();
 
-		evita = new Evita(
+		this.evita = new Evita(
 			getEvitaConfiguration(1)
 		);
 
-		final EvitaSessionContract sessionInactive = evita.createReadOnlySession(TEST_CATALOG);
-		final EvitaSessionContract sessionActive = evita.createReadOnlySession(TEST_CATALOG);
+		final EvitaSessionContract sessionInactive = this.evita.createReadOnlySession(TEST_CATALOG);
+		final EvitaSessionContract sessionActive = this.evita.createReadOnlySession(TEST_CATALOG);
 
-		assertEquals(2L, evita.getActiveSessions().count());
+		assertEquals(2L, this.evita.getActiveSessions().count());
 
 		final long start = System.currentTimeMillis();
 		do {
@@ -601,7 +604,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldCreateAndDropCatalog() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -613,15 +616,15 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.deleteCatalogIfExists(TEST_CATALOG);
+		this.evita.deleteCatalogIfExists(TEST_CATALOG);
 
-		assertFalse(evita.getCatalogNames().contains(TEST_CATALOG));
+		assertFalse(this.evita.getCatalogNames().contains(TEST_CATALOG));
 	}
 
 	@Test
 	void shouldFailToCreateCatalogWithDuplicateNameInOneOfNamingConventions() {
 		try {
-			evita.defineCatalog("test-catalog");
+			this.evita.defineCatalog("test-catalog");
 			fail("Duplicated catalog name should be refused!");
 		} catch (CatalogAlreadyPresentException ex) {
 			assertEquals(
@@ -634,7 +637,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldCreateAndDeleteEntityCollectionFromWithinTheSession() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -654,7 +657,7 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.queryCatalog(
+		this.evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
 				assertThrows(CollectionNotFoundException.class, () -> session.getEntityCollectionSize(Entities.BRAND));
@@ -688,11 +691,11 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldCreateAndDropCollection() {
 		setupCatalogWithProductAndCategory();
 
-		evita.updateCatalog(TEST_CATALOG, session -> {
+		this.evita.updateCatalog(TEST_CATALOG, session -> {
 			session.deleteCollection(Entities.PRODUCT);
 		});
 
-		evita.queryCatalog(TEST_CATALOG, session -> {
+		this.evita.queryCatalog(TEST_CATALOG, session -> {
 			assertThrows(CollectionNotFoundException.class, () -> session.getEntityCollectionSize(Entities.PRODUCT));
 			assertEquals(2, session.getEntityCollectionSize(Entities.CATEGORY));
 			return null;
@@ -708,17 +711,17 @@ class EvitaTest implements EvitaTestSupport {
 			.toFile();
 		assertTrue(theCollectionFile.exists());
 
-		MockCatalogStructuralChangeObserver.reset(evitaInstanceId);
+		MockCatalogStructuralChangeObserver.reset(this.evitaInstanceId);
 
-		evita.updateCatalog(TEST_CATALOG, session -> {
+		this.evita.updateCatalog(TEST_CATALOG, session -> {
 			session.renameCollection(Entities.PRODUCT, Entities.STORE);
 			assertEquals(Entities.STORE, session.getEntitySchemaOrThrow(Entities.STORE).getName());
 		});
 
-		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionCreated(evitaInstanceId, TEST_CATALOG, Entities.STORE));
-		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionDeleted(evitaInstanceId, TEST_CATALOG, Entities.PRODUCT));
+		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionCreated(this.evitaInstanceId, TEST_CATALOG, Entities.STORE));
+		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionDeleted(this.evitaInstanceId, TEST_CATALOG, Entities.PRODUCT));
 
-		evita.queryCatalog(TEST_CATALOG, session -> {
+		this.evita.queryCatalog(TEST_CATALOG, session -> {
 			assertThrows(CollectionNotFoundException.class, () -> session.getEntityCollectionSize(Entities.PRODUCT));
 			assertEquals(1, session.getEntityCollectionSize(Entities.STORE));
 			assertEquals(2, session.getEntityCollectionSize(Entities.CATEGORY));
@@ -738,11 +741,11 @@ class EvitaTest implements EvitaTestSupport {
 			.toFile();
 		assertTrue(theCollectionFile.exists());
 
-		evita.updateCatalog(TEST_CATALOG, session -> {
+		this.evita.updateCatalog(TEST_CATALOG, session -> {
 			session.renameCollection(Entities.PRODUCT, Entities.BRAND);
 		});
 
-		evita.queryCatalog(TEST_CATALOG, session -> {
+		this.evita.queryCatalog(TEST_CATALOG, session -> {
 			assertThrows(CollectionNotFoundException.class, () -> session.getEntityCollectionSize(Entities.PRODUCT));
 			assertEquals(2, session.getEntityCollectionSize(Entities.CATEGORY));
 			assertEquals(1, session.getEntityCollectionSize(Entities.BRAND));
@@ -762,7 +765,7 @@ class EvitaTest implements EvitaTestSupport {
 			.toFile();
 		assertTrue(theCollectionFile.exists());
 
-		evita.updateCatalog(TEST_CATALOG, session -> {
+		this.evita.updateCatalog(TEST_CATALOG, session -> {
 			assertThrows(
 				EntityTypeAlreadyPresentInCatalogSchemaException.class,
 				() -> session.renameCollection(Entities.PRODUCT, Entities.CATEGORY)
@@ -779,16 +782,16 @@ class EvitaTest implements EvitaTestSupport {
 			.toFile();
 		assertTrue(theCollectionFile.exists());
 
-		MockCatalogStructuralChangeObserver.reset(evitaInstanceId);
+		MockCatalogStructuralChangeObserver.reset(this.evitaInstanceId);
 
-		evita.updateCatalog(TEST_CATALOG, session -> {
+		this.evita.updateCatalog(TEST_CATALOG, session -> {
 			session.replaceCollection(Entities.CATEGORY, Entities.PRODUCT);
 		});
 
-		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionSchemaUpdated(evitaInstanceId, TEST_CATALOG, Entities.CATEGORY));
-		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionDeleted(evitaInstanceId, TEST_CATALOG, Entities.PRODUCT));
+		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionSchemaUpdated(this.evitaInstanceId, TEST_CATALOG, Entities.CATEGORY));
+		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionDeleted(this.evitaInstanceId, TEST_CATALOG, Entities.PRODUCT));
 
-		evita.queryCatalog(TEST_CATALOG, session -> {
+		this.evita.queryCatalog(TEST_CATALOG, session -> {
 			assertThrows(CollectionNotFoundException.class, () -> session.getEntityCollectionSize(Entities.PRODUCT));
 			assertEquals(1, session.getEntityCollectionSize(Entities.CATEGORY));
 			return null;
@@ -802,7 +805,7 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldCreateAndRenameCollectionInTransaction() {
 		setupCatalogWithProductAndCategory();
 
-		evita.updateCatalog(TEST_CATALOG, session -> {
+		this.evita.updateCatalog(TEST_CATALOG, session -> {
 			session.goLiveAndClose();
 		});
 
@@ -811,20 +814,20 @@ class EvitaTest implements EvitaTestSupport {
 			.toFile();
 		assertTrue(theCollectionFile.exists());
 
-		MockCatalogStructuralChangeObserver.reset(evitaInstanceId);
+		MockCatalogStructuralChangeObserver.reset(this.evitaInstanceId);
 
-		try (final EvitaSessionContract oldSession = evita.createReadOnlySession(TEST_CATALOG)) {
+		try (final EvitaSessionContract oldSession = this.evita.createReadOnlySession(TEST_CATALOG)) {
 			log.info("Old session catalog version: " + oldSession.getCatalogVersion());
 
-			evita.updateCatalog(TEST_CATALOG, session -> {
+			this.evita.updateCatalog(TEST_CATALOG, session -> {
 				session.renameCollection(Entities.PRODUCT, Entities.STORE);
 				assertEquals(Entities.STORE, session.getEntitySchemaOrThrow(Entities.STORE).getName());
 			});
 
-			assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionCreated(evitaInstanceId, TEST_CATALOG, Entities.STORE));
-			assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionDeleted(evitaInstanceId, TEST_CATALOG, Entities.PRODUCT));
+			assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionCreated(this.evitaInstanceId, TEST_CATALOG, Entities.STORE));
+			assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionDeleted(this.evitaInstanceId, TEST_CATALOG, Entities.PRODUCT));
 
-			evita.queryCatalog(TEST_CATALOG, session -> {
+			this.evita.queryCatalog(TEST_CATALOG, session -> {
 				assertThrows(CollectionNotFoundException.class, () -> session.getEntityCollectionSize(Entities.PRODUCT));
 				assertEquals(1, session.getEntityCollectionSize(Entities.STORE));
 				assertEquals(2, session.getEntityCollectionSize(Entities.CATEGORY));
@@ -855,20 +858,20 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldCreateAndReplaceCollectionInTransaction() {
 		setupCatalogWithProductAndCategory();
 
-		evita.updateCatalog(TEST_CATALOG, session -> {
+		this.evita.updateCatalog(TEST_CATALOG, session -> {
 			session.goLiveAndClose();
 		});
 
-		MockCatalogStructuralChangeObserver.reset(evitaInstanceId);
+		MockCatalogStructuralChangeObserver.reset(this.evitaInstanceId);
 
-		evita.updateCatalog(TEST_CATALOG, session -> {
+		this.evita.updateCatalog(TEST_CATALOG, session -> {
 			session.replaceCollection(Entities.CATEGORY, Entities.PRODUCT);
 		});
 
-		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionSchemaUpdated(evitaInstanceId, TEST_CATALOG, Entities.CATEGORY));
-		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionDeleted(evitaInstanceId, TEST_CATALOG, Entities.PRODUCT));
+		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionSchemaUpdated(this.evitaInstanceId, TEST_CATALOG, Entities.CATEGORY));
+		assertEquals(1, MockCatalogStructuralChangeObserver.getEntityCollectionDeleted(this.evitaInstanceId, TEST_CATALOG, Entities.PRODUCT));
 
-		evita.queryCatalog(TEST_CATALOG, session -> {
+		this.evita.queryCatalog(TEST_CATALOG, session -> {
 			assertThrows(CollectionNotFoundException.class, () -> session.getEntityCollectionSize(Entities.PRODUCT));
 			assertEquals(1, session.getEntityCollectionSize(Entities.CATEGORY));
 			return null;
@@ -879,15 +882,15 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldCreateAndDropCollectionsInTransaction() {
 		setupCatalogWithProductAndCategory();
 
-		evita.updateCatalog(TEST_CATALOG, session -> {
+		this.evita.updateCatalog(TEST_CATALOG, session -> {
 			session.goLiveAndClose();
 		});
 
-		evita.updateCatalog(TEST_CATALOG, session -> {
+		this.evita.updateCatalog(TEST_CATALOG, session -> {
 			session.deleteCollection(Entities.PRODUCT);
 		});
 
-		evita.queryCatalog(TEST_CATALOG, session -> {
+		this.evita.queryCatalog(TEST_CATALOG, session -> {
 			assertThrows(CollectionNotFoundException.class, () -> session.getEntityCollectionSize(Entities.PRODUCT));
 			assertEquals(2, session.getEntityCollectionSize(Entities.CATEGORY));
 			return null;
@@ -896,7 +899,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldUpdateEntitySchemaAttributeDefinitionsReferringToGlobalOnes() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.getCatalogSchema()
@@ -934,7 +937,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldUpdateEntityAttributesReferringToGlobalAttributeThatIsChanged() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.getCatalogSchema()
@@ -956,7 +959,7 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.queryCatalog(
+		this.evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
 				final EntityAttributeSchemaContract productUrl = session.getEntitySchema(Entities.PRODUCT).orElseThrow()
@@ -975,7 +978,7 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.getCatalogSchema()
@@ -991,7 +994,7 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.queryCatalog(
+		this.evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
 				final EntityAttributeSchemaContract productUrl = session.getEntitySchema(Entities.PRODUCT).orElseThrow()
@@ -1013,7 +1016,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldCreateReflectedReference() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				// we can create reflected reference even before the main one is created
@@ -1066,13 +1069,13 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldCreateReflectedReferenceAndRetainInheritanceDuringEngineRestart() {
 		shouldCreateReflectedReference();
 
-		evita.close();
+		this.evita.close();
 
-		evita = new Evita(
+		this.evita = new Evita(
 			getEvitaConfiguration()
 		);
 
-		evita.queryCatalog(
+		this.evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
 				final SealedEntitySchema categorySchema = session.getEntitySchema(Entities.CATEGORY)
@@ -1100,7 +1103,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldUpdateInheritedPropertiesInReflectedReference() {
 		shouldCreateReflectedReference();
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				// we can create reflected reference even before the main one is created
@@ -1145,7 +1148,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldDropReflectedReferenceAndCreateRegularOneOfTheSameName() {
 		shouldCreateReflectedReference();
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				// we can create reflected reference even before the main one is created
@@ -1178,7 +1181,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldDropRegularReferenceAndCreateReflectedOneOfTheSameName() {
 		shouldDropReflectedReferenceAndCreateRegularOneOfTheSameName();
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				// we can create reflected reference even before the main one is created
@@ -1218,7 +1221,7 @@ class EvitaTest implements EvitaTestSupport {
 		assertThrows(
 			InvalidSchemaMutationException.class,
 			() ->
-				evita.updateCatalog(
+				this.evita.updateCatalog(
 					TEST_CATALOG,
 					session -> {
 						session.defineEntitySchema(Entities.CATEGORY)
@@ -1240,7 +1243,7 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldFailToCreateReflectedReferenceToNonIndexedReference() {
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session.defineEntitySchema(Entities.PRODUCT)
@@ -1262,7 +1265,7 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldFailToCreateNonManagedReferenceWhenEntityOfSuchNameExists() {
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session.defineEntitySchema(Entities.CATEGORY)
@@ -1281,7 +1284,7 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldFailToCreateManagedReferenceWhenEntityOfSuchNameDoesntExist() {
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session
@@ -1297,7 +1300,7 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldFailToCreateNonManagedGroupReferenceWhenEntityOfSuchNameExists() {
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session.defineEntitySchema(Entities.PARAMETER_GROUP)
@@ -1319,7 +1322,7 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldFailToCreateManagedGroupReferenceWhenEntityOfSuchNameDoesntExist() {
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session
@@ -1337,7 +1340,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldFailToChangeReferenceToNonIndexedWhenThereIsFilterableAttributePresent() {
 		// set-up correctly created indexed schema with filterable attribute
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -1354,7 +1357,7 @@ class EvitaTest implements EvitaTestSupport {
 		// now try to un-index the reference
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session
@@ -1372,7 +1375,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldFailToChangeReferenceToNonIndexedWhenThereIsUniqueAttributePresent() {
 		// set-up correctly created indexed schema with filterable attribute
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -1389,7 +1392,7 @@ class EvitaTest implements EvitaTestSupport {
 		// now try to un-index the reference
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session
@@ -1407,7 +1410,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldFailToChangeReferenceToNonIndexedWhenThereIsSortableAttributePresent() {
 		// set-up correctly created indexed schema with filterable attribute
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -1424,7 +1427,7 @@ class EvitaTest implements EvitaTestSupport {
 		// now try to un-index the reference
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session
@@ -1442,7 +1445,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldFailToChangeReferenceEntityTypeWhenThereIsReflectedReference() {
 		// first create intertwined references
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.defineEntitySchema(Entities.CATEGORY)
@@ -1464,7 +1467,7 @@ class EvitaTest implements EvitaTestSupport {
 		// now try to change the target entity
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session
@@ -1479,7 +1482,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldFailToChangeReferenceEntityTypeToNonManagedWhenThereIsReflectedReference() {
 		// first create intertwined references
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.defineEntitySchema(Entities.CATEGORY)
@@ -1501,7 +1504,7 @@ class EvitaTest implements EvitaTestSupport {
 		// now try to change the target entity
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session
@@ -1516,7 +1519,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldFailToChangeReferenceToNonIndexed() {
 		// set-up correctly created indexed schema with filterable attribute
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 
@@ -1538,7 +1541,7 @@ class EvitaTest implements EvitaTestSupport {
 		// now try to un-index the reference, and it should be ok
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session
@@ -1556,7 +1559,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldFailToChangeReferenceToNonIndexedWhenThereIsInheritedFilterableAttributePresentInReflectedReference() {
 		// set-up correctly created indexed schema with filterable attribute
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 
@@ -1581,7 +1584,7 @@ class EvitaTest implements EvitaTestSupport {
 		// now try to un-index the reference
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session
@@ -1599,7 +1602,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldFailToChangeReferenceToNonIndexedWhenThereIsInheritedUniqueAttributePresentInReflectedReference() {
 		// set-up correctly created indexed schema with filterable attribute
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 
@@ -1624,7 +1627,7 @@ class EvitaTest implements EvitaTestSupport {
 		// now try to un-index the reference
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session
@@ -1642,7 +1645,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldFailToChangeReferenceToNonIndexedWhenThereIsInheritedSortableAttributePresentInReflectedReference() {
 		// set-up correctly created indexed schema with filterable attribute
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 
@@ -1667,7 +1670,7 @@ class EvitaTest implements EvitaTestSupport {
 		// now try to un-index the reference
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session
@@ -1684,7 +1687,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldFetchEntityByLocalizedGlobalAttributeAutomaticallySelectingProperLocale() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.getCatalogSchema()
@@ -1726,7 +1729,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldFetchEntityByLocalizedGlobalAttributeAutomaticallySelectingProperLocalePerEntity() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.getCatalogSchema()
@@ -1788,7 +1791,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldUpdateExistingPriceInReducedPriceIndexes() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.defineEntitySchema(Entities.CATEGORY)
@@ -1816,7 +1819,7 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.getEntity(Entities.PRODUCT, 1, priceContentAll())
@@ -1827,7 +1830,7 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.queryCatalog(
+		this.evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
 				final SealedEntity sealedEntity = session.getEntity(Entities.PRODUCT, 1, priceContentAll())
@@ -1842,7 +1845,7 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldFailToDefineTwoEntitiesSharingNameInSpecificNamingConvention() {
 		assertThrows(
 			EntityTypeAlreadyPresentInCatalogSchemaException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session.defineEntitySchema("abc");
@@ -1856,7 +1859,7 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldFailToDefineReferencesToManagedEntitiesThatDontExist() {
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session.defineEntitySchema("someEntity")
@@ -1875,7 +1878,7 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldFailToDefineReferencesToManagedEntityGroupThatDoesntExist() {
 		assertThrows(
 			InvalidSchemaMutationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session.defineEntitySchema(
@@ -1895,7 +1898,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldCreateReferencesToNonManagedEntityAndGroup() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.defineEntitySchema(
@@ -1915,7 +1918,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldCreateCircularReferencesToManagedEntitiesAndGroups() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				final ModifyEntitySchemaMutation categoryMutation = session.defineEntitySchema(
@@ -1944,7 +1947,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldFailGracefullyWhenRequestingHierarchyOnNonHierarchyEntity() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -1970,7 +1973,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldCorrectlyWorkWithOverlappingRangesWhenUpdated() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -2023,7 +2026,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldIsolateChangesInSchemaWithinTransactions() {
 		// create some initial state
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.defineEntitySchema(Entities.PRODUCT)
@@ -2034,7 +2037,7 @@ class EvitaTest implements EvitaTestSupport {
 		);
 
 		// now open a new session and modify something
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				assertTrue(session.isTransactionOpen());
@@ -2055,7 +2058,7 @@ class EvitaTest implements EvitaTestSupport {
 				final CountDownLatch latch = new CountDownLatch(1);
 				final Thread testThread = new Thread(() -> {
 					try {
-						evita.queryCatalog(
+						this.evita.queryCatalog(
 							TEST_CATALOG,
 							parallelSession -> {
 								assertNull(parallelSession.getCatalogSchema().getDescription());
@@ -2094,7 +2097,7 @@ class EvitaTest implements EvitaTestSupport {
 		);
 
 		// verify the changes were propagated at last
-		evita.queryCatalog(
+		this.evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
 				assertEquals("This is my beautiful catalog.", session.getCatalogSchema().getDescription());
@@ -2118,12 +2121,102 @@ class EvitaTest implements EvitaTestSupport {
 	}
 
 	@Test
-	void shouldStartEvenIfOneCatalogIsCorrupted() {
-		assertTrue(evita.getCatalogState(TEST_CATALOG + "_1").isEmpty());
+	void shouldReturnCorrectCatalogAndSchemaVersions() {
+		// create some initial state
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withAttribute("someAttribute", String.class)
+					.updateVia(session);
+				session.goLiveAndClose();
+			}
+		);
 
-		evita.defineCatalog(TEST_CATALOG + "_1")
-			.updateViaNewSession(evita);
-		evita.updateCatalog(
+		final int initialCatalogSchemaVersion = this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				return session.getCatalogSchema().version();
+			}
+		);
+
+		// create two parallel sessions
+		final EvitaSessionContract session1 = this.evita.createSession(new SessionTraits(TEST_CATALOG, SessionFlags.READ_WRITE));
+		final EvitaSessionContract session2 = this.evita.createSession(new SessionTraits(TEST_CATALOG, SessionFlags.READ_WRITE));
+
+		// in both modify entity schema
+		session1.getEntitySchema(Entities.PRODUCT)
+			.orElseThrow()
+			.openForWrite()
+			.withDescription("This is my beautiful product collection.")
+			.updateVia(session1);
+
+		session2.getEntitySchema(Entities.PRODUCT)
+			.orElseThrow()
+			.openForWrite()
+			.withAttribute("someAttribute", String.class, thatIs -> thatIs.localized().filterable())
+			.updateVia(session2);
+
+		final List<String> worklog = new CopyOnWriteArrayList<>();
+
+		// commit second first
+		final CommitProgress session2CommitProgress = session2.closeNowWithProgress();
+		session2CommitProgress.onConflictResolved().thenAccept(commitVersions -> worklog.add("Session 2 conflict resolved: " + commitVersions));
+		session2CommitProgress.onWalAppended().thenAccept(commitVersions -> worklog.add("Session 2 WAL appended: " + commitVersions));
+		session2CommitProgress.onChangesVisible().thenAccept(commitVersions -> worklog.add("Session 2 changes visible: " + commitVersions));
+		final CommitVersions versionsAssigned = session2CommitProgress.onChangesVisible().toCompletableFuture().join();
+
+		// commit first
+		final CommitProgress session1CommitProgress = session1.closeNowWithProgress();
+		session1CommitProgress.onConflictResolved().thenAccept(commitVersions -> worklog.add("Session 1 conflict resolved: " + commitVersions));
+		session1CommitProgress.onWalAppended().thenAccept(commitVersions -> worklog.add("Session 1 WAL appended: " + commitVersions));
+		session1CommitProgress.onChangesVisible().thenAccept(commitVersions -> worklog.add("Session 1 changes visible: " + commitVersions));
+		final CommitVersions versionsAssignedAfter = session1CommitProgress.onChangesVisible().toCompletableFuture().join();
+
+		// check work log
+		assertEquals(6, worklog.size());
+		assertArrayEquals(
+			new String[]{
+				"Session 2 conflict resolved: " + versionsAssigned,
+				"Session 2 WAL appended: " + versionsAssigned,
+				"Session 2 changes visible: " + versionsAssigned,
+				"Session 1 conflict resolved: " + versionsAssignedAfter,
+				"Session 1 WAL appended: " + versionsAssignedAfter,
+				"Session 1 changes visible: " + versionsAssignedAfter
+			},
+			worklog.toArray()
+		);
+
+		// versions in second session, committed first will be lesser
+		assertTrue(versionsAssigned.catalogVersion() < versionsAssignedAfter.catalogVersion());
+		assertTrue(versionsAssigned.catalogSchemaVersion() < versionsAssignedAfter.catalogSchemaVersion());
+
+		// verify the changes were propagated at last
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				assertEquals(initialCatalogSchemaVersion + 2, session.getCatalogSchema().version());
+
+				final SealedEntitySchema productSchema = session.getEntitySchema(Entities.PRODUCT).orElseThrow();
+				assertEquals("This is my beautiful product collection.", productSchema.getDescription());
+
+				final AttributeSchemaContract someAttributeSchema = productSchema
+					.getAttribute("someAttribute")
+					.orElseThrow();
+
+				assertTrue(someAttributeSchema.isLocalized());
+				assertTrue(someAttributeSchema.isFilterable());
+			}
+		);
+	}
+
+	@Test
+	void shouldStartEvenIfOneCatalogIsCorrupted() {
+		assertTrue(this.evita.getCatalogState(TEST_CATALOG + "_1").isEmpty());
+
+		this.evita.defineCatalog(TEST_CATALOG + "_1")
+			.updateViaNewSession(this.evita);
+		this.evita.updateCatalog(
 			TEST_CATALOG + "_1",
 			session -> {
 				session
@@ -2135,9 +2228,9 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.defineCatalog(TEST_CATALOG + "_2")
-			.updateViaNewSession(evita);
-		evita.updateCatalog(
+		this.evita.defineCatalog(TEST_CATALOG + "_2")
+			.updateViaNewSession(this.evita);
+		this.evita.updateCatalog(
 			TEST_CATALOG + "_2",
 			session -> {
 				session
@@ -2149,9 +2242,9 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		assertEquals(CatalogState.WARMING_UP, evita.getCatalogState(TEST_CATALOG + "_1").orElseThrow());
+		assertEquals(CatalogState.WARMING_UP, this.evita.getCatalogState(TEST_CATALOG + "_1").orElseThrow());
 
-		evita.close();
+		this.evita.close();
 
 		// damage the TEST_CATALOG_1 contents
 		try {
@@ -2161,18 +2254,18 @@ class EvitaTest implements EvitaTestSupport {
 			fail(ex);
 		}
 
-		evita = new Evita(
+		this.evita = new Evita(
 			getEvitaConfiguration()
 		);
 
-		assertEquals(CatalogState.CORRUPTED, evita.getCatalogState(TEST_CATALOG + "_1").orElseThrow());
+		assertEquals(CatalogState.CORRUPTED, this.evita.getCatalogState(TEST_CATALOG + "_1").orElseThrow());
 
 		final PortManager portManager = getPortManager();
 		final String dataSetName = "evitaTest";
 		final int[] ports = portManager.allocatePorts(dataSetName, 3);
 		try {
 			try (ExternalApiServer externalApiServer = new ExternalApiServer(
-				evita,
+				this.evita,
 				ApiOptions.builder()
 					.certificate(
 						CertificateOptions.builder()
@@ -2187,13 +2280,13 @@ class EvitaTest implements EvitaTestSupport {
 				externalApiServer.start();
 			}
 
-			final Set<String> catalogNames = evita.getCatalogNames();
+			final Set<String> catalogNames = this.evita.getCatalogNames();
 			assertEquals(3, catalogNames.size());
 
 			assertThrows(
 				CatalogCorruptedException.class,
 				() -> {
-					evita.updateCatalog(
+					this.evita.updateCatalog(
 						TEST_CATALOG + "_1",
 						session -> {
 							session.getAllEntityTypes();
@@ -2202,7 +2295,7 @@ class EvitaTest implements EvitaTestSupport {
 				}
 			);
 
-			final CatalogStatistics[] catalogStatistics = evita.management().getCatalogStatistics();
+			final CatalogStatistics[] catalogStatistics = this.evita.management().getCatalogStatistics();
 			assertNotNull(catalogStatistics);
 			assertEquals(3, catalogStatistics.length);
 
@@ -2257,9 +2350,9 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldCreateCatalogEvenIfOneCatalogIsCorrupted() {
-		evita.defineCatalog(TEST_CATALOG + "_1")
-			.updateViaNewSession(evita);
-		evita.updateCatalog(
+		this.evita.defineCatalog(TEST_CATALOG + "_1")
+			.updateViaNewSession(this.evita);
+		this.evita.updateCatalog(
 			TEST_CATALOG + "_1",
 			session -> {
 				session
@@ -2271,9 +2364,9 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.defineCatalog(TEST_CATALOG + "_2")
-			.updateViaNewSession(evita);
-		evita.updateCatalog(
+		this.evita.defineCatalog(TEST_CATALOG + "_2")
+			.updateViaNewSession(this.evita);
+		this.evita.updateCatalog(
 			TEST_CATALOG + "_2",
 			session -> {
 				session
@@ -2285,7 +2378,7 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.close();
+		this.evita.close();
 
 		// damage the TEST_CATALOG_1 contents
 		try {
@@ -2295,7 +2388,7 @@ class EvitaTest implements EvitaTestSupport {
 			fail(ex);
 		}
 
-		evita = new Evita(
+		this.evita = new Evita(
 			getEvitaConfiguration()
 		);
 
@@ -2304,7 +2397,7 @@ class EvitaTest implements EvitaTestSupport {
 		final int[] ports = portManager.allocatePorts(dataSetName, 3);
 		try {
 			try (ExternalApiServer externalApiServer = new ExternalApiServer(
-				evita,
+				this.evita,
 				ApiOptions.builder()
 					.certificate(
 						CertificateOptions.builder()
@@ -2319,13 +2412,13 @@ class EvitaTest implements EvitaTestSupport {
 				externalApiServer.start();
 			}
 
-			final Set<String> catalogNames = evita.getCatalogNames();
+			final Set<String> catalogNames = this.evita.getCatalogNames();
 			assertEquals(3, catalogNames.size());
 
 			assertThrows(
 				CatalogCorruptedException.class,
 				() -> {
-					evita.updateCatalog(
+					this.evita.updateCatalog(
 						TEST_CATALOG + "_1",
 						session -> {
 							session.getAllEntityTypes();
@@ -2335,10 +2428,10 @@ class EvitaTest implements EvitaTestSupport {
 			);
 
 			// but allow creating new catalog
-			evita.defineCatalog(TEST_CATALOG + "_3")
-				.updateViaNewSession(evita);
+			this.evita.defineCatalog(TEST_CATALOG + "_3")
+				.updateViaNewSession(this.evita);
 
-			assertTrue(evita.getCatalogNames().contains(TEST_CATALOG + "_3"));
+			assertTrue(this.evita.getCatalogNames().contains(TEST_CATALOG + "_3"));
 
 		} finally {
 			portManager.releasePorts(dataSetName);
@@ -2347,9 +2440,9 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldReplaceCorruptedCatalogWithCorrectOne() {
-		evita.defineCatalog(TEST_CATALOG + "_1")
-			.updateViaNewSession(evita);
-		evita.updateCatalog(
+		this.evita.defineCatalog(TEST_CATALOG + "_1")
+			.updateViaNewSession(this.evita);
+		this.evita.updateCatalog(
 			TEST_CATALOG + "_1",
 			session -> {
 				session
@@ -2361,9 +2454,9 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.defineCatalog(TEST_CATALOG + "_2")
-			.updateViaNewSession(evita);
-		evita.updateCatalog(
+		this.evita.defineCatalog(TEST_CATALOG + "_2")
+			.updateViaNewSession(this.evita);
+		this.evita.updateCatalog(
 			TEST_CATALOG + "_2",
 			session -> {
 				session
@@ -2375,7 +2468,7 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.close();
+		this.evita.close();
 
 		// damage the TEST_CATALOG_1 contents
 		try {
@@ -2385,7 +2478,7 @@ class EvitaTest implements EvitaTestSupport {
 			fail(ex);
 		}
 
-		evita = new Evita(
+		this.evita = new Evita(
 			getEvitaConfiguration()
 		);
 
@@ -2394,7 +2487,7 @@ class EvitaTest implements EvitaTestSupport {
 		final int[] ports = portManager.allocatePorts(dataSetName, 3);
 		try {
 			try (ExternalApiServer externalApiServer = new ExternalApiServer(
-				evita,
+				this.evita,
 				ApiOptions.builder()
 					.certificate(
 						CertificateOptions.builder()
@@ -2409,13 +2502,13 @@ class EvitaTest implements EvitaTestSupport {
 				externalApiServer.start();
 			}
 
-			final Set<String> catalogNames = evita.getCatalogNames();
+			final Set<String> catalogNames = this.evita.getCatalogNames();
 			assertEquals(3, catalogNames.size());
 
 			assertThrows(
 				CatalogCorruptedException.class,
 				() -> {
-					evita.updateCatalog(
+					this.evita.updateCatalog(
 						TEST_CATALOG + "_1",
 						session -> {
 							session.getAllEntityTypes();
@@ -2425,17 +2518,17 @@ class EvitaTest implements EvitaTestSupport {
 			);
 
 			// but allow creating new catalog
-			evita.defineCatalog(TEST_CATALOG + "_3")
-				.updateViaNewSession(evita);
+			this.evita.defineCatalog(TEST_CATALOG + "_3")
+				.updateViaNewSession(this.evita);
 
-			assertTrue(evita.getCatalogNames().contains(TEST_CATALOG + "_3"));
-			evita.replaceCatalog(TEST_CATALOG + "_3", TEST_CATALOG + "_1");
+			assertTrue(this.evita.getCatalogNames().contains(TEST_CATALOG + "_3"));
+			this.evita.replaceCatalog(TEST_CATALOG + "_3", TEST_CATALOG + "_1");
 
-			final Set<String> catalogNamesAgain = evita.getCatalogNames();
+			final Set<String> catalogNamesAgain = this.evita.getCatalogNames();
 			assertEquals(3, catalogNamesAgain.size());
 
 			// exception should not be thrown again
-			evita.updateCatalog(
+			this.evita.updateCatalog(
 				TEST_CATALOG + "_1",
 				session -> {
 					session.getAllEntityTypes();
@@ -2449,7 +2542,7 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldProperlyHandleFetchingOfNotYetKnownEntities() {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.defineEntitySchema(Entities.BRAND)
@@ -2504,7 +2597,7 @@ class EvitaTest implements EvitaTestSupport {
 	@Test
 	void shouldNotReturnGroupOfNonMatchingLocale() {
 		shouldCreateReflectedReference();
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -2587,10 +2680,10 @@ class EvitaTest implements EvitaTestSupport {
 
 	@Test
 	void shouldCorrectlyLocalizeGloballyUniqueAttribute() {
-		evita.defineCatalog(TEST_CATALOG)
+		this.evita.defineCatalog(TEST_CATALOG)
 			.withAttribute(ATTRIBUTE_URL, String.class, whichIs -> whichIs.localized().uniqueGlobally())
-			.updateViaNewSession(evita);
-		evita.updateCatalog(
+			.updateViaNewSession(this.evita);
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -2607,7 +2700,7 @@ class EvitaTest implements EvitaTestSupport {
 
 		assertThrows(
 			UniqueValueViolationException.class,
-			() -> evita.updateCatalog(
+			() -> this.evita.updateCatalog(
 				TEST_CATALOG,
 				session -> {
 					session.upsertEntity(
@@ -2620,7 +2713,7 @@ class EvitaTest implements EvitaTestSupport {
 
 		assertEquals(
 			new EntityReference(Entities.PRODUCT, 1),
-			evita.queryCatalog(
+			this.evita.queryCatalog(
 				TEST_CATALOG,
 				session -> {
 					return session.queryOne(
@@ -2636,7 +2729,7 @@ class EvitaTest implements EvitaTestSupport {
 
 		assertEquals(
 			new EntityReference(Entities.PRODUCT, 1),
-			evita.queryCatalog(
+			this.evita.queryCatalog(
 				TEST_CATALOG,
 				session -> {
 					return session.queryOne(
@@ -2654,7 +2747,7 @@ class EvitaTest implements EvitaTestSupport {
 		);
 
 		assertNull(
-			evita.queryCatalog(
+			this.evita.queryCatalog(
 				TEST_CATALOG,
 				session -> {
 					return session.queryOne(
@@ -2676,13 +2769,13 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldCreateBackupAndRestoreCatalog() throws IOException, ExecutionException, InterruptedException {
 		setupCatalogWithProductAndCategory();
 
-		final CompletableFuture<FileForFetch> backupPathFuture = evita.management().backupCatalog(TEST_CATALOG, null, null, true);
-		final Path backupPath = backupPathFuture.join().path(evita.getConfiguration().storage().exportDirectory());
+		final CompletableFuture<FileForFetch> backupPathFuture = this.evita.management().backupCatalog(TEST_CATALOG, null, null, true);
+		final Path backupPath = backupPathFuture.join().path(this.evita.getConfiguration().storage().exportDirectory());
 
 		assertTrue(backupPath.toFile().exists());
 
 		try (final BufferedInputStream inputStream = new BufferedInputStream(new FileInputStream(backupPath.toFile()))) {
-			final CompletableFuture<Void> future = evita.management().restoreCatalog(
+			final CompletableFuture<Void> future = this.evita.management().restoreCatalog(
 				TEST_CATALOG + "_restored",
 				Files.size(backupPath),
 				inputStream
@@ -2692,10 +2785,10 @@ class EvitaTest implements EvitaTestSupport {
 			future.get();
 		}
 
-		evita.queryCatalog(TEST_CATALOG,
+		this.evita.queryCatalog(TEST_CATALOG,
 			session -> {
 				// compare contents of both catalogs
-				evita.queryCatalog(TEST_CATALOG + "_restored",
+				this.evita.queryCatalog(TEST_CATALOG + "_restored",
 					session2 -> {
 						final Set<String> allEntityTypes1 = session.getAllEntityTypes();
 						final Set<String> allEntityTypes2 = session2.getAllEntityTypes();
@@ -2724,14 +2817,14 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldCreateBackupAndRestoreTransactionalCatalog() throws IOException, ExecutionException, InterruptedException {
 		setupCatalogWithProductAndCategory();
 
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.goLiveAndClose();
 			}
 		);
 
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.getEntity(Entities.PRODUCT, 1, entityFetchAllContent())
@@ -2742,9 +2835,9 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		final EvitaManagement management = evita.management();
+		final EvitaManagement management = this.evita.management();
 		final CompletableFuture<FileForFetch> backupPathFuture = management.backupCatalog(TEST_CATALOG, null, null, true);
-		final Path backupPath = backupPathFuture.join().path(evita.getConfiguration().storage().exportDirectory());
+		final Path backupPath = backupPathFuture.join().path(this.evita.getConfiguration().storage().exportDirectory());
 
 		assertTrue(backupPath.toFile().exists());
 
@@ -2759,10 +2852,10 @@ class EvitaTest implements EvitaTestSupport {
 			future.get();
 		}
 
-		evita.queryCatalog(TEST_CATALOG,
+		this.evita.queryCatalog(TEST_CATALOG,
 			session -> {
 				// compare contents of both catalogs
-				evita.queryCatalog(TEST_CATALOG + "_restored",
+				this.evita.queryCatalog(TEST_CATALOG + "_restored",
 					session2 -> {
 						final Set<String> allEntityTypes1 = session.getAllEntityTypes();
 						final Set<String> allEntityTypes2 = session2.getAllEntityTypes();
@@ -2787,7 +2880,7 @@ class EvitaTest implements EvitaTestSupport {
 			});
 
 		// verify we can write to the original catalog again
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.getEntity(Entities.PRODUCT, 1, entityFetchAllContent())
@@ -2799,7 +2892,7 @@ class EvitaTest implements EvitaTestSupport {
 		);
 
 		// and to the restored one as well
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG + "_restored",
 			session -> {
 				session.getEntity(Entities.PRODUCT, 1, entityFetchAllContent())
@@ -2815,13 +2908,13 @@ class EvitaTest implements EvitaTestSupport {
 	void shouldListAndCancelTasks() {
 		final int numberOfTasks = 20;
 
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG, session -> {
 				session.goLiveAndClose();
 			}
 		);
 
-		final EvitaManagement management = evita.management();
+		final EvitaManagement management = this.evita.management();
 		ExecutorService executorService = Executors.newFixedThreadPool(numberOfTasks);
 
 		// Step 2: Generate backup tasks using the custom executor
@@ -2916,7 +3009,7 @@ class EvitaTest implements EvitaTestSupport {
 	}
 
 	private void doRenameCatalog(@Nonnull CatalogState catalogState) {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.defineEntitySchema(Entities.BRAND);
@@ -2930,12 +3023,12 @@ class EvitaTest implements EvitaTestSupport {
 		final String renamedCatalogName = TEST_CATALOG + "_renamed";
 		final AtomicInteger versionBeforeRename = new AtomicInteger();
 		if (catalogState == CatalogState.ALIVE) {
-			evita.updateCatalog(TEST_CATALOG, session -> {
+			this.evita.updateCatalog(TEST_CATALOG, session -> {
 				versionBeforeRename.set(session.getCatalogSchema().version());
 				session.goLiveAndClose();
 			});
 		} else {
-			evita.queryCatalog(
+			this.evita.queryCatalog(
 				TEST_CATALOG,
 				session -> {
 					versionBeforeRename.set(session.getCatalogSchema().version());
@@ -2943,12 +3036,12 @@ class EvitaTest implements EvitaTestSupport {
 			);
 		}
 
-		evita.renameCatalog(TEST_CATALOG, renamedCatalogName);
+		this.evita.renameCatalog(TEST_CATALOG, renamedCatalogName);
 
-		assertFalse(evita.getCatalogNames().contains(TEST_CATALOG));
-		assertTrue(evita.getCatalogNames().contains(renamedCatalogName));
+		assertFalse(this.evita.getCatalogNames().contains(TEST_CATALOG));
+		assertTrue(this.evita.getCatalogNames().contains(renamedCatalogName));
 
-		evita.queryCatalog(
+		this.evita.queryCatalog(
 			renamedCatalogName,
 			session -> {
 				assertEquals(renamedCatalogName, session.getCatalogSchema().getName());
@@ -2958,13 +3051,13 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.close();
+		this.evita.close();
 
-		evita = new Evita(
+		this.evita = new Evita(
 			getEvitaConfiguration()
 		);
 
-		evita.queryCatalog(
+		this.evita.queryCatalog(
 			renamedCatalogName,
 			session -> {
 				assertEquals(renamedCatalogName, session.getCatalogSchema().getName());
@@ -2975,7 +3068,7 @@ class EvitaTest implements EvitaTestSupport {
 	}
 
 	private void doReplaceCatalog(@Nonnull CatalogState catalogState) {
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session
@@ -2988,8 +3081,8 @@ class EvitaTest implements EvitaTestSupport {
 		);
 
 		final String temporaryCatalogName = TEST_CATALOG + "_tmp";
-		evita.defineCatalog(temporaryCatalogName);
-		evita.updateCatalog(
+		this.evita.defineCatalog(temporaryCatalogName);
+		this.evita.updateCatalog(
 			temporaryCatalogName,
 			session -> {
 				session
@@ -3003,12 +3096,12 @@ class EvitaTest implements EvitaTestSupport {
 
 		final AtomicInteger versionBeforeRename = new AtomicInteger();
 		if (catalogState == CatalogState.ALIVE) {
-			evita.updateCatalog(temporaryCatalogName, session -> {
+			this.evita.updateCatalog(temporaryCatalogName, session -> {
 				versionBeforeRename.set(session.getCatalogSchema().version());
 				session.goLiveAndClose();
 			});
 		} else {
-			evita.queryCatalog(
+			this.evita.queryCatalog(
 				temporaryCatalogName,
 				session -> {
 					versionBeforeRename.set(session.getCatalogSchema().version());
@@ -3016,19 +3109,19 @@ class EvitaTest implements EvitaTestSupport {
 			);
 		}
 
-		evita.replaceCatalog(temporaryCatalogName, TEST_CATALOG);
+		this.evita.replaceCatalog(temporaryCatalogName, TEST_CATALOG);
 
-		assertFalse(evita.getCatalogNames().contains(temporaryCatalogName));
-		assertTrue(evita.getCatalogNames().contains(TEST_CATALOG));
+		assertFalse(this.evita.getCatalogNames().contains(temporaryCatalogName));
+		assertTrue(this.evita.getCatalogNames().contains(TEST_CATALOG));
 
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.upsertEntity(session.createNewEntity(Entities.PRODUCT, 3));
 			}
 		);
 
-		evita.queryCatalog(
+		this.evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
 				assertEquals(TEST_CATALOG, session.getCatalogSchema().getName());
@@ -3044,20 +3137,20 @@ class EvitaTest implements EvitaTestSupport {
 			}
 		);
 
-		evita.close();
+		this.evita.close();
 
-		evita = new Evita(
+		this.evita = new Evita(
 			getEvitaConfiguration()
 		);
 
-		evita.updateCatalog(
+		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.upsertEntity(session.createNewEntity(Entities.PRODUCT, 4));
 			}
 		);
 
-		evita.queryCatalog(
+		this.evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
 				assertEquals(TEST_CATALOG, session.getCatalogSchema().getName());
@@ -3074,7 +3167,7 @@ class EvitaTest implements EvitaTestSupport {
 	}
 
 	private void setupCatalogWithProductAndCategory() {
-		evita.updateCatalog(TEST_CATALOG, session -> {
+		this.evita.updateCatalog(TEST_CATALOG, session -> {
 			session.defineEntitySchema(Entities.PRODUCT);
 
 			session

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTransactionalFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTransactionalFunctionalTest.java
@@ -26,6 +26,7 @@ package io.evitadb.api;
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.util.Pool;
 import com.github.javafaker.Faker;
+import io.evitadb.api.CommitProgress.CommitVersions;
 import io.evitadb.api.SessionTraits.SessionFlags;
 import io.evitadb.api.TransactionContract.CommitBehavior;
 import io.evitadb.api.configuration.EvitaConfiguration;
@@ -295,7 +296,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 						.map(it -> {
 							assertFalse(Transaction.getTransaction().isPresent());
 							final AtomicReference<EntityReference> createdReference = new AtomicReference<>();
-							final CompletableFuture<Long> targetCatalogVersion = evita.updateCatalogAsync(
+							final CompletableFuture<CommitVersions> targetCatalogVersion = evita.updateCatalogAsync(
 								TEST_CATALOG,
 								session -> {
 									final long currentCatalogVersion = session.getCatalogVersion();
@@ -316,10 +317,12 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 											);
 										}
 									}
-								}, CommitBehavior.WAIT_FOR_WAL_PERSISTENCE, SessionFlags.READ_WRITE
-							);
+								}, SessionFlags.READ_WRITE
+							)
+								.onWalAppended()
+								.toCompletableFuture();
 							try {
-								final Long catalogVersion = targetCatalogVersion.get();
+								final long catalogVersion = targetCatalogVersion.get().catalogVersion();
 								final PkWithCatalogVersion pkWithCatalogVersion = new PkWithCatalogVersion(createdReference.get(), catalogVersion);
 								primaryKeysWithTxIds.add(pkWithCatalogVersion);
 								return pkWithCatalogVersion;
@@ -469,32 +472,32 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 			);
 
 			final BiFunction<String, Faker, Integer> randomEntityPicker = (entityType, faker) -> RANDOM_ENTITY_PICKER.apply(entityType, session, faker);
-			dataGenerator.generateEntities(
-					dataGenerator.getSampleBrandSchema(session),
+			this.dataGenerator.generateEntities(
+					this.dataGenerator.getSampleBrandSchema(session),
 					randomEntityPicker,
 					SEED
 				)
 				.limit(5)
 				.forEach(session::upsertEntity);
 
-			dataGenerator.generateEntities(
-					dataGenerator.getSampleCategorySchema(session),
+			this.dataGenerator.generateEntities(
+					this.dataGenerator.getSampleCategorySchema(session),
 					randomEntityPicker,
 					SEED
 				)
 				.limit(10)
 				.forEach(session::upsertEntity);
 
-			dataGenerator.generateEntities(
-					dataGenerator.getSamplePriceListSchema(session),
+			this.dataGenerator.generateEntities(
+					this.dataGenerator.getSamplePriceListSchema(session),
 					randomEntityPicker,
 					SEED
 				)
 				.limit(4)
 				.forEach(session::upsertEntity);
 
-			dataGenerator.generateEntities(
-					dataGenerator.getSampleStoreSchema(session),
+			this.dataGenerator.generateEntities(
+					this.dataGenerator.getSampleStoreSchema(session),
 					randomEntityPicker,
 					SEED
 				)
@@ -502,7 +505,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 				.forEach(session::upsertEntity);
 
 			// create product schema
-			return dataGenerator.getSampleProductSchema(
+			return this.dataGenerator.getSampleProductSchema(
 				session, schemaBuilder -> {
 					return schemaBuilder
 						.withoutGeneratedPrimaryKey()
@@ -514,7 +517,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 
 	@AfterEach
 	void tearDown() {
-		observableOutputKeeper.close();
+		this.observableOutputKeeper.close();
 	}
 
 	@DisplayName("Catalog should be automatically updated after a load with existing WAL contents.")
@@ -532,7 +535,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 			0L,
 			TEST_CATALOG,
 			catalogDirectory,
-			catalogKryoPool,
+			this.catalogKryoPool,
 			StorageOptions.builder().build(),
 			TransactionOptions.builder().build(),
 			Mockito.mock(Scheduler.class),
@@ -543,7 +546,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 
 		// create WAL file with a few contents first
 		final Map<Long, List<EntityContract>> generatedEntities = appendWal(
-			1L, offHeapMemoryManager, wal, new int[]{3, 4, 2}, catalogSchema, productSchema
+			1L, this.offHeapMemoryManager, wal, new int[]{3, 4, 2}, catalogSchema, productSchema
 		);
 
 		// start evita again and wait for the WAL to be processed
@@ -558,7 +561,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 
 		// append a few additional WAL entries
 		final Map<Long, List<EntityContract>> additionalGeneratedEntities = appendWal(
-			4L, offHeapMemoryManager, wal, new int[]{5, 7}, catalogSchema, productSchema
+			4L, this.offHeapMemoryManager, wal, new int[]{5, 7}, catalogSchema, productSchema
 		);
 
 		// start evitaDB again and wait for the WAL to be processed
@@ -588,7 +591,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 				0L,
 				TEST_CATALOG,
 				catalogDirectory,
-				catalogKryoPool,
+				this.catalogKryoPool,
 				StorageOptions.builder().build(),
 				TransactionOptions.builder().build(),
 				Mockito.mock(Scheduler.class),
@@ -620,7 +623,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 			for (int[] transactionSize : transactionSizes) {
 				// create WAL file with a few contents first
 				appendWal(
-					catalogVersion, offHeapMemoryManager, wal, transactionSize, catalogSchema, productSchema
+					catalogVersion, this.offHeapMemoryManager, wal, transactionSize, catalogSchema, productSchema
 				);
 				catalogVersion += transactionSize.length;
 
@@ -796,7 +799,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 			TEST_CATALOG,
 			session -> {
 				final BiFunction<String, Faker, Integer> randomEntityPicker = (entityType, faker) -> RANDOM_ENTITY_PICKER.apply(entityType, session, faker);
-				final Optional<SealedEntity> upsertedEntity = dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
+				final Optional<SealedEntity> upsertedEntity = this.dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
 					.limit(1)
 					.map(session::upsertAndFetchEntity)
 					.findFirst();
@@ -823,7 +826,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 			TEST_CATALOG,
 			session -> {
 				final BiFunction<String, Faker, Integer> randomEntityPicker = (entityType, faker) -> RANDOM_ENTITY_PICKER.apply(entityType, session, faker);
-				final Optional<SealedEntity> upsertedEntity = dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
+				final Optional<SealedEntity> upsertedEntity = this.dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
 					.limit(1)
 					.map(session::upsertAndFetchEntity)
 					.findFirst();
@@ -831,7 +834,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 				return upsertedEntity.get();
 			},
 			CommitBehavior.WAIT_FOR_CONFLICT_RESOLUTION
-		);
+		).toCompletableFuture();
 
 		while (!addedEntity.isDone()) {
 			Thread.onSpinWait();
@@ -860,7 +863,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 		final EvitaSessionContract session = evita.createSession(new SessionTraits(TEST_CATALOG, CommitBehavior.WAIT_FOR_INDEX_PROPAGATION, SessionFlags.READ_WRITE));
 
 		final BiFunction<String, Faker, Integer> randomEntityPicker = (entityType, faker) -> RANDOM_ENTITY_PICKER.apply(entityType, session, faker);
-		final Optional<EntityMutation> entityMutation = dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
+		final Optional<EntityMutation> entityMutation = this.dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
 			.findFirst()
 			.flatMap(InstanceEditor::toMutation);
 		assertTrue(entityMutation.isPresent());
@@ -900,7 +903,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 				TEST_CATALOG,
 				session -> {
 					final BiFunction<String, Faker, Integer> randomEntityPicker = (entityType, faker) -> RANDOM_ENTITY_PICKER.apply(entityType, session, faker);
-					final Optional<EntityMutation> entityMutation = dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
+					final Optional<EntityMutation> entityMutation = this.dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
 						.findFirst()
 						.flatMap(InstanceEditor::toMutation);
 					assertTrue(entityMutation.isPresent());
@@ -932,7 +935,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 			TEST_CATALOG,
 			session -> {
 				final BiFunction<String, Faker, Integer> randomEntityPicker = (entityType, faker) -> RANDOM_ENTITY_PICKER.apply(entityType, session, faker);
-				final Optional<EntityMutation> entityMutation = dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
+				final Optional<EntityMutation> entityMutation = this.dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
 					.findFirst()
 					.flatMap(InstanceEditor::toMutation);
 				assertTrue(entityMutation.isPresent());
@@ -953,7 +956,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
-				final Optional<SealedEntity> fetchedEntity = session.getEntity(productSchema.getName(), addedEntity.getPrimaryKey());
+				final Optional<SealedEntity> fetchedEntity = session.getEntity(productSchema.getName(), addedEntity.getPrimaryKeyOrThrowException());
 				assertTrue(fetchedEntity.isPresent());
 				assertEquals(addedEntity, fetchedEntity.get());
 			}
@@ -969,7 +972,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 			TEST_CATALOG,
 			session -> {
 				final BiFunction<String, Faker, Integer> randomEntityPicker = (entityType, faker) -> RANDOM_ENTITY_PICKER.apply(entityType, session, faker);
-				final Optional<SealedEntity> upsertedEntity = dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
+				final Optional<SealedEntity> upsertedEntity = this.dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
 					.limit(1)
 					.map(session::upsertAndFetchEntity)
 					.findFirst();
@@ -993,27 +996,29 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 	@UseDataSet(value = TRANSACTIONAL_DATA_SET, destroyAfterTest = true)
 	@Test
 	void shouldUpdateCatalogWithAnotherProductAsynchronouslyUsingRunnable(EvitaContract evita, SealedEntitySchema productSchema) {
+		final CommitVersions nonSenseValue = new CommitVersions(Long.MIN_VALUE, Integer.MIN_VALUE);
 		final AtomicReference<SealedEntity> addedEntity = new AtomicReference<>();
-		final CompletableFuture<Long> nextCatalogVersion = evita.updateCatalogAsync(
+		final CompletableFuture<CommitVersions> nextCatalogVersion = evita.updateCatalogAsync(
 			TEST_CATALOG,
 			session -> {
 				final BiFunction<String, Faker, Integer> randomEntityPicker = (entityType, faker) -> RANDOM_ENTITY_PICKER.apply(entityType, session, faker);
-				final Optional<SealedEntity> upsertedEntity = dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
+				final Optional<SealedEntity> upsertedEntity = this.dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
 					.limit(1)
 					.map(session::upsertAndFetchEntity)
 					.findFirst();
 				assertTrue(upsertedEntity.isPresent());
 				addedEntity.set(upsertedEntity.get());
-			},
-			CommitBehavior.WAIT_FOR_CONFLICT_RESOLUTION
-		);
+			}
+		)
+			.onConflictResolved()
+			.toCompletableFuture();
 
-		final Integer addedEntityPrimaryKey = addedEntity.get().getPrimaryKey();
+		final int addedEntityPrimaryKey = addedEntity.get().getPrimaryKeyOrThrowException();
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
 				final long catalogVersion = session.getCatalogVersion();
-				if (nextCatalogVersion.isDone() && nextCatalogVersion.getNow(Long.MIN_VALUE) == catalogVersion) {
+				if (nextCatalogVersion.isDone() && nextCatalogVersion.getNow(nonSenseValue).catalogVersion() == catalogVersion) {
 					// the entity is already propagated to indexes
 					final Optional<SealedEntity> fetchedEntity = session.getEntity(productSchema.getName(), addedEntityPrimaryKey);
 					assertTrue(fetchedEntity.isPresent());
@@ -1033,7 +1038,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 				session -> {
 					final Optional<SealedEntity> entityFetchedAgain = session.getEntity(productSchema.getName(), addedEntityPrimaryKey);
 					final long catalogVersion = session.getCatalogVersion();
-					final long expectedCatalogVersion = nextCatalogVersion.getNow(Long.MIN_VALUE);
+					final long expectedCatalogVersion = nextCatalogVersion.getNow(nonSenseValue).catalogVersion();
 					if (entityFetchedAgain.isPresent()) {
 						assertEquals(expectedCatalogVersion, catalogVersion);
 						return true;
@@ -1090,7 +1095,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 				TEST_CATALOG,
 				session -> {
 					final int bulkSize = 16;
-					dataGenerator.generateEntities(
+					this.dataGenerator.generateEntities(
 							productSchema,
 							(entityType, faker) -> {
 								try (EvitaSessionContract readOnlySession = evita.createReadOnlySession(TEST_CATALOG)) {
@@ -1162,7 +1167,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 
 		final BiFunction<String, Faker, Integer> randomEntityPicker = (entityType, faker) -> RANDOM_ENTITY_PICKER.apply(entityType, session, faker);
 		final int entityCount = 500;
-		dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
+		this.dataGenerator.generateEntities(productSchema, randomEntityPicker, SEED)
 			.limit(entityCount)
 			.map(InstanceEditor::toMutation)
 			.flatMap(Optional::stream)
@@ -1494,10 +1499,13 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 								.setAttribute(attributePrice, BigDecimal.valueOf(faker.number().randomDouble(2, 1, 1000)));
 							theEntityRef.set(entityBuilder.toInstance());
 							entityBuilder.upsertVia(session);
-						},
+						}
+					)
 						// fast track - we don't wait for anything (to cause as much "churn" as we can)
-						CommitBehavior.WAIT_FOR_WAL_PERSISTENCE
-					).get();
+						.onWalAppended()
+						.toCompletableFuture()
+						.get()
+						.catalogVersion();
 
 					final SealedEntity theEntity = theEntityRef.get();
 					if (theEntity != null) {
@@ -1659,7 +1667,7 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 		final Map<Long, List<EntityContract>> entitiesInMutations = CollectionUtils.createHashMap(transactionSizes.length);
 		for (int i = 0; i < transactionSizes.length; i++) {
 			int txSize = transactionSizes[i];
-			final LinkedList<InstanceWithMutation> entities = dataGenerator.generateEntities(
+			final LinkedList<InstanceWithMutation> entities = this.dataGenerator.generateEntities(
 					productSchema,
 					(serializable, faker) -> null,
 					42
@@ -1703,16 +1711,16 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 
 		@Override
 		public int compareTo(PkWithCatalogVersion o) {
-			final int first = entityReference.compareTo(o.entityReference);
-			return first == 0 ? Long.compare(catalogVersion, o.catalogVersion) : first;
+			final int first = this.entityReference.compareTo(o.entityReference);
+			return first == 0 ? Long.compare(this.catalogVersion, o.catalogVersion) : first;
 		}
 
 		public String getType() {
-			return entityReference.getType();
+			return this.entityReference.getType();
 		}
 
 		public int getPrimaryKey() {
-			return entityReference.getPrimaryKey();
+			return this.entityReference.getPrimaryKey();
 		}
 	}
 

--- a/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadWriteTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadWriteTest.java
@@ -26,6 +26,7 @@ package io.evitadb.driver;
 import com.github.javafaker.Faker;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
+import io.evitadb.api.CommitProgress;
 import io.evitadb.api.EvitaContract;
 import io.evitadb.api.EvitaManagementContract;
 import io.evitadb.api.EvitaSessionContract;
@@ -127,6 +128,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
+@SuppressWarnings("DataFlowIssue")
 @Slf4j
 @ExtendWith(EvitaParameterResolver.class)
 class EvitaClientReadWriteTest implements TestConstants, EvitaTestSupport {
@@ -1190,7 +1192,7 @@ class EvitaClientReadWriteTest implements TestConstants, EvitaTestSupport {
 					.withGlobalAttribute(ATTRIBUTE_CODE)
 					.updateVia(session);
 				assertTrue(session.getAllEntityTypes().contains(newCollection));
-				productSchemaVersion.set(session.getEntitySchemaOrThrow(Entities.PRODUCT).version());
+				productSchemaVersion.set(session.getEntitySchemaOrThrowException(Entities.PRODUCT).version());
 				productCount.set(session.getEntityCollectionSize(Entities.PRODUCT));
 			}
 		);
@@ -1208,7 +1210,7 @@ class EvitaClientReadWriteTest implements TestConstants, EvitaTestSupport {
 			session -> {
 				assertFalse(session.getAllEntityTypes().contains(Entities.PRODUCT));
 				assertTrue(session.getAllEntityTypes().contains(newCollection));
-				assertEquals(productSchemaVersion.get() + 1, session.getEntitySchemaOrThrow(newCollection).version());
+				assertEquals(productSchemaVersion.get() + 1, session.getEntitySchemaOrThrowException(newCollection).version());
 				assertEquals(productCount.get(), session.getEntityCollectionSize(newCollection));
 			}
 		);
@@ -1225,7 +1227,7 @@ class EvitaClientReadWriteTest implements TestConstants, EvitaTestSupport {
 			session -> {
 				assertTrue(session.getAllEntityTypes().contains(Entities.PRODUCT));
 				assertFalse(session.getAllEntityTypes().contains(newCollection));
-				productSchemaVersion.set(session.getEntitySchemaOrThrow(Entities.PRODUCT).version());
+				productSchemaVersion.set(session.getEntitySchemaOrThrowException(Entities.PRODUCT).version());
 				productCount.set(session.getEntityCollectionSize(Entities.PRODUCT));
 			}
 		);
@@ -1279,7 +1281,7 @@ class EvitaClientReadWriteTest implements TestConstants, EvitaTestSupport {
 	@Test
 	void shouldUpdateCatalogWithAnotherProductAsynchronously(EvitaContract evita, SealedEntitySchema productSchema) {
 		final AtomicInteger addedEntityPrimaryKey = new AtomicInteger();
-		final CompletableFuture<SealedEntity> addedEntity = evita.updateCatalogAsync(
+		final CommitProgress commitProgress = evita.updateCatalogAsync(
 			TEST_CATALOG,
 			session -> {
 				final Optional<SealedEntity> upsertedEntity = DATA_GENERATOR.generateEntities(productSchema, RANDOM_ENTITY_PICKER, SEED)
@@ -1288,20 +1290,30 @@ class EvitaClientReadWriteTest implements TestConstants, EvitaTestSupport {
 					.findFirst();
 				assertTrue(upsertedEntity.isPresent());
 				addedEntityPrimaryKey.set(upsertedEntity.get().getPrimaryKey());
-				return upsertedEntity.get();
 			},
 			CommitBehavior.WAIT_FOR_CONFLICT_RESOLUTION
 		);
 
-		final int expectedEntityPrimaryKey = addedEntityPrimaryKey.get();
-		while (!addedEntity.isDone()) {
-			Thread.onSpinWait();
-		}
+		List<String> worklog = new ArrayList<>();
+		commitProgress.onConflictResolved().thenAccept(it -> worklog.add("Conflict resolved!"));
+		commitProgress.onWalAppended().thenAccept(it -> worklog.add("WAL appended!"));
+		commitProgress.onChangesVisible().thenAccept(it -> worklog.add("Changes visible!"));
+
+		commitProgress.onChangesVisible().toCompletableFuture().join();
+
+		assertArrayEquals(
+			new String[] {
+				"Conflict resolved!",
+				"WAL appended!",
+				"Changes visible!"
+			},
+			worklog.toArray(new String[0])
+		);
 
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {
-				final Optional<SealedEntity> entityFetchedAgain = session.getEntity(productSchema.getName(), expectedEntityPrimaryKey, entityFetchAllContent());
+				final Optional<SealedEntity> entityFetchedAgain = session.getEntity(productSchema.getName(), addedEntityPrimaryKey.get(), entityFetchAllContent());
 				assertTrue(entityFetchedAgain.isPresent(), "Entity not found in catalog!");
 			}
 		);
@@ -1594,11 +1606,11 @@ class EvitaClientReadWriteTest implements TestConstants, EvitaTestSupport {
 				final SealedEntity updatedEntity = session.upsertAndFetchEntity(
 					entityMutation, entityFetchAll().getRequirements()
 				);
-				newProductId.set(updatedEntity.getPrimaryKey());
+				newProductId.set(updatedEntity.getPrimaryKeyOrThrowException());
 				theEntity.set(updatedEntity);
 
 				final ProductInterface archivedEntity = session.archiveEntity(
-					ProductInterface.class, updatedEntity.getPrimaryKey(), entityFetchAllContent()
+					ProductInterface.class, updatedEntity.getPrimaryKeyOrThrowException(), entityFetchAllContent()
 				).orElseThrow();
 
 				assertProduct(updatedEntity, archivedEntity, originalCategories);


### PR DESCRIPTION
As for now the catalog schema on the client side is invalidate regurarly on obsolete checks and doesn't immediatelly detect catalog schema changes executed by different clients. We should return current catalog schema version at the close session method and similar places so that the client can immediatelly detect and invalidate the catalog schema.

BREAKING-CHANGE: `CompletableFuture` in `EvitaContract` and `EvitaSessionContract` were replaced with `CompletionStage`, which is read-only (intended) and can be easily converted to `CompletableFuture`.