### PR TITLE
fix: Transactional maps are not correctly cleared when GlobalUniqueIndex is dropped

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -369,6 +369,8 @@ public class GlobalUniqueIndex implements VoidTransactionMemoryProducer<GlobalUn
 		this.dirty.removeLayer(transactionalLayer);
 		this.uniqueValueToEntityTuple.removeLayer(transactionalLayer);
 		this.entitiesPerType.removeLayer(transactionalLayer);
+		this.localeToIdIndex.removeLayer(transactionalLayer);
+		this.idToLocaleIndex.removeLayer(transactionalLayer);
 	}
 
 	/*


### PR DESCRIPTION
When GlobalUniqueIndex gets discarded it's responsible for discarding all changes in its internal transactional datastructures so that final transactional check doesn't find orphaned diff layers in memory. This is unfortunatelly done properly and `localeToIdIndex` + `idToLocaleIndex` is not removed in method `GlobalUniqueIndex`

Refs: #880