### PR TITLE
fix: Error while decompressing data

### DIFF
--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/kryo/ObservableInput.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/kryo/ObservableInput.java
@@ -317,15 +317,14 @@ public class ObservableInput<T extends InputStream> extends Input {
 						}
 						// check how much data has been read from the decompression buffer so far
 						final int currentlyReadBytes = Math.toIntExact(this.inflater.getBytesRead());
-						/* TODO JNO - tady bychom možná mohli číst a plnit buffer úplně celý, stejně se pak swapne */
-						final int leftToRead = this.expectedPayloadLength - (this.payloadReadLength + (currentlyReadBytes - this.inflaterReadBytesOnLastDecompressionBufferFill));
+						final int leftToRead = this.expectedPayloadLength - currentlyReadBytes;
 						if (leftToRead > 0) {
 							// attempt to read next chunk of data from the underlying stream into the decompression buffer
 							final int readLength = IOUtils.executeSafely(
 								KryoException::new,
 								() -> this.inputStream.read(
 									this.decompressionBuffer, 0,
-									Math.min(this.decompressionBuffer.length, leftToRead)
+									this.decompressionBuffer.length
 								)
 							);
 							if (readLength == -1) {


### PR DESCRIPTION
When compression enabled we randomly see problems like:

```
Unexpected record length - data probably corrupted (record should be long 24412B, but was read 16405B and another 16384B was requested for reading).
```

Refs: #887