### PR TITLE
Hotfix release

### DIFF
--- a/documentation/user/en/use/api/example/manual-transaction-management.java
+++ b/documentation/user/en/use/api/example/manual-transaction-management.java
@@ -1,7 +1,34 @@
+try{
+	/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
 // open session manually, read-write sessions automatically open a transaction
-final EvitaSessionContract session = evita.createReadWriteSession("evita");
-// in case of error, mark transaction as rollback only
-session.setRollbackOnly();
-// close the entire session - this implicitly closes the internal transaction
-// if `setRollbackOnly` wouldn't have been called, the transaction would have been committed
-session.close();
+	final EvitaSessionContract session = evita.createReadWriteSession("evita");
+	// in case of error, mark transaction as rollback only
+	session.setRollbackOnly();
+	// close the entire session - this implicitly closes the internal transaction
+	// if `setRollbackOnly` wouldn't have been called, the transaction would have been committed
+	session.close();
+} catch (RollbackException e) {
+	// handle information about rollback
+}

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/resolver/constraint/ConstraintDescriptorResolver.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/resolver/constraint/ConstraintDescriptorResolver.java
@@ -33,6 +33,7 @@ import io.evitadb.api.requestResponse.schema.AssociatedDataSchemaContract;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.CatalogSchemaContract;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.api.requestResponse.schema.NamedSchemaContract;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.externalApi.api.catalog.dataApi.constraint.ConstraintProcessingUtils;
 import io.evitadb.externalApi.api.catalog.dataApi.constraint.DataLocator;
@@ -206,7 +207,9 @@ class ConstraintDescriptorResolver {
 				final EntitySchemaContract schemaForClassifier = catalogSchema.getEntitySchemaOrThrowException(parentDataLocator.entityType());
 				return switch (constraintDescriptor.propertyType()) {
 					case ATTRIBUTE -> schemaForClassifier.getAttributeByName(c, CLASSIFIER_NAMING_CONVENTION)
-						.map(AttributeSchemaContract::getName)
+						.map(NamedSchemaContract.class::cast)
+						.or(() -> schemaForClassifier.getSortableAttributeCompoundByName(c, CLASSIFIER_NAMING_CONVENTION))
+						.map(NamedSchemaContract::getName)
 						.orElseThrow(() -> new ExternalApiInternalError(
 							"Could not find attribute schema for classifier `" + c + "`."
 						));

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/constraint/GraphQLConstraintSchemaBuilder.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/constraint/GraphQLConstraintSchemaBuilder.java
@@ -96,7 +96,7 @@ public abstract class GraphQLConstraintSchemaBuilder extends ConstraintSchemaBui
 		final GraphQLInputObjectType.Builder containerBuilder = newInputObject().name(containerName);
 		final GraphQLInputType containerPointer = typeRef(containerName);
 		// cache new container for reuse
-		sharedContext.cacheContainer(containerKey, containerPointer);
+		this.sharedContext.cacheContainer(containerKey, containerPointer);
 
 		final List<GraphQLInputObjectField> children = new LinkedList<>();
 		children.addAll(buildGenericChildren(buildContext, allowedChildrenPredicate));
@@ -125,7 +125,7 @@ public abstract class GraphQLConstraintSchemaBuilder extends ConstraintSchemaBui
 			containerBuilder.field(field);
 		});
 
-		sharedContext.addNewType(containerBuilder.build());
+		this.sharedContext.addNewType(containerBuilder.build());
 		return containerPointer;
 	}
 

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/constraint/FacetSummaryResolver.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/constraint/FacetSummaryResolver.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -78,6 +78,7 @@ public class FacetSummaryResolver {
 	 * Entity schemas for references of {@link #entitySchema} by field-formatted names.
 	 */
 	@Nonnull private final Map<String, EntitySchemaContract> referencedEntitySchemas;
+	@Nonnull private final Map<String, EntitySchemaContract> referencedGroupEntitySchemas;
 	@Nonnull private final EntityFetchRequireResolver entityFetchRequireResolver;
 	@Nonnull private final FilterConstraintResolver filterConstraintResolver;
 	@Nonnull private final OrderConstraintResolver orderConstraintResolver;
@@ -232,7 +233,7 @@ public class FacetSummaryResolver {
 			.flatMap(groupEntityField -> entityFetchRequireResolver.resolveGroupFetch(
 				SelectionSetAggregator.from(groupEntityField.getSelectionSet()),
 				desiredLocale,
-				referencedEntitySchemas.get(referenceName)
+				referencedGroupEntitySchemas.get(referenceName)
 			));
 	}
 }

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/dataFetcher/QueryEntitiesDataFetcher.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/dataFetcher/QueryEntitiesDataFetcher.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -98,6 +98,10 @@ public class QueryEntitiesDataFetcher implements DataFetcher<DataFetcherResult<E
 	 * Entity schemas for references of {@link #entitySchema} by field-formatted names.
 	 */
 	@Nonnull private final Map<String, EntitySchemaContract> referencedEntitySchemas;
+	/**
+	 * Entity schemas of group types in references by field-formatted names.
+	 */
+	@Nonnull private final Map<String, EntitySchemaContract> referencedGroupEntitySchemas;
 
 	@Nonnull private final HeadConstraintResolver headConstraintResolver;
 	@Nonnull private final FilterConstraintResolver filterConstraintResolver;
@@ -131,6 +135,16 @@ public class QueryEntitiesDataFetcher implements DataFetcher<DataFetcherResult<E
 				final EntitySchemaContract referencedEntitySchema = catalogSchema.getEntitySchemaOrThrowException(referenceSchema.getReferencedEntityType());
 				this.referencedEntitySchemas.put(referenceSchema.getName(), referencedEntitySchema);
 			});
+		this.referencedGroupEntitySchemas = createHashMap(entitySchema.getReferences().size());
+		entitySchema.getReferences()
+			.values()
+			.stream()
+			.filter(ReferenceSchemaContract::isReferencedGroupTypeManaged)
+			.forEach(referenceSchema -> {
+				//noinspection DataFlowIssue
+				final EntitySchemaContract referencedGroupEntitySchema = catalogSchema.getEntitySchemaOrThrowException(referenceSchema.getReferencedGroupType());
+				this.referencedGroupEntitySchemas.put(referenceSchema.getName(), referencedGroupEntitySchema);
+			});
 
 		this.headConstraintResolver = new HeadConstraintResolver(catalogSchema);
 		this.filterConstraintResolver = new FilterConstraintResolver(catalogSchema);
@@ -154,6 +168,7 @@ public class QueryEntitiesDataFetcher implements DataFetcher<DataFetcherResult<E
 		this.facetSummaryResolver = new FacetSummaryResolver(
 			entitySchema,
 			referencedEntitySchemas,
+			referencedGroupEntitySchemas,
 			entityFetchRequireResolver,
 			filterConstraintResolver,
 			orderConstraintResolver

--- a/evita_functional_tests/src/test/java/io/evitadb/api/query/descriptor/ConstraintProcessorTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/query/descriptor/ConstraintProcessorTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -230,6 +230,7 @@ class ConstraintProcessorTest {
 			new SupportedValues(
 				Set.of(String.class),
 				true,
+				false,
 				ConstraintNullabilitySupport.NULLABLE_AND_NONNULL
 			),
 			new ConstraintCreator(
@@ -324,6 +325,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -341,6 +343,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -355,6 +358,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public String getName() {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 
@@ -383,12 +387,14 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public String toString() {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 
 		@Nonnull
 		@Override
 		public ConstraintWithoutType cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -403,6 +409,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public String getName() {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 
@@ -431,12 +438,14 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public String toString() {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -461,6 +470,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -479,6 +489,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -497,6 +508,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -515,6 +527,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -533,6 +546,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -551,6 +565,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -569,6 +584,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -592,6 +608,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -610,6 +627,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -632,6 +650,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -654,6 +673,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -672,6 +692,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -690,6 +711,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -708,6 +730,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -740,6 +763,7 @@ class ConstraintProcessorTest {
 		@Nonnull
 		@Override
 		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+			//noinspection ReturnOfNull,DataFlowIssue
 			return null;
 		}
 	}
@@ -779,16 +803,18 @@ class ConstraintProcessorTest {
 			visitor.visit(this);
 		}
 
-		@Nonnull
-		@Override
-		public FilterConstraint getCopyWithNewChildren(@Nonnull FilterConstraint[] children, @Nonnull Constraint<?>[] additionalChildren) {
-			return null;
-		}
+	    @Nonnull
+	    @Override
+	    public FilterConstraint getCopyWithNewChildren(@Nonnull FilterConstraint[] children, @Nonnull Constraint<?>[] additionalChildren) {
+	        //noinspection ReturnOfNull,DataFlowIssue
+	        return null;
+			}
 
-		@Nonnull
-		@Override
-		public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
-			return null;
+	    @Nonnull
+	    @Override
+	    public FilterConstraint cloneWithArguments(@Nonnull Serializable[] newArguments) {
+	        //noinspection ReturnOfNull,DataFlowIssue
+	        return null;
 		}
 	}
 }

--- a/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLQueryEntityQueryFunctionalTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLQueryEntityQueryFunctionalTest.java
@@ -3712,6 +3712,66 @@ public class CatalogGraphQLQueryEntityQueryFunctionalTest extends CatalogGraphQL
 
 	@Test
 	@UseDataSet(GRAPHQL_THOUSAND_PRODUCTS)
+	@DisplayName("Should order entities by sortable attribute compound")
+	void shouldOrderEntitiesBySortableAttributeCompound(Evita evita, GraphQLTester tester) {
+		final Integer[] expectedEntities = evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				return session.query(
+						query(
+							collection(Entities.PRODUCT),
+							filterBy(
+								entityLocaleEquals(CZECH_LOCALE)
+							),
+							orderBy(
+								attributeNatural(SORTABLE_ATTRIBUTE_COMPOUND_CODE_NAME, DESC)
+							),
+							require(
+								page(1, 30)
+							)
+						),
+						EntityReference.class
+					)
+					.getRecordData()
+					.stream()
+					.map(EntityReference::getPrimaryKey)
+					.toArray(Integer[]::new);
+			}
+		);
+		Assert.isPremiseValid(expectedEntities.length == 30, "Expected entities");
+
+		tester.test(TEST_CATALOG)
+			.document(
+				"""
+		            query {
+		                queryProduct(
+		                    filterBy: {
+		                        entityLocaleEquals: cs_CZ
+		                    },
+		                    orderBy: {
+		                        attributeCodeNameNatural: DESC
+		                    }
+		                ) {
+		                    recordStrip(limit: 30) {
+		                        data {
+		                            primaryKey
+		                        }
+		                    }
+		                }
+		            }
+					"""
+			)
+			.executeAndThen()
+			.statusCode(200)
+			.body(ERRORS_PATH, nullValue())
+			.body(
+				PRODUCT_QUERY_PATH + "." + ResponseDescriptor.RECORD_STRIP.name() + "." + RecordPageDescriptor.DATA.name() + "." + EntityDescriptor.PRIMARY_KEY.name(),
+				contains(expectedEntities)
+			);
+	}
+
+	@Test
+	@UseDataSet(GRAPHQL_THOUSAND_PRODUCTS)
 	@DisplayName("Should return page of entities")
 	void shouldReturnPageOfEntities(Evita evita, GraphQLTester tester) {
 		final List<Integer> expectedEntities = evita.queryCatalog(

--- a/evita_functional_tests/src/test/java/io/evitadb/store/catalog/PostMortemAnalysisTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/catalog/PostMortemAnalysisTest.java
@@ -39,8 +39,11 @@ import io.evitadb.core.Evita;
 import io.evitadb.core.async.Scheduler;
 import io.evitadb.core.metric.event.storage.FileType;
 import io.evitadb.dataType.PaginatedList;
+import io.evitadb.store.kryo.ObservableInput;
 import io.evitadb.store.kryo.ObservableOutputKeeper;
 import io.evitadb.store.offsetIndex.OffsetIndex;
+import io.evitadb.store.offsetIndex.OffsetIndex.FileOffsetIndexStatistics;
+import io.evitadb.store.offsetIndex.OffsetIndexSerializationService;
 import io.evitadb.store.offsetIndex.io.WriteOnlyFileHandle;
 import io.evitadb.store.offsetIndex.model.OffsetIndexRecordTypeRegistry;
 import io.evitadb.store.service.KryoFactory;
@@ -48,13 +51,16 @@ import io.evitadb.store.spi.model.CatalogHeader;
 import io.evitadb.store.spi.model.reference.WalFileReference;
 import io.evitadb.store.wal.CatalogWriteAheadLog;
 import io.evitadb.store.wal.WalKryoConfigurer;
+import io.evitadb.stream.RandomAccessFileInputStream;
 import io.evitadb.test.EvitaTestSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.UUID;
@@ -305,4 +311,45 @@ public class PostMortemAnalysisTest implements EvitaTestSupport {
 
 		}
 	}
+
+	@Test
+	void shouldVerifyCrc32() throws FileNotFoundException {
+		final StorageOptions storageOptions = StorageOptions.builder()
+			.storageDirectory(Path.of("/www/oss/evitaDB-temporary/data"))
+			.exportDirectory(Path.of("/www/oss/evitaDB-temporary/export"))
+			.fileSizeCompactionThresholdBytes(1_073_741_824L)
+			.minimalActiveRecordShare(0.7d)
+			.compress(true)
+			.build();
+		final String catalogName = "decodoma_cz";
+		final Path fileToCheck = storageOptions.storageDirectory().resolve(catalogName).resolve("decodoma_cz_0.catalog");
+		try (
+			final ObservableInput<RandomAccessFileInputStream> observableInput = new ObservableInput<>(
+				new RandomAccessFileInputStream(
+					new RandomAccessFile(fileToCheck.toFile(), "r")
+				)
+			)
+		) {
+			if (storageOptions.compress()) {
+				observableInput.compress();
+			}
+			if (storageOptions.computeCRC32C()) {
+				observableInput.computeCRC32();
+			}
+			final FileOffsetIndexStatistics statistics = new FileOffsetIndexStatistics(0, 0L);
+			OffsetIndexSerializationService.verify(
+				observableInput,
+				fileToCheck.toFile().length(),
+				statistics,
+				storageOptions
+			);
+			log.info(
+				"File `{}` CRC32C checksum is valid - total records: {}, size: {}B",
+				fileToCheck,
+				statistics.getRecordCount(),
+				statistics.getTotalSize()
+			);
+		}
+	}
+
 }

--- a/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
@@ -345,7 +345,8 @@ class OffsetIndexTest implements EvitaTestSupport, TimeBoundedTestSupport {
 				new OffsetIndexDescriptor(
 					fileOffsetIndexDescriptor.fileLocation(),
 					fileOffsetIndexDescriptor,
-					1.0, 0L
+					1.0,
+					fileOffsetIndexDescriptor.getFileSize()
 				),
 				limitedBufferOptions,
 				offsetIndexRecordTypeRegistry,
@@ -369,7 +370,8 @@ class OffsetIndexTest implements EvitaTestSupport, TimeBoundedTestSupport {
 				new OffsetIndexDescriptor(
 					updatedOffsetIndexDescriptor.fileLocation(),
 					updatedOffsetIndexDescriptor,
-					1.0, 0L
+					1.0,
+					updatedOffsetIndexDescriptor.getFileSize()
 				),
 				limitedBufferOptions,
 				offsetIndexRecordTypeRegistry,
@@ -453,7 +455,8 @@ class OffsetIndexTest implements EvitaTestSupport, TimeBoundedTestSupport {
 				new OffsetIndexDescriptor(
 					fileOffsetIndexInfo.fileLocation(),
 					fileOffsetIndexInfo,
-					1.0, 0L
+					1.0,
+					fileOffsetIndexInfo.getFileSize()
 				),
 				storageOptions,
 				offsetIndexRecordTypeRegistry,
@@ -521,7 +524,8 @@ class OffsetIndexTest implements EvitaTestSupport, TimeBoundedTestSupport {
 				new OffsetIndexDescriptor(
 					fileOffsetIndexDescriptor.fileLocation(),
 					fileOffsetIndexDescriptor,
-					1.0, 0L
+					1.0,
+					fileOffsetIndexDescriptor.getFileSize()
 				),
 				storageOptions,
 				offsetIndexRecordTypeRegistry,
@@ -753,7 +757,8 @@ class OffsetIndexTest implements EvitaTestSupport, TimeBoundedTestSupport {
 						new OffsetIndexDescriptor(
 							fileOffsetIndexDescriptor.fileLocation(),
 							fileOffsetIndexDescriptor,
-							1.0, 0L
+							1.0,
+							fileOffsetIndexDescriptor.getFileSize()
 						),
 						storageOptions,
 						offsetIndexRecordTypeRegistry,
@@ -843,7 +848,8 @@ class OffsetIndexTest implements EvitaTestSupport, TimeBoundedTestSupport {
 							new OffsetIndexDescriptor(
 								compactedDescriptor.fileLocation(),
 								compactedDescriptor,
-								1.0, 0L
+								1.0,
+								compactedDescriptor.getFileSize()
 							),
 							storageOptions,
 							offsetIndexRecordTypeRegistry,
@@ -942,7 +948,8 @@ class OffsetIndexTest implements EvitaTestSupport, TimeBoundedTestSupport {
 				new OffsetIndexDescriptor(
 					fileOffsetIndexDescriptor.fileLocation(),
 					fileOffsetIndexDescriptor,
-					1.0, 0L
+					1.0,
+					fileOffsetIndexDescriptor.getFileSize()
 				),
 				storageOptions,
 				offsetIndexRecordTypeRegistry,

--- a/evita_functional_tests/src/test/java/io/evitadb/utils/FileUtilsTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/utils/FileUtilsTest.java
@@ -51,25 +51,25 @@ class FileUtilsTest {
 
 	@BeforeEach
 	void setUp() {
-		directoryTest = tmpFolder.resolve("directoryTest");
-		directoryTest.toFile().mkdirs();
+		this.directoryTest = this.tmpFolder.resolve("directoryTest");
+		this.directoryTest.toFile().mkdirs();
 	}
 
 	@AfterEach
 	void tearDown() throws IOException {
-		FileUtils.deleteDirectory(directoryTest);
+		FileUtils.deleteDirectory(this.directoryTest);
 	}
 
 	@Test
 	void shouldListDirectories() throws IOException {
-		org.apache.commons.io.FileUtils.deleteDirectory(directoryTest.toFile());
+		org.apache.commons.io.FileUtils.deleteDirectory(this.directoryTest.toFile());
 
-		assertTrue(directoryTest.toFile().mkdirs());
-		assertTrue(directoryTest.resolve("A").toFile().mkdirs());
-		assertTrue(directoryTest.resolve("B").toFile().mkdirs());
-		assertTrue(directoryTest.resolve("C").toFile().mkdirs());
+		assertTrue(this.directoryTest.toFile().mkdirs());
+		assertTrue(this.directoryTest.resolve("A").toFile().mkdirs());
+		assertTrue(this.directoryTest.resolve("B").toFile().mkdirs());
+		assertTrue(this.directoryTest.resolve("C").toFile().mkdirs());
 
-		final Path[] paths = FileUtils.listDirectories(directoryTest);
+		final Path[] paths = FileUtils.listDirectories(this.directoryTest);
 		assertEquals(3, paths.length);
 
 		assertArrayEquals(
@@ -77,20 +77,20 @@ class FileUtilsTest {
 			Arrays.stream(paths).map(Path::toFile).map(File::getName).sorted().toArray(String[]::new)
 		);
 
-		org.apache.commons.io.FileUtils.deleteDirectory(directoryTest.toFile());
+		org.apache.commons.io.FileUtils.deleteDirectory(this.directoryTest.toFile());
 	}
 
 	@Test
 	void shouldCalculateDirectorySizeIncludingSubdirectories() throws IOException {
 		// Create some files in the temp directory
-		Path file1 = directoryTest.resolve("file1.txt");
+		Path file1 = this.directoryTest.resolve("file1.txt");
 		Files.write(file1, "Hello".getBytes(), StandardOpenOption.CREATE);
 
-		Path file2 = directoryTest.resolve("file2.txt");
+		Path file2 = this.directoryTest.resolve("file2.txt");
 		Files.write(file2, "World".getBytes(), StandardOpenOption.CREATE);
 
 		// Create a subdirectory and a file in it
-		Path subDir = directoryTest.resolve("subdir");
+		Path subDir = this.directoryTest.resolve("subdir");
 		Files.createDirectory(subDir);
 		Path file3 = subDir.resolve("file3.txt");
 		Files.write(file3, "Hello, Subdirectory".getBytes(), StandardOpenOption.CREATE);
@@ -99,7 +99,7 @@ class FileUtilsTest {
 		long expectedSize = Files.size(file1) + Files.size(file2) + Files.size(file3);
 
 		// Call the method under test
-		long actualSize = FileUtils.getDirectorySize(directoryTest);
+		long actualSize = FileUtils.getDirectorySize(this.directoryTest);
 
 		// Assert that the actual size matches the expected size
 		assertEquals(expectedSize, actualSize);
@@ -113,7 +113,7 @@ class FileUtilsTest {
 	@Test
 	void shouldDeleteFileIfExists() throws IOException {
 		// Create a file in the temp directory
-		Path testFile = directoryTest.resolve("testFile.txt");
+		Path testFile = this.directoryTest.resolve("testFile.txt");
 		Files.write(testFile, "test content".getBytes(), StandardOpenOption.CREATE);
 
 		// Assert the file exists
@@ -168,8 +168,8 @@ class FileUtilsTest {
 	@Test
 	void shouldRenameFolderSuccessfully() throws IOException {
 		// Set up source and target directories
-		Path sourceDir = directoryTest.resolve("sourceDir");
-		Path targetDir = directoryTest.resolve("targetDir");
+		Path sourceDir = this.directoryTest.resolve("sourceDir");
+		Path targetDir = this.directoryTest.resolve("targetDir");
 
 		Files.createDirectory(sourceDir);
 		Files.write(sourceDir.resolve("file1.txt"), "File 1 content".getBytes());
@@ -193,8 +193,8 @@ class FileUtilsTest {
 	@Test
 	void shouldThrowExceptionWhenSourceDoesNotExist() {
 		// Set up source and target directories
-		Path nonExistentSource = directoryTest.resolve("nonExistentSource");
-		Path targetDir = directoryTest.resolve("targetDir");
+		Path nonExistentSource = this.directoryTest.resolve("nonExistentSource");
+		Path targetDir = this.directoryTest.resolve("targetDir");
 
 		// Verify source does not exist
 		assertFalse(Files.exists(nonExistentSource));
@@ -209,8 +209,8 @@ class FileUtilsTest {
 	@Test
 	void shouldRenameFolderWithNestedStructureSuccessfully() throws IOException {
 		// Set up source and target directories with nested structure
-		Path sourceDir = directoryTest.resolve("nestedSource");
-		Path targetDir = directoryTest.resolve("nestedTarget");
+		Path sourceDir = this.directoryTest.resolve("nestedSource");
+		Path targetDir = this.directoryTest.resolve("nestedTarget");
 
 		Files.createDirectory(sourceDir);
 		Files.createDirectory(sourceDir.resolve("nested1"));
@@ -230,7 +230,7 @@ class FileUtilsTest {
 	}
 	@Test
 	void shouldGetLastModifiedTimeWhenFileExists() {
-		Path testFile = directoryTest.resolve("testFile.txt");
+		Path testFile = this.directoryTest.resolve("testFile.txt");
 		try {
 			Files.write(testFile, "test content".getBytes(), StandardOpenOption.CREATE);
 			Optional<OffsetDateTime> lastModifiedTimeOpt = FileUtils.getFileLastModifiedTime(testFile);
@@ -245,7 +245,7 @@ class FileUtilsTest {
 
 	@Test
 	void shouldReturnEmptyWhenFileNotExists() {
-		Path nonExistentFile = directoryTest.resolve("nonExistentFile.txt");
+		Path nonExistentFile = this.directoryTest.resolve("nonExistentFile.txt");
 		Optional<OffsetDateTime> lastModifiedTimeOpt = FileUtils.getFileLastModifiedTime(nonExistentFile);
 		assertTrue(lastModifiedTimeOpt.isEmpty());
 	}
@@ -253,45 +253,46 @@ class FileUtilsTest {
 	@Test
 	void shouldCompressDirectorySuccessfully() throws IOException {
 		// Arrange
-		Path subDir = directoryTest.resolve("subDir");
+		Path subDir = this.directoryTest.resolve("subDir");
 		Files.createDirectory(subDir);
-		Path file1 = directoryTest.resolve("file1.txt");
+		Path file1 = this.directoryTest.resolve("file1.txt");
 		Path file2 = subDir.resolve("file2.txt");
 		Files.write(file1, "File1 Content".getBytes(), StandardOpenOption.CREATE);
 		Files.write(file2, "File2 Content".getBytes(), StandardOpenOption.CREATE);
 
-		Path zipFile = tmpFolder.resolve("output.zip");
+		Path zipFile = this.tmpFolder.resolve("output.zip");
 
 		// Act
 		try (OutputStream outputStream = Files.newOutputStream(zipFile)) {
-			FileUtils.compressDirectory(directoryTest, outputStream);
+			FileUtils.compressDirectory(this.directoryTest, outputStream);
 		}
 
 		// Assert
 		assertTrue(Files.exists(zipFile));
 		try (java.util.zip.ZipInputStream zis = new java.util.zip.ZipInputStream(Files.newInputStream(zipFile))) {
-			java.util.zip.ZipEntry entry = zis.getNextEntry();
-			assertNotNull(entry);
-			assertEquals("file1.txt", entry.getName());
+			// Collect all entries from the ZIP file
+			java.util.List<String> entryNames = new java.util.ArrayList<>();
+			java.util.zip.ZipEntry entry;
+			while ((entry = zis.getNextEntry()) != null) {
+				entryNames.add(entry.getName());
+			}
 
-			entry = zis.getNextEntry();
-			assertNotNull(entry);
-			assertEquals("subDir/", entry.getName());
-
-			entry = zis.getNextEntry();
-			assertNotNull(entry);
-			assertEquals("subDir" + File.separatorChar + "file2.txt", entry.getName());
+			// Verify that all expected entries are present, regardless of their order
+			assertEquals(3, entryNames.size(), "Expected 3 entries in the ZIP file");
+			assertTrue(entryNames.contains("file1.txt"), "ZIP should contain file1.txt");
+			assertTrue(entryNames.contains("subDir/"), "ZIP should contain subDir/");
+			assertTrue(entryNames.contains("subDir" + File.separatorChar + "file2.txt"), "ZIP should contain subDir/file2.txt");
 		}
 	}
 
 	@Test
 	void shouldHandleCompressionOfEmptyDirectory() throws IOException {
 		// Arrange
-		Path zipFile = tmpFolder.resolve("output_empty.zip");
+		Path zipFile = this.tmpFolder.resolve("output_empty.zip");
 
 		// Act
 		try (OutputStream outputStream = Files.newOutputStream(zipFile)) {
-			FileUtils.compressDirectory(directoryTest, outputStream);
+			FileUtils.compressDirectory(this.directoryTest, outputStream);
 		}
 
 		// Assert
@@ -304,8 +305,8 @@ class FileUtilsTest {
 	@Test
 	void shouldThrowExceptionWhenDirectoryDoesNotExist() {
 		// Arrange
-		Path nonExistentDirectory = tmpFolder.resolve("nonExistentDir");
-		Path zipFile = tmpFolder.resolve("output_error.zip");
+		Path nonExistentDirectory = this.tmpFolder.resolve("nonExistentDir");
+		Path zipFile = this.tmpFolder.resolve("output_error.zip");
 
 		// Act & Assert
 		try (OutputStream outputStream = Files.newOutputStream(zipFile)) {

--- a/evita_functional_tests/src/test/resources/META-INF/documentation/imports.java
+++ b/evita_functional_tests/src/test/resources/META-INF/documentation/imports.java
@@ -78,6 +78,7 @@ import io.evitadb.api.requestResponse.data.structure.ExistingEntityBuilder;
 import io.evitadb.api.query.visitor.PrettyPrintingVisitor.StringWithParameters;
 import io.evitadb.api.query.expression.ExpressionFactory;
 import io.evitadb.api.exception.ContextMissingException;
+import io.evitadb.api.exception.RollbackException;
 import io.evitadb.api.requestResponse.data.SealedInstance;
 import io.evitadb.api.requestResponse.data.InstanceEditor;
 import io.evitadb.externalApi.graphql.GraphQLProvider;

--- a/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintDescriptor.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintDescriptor.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -254,10 +254,12 @@ public class ConstraintDescriptor implements Comparable<ConstraintDescriptor> {
 	 *
 	 * @param dataTypes set of value data types of target data this query can operate on
 	 * @param supportsArrays if target data can be an array of supported data types
+	 * @param compoundsSupported if target data can be a compound of supported data types
 	 * @param nullability whether the constraint supports only nullable data or only nonnull data or both and so on.
 	 */
 	public record SupportedValues(@Nonnull Set<Class<?>> dataTypes,
 	                              boolean supportsArrays,
+								  boolean compoundsSupported,
 	                              @Nonnull ConstraintNullabilitySupport nullability) {}
 
 }

--- a/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintDescriptorProvider.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintDescriptorProvider.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -206,6 +206,22 @@ public class ConstraintDescriptorProvider {
 				cd.supportedValues().dataTypes().contains(requiredSupportedValueType.isPrimitive() ? EvitaDataTypes.getWrappingPrimitiveClass(requiredSupportedValueType) : requiredSupportedValueType) &&
 				verifyNullabilitySupport(cd.supportedValues().nullability(), nullableData) &&
 				(!arraySupportRequired || cd.supportedValues().supportsArrays()))
+			.collect(Collectors.toUnmodifiableSet());
+	}
+
+	/**
+	 * @return descriptors of all correctly registered constraints supporting compound data types
+	 */
+	@Nonnull
+	public static Set<ConstraintDescriptor> getConstraintsSupportingCompounds(@Nonnull ConstraintType requiredType,
+	                                                                          @Nonnull ConstraintPropertyType requiredPropertyType,
+	                                                                          @Nonnull ConstraintDomain requiredSupportedDomain) {
+		return CONSTRAINT_DESCRIPTORS.stream()
+			.filter(cd -> cd.type().equals(requiredType) &&
+				cd.propertyType().equals(requiredPropertyType) &&
+				cd.supportedIn().contains(requiredSupportedDomain) &&
+				cd.supportedValues() != null &&
+				cd.supportedValues().compoundsSupported())
 			.collect(Collectors.toUnmodifiableSet());
 	}
 

--- a/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintProcessor.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/descriptor/ConstraintProcessor.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -160,10 +160,11 @@ class ConstraintProcessor {
 			supportedValues = null;
 		} else {
 			supportedValues = new SupportedValues(
-				constraintSupportedValues.supportedTypes().length > 0 ?
-					Set.of(constraintSupportedValues.supportedTypes()) :
-					EvitaDataTypes.getSupportedDataTypes(),
+				constraintSupportedValues.allTypesSupported()
+					? EvitaDataTypes.getSupportedDataTypes()
+					: Set.of(constraintSupportedValues.supportedTypes()),
 				constraintDefinition.supportedValues().arraysSupported(),
+				constraintDefinition.supportedValues().compoundsSupported(),
 				constraintDefinition.supportedValues().nullability()
 			);
 		}

--- a/evita_query/src/main/java/io/evitadb/api/query/descriptor/annotation/ConstraintSupportedValues.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/descriptor/annotation/ConstraintSupportedValues.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -45,6 +45,8 @@ public @interface ConstraintSupportedValues {
 
 	/**
 	 * Set of value data types of target data this query can operate on. Cannot be primitive types.
+	 *
+	 * If {@link #allTypesSupported()} is set to true, this parameter is ignored.
 	 */
 	Class<?>[] supportedTypes() default {};
 
@@ -58,6 +60,11 @@ public @interface ConstraintSupportedValues {
 	 * Flag stating that those {@link #supportedTypes()} can be in arrays in queried data.
 	 */
 	boolean arraysSupported() default false;
+
+	/**
+	 * Flag stating that compound types can be used as a value in the constraint.
+	 */
+	boolean compoundsSupported() default false;
 
 	/**
 	 * Whether the constraint supports only nullable data or only nonnull data or both and so on.

--- a/evita_query/src/main/java/io/evitadb/api/query/order/AttributeNatural.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/order/AttributeNatural.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ import java.io.Serializable;
     shortDescription = "The constraint sorts returned entities by natural ordering of the values in the specified attribute.",
     userDocsLink = "/documentation/query/ordering/comparable#attribute-natural",
     supportedIn = { ConstraintDomain.ENTITY, ConstraintDomain.REFERENCE, ConstraintDomain.INLINE_REFERENCE },
-    supportedValues = @ConstraintSupportedValues(allTypesSupported = true)
+    supportedValues = @ConstraintSupportedValues(allTypesSupported = true, compoundsSupported = true)
 )
 public class AttributeNatural extends AbstractOrderConstraintLeaf implements AttributeConstraint<OrderConstraint> {
 

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/OffHeapMemoryOutputStream.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/OffHeapMemoryOutputStream.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -210,8 +210,10 @@ public class OffHeapMemoryOutputStream extends OutputStream {
 		if (mode == Mode.READ) {
 			switchMode(Mode.WRITE);
 		}
+		// reset position to first byte before dumping data
+		buffer.flip();
+		// write all data in a cycle
 		while(buffer.hasRemaining()) {
-			buffer.flip();
 			final int written = fileChannel.write(buffer);
 			Assert.isPremiseValid(
 				written == buffer.limit(),

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/CatalogOffsetIndexStoragePartPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/CatalogOffsetIndexStoragePartPersistenceService.java
@@ -155,14 +155,13 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 	) {
 		final CatalogHeader catalogHeader = previous.getCatalogHeader(catalogVersion);
 		final OffsetIndex previousOffsetIndex = previous.offsetIndex;
-		final long totalSize = previousOffsetIndex.getTotalSizeBytes();
 		final OffsetIndexDescriptor offsetIndexDescriptor = new OffsetIndexDescriptor(
 			previousOffsetIndex.getVersion(),
 			previousOffsetIndex.getFileOffsetIndexLocation(),
 			catalogHeader.compressedKeys(),
 			kryoFactory,
-			previousOffsetIndex.getActiveRecordShare(totalSize),
-			totalSize
+			previousOffsetIndex.getActiveRecordShare(previousOffsetIndex.getTotalSizeBytes()),
+			catalogFilePath.toFile().length()
 		);
 
 		final OffsetIndex offsetIndex = new OffsetIndex(

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java
@@ -816,7 +816,6 @@ public class DefaultEntityCollectionPersistenceService implements EntityCollecti
 
 		final OffsetIndexStoragePartPersistenceService previousStoragePartService = previous.storagePartPersistenceService;
 		final OffsetIndex previousOffsetIndex = previousStoragePartService.offsetIndex;
-		final long totalSize = previousOffsetIndex.getTotalSizeBytes();
 		this.storagePartPersistenceService = new OffsetIndexStoragePartPersistenceService(
 			catalogVersion,
 			catalogName,
@@ -844,8 +843,8 @@ public class DefaultEntityCollectionPersistenceService implements EntityCollecti
 					previousOffsetIndex.getFileOffsetIndexLocation(),
 					entityTypeHeader.compressedKeys(),
 					VERSIONED_KRYO_FACTORY,
-					previousOffsetIndex.getActiveRecordShare(totalSize),
-					totalSize
+					previousOffsetIndex.getActiveRecordShare(previousOffsetIndex.getTotalSizeBytes()),
+					this.entityCollectionFile.toFile().length()
 				)
 			),
 			previousStoragePartService.offHeapMemoryManager,


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across multiple files, focusing on improving functionality related to schema constraints, adding new tests, and refining code quality. Key changes include the addition of support for sortable attribute compound schemas, a new long-running test for file rotation and compaction, and minor code adjustments for clarity and compliance.

### Fixes

- cannot sort by sortable attribute compounds in GQL and REST APIs (984)[https://github.com/FgForrest/evitaDB/issues/894]
- prevention of pointers outside file, minor fixes for edge cases

### Enhancements to schema constraints:
* [`ConstraintSchemaBuilder.java`](diffhunk://#diff-a94afc1e85fb747226578ba687873abe99775dd8dff9cbebe6bdc2fdfac94ec0R433-R459): Added support for sortable attribute compound schemas, enabling dynamic classifiers and constraints for indexed attributes. This includes the addition of the `findSortableAttributeCompoundSchemas` method and updates to the `buildAttributeChildren` method. [[1]](diffhunk://#diff-a94afc1e85fb747226578ba687873abe99775dd8dff9cbebe6bdc2fdfac94ec0R433-R459) [[2]](diffhunk://#diff-a94afc1e85fb747226578ba687873abe99775dd8dff9cbebe6bdc2fdfac94ec0R1004-R1024)
* [`ConstraintDescriptorResolver.java`](diffhunk://#diff-4f326dbbc373794db28717cd8805762a455935a3fe50094c7598f2fffc18ee96L209-R212): Modified the `resolveActualClassifier` method to handle sortable attribute compound schemas by mapping them to `NamedSchemaContract`.

### Improvements to testing:
* [`EvitaTransactionalFunctionalTest.java`](diffhunk://#diff-c10e188b0fe274b3e361dfa3e505f31ebf5a78ca1a56dc76721badfdafcc0676R1757-R1946): Added a new long-running test, `shouldCorrectlyRotateAllFilesManyItems`, to verify the rotation and compaction of data files under various conditions. This includes detailed checks for entity attributes and catalog versions.
* [`ConstraintProcessorTest.java`](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364R233): Updated multiple test cases with `//noinspection` comments for clarity and added a new parameter to `SupportedValues` for better test coverage. [[1]](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364R233) [[2]](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364R328) [[3]](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364R346) [[4]](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364R361) [[5]](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364R390-R397) [[6]](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364R412) [[7]](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364R441-R448) [[8]](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364R473) [[9]](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364R492) [[10]](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364R511)

### Minor code adjustments:
* [`GraphQLConstraintSchemaBuilder.java`](diffhunk://#diff-9ee1426fc20f8f6e2432c2ee70f22b3b8ef0f0c6adbea7eecf322e05beae69a5L99-R99): Added `this` to `sharedContext` references for consistency and clarity in the `buildContainer` method. [[1]](diffhunk://#diff-9ee1426fc20f8f6e2432c2ee70f22b3b8ef0f0c6adbea7eecf322e05beae69a5L99-R99) [[2]](diffhunk://#diff-9ee1426fc20f8f6e2432c2ee70f22b3b8ef0f0c6adbea7eecf322e05beae69a5L128-R128)
* [`ConstraintProcessorTest.java`](diffhunk://#diff-458c64a3da710f9b9f7749fe612a99da7305532c02879db428d4fa0241135364L9-R9): Updated copyright year to 2025 in the header comments.

### Documentation updates:
* [`manual-transaction-management.java`](diffhunk://#diff-6681749c998b863869eb63e40e5fcf8d181191f9951d919055efb3c5fac6b159R1-R34): Added licensing information and handling for `RollbackException` in example code for manual transaction management.