### PR TITLE
perf: InScope LIVE + ARCHIVE prevents prefetching

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanner.java
@@ -41,6 +41,7 @@ import io.evitadb.core.query.algebra.prefetch.PrefetchFormulaVisitor;
 import io.evitadb.core.query.extraResult.ExtraResultPlanningVisitor;
 import io.evitadb.core.query.extraResult.ExtraResultProducer;
 import io.evitadb.core.query.filter.FilterByVisitor;
+import io.evitadb.core.query.filter.FormulaOptimizer;
 import io.evitadb.core.query.indexSelection.IndexSelectionResult;
 import io.evitadb.core.query.indexSelection.IndexSelectionVisitor;
 import io.evitadb.core.query.indexSelection.TargetIndexes;
@@ -264,7 +265,12 @@ public class QueryPlanner {
 
 						final PrefetchFormulaVisitor prefetchFormulaVisitor = new PrefetchFormulaVisitor(queryContext, targetIndex);
 						ofNullable(queryContext.getFilterBy()).ifPresent(filterByVisitor::visit);
-						adeptFormula = queryContext.analyse(filterByVisitor.getFormula(prefetchFormulaVisitor));
+						adeptFormula = queryContext.analyse(
+							filterByVisitor.getFormula(
+								new FormulaOptimizer(),
+								prefetchFormulaVisitor
+							)
+						);
 
 						final QueryPlanBuilder queryPlanBuilder = new QueryPlanBuilder(
 							queryContext, adeptFormula, filterByVisitor, targetIndex, prefetchFormulaVisitor

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/attribute/AttributeFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/attribute/AttributeFormula.java
@@ -29,6 +29,7 @@ import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.prefetch.RequirementsDefiner;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.bitmap.Bitmap;
@@ -93,8 +94,12 @@ public class AttributeFormula extends AbstractFormula implements RequirementsDef
 	@Nonnull
 	@Override
 	public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {
-		Assert.isTrue(innerFormulas.length == 1, ERROR_SINGLE_FORMULA_EXPECTED);
-		return new AttributeFormula(this.targetsGlobalAttribute, this.attributeKey, innerFormulas[0], this.requestedPredicate);
+		if (innerFormulas.length == 0) {
+			return new AttributeFormula(this.targetsGlobalAttribute, this.attributeKey, EmptyFormula.INSTANCE, this.requestedPredicate);
+		} else {
+			Assert.isTrue(innerFormulas.length == 1, ERROR_SINGLE_FORMULA_EXPECTED);
+			return new AttributeFormula(this.targetsGlobalAttribute, this.attributeKey, innerFormulas[0], this.requestedPredicate);
+		}
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
@@ -193,11 +193,13 @@ public class FormulaCloner implements FormulaVisitor {
 		return stack.pop();
 	}
 
-	/*
-		PRIVATE METHODS
+	/**
+	 * Stores the given formula in the resultClone field if the treeStack is empty,
+	 * otherwise adds the formula to the top element of the treeStack.
+	 *
+	 * @param formula the formula to be stored or added into the current tree structure, must not be null
 	 */
-
-	private void storeFormula(@Nonnull Formula formula) {
+	protected void storeFormula(@Nonnull Formula formula) {
 		// store updated formula
 		if (this.treeStack.isEmpty()) {
 			this.resultClone = formula;

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/FormulaOptimizer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/FormulaOptimizer.java
@@ -1,0 +1,182 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.filter;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.FormulaPostProcessor;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.base.NotFormula;
+import io.evitadb.core.query.algebra.base.OrFormula;
+import io.evitadb.core.query.algebra.utils.visitor.FormulaCloner;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import static io.evitadb.core.query.filter.FilterByVisitor.isConjunctiveFormula;
+
+/**
+ * Optimizes a {@link Formula} tree produced by the query planning phase.
+ *
+ * The optimizer performs two inexpensive structural rewrites:
+ *
+ * - removes an entire conjunctive container (AND-like node) if any of its children is
+ *   {@link EmptyFormula} or replaces it with {@link EmptyFormula} depending on parent scope
+ *   (the whole conjunction is unsatisfiable)
+ * - unwraps an {@link OrFormula} that contains exactly one inner formula (no need for the container)
+ *
+ * The optimizer is implemented as a {@link FormulaPostProcessor} on top of {@link FormulaCloner} and is
+ * safe to run repeatedly. It does not change the semantics of the tree; it only prunes dead branches and
+ * redundant containers to reduce evaluation cost downstream.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+public class FormulaOptimizer extends FormulaCloner implements FormulaPostProcessor {
+	private boolean conjunctiveScope = true;
+
+	/**
+	 * Creates a new optimizer backed by the {@link Optimizer} strategy used by {@link FormulaCloner}.
+	 */
+	public FormulaOptimizer() {
+		super(Optimizer.INSTANCE);
+	}
+
+	@Override
+	public void visit(@Nonnull Formula formula) {
+		final Formula alreadyProcessedFormula = this.formulasProcessed.get(formula);
+		if (alreadyProcessedFormula != null) {
+			storeFormula(alreadyProcessedFormula);
+		} else {
+			final boolean formerConjunctiveScope = this.conjunctiveScope;
+			try {
+				if (!FilterByVisitor.isConjunctiveFormula(formula.getClass())) {
+					this.conjunctiveScope = false;
+				}
+
+				final Formula formulaToStore;
+				pushContext(this.treeStack, formula);
+				this.parents.push(formula);
+				for (Formula innerFormula : formula.getInnerFormulas()) {
+					innerFormula.accept(this);
+				}
+				this.parents.pop();
+				final SubTree subTree = popContext(this.treeStack);
+				final Set<Formula> updatedChildren = subTree.getChildren();
+				final boolean childrenHaveNotChanged = updatedChildren.size() == formula.getInnerFormulas().length &&
+					Arrays.stream(formula.getInnerFormulas()).allMatch(updatedChildren::contains);
+
+				if (childrenHaveNotChanged) {
+					// use entire formula tree block
+					formulaToStore = this.mutator.apply(this, formula);
+				} else if (formula instanceof NotFormula && updatedChildren.size() == 1) {
+					formulaToStore = updatedChildren.iterator().next();
+				} else {
+					// recreate parent formula with new children
+					formulaToStore = this.mutator.apply(
+						this,
+						formula.getCloneWithInnerFormulas(
+							updatedChildren.toArray(Formula[]::new)
+						)
+					);
+				}
+
+				if (formulaToStore != null) {
+					this.formulasProcessed.put(formula, formulaToStore);
+					storeFormula(formulaToStore);
+				}
+			} finally {
+				this.conjunctiveScope = formerConjunctiveScope;
+			}
+		}
+	}
+
+	/**
+	 * Returns the optimized clone of the input formula tree.
+	 *
+	 * @return optimized formula tree, never {@code null}
+	 */
+	@Nonnull
+	@Override
+	public Formula getPostProcessedFormula() {
+		final Formula resultClone = getResultClone();
+		return resultClone == null ? EmptyFormula.INSTANCE : resultClone;
+	}
+
+	/**
+	 * Strategy used by {@link FormulaCloner} to optionally replace nodes during cloning.
+	 *
+	 * The function may return:
+	 *
+	 * - {@code null}: signal to the cloner that the current node should be dropped from the output tree
+	 * - a different {@link Formula}: replacement for the current node
+	 * - the same {@link Formula}: no structural change
+	 */
+	private static class Optimizer implements BiFunction<FormulaCloner, Formula, Formula> {
+		public static final Optimizer INSTANCE = new Optimizer();
+
+		/**
+		 * Applies local optimizations:
+		 *
+		 * - if the current node is a conjunctive container (e.g. AND) and any child is {@link EmptyFormula},
+		 *   the action depends on the traversal scope managed by {@link FormulaOptimizer}:
+		 *   - in conjunctive scope, replace the container with {@link EmptyFormula} (the whole conjunction
+		 *     is unsatisfiable)
+		 *   - in disjunctive scope, drop the entire container (return {@code null}) so the enclosing
+		 *     disjunction can continue with other alternatives
+		 * - if the current node is an {@link OrFormula} with a single child, unwrap the container
+		 *
+		 * @param formulaCloner the active cloner driving the traversal
+		 * @param formula the current formula node being visited
+		 * @return {@code null} to drop the node, a replacement formula, or the same instance if unchanged
+		 */
+		@Nullable
+		@Override
+		public Formula apply(final FormulaCloner formulaCloner, final Formula formula) {
+			// If this is a conjunctive (AND-like) formula, check for an empty child.
+			if (isConjunctiveFormula(formula.getClass())) {
+				for (final Formula innerFormula : formula.getInnerFormulas()) {
+					// Any EmptyFormula inside AND makes the whole conjunction unsatisfiable.
+					if (innerFormula instanceof EmptyFormula) {
+						if (((FormulaOptimizer)formulaCloner).conjunctiveScope) {
+							// in conjunctive scope, replace the entire container with an empty formula
+							return EmptyFormula.INSTANCE;
+						} else {
+							// in disjunctive scope, drop this entire container from the cloned tree
+							return null;
+						}
+					}
+				}
+			// If this is an OR with a single child, the container is redundant – unwrap it.
+			} else if (formula instanceof OrFormula orFormula &&
+					orFormula.getInnerFormulas().length == 1) {
+				return orFormula.getInnerFormulas()[0];
+			}
+			// No change for other cases – keep the node as is.
+			return formula;
+		}
+
+	}
+}


### PR DESCRIPTION
When query uses both scopes for filtering, the result formula tree is always wrapped in OR container, which prevents prefetching mode of the query processing. When client uses exact `entityPrimaryKeyInSet` it means that the entity is either in LIVE or in ARCHIVE scope, but it can never be in both at the same time. So the prefetching strategy is still valid approach in this situation.

Also there is another optimization possibility. We could prune the formula tree safely by applying following rules:

- when conjunctive formula (AND for example) contains EMPTY formula, it can be immediatelly pruned
- when OR formula contains only single sub-formula, it could be replaced by this constraint

Pruning of conjunctive formula needs to be handled separately depending of upper constraints in the formula tree:

- if they are conjunctive - it needs to be itself replaced with EmptyFormula
- if they are disjunctive - it could be removed entirely

Refs: #939