### PR TITLE
fix: Unnecessary facet indexes

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/index/ReducedEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/ReducedEntityIndex.java
@@ -394,6 +394,28 @@ public class ReducedEntityIndex extends EntityIndex
 		);
 	}
 
+	@Override
+	public void addFacet(
+		@Nullable ReferenceSchemaContract referenceSchema,
+		@Nonnull ReferenceKey referenceKey,
+		@Nullable Integer groupId,
+		int entityPrimaryKey
+	) {
+		assertPartitioningIndex(referenceSchema);
+		super.addFacet(referenceSchema, referenceKey, groupId, entityPrimaryKey);
+	}
+
+	@Override
+	public void removeFacet(
+		@Nullable ReferenceSchemaContract referenceSchema,
+		@Nonnull ReferenceKey referenceKey,
+		@Nullable Integer groupId,
+		int entityPrimaryKey
+	) {
+		assertPartitioningIndex(referenceSchema);
+		super.removeFacet(referenceSchema, referenceKey, groupId, entityPrimaryKey);
+	}
+
 	@Nonnull
 	@Override
 	public ReducedEntityIndex createCopyWithMergedTransactionalMemory(@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {

--- a/evita_engine/src/main/java/io/evitadb/index/facet/FacetIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/facet/FacetIndex.java
@@ -27,6 +27,7 @@ import io.evitadb.api.query.filter.FacetHaving;
 import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
 import io.evitadb.api.requestResponse.data.structure.Entity;
 import io.evitadb.api.requestResponse.data.structure.EntityReference;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.core.Transaction;
 import io.evitadb.core.buffer.TrappedChanges;
 import io.evitadb.core.query.algebra.facet.FacetGroupFormula;
@@ -140,7 +141,12 @@ public class FacetIndex implements FacetIndexContract, TransactionalLayerProduce
 	}
 
 	@Override
-	public void addFacet(@Nonnull ReferenceKey referenceKey, @Nullable Integer groupId, int entityPrimaryKey) {
+	public void addFacet(
+		@Nullable ReferenceSchemaContract referenceSchema,
+		@Nonnull ReferenceKey referenceKey,
+		@Nullable Integer groupId,
+		int entityPrimaryKey
+	) {
 		// we need to keep track of created internal transactional memory related data structures
 		final FacetIndexChanges txLayer = Transaction.getOrCreateTransactionalMemoryLayer(this);
 		// fetch or create index for referenced entity type
@@ -160,7 +166,12 @@ public class FacetIndex implements FacetIndexContract, TransactionalLayerProduce
 	}
 
 	@Override
-	public void removeFacet(@Nonnull ReferenceKey referenceKey, @Nullable Integer groupId, int entityPrimaryKey) {
+	public void removeFacet(
+		@Nullable ReferenceSchemaContract referenceSchema,
+		@Nonnull ReferenceKey referenceKey,
+		@Nullable Integer groupId,
+		int entityPrimaryKey
+	) {
 		// fetch index for referenced entity type
 		final FacetReferenceIndex facetEntityTypeIndex = this.facetingEntities.get(referenceKey.referenceName());
 		Assert.notNull(facetEntityTypeIndex, "No facet found for reference `" + referenceKey.referenceName() + "`!");

--- a/evita_engine/src/main/java/io/evitadb/index/facet/FacetIndexContract.java
+++ b/evita_engine/src/main/java/io/evitadb/index/facet/FacetIndexContract.java
@@ -53,7 +53,12 @@ public interface FacetIndexContract {
 	/**
 	 * Registers new facet to `referenceKey` for passed `entityPrimaryKey`.
 	 */
-	void addFacet(@Nonnull ReferenceKey referenceKey, @Nullable Integer groupId, int entityPrimaryKey);
+	void addFacet(
+		@Nullable ReferenceSchemaContract referenceSchema,
+		@Nonnull ReferenceKey referenceKey,
+		@Nullable Integer groupId,
+		int entityPrimaryKey
+	);
 
 	/**
 	 * Unregisters existing facet to `referenceKey` for passed `entityPrimaryKey`. Method automatically removes all
@@ -61,7 +66,12 @@ public interface FacetIndexContract {
 	 *
 	 * @throws IllegalArgumentException when `entityPrimaryKey` is not present in the index for passed facet
 	 */
-	void removeFacet(@Nonnull ReferenceKey referenceKey, @Nullable Integer groupId, int entityPrimaryKey);
+	void removeFacet(
+		@Nullable ReferenceSchemaContract referenceSchema,
+		@Nonnull ReferenceKey referenceKey,
+		@Nullable Integer groupId,
+		int entityPrimaryKey
+	);
 
 	/**
 	 * Returns set of {@link EntityReference#getType()} that has at least one facet indexed.

--- a/evita_functional_tests/src/test/java/io/evitadb/api/EvitaBackwardCompatibilityTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/api/EvitaBackwardCompatibilityTest.java
@@ -79,7 +79,7 @@ public class EvitaBackwardCompatibilityTest implements EvitaTestSupport {
 	@Tag(LONG_RUNNING_TEST)
 	@ParameterizedTest
 	@ValueSource(
-		strings = {"2024.5", "2025.1", "2025.3"}
+		strings = {"2024.5", "2025.1", "2025.3", "2025.6"}
 	)
 	void verifyBackwardCompatibilityTo(String version) throws IOException {
 		final Path targetDirectory = this.mainDirectory.resolve(version);
@@ -88,7 +88,7 @@ public class EvitaBackwardCompatibilityTest implements EvitaTestSupport {
 			log.info("Downloading and unzipping " + fileName);
 
 			targetDirectory.toFile().mkdirs();
-			// first download the file from https://evitadb.io/test/evita-demo-dataset_2024.5.zip to tmp folder and unzip it
+			// first download the file from https://evitadb.io/test/evita-demo-dataset_202X.Y.zip to tmp folder and unzip it
 			final Path targetZipFile = targetDirectory.resolve(fileName);
 			try (final InputStream is = new URL("https://evitadb.io/download/test/" + fileName).openStream()) {
 				Files.copy(is, targetZipFile, StandardCopyOption.REPLACE_EXISTING);

--- a/evita_functional_tests/src/test/java/io/evitadb/index/mutation/ReferenceIndexMutatorTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/index/mutation/ReferenceIndexMutatorTest.java
@@ -104,8 +104,9 @@ class ReferenceIndexMutatorTest extends AbstractMutatorTestBase {
 	void shouldInsertNewReference() {
 		final RepresentativeReferenceKey referenceKey = new RepresentativeReferenceKey(new ReferenceKey(Entities.BRAND, 10));
 		final ReducedEntityIndex referenceIndex = new ReducedEntityIndex(2, this.productSchema.getName(), new EntityIndexKey(EntityIndexType.REFERENCED_ENTITY, Scope.DEFAULT_SCOPE, referenceKey));
+		final ReferenceSchema referenceSchema = this.productSchema.getReferenceOrThrowException(Entities.BRAND);
 		referenceInsert(
-			1, this.productSchema, this.executor, this.entityIndex, this.referenceTypesIndex, referenceIndex, referenceKey, null,
+			1, this.productSchema, referenceSchema, this.executor, this.entityIndex, this.referenceTypesIndex, referenceIndex, referenceKey, null,
 			getEntityAttributeValueSupplierFactory(this.productSchema, 1), DO_NOTHING_CONSUMER
 		);
 		assertArrayEquals(new int[]{2}, this.referenceTypesIndex.getAllPrimaryKeys().getArray());
@@ -117,21 +118,25 @@ class ReferenceIndexMutatorTest extends AbstractMutatorTestBase {
 		final ReferenceKey referenceKey = new ReferenceKey(Entities.BRAND, 10);
 		final ReducedEntityIndex referenceIndex = new ReducedEntityIndex(2, this.productSchema.getName(), new EntityIndexKey(EntityIndexType.REFERENCED_ENTITY, Scope.DEFAULT_SCOPE, new RepresentativeReferenceKey(referenceKey)));
 		final ExistingDataSupplierFactory entityAttributeValueSupplierFactory = getEntityAttributeValueSupplierFactory(this.productSchema, 1);
+		final ReferenceSchema referenceSchema = this.productSchema.getReferenceOrThrowException(Entities.BRAND);
 
 		referenceInsert(
-			1, this.productSchema, this.executor, this.entityIndex, this.referenceTypesIndex, referenceIndex, new RepresentativeReferenceKey(referenceKey), null, entityAttributeValueSupplierFactory, DO_NOTHING_CONSUMER
+			1, this.productSchema, referenceSchema, this.executor, this.entityIndex, this.referenceTypesIndex, referenceIndex, new RepresentativeReferenceKey(referenceKey), null, entityAttributeValueSupplierFactory, DO_NOTHING_CONSUMER
 		);
 		final ReferenceAttributeMutation referenceMutation = new ReferenceAttributeMutation(referenceKey, new UpsertAttributeMutation(new AttributeKey(ATTRIBUTE_VARIANT_COUNT), 55));
 		attributeUpdate(
-			this.executor, entityAttributeValueSupplierFactory, this.referenceTypesIndex, referenceIndex, new RepresentativeReferenceKey(referenceMutation.getReferenceKey()), referenceMutation.getAttributeMutation()
+			this.executor, entityAttributeValueSupplierFactory, this.referenceTypesIndex, referenceIndex,
+			referenceSchema, new RepresentativeReferenceKey(referenceMutation.getReferenceKey()), referenceMutation.getAttributeMutation()
 		);
 		final ReferenceAttributeMutation a = new ReferenceAttributeMutation(referenceKey, new UpsertAttributeMutation(new AttributeKey(ATTRIBUTE_BRAND_CODE), "A"));
 		attributeUpdate(
-			this.executor, entityAttributeValueSupplierFactory, this.referenceTypesIndex, referenceIndex, new RepresentativeReferenceKey(a.getReferenceKey()), a.getAttributeMutation()
+			this.executor, entityAttributeValueSupplierFactory, this.referenceTypesIndex, referenceIndex,
+			referenceSchema, new RepresentativeReferenceKey(a.getReferenceKey()), a.getAttributeMutation()
 		);
 		final ReferenceAttributeMutation referenceMutation1 = new ReferenceAttributeMutation(referenceKey, new UpsertAttributeMutation(new AttributeKey(ATTRIBUTE_BRAND_EAN), "EAN-001"));
 		attributeUpdate(
-			this.executor, entityAttributeValueSupplierFactory, this.referenceTypesIndex, referenceIndex, new RepresentativeReferenceKey(referenceMutation1.getReferenceKey()), referenceMutation1.getAttributeMutation()
+			this.executor, entityAttributeValueSupplierFactory, this.referenceTypesIndex, referenceIndex,
+			referenceSchema, new RepresentativeReferenceKey(referenceMutation1.getReferenceKey()), referenceMutation1.getAttributeMutation()
 		);
 
 		assertArrayEquals(new int[]{2}, this.referenceTypesIndex.getAllPrimaryKeys().getArray());

--- a/evita_server/run-server-in-docker.sh
+++ b/evita_server/run-server-in-docker.sh
@@ -6,7 +6,7 @@
 #             |  __/\ V /| | || (_| | |_| | |_) |
 #              \___| \_/ |_|\__\__,_|____/|____/
 #
-#   Copyright (c) 2023-2024
+#   Copyright (c) 2023-2025
 #
 #   Licensed under the Business Source License, Version 1.1 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -22,16 +22,16 @@
 #
 
 echo "Pulling down new evitaDB image"
-docker pull index.docker.io/evitadb/evitadb:latest
+docker pull index.docker.io/evitadb/evitadb:canary
 echo "Stopping running evitaDB server"
 docker stop evitadb
 docker rm evitadb
 echo "Recreating evitaDB container and starting it"
 docker run --name evitadb -i --net=host \
-      -v "/www/oss/evitaDB/data:/evita/data" \
-      -v "/www/oss/evitaDB/evita_server/evita-server-certificates:/evita/certificates" \
-      -v "/www/oss/evitaDB/evita_server/logback.xml:/evita/logback.xml" \
-      -v "/www/oss/evitaDB/evita_server/logs:/evita/logs" \
-      -e "EVITA_ARGS=cache.enabled=false api.exposedOn=localhost" \
-      index.docker.io/evitadb/evitadb:latest
+      -v "/www/oss/evitaDB-temporary/data:/evita/data" \
+      -v "/www/oss/evitaDB-temporary/evita_server/evita-server-certificates:/evita/certificates" \
+      -v "/www/oss/evitaDB-temporary/evita_server/logback.xml:/evita/logback.xml" \
+      -v "/www/oss/evitaDB-temporary/evita_server/logs:/evita/logs" \
+      -e "EVITA_ARGS=server.trafficRecording.enabled=true server.trafficRecording.trafficFlushIntervalInMilliseconds=0 server.trafficRecording.sourceQueryTracking=true server.closeSessionsAfterSecondsOfInactivity=0 storage.compress=true api.exposedOn=localhost api.accessLog=true cache.enabled=false api.certificate.generateAndUseSelfSigned=true api.endpoints.graphQL.tlsMode=RELAXED api.endpoints.rest.tlsMode=RELAXED api.endpoints.lab.tlsMode=RELAXED api.endpoints.gRPC.tlsMode=RELAXED api.endpoints.gRPC.exposeDocsService=true api.endpoints.gRPC.mTLS.enabled=false" \
+      index.docker.io/evitadb/evitadb:canary
 echo "Done"


### PR DESCRIPTION
Reduced indexes contain unnecessary facet indexes when reference is indexed only FOR_FILTERING which consume memory unnecessarily. This should be already eliminated by original implementation, but it is not.

Refs: #965