### PR TITLE
fix: ObsoleteFileMaintainer is closed during catalog replacement

### DIFF
--- a/evita_common/src/main/java/io/evitadb/utils/FolderLock.java
+++ b/evita_common/src/main/java/io/evitadb/utils/FolderLock.java
@@ -27,6 +27,7 @@ package io.evitadb.utils;
 import io.evitadb.exception.FolderAlreadyUsedException;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.exception.UnexpectedIOException;
+import io.evitadb.utils.IOUtils.ExceptionThrowingRunnable;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
@@ -115,8 +116,8 @@ public class FolderLock implements Closeable {
 				"Failed to release and close the lock file " + this.lockFilePath + ".",
 				"Failed to release and close the lock file."
 			),
-			(IOUtils.IOExceptionThrowingRunnable) this.lockFileLock::release,
-			(IOUtils.IOExceptionThrowingRunnable) this.lockFileChannel::close
+			(ExceptionThrowingRunnable) this.lockFileLock::release,
+			(ExceptionThrowingRunnable) this.lockFileChannel::close
 		);
 		FileUtils.deleteFileIfExists(this.lockFilePath);
 		ACQUIRED_LOCKS.remove(this.lockFilePath.toAbsolutePath().toString());

--- a/evita_common/src/main/java/io/evitadb/utils/IOUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/IOUtils.java
@@ -111,26 +111,26 @@ public class IOUtils {
 	}
 
 	/**
-	 * Executes lambda logic encapsulated in {@link IOExceptionThrowingRunnable} instances, suppressing
+	 * Executes lambda logic encapsulated in {@link ExceptionThrowingRunnable} instances, suppressing
 	 * and aggregating any {@link IOException} that occurs during execution. If any exceptions are thrown, they
 	 * are encapsulated and re-thrown as a single exception provided by the {@code exceptionFactory}.
 	 *
 	 * @param <T>               the type of exception that will be thrown if any {@link IOException} occurs
 	 * @param exceptionFactory  a supplier that provides an exception of type {@code T}, used to wrap any
 	 *                          {@link IOException} thrown during the execution of the provided runnables
-	 * @param consumer          varargs of {@link IOExceptionThrowingRunnable} instances which encapsulate
+	 * @param consumer          varargs of {@link ExceptionThrowingRunnable} instances which encapsulate
 	 *                          the resources/actions to be closed or executed
 	 * @throws T                the consolidated exception containing any {@link IOException}s that were
 	 *                          thrown by the provided runnables
 	 */
 	public static <T extends RuntimeException> void executeSafely(
 		@Nonnull Supplier<T> exceptionFactory,
-		@Nonnull IOExceptionThrowingRunnable consumer
+		@Nonnull ExceptionThrowingRunnable consumer
 	) throws T {
 		T exception = null;
 		try {
 			consumer.run();
-		} catch (IOException e) {
+		} catch (Exception e) {
 			exception = exceptionFactory.get();
 			exception.addSuppressed(e);
 		}
@@ -179,7 +179,7 @@ public class IOUtils {
 	 *                          {@link IOException} thrown during the execution of the provided runnables
 	 * @param consumer          varargs of {@link IOExceptionThrowingConsumer} instances which encapsulate
 	 *                          the resources/actions to be closed or executed
-	 * @throws T                the consolidated exception containing any {@link IOException}s that were
+	 * @throws U                the consolidated exception containing any {@link Exception}s that were
 	 *                          thrown by the provided runnables
 	 */
 	public static <S, T, U extends RuntimeException> void executeSafely(
@@ -234,24 +234,24 @@ public class IOUtils {
 	}
 
 	/**
-	 * Closes multiple resources encapsulated in {@link IOExceptionThrowingRunnable} instances, suppressing
+	 * Closes multiple resources encapsulated in {@link ExceptionThrowingRunnable} instances, suppressing
 	 * and aggregating any {@link IOException} that occurs during execution. If any exceptions are thrown, they
 	 * are encapsulated and re-thrown as a single exception provided by the {@code exceptionFactory}.
 	 *
 	 * @param <T>               the type of exception that will be thrown if any {@link IOException} occurs
 	 * @param exceptionFactory  a supplier that provides an exception of type {@code T}, used to wrap any
 	 *                          {@link IOException} thrown during the execution of the provided runnables
-	 * @param runnable          varargs of {@link IOExceptionThrowingRunnable} instances which encapsulate
+	 * @param runnable          varargs of {@link ExceptionThrowingRunnable} instances which encapsulate
 	 *                          the resources/actions to be closed or executed
 	 * @throws T                the consolidated exception containing any {@link IOException}s that were
 	 *                          thrown by the provided runnables
 	 */
 	public static <T extends RuntimeException> void close(
 		@Nonnull Supplier<T> exceptionFactory,
-		@Nonnull IOExceptionThrowingRunnable... runnable
+		@Nonnull ExceptionThrowingRunnable... runnable
 	) throws T {
 		T exception = null;
-		for (IOExceptionThrowingRunnable lambda : runnable) {
+		for (ExceptionThrowingRunnable lambda : runnable) {
 			try {
 				lambda.run();
 			} catch (Exception e) {
@@ -269,7 +269,7 @@ public class IOUtils {
 	 * and aggregating any {@link Throwable} that occurs during execution. If any exceptions are thrown, they
 	 * are encapsulated and re-thrown as a single exception provided by the {@code exceptionFactory}.
 	 *
-	 * Unlike {@link #close(Supplier, IOExceptionThrowingRunnable...)}, this method catches any {@link Throwable}
+	 * Unlike {@link #close(Supplier, ExceptionThrowingRunnable...)}, this method catches any {@link Throwable}
 	 * rather than just {@link Exception}, providing a more robust safety net for resource cleanup.
 	 *
 	 * @param <T>               the type of exception that will be thrown if any exception occurs
@@ -299,7 +299,7 @@ public class IOUtils {
 	}
 
 	/**
-	 * Executes the provided {@link IOExceptionThrowingRunnable} instances, ensuring that exceptions thrown
+	 * Executes the provided {@link ExceptionThrowingRunnable} instances, ensuring that exceptions thrown
 	 * during their execution are logged but not propagated. This method is typically used for safely closing
 	 * resources without allowing individual close failures to disrupt the overall process.
 	 *
@@ -310,9 +310,9 @@ public class IOUtils {
 	 * @throws T if a runtime exception specific to the implementation needs propagation
 	 */
 	public static <T extends RuntimeException> void closeQuietly(
-		@Nonnull IOExceptionThrowingRunnable... runnable
+		@Nonnull ExceptionThrowingRunnable... runnable
 	) throws T {
-		for (IOExceptionThrowingRunnable lambda : runnable) {
+		for (ExceptionThrowingRunnable lambda : runnable) {
 			try {
 				lambda.run();
 			} catch (Exception e) {
@@ -327,7 +327,7 @@ public class IOUtils {
 	 * during their execution are logged but not propagated. This method is typically used for safely closing
 	 * resources without allowing individual close failures to disrupt the overall process.
 	 *
-	 * Unlike {@link #closeQuietly(IOExceptionThrowingRunnable...)}, this method catches any {@link Throwable}
+	 * Unlike {@link #closeQuietly(ExceptionThrowingRunnable...)}, this method catches any {@link Throwable}
 	 * rather than just {@link Exception}, providing a more robust safety net for resource cleanup.
 	 *
 	 * @param runnable the runnable instances, which may throw any exception during execution
@@ -351,25 +351,25 @@ public class IOUtils {
 
 	/**
 	 * Represents a functional interface that can be used to encapsulate a block of code
-	 * that may throw an {@link IOException}. This interface is effectively a specialized
+	 * that may throw an {@link Exception}. This interface is effectively a specialized
 	 * form of {@link Runnable} for operations where checked I/O exceptions need to be handled.
 	 *
 	 * Implementations of this interface enable the execution of operations with the awareness
-	 * and explicit handling of {@link IOException}. This is especially useful in scenarios
+	 * and explicit handling of {@link Exception}. This is especially useful in scenarios
 	 * where multiple such operations need to be executed or wrapped with exception aggregation,
 	 * for example, in utility methods like resource handling or cleanup.
 	 *
 	 * Method {@code run} is similar to the {@link Runnable#run()} method but allows an
-	 * {@link IOException} to be thrown.
+	 * {@link Exception} to be thrown.
 	 *
 	 * Functional-style programming can make use of this interface to define inline behaviors
-	 * for operations expected to throw {@link IOException}. It can also be integrated with
+	 * for operations expected to throw {@link Exception}. It can also be integrated with
 	 * various utility methods that leverage this interface for exception handling and resource management.
 	 */
 	@FunctionalInterface
-	public interface IOExceptionThrowingRunnable {
+	public interface ExceptionThrowingRunnable {
 
-		void run() throws IOException;
+		void run() throws Exception;
 
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/executor/DelayedAsyncTask.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/DelayedAsyncTask.java
@@ -25,6 +25,7 @@ package io.evitadb.core.executor;
 
 import io.evitadb.core.metric.event.system.BackgroundTaskFinishedEvent;
 import io.evitadb.core.metric.event.system.BackgroundTaskStartedEvent;
+import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.utils.Assert;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -147,6 +148,7 @@ public class DelayedAsyncTask implements Closeable {
 	 * The task is scheduled using the scheduler's schedule method.
 	 */
 	public void scheduleImmediately() {
+		assertNotClosed();
 		final OffsetDateTime now = OffsetDateTime.now();
 		if (this.nextPlannedExecution.compareAndExchange(OffsetDateTime.MIN, now) == OffsetDateTime.MIN) {
 			scheduleTask(computeMinimalSchedulingGap(now.toInstant().toEpochMilli()));
@@ -162,6 +164,8 @@ public class DelayedAsyncTask implements Closeable {
 	 * The task is scheduled using the scheduler's schedule method.
 	 */
 	public void schedule() {
+		assertNotClosed();
+
 		if (this.delay == Long.MAX_VALUE) {
 			// the task is manual task and will never be scheduled
 			return;
@@ -191,6 +195,20 @@ public class DelayedAsyncTask implements Closeable {
 			}
 			// release the lambda to allow garbage collection
 			this.lambda.set(null);
+			this.nextPlannedExecution.set(OffsetDateTime.MIN);
+		}
+	}
+
+	/**
+	 * Ensures that the task is not closed before proceeding with its execution or scheduling.
+	 * If the task is already marked as closed, this method throws a GenericEvitaInternalError
+	 * to indicate that the operation cannot be performed on a closed task.
+	 *
+	 * @throws GenericEvitaInternalError if the task is marked as closed
+	 */
+	private void assertNotClosed() {
+		if (this.closed.get()) {
+			throw new GenericEvitaInternalError("Cannot schedule task `" + this.taskName + "` that has been closed.");
 		}
 	}
 
@@ -223,8 +241,9 @@ public class DelayedAsyncTask implements Closeable {
 		if (lastFinishedExecutionTime.equals(OffsetDateTime.MIN)) {
 			return 0;
 		} else {
-			return Math.max(0, this.minimalSchedulingGap - (nowMillis - lastFinishedExecutionTime.toInstant()
-			                                                                                     .toEpochMilli())
+			return Math.max(
+				0, this.minimalSchedulingGap - (nowMillis - lastFinishedExecutionTime.toInstant()
+					.toEpochMilli())
 			);
 		}
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/file/ExportFileService.java
+++ b/evita_engine/src/main/java/io/evitadb/core/file/ExportFileService.java
@@ -494,24 +494,30 @@ public class ExportFileService implements Closeable {
 			log.error("Failed to list files in the directory: {}", this.storageOptions.exportDirectory(), e);
 		}
 
-		// then check the size of the directory and delete oldest files until the directory size is below the limit
-		final long directorySize = FileUtils.getDirectorySize(this.storageOptions.exportDirectory());
-		// delete the oldest files until the directory size is below the limit
-		if (directorySize > this.storageOptions.exportDirectorySizeLimitBytes()) {
-			final List<FileForFetch> filesByCreationDate = this.files.stream()
-				.sorted(Comparator.comparing(FileForFetch::created))
-				.toList();
-			long savedSize = 0L;
-			for (FileForFetch it : filesByCreationDate) {
-				log.info("Purging the oldest file, because the export directory grew too big: {}", it);
-				final long metadataFileSize = it.metadataPath(this.storageOptions.exportDirectory()).toFile().length();
-				deleteFile(it.fileId());
-				savedSize += it.totalSizeInBytes() + metadataFileSize;
-				// finish removing files if the directory size is below the limit
-				if (directorySize - savedSize <= this.storageOptions.exportDirectorySizeLimitBytes()) {
-					break;
+		try {
+			// then check the size of the directory and delete oldest files until the directory size is below the limit
+			final long directorySize = FileUtils.getDirectorySize(this.storageOptions.exportDirectory());
+			// delete the oldest files until the directory size is below the limit
+			if (directorySize > this.storageOptions.exportDirectorySizeLimitBytes()) {
+				final List<FileForFetch> filesByCreationDate = this.files.stream()
+					.sorted(Comparator.comparing(FileForFetch::created))
+					.toList();
+				long savedSize = 0L;
+				for (FileForFetch it : filesByCreationDate) {
+					log.info("Purging the oldest file, because the export directory grew too big: {}", it);
+					final long metadataFileSize = it.metadataPath(this.storageOptions.exportDirectory())
+						.toFile()
+						.length();
+					deleteFile(it.fileId());
+					savedSize += it.totalSizeInBytes() + metadataFileSize;
+					// finish removing files if the directory size is below the limit
+					if (directorySize - savedSize <= this.storageOptions.exportDirectorySizeLimitBytes()) {
+						break;
+					}
 				}
 			}
+		} catch (UnexpectedIOException e) {
+			log.error("Failed to calculate size of the directory: {}", this.storageOptions.exportDirectory(), e);
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/traffic/task/TrafficRecorderTask.java
+++ b/evita_engine/src/main/java/io/evitadb/core/traffic/task/TrafficRecorderTask.java
@@ -39,6 +39,7 @@ import io.evitadb.store.spi.SessionSink;
 import io.evitadb.stream.RandomAccessFileInputStream;
 import io.evitadb.utils.Assert;
 import io.evitadb.utils.IOUtils;
+import io.evitadb.utils.IOUtils.ExceptionThrowingRunnable;
 import io.evitadb.utils.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 
@@ -212,7 +213,7 @@ public class TrafficRecorderTask extends ClientInfiniteCallableTask<TrafficRecor
 			if (exportSessionSink != null) {
 				IOUtils.close(
 					() -> new UnexpectedIOException("Failed to close export session sink."),
-					(IOUtils.IOExceptionThrowingRunnable) exportSessionSink::close
+					(ExceptionThrowingRunnable) exportSessionSink::close
 				);
 			}
 		}

--- a/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
+++ b/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
@@ -299,10 +299,15 @@ class OffsetIndexTest implements EvitaTestSupport, TimeBoundedTestSupport {
 	@ParameterizedTest
 	@MethodSource("combineSettings")
 	void shouldSerializeAndReconstructEmptyOffsetIndex(Crc32Check crc32Check, Compression compression) {
-		final InsertionOutput insertionOutput = shouldSerializeAndReconstructOffsetIndex(
-			configure(StorageOptions.temporary(), crc32Check, compression), EntityBodyStoragePart::new, 0
-		);
-		IOUtils.closeQuietly(insertionOutput.fileOffsetIndex::close);
+		final StorageOptions storageOptions = configure(StorageOptions.temporary(), crc32Check, compression);
+		try (final ObservableOutputKeeper observableOutputKeeper = new ObservableOutputKeeper(TEST_CATALOG, storageOptions, Mockito.mock(Scheduler.class))) {
+			final InsertionOutput insertionOutput = shouldSerializeAndReconstructOffsetIndex(
+				storageOptions,
+				observableOutputKeeper,
+				EntityBodyStoragePart::new, 0
+			);
+			IOUtils.closeQuietly(insertionOutput.fileOffsetIndex::close);
+		}
 	}
 
 	@DisplayName("Offset index can be stored empty and then new records added.")
@@ -310,22 +315,26 @@ class OffsetIndexTest implements EvitaTestSupport, TimeBoundedTestSupport {
 	@MethodSource("combineSettings")
 	void shouldSerializeEmptyOffsetIndexWithLaterAddingRecordsAndReconstructCorrectly(Crc32Check crc32Check, Compression compression) {
 		final StorageOptions storageOptions = configure(StorageOptions.temporary(), crc32Check, compression);
-		final InsertionOutput insertionOutput = shouldSerializeAndReconstructOffsetIndex(storageOptions, EntityBodyStoragePart::new, 0);
-		final OffsetIndex offsetIndex = insertionOutput.fileOffsetIndex();
-		final InsertionOutput insertionOutput2 = createRecordsInFileOffsetIndex(offsetIndex, 100, 0, 1);
-		/* input count records +1 record for the OffsetIndex itself */
-		if (crc32Check == Crc32Check.YES) {
-			assertEquals(
-				/* 100 records, 1 empty header, 1 header with single fragment */
-				100 + computeExpectedRecordCount(storageOptions, 100).fragments() + 1,
-				offsetIndex.verifyContents().getRecordCount()
+		try (final ObservableOutputKeeper observableOutputKeeper = new ObservableOutputKeeper(TEST_CATALOG, storageOptions, Mockito.mock(Scheduler.class))) {
+			final InsertionOutput insertionOutput = shouldSerializeAndReconstructOffsetIndex(
+				storageOptions, observableOutputKeeper, EntityBodyStoragePart::new, 0
 			);
+			final OffsetIndex offsetIndex = insertionOutput.fileOffsetIndex();
+			final InsertionOutput insertionOutput2 = createRecordsInFileOffsetIndex(offsetIndex, 100, 0, 1);
+			/* input count records +1 record for the OffsetIndex itself */
+			if (crc32Check == Crc32Check.YES) {
+				assertEquals(
+					/* 100 records, 1 empty header, 1 header with single fragment */
+					100 + computeExpectedRecordCount(storageOptions, 100).fragments() + 1,
+					offsetIndex.verifyContents().getRecordCount()
+				);
+			}
+			assertEquals(
+				100,
+				offsetIndex.count(insertionOutput2.catalogVersion())
+			);
+			IOUtils.closeQuietly(offsetIndex::close);
 		}
-		assertEquals(
-			100,
-			offsetIndex.count(insertionOutput2.catalogVersion())
-		);
-		IOUtils.closeQuietly(offsetIndex::close);
 	}
 
 	@DisplayName("Hundreds entities should be stored in OffsetIndex and retrieved intact.")
@@ -922,19 +931,21 @@ class OffsetIndexTest implements EvitaTestSupport, TimeBoundedTestSupport {
 		@Nonnull StorageOptions storageOptions,
 		@Nonnull IntFunction<EntityBodyStoragePart> bodyPartFactory
 	) {
-		return shouldSerializeAndReconstructOffsetIndex(storageOptions, bodyPartFactory, 600);
+		try (final ObservableOutputKeeper observableOutputKeeper = new ObservableOutputKeeper(TEST_CATALOG, storageOptions, Mockito.mock(Scheduler.class))) {
+			return shouldSerializeAndReconstructOffsetIndex(storageOptions, observableOutputKeeper, bodyPartFactory, 600);
+		}
 	}
 
 	@Nonnull
 	private InsertionOutput shouldSerializeAndReconstructOffsetIndex(
 		@Nonnull StorageOptions storageOptions,
+		@Nonnull ObservableOutputKeeper observableOutputKeeper,
 		@Nonnull IntFunction<EntityBodyStoragePart> bodyPartFactory,
 		int recordCount
 	) {
 		OffsetIndex loadedFileOffsetIndex = null;
 		try (
-			final ObservableOutputKeeper observableOutputKeeper = new ObservableOutputKeeper(TEST_CATALOG, storageOptions, Mockito.mock(Scheduler.class));
-			final WriteOnlyFileHandle writeHandle = new WriteOnlyFileHandle(this.targetFile, storageOptions, observableOutputKeeper);
+			final WriteOnlyFileHandle writeHandle = new WriteOnlyFileHandle(this.targetFile, storageOptions, observableOutputKeeper)
 		) {
 			final OffsetIndex fileOffsetIndex = new OffsetIndex(
 				0L,

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -130,7 +130,7 @@ import io.evitadb.utils.ConsoleWriter;
 import io.evitadb.utils.ConsoleWriter.ConsoleColor;
 import io.evitadb.utils.FileUtils;
 import io.evitadb.utils.IOUtils;
-import io.evitadb.utils.IOUtils.IOExceptionThrowingRunnable;
+import io.evitadb.utils.IOUtils.ExceptionThrowingRunnable;
 import io.evitadb.utils.NamingConvention;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -283,6 +283,10 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	 * This lock synchronizes the access to the bootstrap file.
 	 */
 	private final ReentrantLock bootstrapWriteLock = new ReentrantLock();
+	/**
+	 * This lock synchronizes the access to the write ahead log file.
+	 */
+	private final ReentrantLock walWriteLock = new ReentrantLock();
 	/**
 	 * Scheduled executor service is used for planning maintenance tasks on the data level.
 	 */
@@ -1143,38 +1147,56 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		}
 	}
 
-	private DefaultCatalogPersistenceService(
-		@Nonnull DefaultCatalogPersistenceService previous,
-		@Nonnull CatalogOffsetIndexStoragePartPersistenceService previousCatalogStoragePartPersistenceService,
+	public DefaultCatalogPersistenceService(
 		@Nonnull String catalogName,
-		@Nonnull Path catalogStoragePath,
-		@Nonnull CatalogBootstrap bootstrapUsed,
-		@Nonnull BootstrapWriteOnlyFileHandle bootstrapWriteHandle,
-		@Nonnull Map<CollectionFileReference, DefaultEntityCollectionPersistenceService> previousEntityCollectionPersistenceServices
+		@Nonnull DefaultCatalogPersistenceService formerService
 	) {
-		this.bootstrapUsed = bootstrapUsed;
-		this.recordTypeRegistry = previous.recordTypeRegistry;
-		this.observableOutputKeeper = previous.observableOutputKeeper;
-		this.offHeapMemoryManager = previous.offHeapMemoryManager;
-		this.exportFileService = previous.exportFileService;
+		this.storageOptions = formerService.storageOptions;
+		this.bootstrapStorageOptions = modifyStorageOptionsForBootstrapFile(this.storageOptions);
+		this.transactionOptions = formerService.transactionOptions;
+		this.scheduler = formerService.scheduler;
+		this.exportFileService = formerService.exportFileService;
+		this.offHeapMemoryManager = new CatalogOffHeapMemoryManager(
+			catalogName,
+			this.transactionOptions.transactionMemoryBufferLimitSizeBytes(),
+			this.transactionOptions.transactionMemoryRegionCount()
+		);
 		this.catalogName = catalogName;
 		this.walFileNameProvider = index -> CatalogPersistenceService.getWalFileName(catalogName, index);
-		this.catalogStoragePath = catalogStoragePath;
-		this.bootstrapWriteHandle = new AtomicReference<>(bootstrapWriteHandle);
-		this.storageOptions = previous.storageOptions;
-		this.bootstrapStorageOptions = previous.bootstrapStorageOptions;
-		this.transactionOptions = previous.transactionOptions;
-		this.scheduler = previous.scheduler;
-		this.obsoleteFileMaintainer = previous.obsoleteFileMaintainer;
-		this.catalogWal = previous.catalogWal;
+		this.catalogStoragePath = pathForCatalog(catalogName, this.storageOptions.storageDirectory());
+		this.observableOutputKeeper = new ObservableOutputKeeper(catalogName, this.storageOptions, this.scheduler);
+		this.recordTypeRegistry = new OffsetIndexRecordTypeRegistry();
+		this.obsoleteFileMaintainer = new ObsoleteFileMaintainer(
+			catalogName,
+			this.scheduler,
+			this.catalogStoragePath,
+			this.storageOptions.timeTravelEnabled(),
+			this::fetchDataFilesInfo
+		);
+		final String verifiedCatalogName = verifyDirectory(this.catalogStoragePath, false);
+		// TOBEDONE #538 - introduced with #650 and could be removed later when no version prior to 2025.2 is used
+		// TOBEDONE #538 - original contents: getLastCatalogBootstrap(verifiedCatalogName, this.bootstrapStorageOptions);
+		this.bootstrapUsed = getLastCatalogBootstrapWithAutomaticUpgrade(
+			verifiedCatalogName, this.bootstrapStorageOptions, this.storageOptions, this.exportFileService
+		);
+		this.bootstrapWriteHandle = new AtomicReference<>(
+			createBootstrapWriteOnlyHandle(catalogName, this.bootstrapStorageOptions, this.catalogStoragePath)
+		);
 
 		final String catalogFileName = getCatalogDataStoreFileName(catalogName, this.bootstrapUsed.catalogFileIndex());
 		final Path catalogFilePath = this.catalogStoragePath.resolve(catalogFileName);
 		final long catalogVersion = this.bootstrapUsed.catalogVersion();
+		this.catalogWal = createWalIfAnyWalFilePresent(
+			catalogVersion, catalogName, this.walFileNameProvider,
+			this.storageOptions, this.transactionOptions, this.scheduler,
+			this::trimBootstrapFile, this.obsoleteFileMaintainer::createWalPurgeCallback,
+			this.catalogStoragePath, this.walKryoPool
+		);
 
-		final CatalogOffsetIndexStoragePartPersistenceService catalogStoragePartPersistenceService = CatalogOffsetIndexStoragePartPersistenceService.create(
-			catalogVersion,
-			catalogFileName,
+		this.catalogStoragePartPersistenceService = CollectionUtils.createConcurrentHashMap(16);
+		final CatalogOffsetIndexStoragePartPersistenceService catalogStoragePartPersistenceService = verifyAndUpgradeStorageFormat(
+			() -> CatalogOffsetIndexStoragePartPersistenceService.create(
+				this.catalogName,
 			catalogFilePath,
 			this.storageOptions,
 			this.transactionOptions,
@@ -1184,10 +1206,15 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 			this.observableOutputKeeper,
 			VERSIONED_KRYO_FACTORY,
 			nonFlushedBlock -> this.reportNonFlushedContents(catalogName, nonFlushedBlock),
-			oldestRecordTimestamp -> reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null)),
-			previousCatalogStoragePartPersistenceService
+				oldestRecordTimestamp -> reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null))
+			),
+			this.bootstrapUsed.catalogVersion()
 		);
-		this.catalogStoragePartPersistenceService = CollectionUtils.createConcurrentHashMap(16);
+		if (this.bootstrapUsed.storageProtocolVersion() != STORAGE_PROTOCOL_VERSION) {
+			throw new StoredProtocolVersionNotSupportedException(
+				this.bootstrapUsed.storageProtocolVersion(), STORAGE_PROTOCOL_VERSION
+			);
+		}
 		this.catalogStoragePartPersistenceService.put(
 			catalogVersion,
 			catalogStoragePartPersistenceService
@@ -1195,33 +1222,15 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		this.catalogPersistenceServiceVersions = new long[]{catalogVersion};
 		this.warmUpVersionCardinality = catalogVersion == 0 ? 1 : 0;
 
-		final CatalogHeader catalogHeader = catalogStoragePartPersistenceService.getCatalogHeader(catalogVersion);
 		this.entityCollectionPersistenceServices = CollectionUtils.createConcurrentHashMap(
-			catalogHeader.getEntityTypeFileIndexes().size()
-		);
-
-		// we rebuild the storage services for all entity collections building upon previous versions
-		for (CollectionFileReference entityTypeFileIndex : catalogHeader.getEntityTypeFileIndexes()) {
-			final CollectionFileReference reference = new CollectionFileReference(
-				entityTypeFileIndex.entityType(),
-				entityTypeFileIndex.entityTypePrimaryKey(),
-				entityTypeFileIndex.fileIndex(),
-				entityTypeFileIndex.fileLocation()
+			catalogStoragePartPersistenceService.getCatalogHeader(catalogVersion).getEntityTypeFileIndexes().size()
 			);
 
-			final DefaultEntityCollectionPersistenceService previousService = previousEntityCollectionPersistenceServices.get(
-				reference);
-			this.entityCollectionPersistenceServices.put(
-				reference,
-				new DefaultEntityCollectionPersistenceService(
-					this.bootstrapUsed.catalogVersion(),
-					this.catalogName,
-					this.catalogStoragePath,
-					previousService,
-					this.storageOptions,
-					this.recordTypeRegistry
-				)
-			);
+		try {
+			verifyCatalogNameMatches(catalogVersion, this.catalogStoragePath, catalogStoragePartPersistenceService);
+		} catch (UnexpectedCatalogContentsException ex) {
+			this.close();
+			throw ex;
 		}
 	}
 
@@ -1707,6 +1716,8 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		@Nonnull TransactionMutation transactionMutation,
 		@Nonnull OffHeapWithFileBackupReference walReference
 	) {
+		this.walWriteLock.lock();
+		try {
 		try (walReference) {
 			if (this.catalogWal == null) {
 				final CatalogHeader catalogHeader = getCatalogHeader(catalogVersion);
@@ -1729,6 +1740,9 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 
 			return Objects.requireNonNull(this.catalogWal.append(transactionMutation, walReference).fileLocation())
 			              .recordLength();
+		}
+		} finally {
+			this.walWriteLock.unlock();
 		}
 	}
 
@@ -1793,15 +1807,11 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		);
 
 		final int catalogIndex = this.bootstrapUsed.catalogFileIndex();
-		final CatalogBootstrap newCatalogBootstrap = recordBootstrap(
+		recordBootstrap(
 			newCatalogVersion,
 			catalogNameToBeReplaced,
 			catalogIndex,
 			dataStoreMemoryBuffer
-		);
-
-		final HashMap<CollectionFileReference, DefaultEntityCollectionPersistenceService> previousEntityCollectionServices = new HashMap<>(
-			this.entityCollectionPersistenceServices
 		);
 
 		// close the catalog
@@ -1863,13 +1873,7 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 				.ifPresent(FileUtils::deleteDirectory);
 
 			return new DefaultCatalogPersistenceService(
-				this,
-				storagePartPersistenceService,
-				catalogNameToBeReplaced,
-				newPath,
-				newCatalogBootstrap,
-				createBootstrapWriteOnlyHandle(catalogNameToBeReplaced, this.bootstrapStorageOptions, newPath),
-				previousEntityCollectionServices
+				catalogNameToBeReplaced, this
 			);
 		} catch (RuntimeException ex) {
 			// rename original directory back
@@ -2351,15 +2355,20 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 			this.closed = true;
 			// close WAL
 			if (this.catalogWal != null) {
-				IOUtils.closeQuietly(this.catalogWal::close);
+				this.walWriteLock.lock();
+				try {
+					IOUtils.closeQuietly(this.catalogWal::close);
+				} finally {
+					this.walWriteLock.unlock();
+				}
 			}
 			// close all services
 			IOUtils.closeQuietly(
 				this.entityCollectionPersistenceServices
 					.values()
 					.stream()
-					.map(service -> (IOExceptionThrowingRunnable) service::close)
-					.toArray(IOExceptionThrowingRunnable[]::new)
+					.map(service -> (ExceptionThrowingRunnable) service::close)
+					.toArray(ExceptionThrowingRunnable[]::new)
 			);
 			this.entityCollectionPersistenceServices.clear();
 			// close current file offset index
@@ -2367,8 +2376,8 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 				this.catalogStoragePartPersistenceService
 					.values()
 					.stream()
-					.map(service -> (IOExceptionThrowingRunnable) service::close)
-					.toArray(IOExceptionThrowingRunnable[]::new)
+					.map(service -> (ExceptionThrowingRunnable) service::close)
+					.toArray(ExceptionThrowingRunnable[]::new)
 			);
 			this.catalogPersistenceServiceVersions = ArrayUtils.EMPTY_LONG_ARRAY;
 			this.catalogStoragePartPersistenceService.clear();
@@ -2702,8 +2711,11 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 	 * file.
 	 *
 	 * @param catalogInstance               the catalog contract instance
+	 * @param catalogVersion                the version of the catalog
 	 * @param catalogStoragePath            the path to the catalog storage directory
 	 * @param storagePartPersistenceService the storage part persistence service
+	 * @param onDifferentCatalogName       the action to take when catalog names differ
+	 * @param bootstrapUsed  			 the bootstrap used to load the catalog
 	 */
 	private void verifyCatalogNameMatches(
 		@Nonnull CatalogContract catalogInstance,
@@ -2775,6 +2787,30 @@ public class DefaultCatalogPersistenceService implements CatalogPersistenceServi
 		}
 	}
 
+	/**
+	 * Verifies that the catalog name (derived from catalog directory) matches the catalog schema stored in the catalog
+	 * file.
+	 *
+	 * @param catalogVersion                the version of the catalog
+	 * @param catalogStoragePath            the path to the catalog storage directory
+	 * @param storagePartPersistenceService the storage part persistence service
+	 */
+	private void verifyCatalogNameMatches(
+		long catalogVersion,
+		@Nonnull Path catalogStoragePath,
+		@Nonnull CatalogStoragePartPersistenceService storagePartPersistenceService
+	) {
+		// verify that the catalog schema is the same as the one in the catalog directory
+		final CatalogHeader catalogHeader = storagePartPersistenceService.getCatalogHeader(catalogVersion);
+		final boolean catalogNameIsSame = catalogHeader.catalogName().equals(this.catalogName);
+		Assert.isTrue(
+			catalogNameIsSame,
+			() -> new UnexpectedCatalogContentsException(
+				"Directory " + catalogStoragePath + " contains data of " + catalogHeader.catalogName() +
+					" catalog. Cannot load catalog " + this.catalogName + " from this directory!"
+			)
+		);
+	}
 	/**
 	 * Method stores solely the {@link CatalogBootstrap} record to the catalog bootstrap file. You probably want to use
 	 * more high-level method {@link #recordBootstrap(long, String, int, long, DataStoreMemoryBuffer)} or

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/ObsoleteFileMaintainer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/ObsoleteFileMaintainer.java
@@ -224,15 +224,17 @@ public class ObsoleteFileMaintainer implements CatalogConsumersListener, Closeab
 	private long purgeObsoleteFiles() {
 		final long lastKnownMinimalActiveVersion = this.lastKnownMinimalActiveVersion.get();
 		/* TOBEDONE JNO - this is only for debugging purposes, we should rely on events instead */
-		log.debug(
-			"Purging obsolete files - last known minimal active version: {}\nFiles waiting for removal:\n{}",
-			lastKnownMinimalActiveVersion,
-			this.maintainedFiles.stream()
-				.map(MaintainedFile::path)
-				.map(Path::toString)
-				.map(path -> "\t - " + path)
-				.collect(Collectors.joining("\n"))
-		);
+		if (!this.maintainedFiles.isEmpty()) {
+			log.info(
+				"Purging obsolete files - last known minimal active version: {}\nFiles waiting for removal:\n{}",
+				lastKnownMinimalActiveVersion,
+				this.maintainedFiles.stream()
+					.map(MaintainedFile::path)
+					.map(Path::toString)
+					.map(path -> "\t - " + path)
+					.collect(Collectors.joining("\n"))
+			);
+		}
 		final List<MaintainedFile> itemsToRemove = new LinkedList<>();
 		long newFirstCatalogVersion = 0L;
 		for (MaintainedFile maintainedFile : this.maintainedFiles) {

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
@@ -59,7 +59,7 @@ import io.evitadb.utils.Assert;
 import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.FileUtils;
 import io.evitadb.utils.IOUtils;
-import io.evitadb.utils.IOUtils.IOExceptionThrowingRunnable;
+import io.evitadb.utils.IOUtils.ExceptionThrowingRunnable;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
@@ -1494,7 +1494,7 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 							firstVersionToBeKept = pendingRemoval.version();
 						}
 						toRemove.add(pendingRemoval);
-					} catch (IOException ex) {
+					} catch (Exception ex) {
 						// failed to remove the file, we will try again later and continue with the next one
 						AbstractMutationLog.log.error(ex.getMessage(), ex);
 					}
@@ -1922,7 +1922,7 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	 */
 	protected record PendingRemoval(
 		long version,
-		@Nonnull IOExceptionThrowingRunnable removeLambda
+		@Nonnull ExceptionThrowingRunnable removeLambda
 	) {
 
 		@Override


### PR DESCRIPTION
When catalog is replaced with another catalog contents, its ObsoleteFileMaintainer is closed which effectivelly stops old files purging. The replaced catalog continues to be used (and functional) while the purging logic is non functional.

Refs: #989