### PR TITLE
fix: Constraint facetHaving with includingChildrenHaving no longer works when selected reference has no direct entity assignment

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormula.java
@@ -45,6 +45,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
 
 /**
  * Translates referenced entity primary keys produced by the inner formula into primary keys of
@@ -95,29 +96,35 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula extends AbstractF
 	 * {@code index.size}.
 	 */
 	private final int worstCardinality;
+	/**
+	 * Optional expansion function that will expand the inner formula result before applying the translation.
+	 */
+	private final UnaryOperator<Bitmap> expansionFunction;
 
 	/**
 	 * Internal constructor used by cloning and tests.
 	 *
-	 * @param referencedEntitySuperSet optional superset of referenced entity primary keys to limit
-	 *        the translation; may be {@code null}
+	 * @param referencedEntitySuperSet                    optional superset of referenced entity primary keys to limit
+	 *                                                    the translation; may be {@code null}
 	 * @param referencedEntityTypeSuperSetTransactionalId transactional ids of contributing
-	 *        {@link GlobalEntityIndex} instances used for cache-key hashing
-	 * @param referencedEntityTypeIndex target index for the translation
-	 * @param worstCardinality worst-case estimate of the result cardinality
-	 * @param innerFormula inner formula producing referenced entity primary keys
+	 *                                                    {@link GlobalEntityIndex} instances used for cache-key hashing
+	 * @param referencedEntityTypeIndex                   target index for the translation
+	 * @param worstCardinality                            worst-case estimate of the result cardinality
+	 * @param innerFormula                                inner formula producing referenced entity primary keys
 	 */
 	ReferencedEntityIndexPrimaryKeyTranslatingFormula(
 		@Nullable Bitmap referencedEntitySuperSet,
 		@Nonnull long[] referencedEntityTypeSuperSetTransactionalId,
 		@Nonnull ReferencedTypeEntityIndex referencedEntityTypeIndex,
 		int worstCardinality,
+		@Nonnull UnaryOperator<Bitmap> expansionFunction,
 		@Nonnull Formula innerFormula
 	) {
 		this.referencedEntitySuperSet = referencedEntitySuperSet;
 		this.referencedEntityTypeSuperSetTransactionalIds = referencedEntityTypeSuperSetTransactionalId;
 		this.referencedEntityTypeIndex = referencedEntityTypeIndex;
 		this.worstCardinality = worstCardinality;
+		this.expansionFunction = expansionFunction;
 		this.initFields(innerFormula);
 	}
 
@@ -144,7 +151,8 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula extends AbstractF
 		@Nonnull BiFunction<String, Scope, Optional<GlobalEntityIndex>> referencedEntitySuperSetSupplier,
 		@Nonnull ReferencedTypeEntityIndex referencedTypeEntityIndex,
 		@Nonnull Formula innerFormula,
-		@Nonnull Set<Scope> scopes
+		@Nonnull Set<Scope> scopes,
+		@Nullable UnaryOperator<Bitmap> expansionFunction
 	) {
 		if (referenceSchema.isReferencedEntityTypeManaged()) {
 			RoaringBitmap bitmap = null;
@@ -178,6 +186,7 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula extends AbstractF
 			this.referencedEntityTypeSuperSetTransactionalIds = ArrayUtils.EMPTY_LONG_ARRAY;
 		}
 
+		this.expansionFunction = expansionFunction != null ? expansionFunction : UnaryOperator.identity();
 		this.referencedEntityTypeIndex = referencedTypeEntityIndex;
 		this.worstCardinality = this.referencedEntitySuperSet == null ?
 			referencedTypeEntityIndex.getSize() :
@@ -227,7 +236,7 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula extends AbstractF
 	@Nonnull
 	@Override
 	protected Bitmap computeInternal() {
-		final Bitmap referencedEntityIds = this.innerFormulas[0].compute();
+		final Bitmap referencedEntityIds = this.expansionFunction.apply(this.innerFormulas[0].compute());
 		final int cnt = referencedEntityIds.size();
 		if (cnt == 0) {
 			return EmptyBitmap.INSTANCE;
@@ -255,6 +264,7 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula extends AbstractF
 			this.referencedEntityTypeSuperSetTransactionalIds,
 			this.referencedEntityTypeIndex,
 			this.worstCardinality,
+			this.expansionFunction,
 			innerFormulas[0]
 		);
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/FilterByVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/FilterByVisitor.java
@@ -58,6 +58,7 @@ import io.evitadb.core.query.algebra.facet.ScopeContainerFormula;
 import io.evitadb.core.query.algebra.facet.UserFilterFormula;
 import io.evitadb.core.query.algebra.infra.SkipFormula;
 import io.evitadb.core.query.algebra.prefetch.SelectionFormula;
+import io.evitadb.core.query.algebra.reference.ReferencedEntityIndexPrimaryKeyTranslatingFormula;
 import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.core.query.common.translator.SelfTraversingTranslator;
 import io.evitadb.core.query.filter.translator.FilterByTranslator;
@@ -119,6 +120,7 @@ import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import static io.evitadb.utils.Assert.isPremiseValid;
@@ -1087,11 +1089,12 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 		@Nonnull Class<? extends FilterConstraint>... suppressedConstraints
 	) {
 		try {
+			final ProcessingScope<? extends Index<?>> currentProcessingScope = this.getProcessingScope();
 			this.scope.push(
 				new ProcessingScope<>(
 					indexType,
 					targetIndexSupplier,
-					this.getProcessingScope().getScopes(),
+					currentProcessingScope.getScopes(),
 					requirements,
 					entitySchema,
 					referenceSchema,
@@ -1099,6 +1102,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 					entityNestedQueryComparator,
 					attributeSchemaAccessor,
 					attributeValueAccessor,
+					currentProcessingScope.getReferencedEntityExpansionFunction(),
 					suppressedConstraints
 				)
 			);
@@ -1465,6 +1469,12 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 		 */
 		@Nullable
 		private Formula superSetFormula;
+		/**
+		 * Function that allows to expand referenced entity primary keys from the input bitmap of base primary keys.
+		 * Used for hierarchical entity structures.
+		 */
+		@Nullable
+		@Getter private UnaryOperator<Bitmap> referencedEntityExpansionFunction;
 
 		/**
 		 * Recursively examines all children of the specified parent constraint using the provided lambda function.
@@ -1561,6 +1571,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 			@Nullable EntityNestedQueryComparator entityNestedQueryComparator,
 			@Nonnull AttributeSchemaAccessor attributeSchemaAccessor,
 			@Nonnull TriFunction<EntityContract, String, Locale, Stream<Optional<AttributeValue>>> attributeValueAccessor,
+			@Nullable UnaryOperator<Bitmap> referencedEntityExpansionFunction,
 			@Nonnull Class<? extends FilterConstraint>... suppressedConstraints
 		) {
 			this.indexType = indexType;
@@ -1580,6 +1591,7 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 			this.nestedQueryFormulaEnricher = nestedQueryFormulaEnricher == null ? Function.identity() : nestedQueryFormulaEnricher;
 			this.entityNestedQueryComparator = entityNestedQueryComparator;
 			this.indexSupplier = targetIndexSupplier;
+			this.referencedEntityExpansionFunction = referencedEntityExpansionFunction;
 			this.indexes = null;
 		}
 
@@ -1767,6 +1779,36 @@ public class FilterByVisitor implements ConstraintVisitor, PrefetchStrategyResol
 				return lambda.get();
 			} finally {
 				this.requiredScopes.pop();
+			}
+		}
+
+		/**
+		 * Executes the given supplier within the context of the specified referenced entity expansion function.
+		 * This method ensures that the specified function is applied for the duration of the supplier's execution
+		 * and then restores the previous function afterwards.
+		 *
+		 * The function is used when {@link ReferencedEntityIndexPrimaryKeyTranslatingFormula} translates original
+		 * referenced entity primary keys to list of available indexes. This is necessary for correct handling of
+		 * hierarchical entity structures, that should take their children into an account.
+		 *
+		 * @param referencedEntityExpansionFunction function that expands referenced entity primary keys
+		 * @param lambda the supplier function to be executed within the specified context
+		 * @return the result produced by the supplier
+		 * @param <S> type of result returned by the supplier
+		 */
+		public <S> S doWithReferencedEntityExpansionFunction(
+			@Nonnull UnaryOperator<Bitmap> referencedEntityExpansionFunction,
+			@Nonnull Supplier<S> lambda
+		) {
+			try {
+				Assert.isPremiseValid(
+					this.referencedEntityExpansionFunction == null,
+					"Referenced entity expansion function is already set!"
+				);
+				this.referencedEntityExpansionFunction = referencedEntityExpansionFunction;
+				return lambda.get();
+			} finally {
+				this.referencedEntityExpansionFunction = null;
 			}
 		}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/entity/EntityPrimaryKeyInSetTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/entity/EntityPrimaryKeyInSetTranslator.java
@@ -91,7 +91,8 @@ public class EntityPrimaryKeyInSetTranslator implements FilteringConstraintTrans
 							     filterByVisitor::getGlobalEntityIndexIfExists,
 							     it,
 							     standardResult,
-							     processingScope.getScopes()
+							     processingScope.getScopes(),
+							     processingScope.getReferencedEntityExpansionFunction()
 						     )
 						)
 						.toArray(Formula[]::new)

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/facet/FacetHavingTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/facet/FacetHavingTranslator.java
@@ -35,6 +35,7 @@ import io.evitadb.core.exception.ReferenceNotFacetedException;
 import io.evitadb.core.query.QueryPlanner.FutureNotFormula;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.base.NotFormula;
 import io.evitadb.core.query.algebra.facet.CombinedFacetFormula;
@@ -51,6 +52,7 @@ import io.evitadb.dataType.Scope;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.EntityIndex;
 import io.evitadb.index.Index;
+import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 
@@ -64,6 +66,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -238,39 +241,51 @@ public class FacetHavingTranslator implements FilteringConstraintTranslator<Face
 					filterByVisitor, facetHaving.getChildren(), referenceSchema, scopes
 				);
 
-				final Formula mainFacetIds = filterByVisitor.getReferencedRecordIdFormula(
-					entitySchema,
-					referenceSchema,
-					facetFiltering.mainFiltering()
+				final Bitmap finalFacetIds = processingScope.doWithReferencedEntityExpansionFunction(
+					facetFiltering.includeChildren() ?
+						mainFacetIdsBitmap -> {
+							if (mainFacetIdsBitmap.isEmpty()) {
+								return mainFacetIdsBitmap;
+							} else {
+								final int[] mainFacetIds = mainFacetIdsBitmap.getArray();
+								final HierarchyWithin hierarchyWithin = Objects.requireNonNull(
+										facetFiltering.hierarchyFiltering())
+									.apply(mainFacetIds);
+								final Formula resultFormula = FormulaFactory.or(
+									Stream.concat(
+										Stream.of(new ConstantFormula(mainFacetIdsBitmap)),
+										Arrays.stream(Objects.requireNonNull(facetFiltering.targetIndex()))
+											.map(targetIndex ->
+												     HierarchyWithinTranslator.createFormulaFromHierarchyIndex(
+													     hierarchyWithin,
+													     Objects.requireNonNull(targetIndex),
+													     mainFacetIds,
+													     filterByVisitor.getQueryContext(),
+													     scopes,
+													     referenceSchema,
+													     Objects.requireNonNull(facetFiltering.targetSchema())
+												     )
+											)
+									).toArray(Formula[]::new)
+								);
+								resultFormula.initialize(filterByVisitor.getInternalExecutionContext());
+								return resultFormula.compute();
+							}
+						} :
+						UnaryOperator.identity(),
+					() -> {
+						final Formula finalFacetIdsFormula = filterByVisitor.getReferencedRecordIdFormula(
+							entitySchema,
+							referenceSchema,
+							facetFiltering.mainFiltering()
+						);
+
+						// initialize the formula before compute is called
+						finalFacetIdsFormula.initialize(filterByVisitor.getInternalExecutionContext());
+						// calculate result
+						return finalFacetIdsFormula.compute();
+					}
 				);
-
-				final Formula finalFacetIds;
-				if (facetFiltering.includeChildren()) {
-					final HierarchyWithin hierarchyWithin = Objects.requireNonNull(facetFiltering.hierarchyFiltering())
-						.apply(mainFacetIds.compute().getArray());
-					finalFacetIds = FormulaFactory.or(
-						Stream.concat(
-							Stream.of(mainFacetIds),
-							Arrays.stream(Objects.requireNonNull(facetFiltering.targetIndex()))
-								.map(targetIndex ->
-									HierarchyWithinTranslator.createFormulaFromHierarchyIndex(
-										hierarchyWithin,
-										Objects.requireNonNull(targetIndex),
-										mainFacetIds.compute().getArray(),
-										filterByVisitor.getQueryContext(),
-										scopes,
-										referenceSchema,
-										Objects.requireNonNull(facetFiltering.targetSchema())
-									)
-								)
-						).toArray(Formula[]::new)
-					);
-				} else {
-					finalFacetIds = mainFacetIds;
-				}
-
-				// initialize the formula before compute is called
-				finalFacetIds.initialize(filterByVisitor.getInternalExecutionContext());
 				// first collect all formulas
 				return entityIndex.getFacetReferencingEntityIdsFormula(
 					facetHaving.getReferenceName(),
@@ -287,7 +302,7 @@ public class FacetHavingTranslator implements FilteringConstraintTranslator<Face
 							);
 						}
 					},
-					finalFacetIds.compute()
+					finalFacetIds
 				).stream();
 			});
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/reference/EntityHavingTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/reference/EntityHavingTranslator.java
@@ -224,7 +224,8 @@ public class EntityHavingTranslator implements FilteringConstraintTranslator<Ent
 										     filterByVisitor::getGlobalEntityIndexIfExists,
 										     it,
 										     nestedResult.filter(),
-										     processingScope.getScopes()
+										     processingScope.getScopes(),
+										     processingScope.getReferencedEntityExpansionFunction()
 									     )
 									)
 									.toArray(Formula[]::new)


### PR DESCRIPTION
This issue relates to rework of indexed data which has been undertaken in issue #906. When the targeted and filtered referenced entity hasn't had direct reference by the source entity, the result was empty.
### Hierarchical Entity Expansion Support

* Added an optional `UnaryOperator<Bitmap> expansionFunction` to `ReferencedEntityIndexPrimaryKeyTranslatingFormula`, which can expand the inner formula result before primary key translation. This is now used in both constructors and the internal computation logic. [[1]](diffhunk://#diff-f24842350bf6e450ab97a39682fc11d03853507e6dda42234c76946641e9d1e8R99-R102) [[2]](diffhunk://#diff-f24842350bf6e450ab97a39682fc11d03853507e6dda42234c76946641e9d1e8R120-R127) [[3]](diffhunk://#diff-f24842350bf6e450ab97a39682fc11d03853507e6dda42234c76946641e9d1e8L147-R155) [[4]](diffhunk://#diff-f24842350bf6e450ab97a39682fc11d03853507e6dda42234c76946641e9d1e8R189) [[5]](diffhunk://#diff-f24842350bf6e450ab97a39682fc11d03853507e6dda42234c76946641e9d1e8L230-R239)
* Updated `FilterByVisitor.ProcessingScope` to track a `referencedEntityExpansionFunction`, and added a method to temporarily set this function while executing queries, ensuring correct expansion logic for hierarchical entities. [[1]](diffhunk://#diff-0ecbedbb96bc126e8249e6a6b1ebe470aea790368e63f4239edb81ac24f6efdfR1472-R1477) [[2]](diffhunk://#diff-0ecbedbb96bc126e8249e6a6b1ebe470aea790368e63f4239edb81ac24f6efdfR1574) [[3]](diffhunk://#diff-0ecbedbb96bc126e8249e6a6b1ebe470aea790368e63f4239edb81ac24f6efdfR1594) [[4]](diffhunk://#diff-0ecbedbb96bc126e8249e6a6b1ebe470aea790368e63f4239edb81ac24f6efdfR1785-R1814)

### Propagation of Expansion Function

* Modified usage of `ReferencedEntityIndexPrimaryKeyTranslatingFormula` in entity and reference translators to pass the expansion function from the processing scope, ensuring expansion logic is applied where necessary. [[1]](diffhunk://#diff-ca34b0411036d371dc9688619683975fbe52777cb6d9f799dbb8131c05fd3e63L94-R95) [[2]](diffhunk://#diff-a14312ad69adfbd57335c88ba28d5375306651bd553f36e550df72dccdd5fe7eL227-R228)

### Facet Filtering with Hierarchical Expansion

* Refactored `FacetHavingTranslator` to use the new expansion function mechanism. When hierarchical facet filtering is required, the expansion function computes facet ids including children entities; otherwise, it defaults to identity. This ensures correct facet selection in hierarchical contexts. [[1]](diffhunk://#diff-82a05e8f76c29835779000b14be706cc9cf4e72e0df9541be41fbdf092db827fL241-R262) [[2]](diffhunk://#diff-82a05e8f76c29835779000b14be706cc9cf4e72e0df9541be41fbdf092db827fL268-R288) [[3]](diffhunk://#diff-82a05e8f76c29835779000b14be706cc9cf4e72e0df9541be41fbdf092db827fL290-R305)