### PR TITLE
fix: Entity reference comparator doesn't take selected hierarchy tree into an account

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferencePredecessorAttributeComparator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/translator/TraverseReferencePredecessorAttributeComparator.java
@@ -45,6 +45,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serial;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Objects;
@@ -135,7 +136,9 @@ public class TraverseReferencePredecessorAttributeComparator
 				return false;
 			};
 		} else {
-			this.pickerPredicate = referenceContract -> true;
+			this.pickerPredicate = referenceContract ->
+				this.referenceKey == null ||
+					this.referenceKey.referenceKey().equals(referenceContract.getReferenceKey());
 		}
 	}
 
@@ -157,17 +160,13 @@ public class TraverseReferencePredecessorAttributeComparator
 	@Nonnull
 	@Override
 	protected Optional<ReferenceContract> pickReference(@Nonnull EntityContract entity) {
-		return // pick first if none is set
-			Optional.of(entity.getReferences(this.referenceName))
-			        .filter(it -> !it.isEmpty())
-			        .map(it -> {
-				        for (ReferenceContract reference : it) {
-					        if (this.pickerPredicate.test(reference)) {
-						        return reference;
-					        }
-				        }
-				        return null;
-			        });
+		final Collection<ReferenceContract> references = entity.getReferences(this.referenceName);
+		for (ReferenceContract reference : references) {
+			if (this.pickerPredicate.test(reference)) {
+				return Optional.of(reference);
+			}
+		}
+		return Optional.empty();
 	}
 
 	@Override


### PR DESCRIPTION
During implementation of #906 we introduced new bug in `TraverseReferencePredecessorAttributeComparator`, which results in ignoring selected hierarchy for selecting right reference for acquiring the data comparator orders by.

Refs: #1026