### PR TITLE
perf: Performance regression when entityHaving filtering constraints used

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/EvitaRequest.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/EvitaRequest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2025
+ *   Copyright (c) 2023-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -453,6 +453,7 @@ public class EvitaRequest {
 		this.facetGroupNegation = null;
 		this.expectedType = evitaRequest.expectedType;
 		this.debugModes = null;
+		this.queryTelemetryRequested = evitaRequest.queryTelemetryRequested;
 		this.scopes = scopes;
 		this.scopesAsArray = this.scopes == null ?
 			null : this.scopes.toArray(Scope[]::new);
@@ -723,6 +724,7 @@ public class EvitaRequest {
 			if (entityFetch == null) {
 				this.entityPrices = PriceContentMode.NONE;
 				this.additionalPriceLists = ArrayUtils.EMPTY_STRING_ARRAY;
+				this.accompanyingPrices = AccompanyingPrice.EMPTY_ARRAY;
 			} else {
 				final Optional<PriceContent> priceContentRequirement = ofNullable(QueryUtils.findConstraint(entityFetch, PriceContent.class, SeparateEntityContentRequireContainer.class));
 				this.entityPrices = priceContentRequirement

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/EvitaResponse.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/EvitaResponse.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2025
+ *   Copyright (c) 2023-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -224,7 +224,7 @@ public abstract sealed class EvitaResponse<T extends Serializable>
 				this.extraResults.size() == ((EvitaResponse<?>) o).extraResults.size() &&
 				this.extraResults.entrySet()
 					.stream()
-					.filter(it -> !(it instanceof QueryTelemetry))
+					.filter(it -> !(it.getKey().equals(QueryTelemetry.class)))
 					.allMatch(it -> it.getValue().equals(((EvitaResponse<?>) o).extraResults.get(it.getKey())))
 			);
 	}

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2025
+ *   Copyright (c) 2023-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -1183,6 +1183,7 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nonnull String priceName,
 		@Nonnull String... priceListPriority
 	) implements Serializable {
+		public static final AccompanyingPrice[] EMPTY_ARRAY = new AccompanyingPrice[0];
 
 		@Override
 		public boolean equals(Object o) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryExecutionContext.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryExecutionContext.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024-2025
+ *   Copyright (c) 2024-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -79,6 +79,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -466,14 +468,24 @@ public class QueryExecutionContext implements Closeable {
 	}
 
 	/**
-	 * Returns finalized {@link QueryTelemetry} or throws an exception.
+	 * Returns root node of {@link QueryTelemetry} or throws an exception.
 	 */
 	@Nonnull
-	public QueryTelemetry finalizeAndGetTelemetry() {
+	public Optional<QueryTelemetry> getTelemetryRoot() {
 		if (isDryRun()) {
-			return new QueryTelemetry(QueryPhase.OVERALL);
+			return of(new QueryTelemetry(QueryPhase.OVERALL));
 		} else {
-			return this.queryContext.finalizeAndGetTelemetry();
+			return this.queryContext.getEvitaRequest().isQueryTelemetryRequested() ?
+				of(this.queryContext.getTelemetryRoot()) : empty();
+		}
+	}
+
+	/**
+	 * Finalizes telemetry data by stopping the timer.
+	 */
+	public void finalizeTelemetry() {
+		if (!isDryRun() && this.queryContext.getEvitaRequest().isQueryTelemetryRequested()) {
+			this.queryContext.finalizeTelemetry();
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlan.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlan.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2025
+ *   Copyright (c) 2023-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -326,6 +326,8 @@ public class QueryPlan {
 					);
 				}
 
+				executionContext.finalizeTelemetry();
+
 				ofNullable(this.queryContext.getQueryFinishedEvent())
 					.ifPresent(
 						it -> it.finish(
@@ -377,9 +379,8 @@ public class QueryPlan {
 			}
 		}
 
-		if (executionContext.getEvitaRequest().isQueryTelemetryRequested()) {
-			extraResults.add(executionContext.finalizeAndGetTelemetry());
-		}
+		executionContext.getTelemetryRoot()
+			.ifPresent(extraResults::add);
 
 		return extraResults.toArray(EvitaResponseExtraResult[]::new);
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanningContext.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanningContext.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2025
+ *   Copyright (c) 2023-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -538,10 +538,19 @@ public class QueryPlanningContext implements LocaleProvider, PrefetchStrategyRes
 	}
 
 	/**
-	 * Returns finalized {@link QueryTelemetry} or throws an exception.
+	 * Returns {@link QueryTelemetry} root or throws an exception if no telemetry is initialized.
 	 */
 	@Nonnull
-	public QueryTelemetry finalizeAndGetTelemetry() {
+	public QueryTelemetry getTelemetryRoot() {
+		Assert.isPremiseValid(!this.telemetryStack.isEmpty(), "The telemetry is not initialized!");
+		return this.telemetryStack.getFirst();
+	}
+
+	/**
+	 * Finalizes {@link QueryTelemetry} or throws an exception. This method can be called only once, because it
+	 * empties the internal telemetry stack.
+	 */
+	public void finalizeTelemetry() {
 		Assert.isPremiseValid(!this.telemetryStack.isEmpty(), "The telemetry has been already retrieved!");
 
 		// there may be some steps still open at the time extra results is fabricated
@@ -550,8 +559,6 @@ public class QueryPlanningContext implements LocaleProvider, PrefetchStrategyRes
 			rootStep = this.telemetryStack.pop();
 			rootStep.finish();
 		} while (!this.telemetryStack.isEmpty());
-
-		return rootStep;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/reference/EntityHavingTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/reference/EntityHavingTranslator.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2025
+ *   Copyright (c) 2023-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -231,13 +231,13 @@ public class EntityHavingTranslator implements FilteringConstraintTranslator<Ent
 									.toArray(Formula[]::new)
 							);
 						} else {
+							if (nestedResult.globalIndex() == null) {
+								return EmptyFormula.INSTANCE;
+							}
 							return filterByVisitor.computeOnlyOnce(
-								processingScope.getIndexes(),
+								List.of(nestedResult.globalIndex()),
 								filterConstraint,
 								() -> {
-									if (nestedResult.globalIndex() == null) {
-										return EmptyFormula.INSTANCE;
-									}
 									final ReferenceOwnerTranslatingFormula outputFormula = new ReferenceOwnerTranslatingFormula(
 										nestedResult.globalIndex(),
 										nestedResult.filter(),

--- a/evita_engine/src/main/java/io/evitadb/core/query/response/ServerEntityDecorator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/response/ServerEntityDecorator.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2024-2025
+ *   Copyright (c) 2024-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -285,7 +285,7 @@ public class ServerEntityDecorator extends EntityDecorator implements EntityFetc
 							.filter(Optional::isPresent)
 							.map(Optional::get)
 							.map(ServerEntityDecorator.class::cast)
-							.mapToInt(ServerEntityDecorator::getIoFetchedBytes)
+							.mapToInt(ServerEntityDecorator::getIoFetchCount)
 							.sum()
 						:
 						0
@@ -303,7 +303,7 @@ public class ServerEntityDecorator extends EntityDecorator implements EntityFetc
 						getParentEntity()
 							.filter(ServerEntityDecorator.class::isInstance)
 							.map(ServerEntityDecorator.class::cast)
-							.map(ServerEntityDecorator::getIoFetchCount)
+							.map(ServerEntityDecorator::getIoFetchedBytes)
 							.orElse(0)
 						:
 						0

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2025
+ *   Copyright (c) 2023-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ import io.evitadb.core.metric.event.storage.DataFileCompactEvent;
 import io.evitadb.core.metric.event.storage.FileType;
 import io.evitadb.core.metric.event.storage.OffsetIndexHistoryKeptEvent;
 import io.evitadb.core.metric.event.storage.OffsetIndexNonFlushedEvent;
+import io.evitadb.core.query.response.ServerEntityDecorator;
 import io.evitadb.dataType.Scope;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.exception.UnexpectedIOException;
@@ -117,7 +118,9 @@ import io.evitadb.store.spi.model.storageParts.index.*;
 import io.evitadb.store.spi.model.storageParts.index.AttributeIndexStoragePart.AttributeIndexType;
 import io.evitadb.store.wal.TransactionalStoragePartPersistenceService;
 import io.evitadb.utils.CollectionUtils;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -1005,7 +1008,8 @@ public class DefaultEntityCollectionPersistenceService implements EntityCollecti
 		@Nonnull ChunkTransformerAccessor referenceChunkTransformer
 	) {
 		final int entityPrimaryKey = Objects.requireNonNull(entityDecorator.getPrimaryKey());
-		final IoFetchStatistics ioFetchStatistics = new IoFetchStatistics();
+		final IoFetchStatistics ioFetchStatistics = entityDecorator instanceof ServerEntityDecorator sed ?
+			new IoFetchStatistics(sed.getIoFetchCount(), sed.getIoFetchedBytes()) : new IoFetchStatistics();
 
 		// body part is fetched everytime - we need to at least test the version
 		final EntityBodyStoragePart bodyPart = ioFetchStatistics.record(
@@ -1623,6 +1627,8 @@ public class DefaultEntityCollectionPersistenceService implements EntityCollecti
 	 * Collects the information about fetched data.
 	 */
 	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
 	private static final class IoFetchStatistics {
 		private int ioFetchCount;
 		private int ioFetchedBytes;


### PR DESCRIPTION
In version `2025.7` we introduced performance regresion in `io.evitadb.core.query.filter.translator.reference.EntityHavingTranslator#translate` that effectively took out caching mechanism and for queries that operate with large quantity of reference indexes it resulted in excessive query duration.

The fix is in class `EntityHavingTranslator`, additional changes fix minor issues with incomplete query telemetry and and incorrectly calculated I/O fetch count.

Refs: #1052