### PR TITLE
Fix named references lost on entity rewrap

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/EntityDecorator.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/EntityDecorator.java
@@ -103,7 +103,7 @@ public class EntityDecorator implements SealedEntity {
 	/**
 	 * Contains reference to the (possibly richer than requested) entity object.
 	 */
-	@Getter protected final Entity delegate;
+	@Getter private final Entity delegate;
 	/**
 	 * Copy of the {@link EvitaRequest#getAlignedNow()} that was actual when entity was fetched from the database.
 	 */

--- a/evita_engine/src/main/java/io/evitadb/core/query/response/ServerEntityDecorator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/response/ServerEntityDecorator.java
@@ -355,8 +355,8 @@ public class ServerEntityDecorator extends EntityDecorator implements EntityFetc
 		if (this.memoizedIoFetchCount == -1) {
 			this.memoizedIoFetchCount = this.ioFetchCount +
 				(
-					this.delegate.parentAvailable() ?
-						this.delegate.getParentEntity()
+					parentAvailable() ?
+						getParentEntity()
 							.filter(ServerEntityDecorator.class::isInstance)
 							.map(ServerEntityDecorator.class::cast)
 							.map(ServerEntityDecorator::getIoFetchCount)
@@ -365,8 +365,8 @@ public class ServerEntityDecorator extends EntityDecorator implements EntityFetc
 						0
 				) +
 				(
-					this.delegate.referencesAvailable() ?
-						this.delegate.getReferences().stream()
+					referencesAvailable() ?
+						getReferences().stream()
 							.map(ReferenceContract::getReferencedEntity)
 							.filter(Optional::isPresent)
 							.map(Optional::get)
@@ -385,8 +385,8 @@ public class ServerEntityDecorator extends EntityDecorator implements EntityFetc
 		if (this.memoizedIoFetchedBytes == -1) {
 			this.memoizedIoFetchedBytes = this.ioFetchedBytes +
 				(
-					this.delegate.parentAvailable() ?
-						this.delegate.getParentEntity()
+					parentAvailable() ?
+						getParentEntity()
 							.filter(ServerEntityDecorator.class::isInstance)
 							.map(ServerEntityDecorator.class::cast)
 							.map(ServerEntityDecorator::getIoFetchedBytes)
@@ -395,8 +395,8 @@ public class ServerEntityDecorator extends EntityDecorator implements EntityFetc
 						0
 				) +
 				(
-					this.delegate.referencesAvailable() ?
-						this.delegate.getReferences().stream()
+					referencesAvailable() ?
+						getReferences().stream()
 							.map(ReferenceContract::getReferencedEntity)
 							.filter(Optional::isPresent)
 							.map(Optional::get)


### PR DESCRIPTION
## Summary

- Preserve `namedReferenceSets` when rewrapping entities in `ServerEntityDecorator.decorate`
- Change `delegate` field visibility in `EntityDecorator` to `protected` for subclass access
- Use `this.delegate.*` in IO counting methods to access the underlying delegate directly

Fixes #1077