### PR TITLE
Fix ForkJoinPool RejectedExecutionException on compensating thread exhaustion

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/executor/ObservableThreadExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/ObservableThreadExecutor.java
@@ -27,6 +27,7 @@ import io.evitadb.api.configuration.ThreadPoolOptions;
 import io.evitadb.api.observability.trace.TracingContext;
 import io.evitadb.api.requestResponse.progress.UnrejectableTask;
 import io.evitadb.core.metric.event.system.BackgroundTaskTimedOutEvent;
+import io.evitadb.core.metric.event.system.ForkJoinPoolSaturatedEvent;
 import jdk.jfr.Event;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -147,7 +148,16 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 				options.minThreadCount(),
 				options.maxThreadCount(),
 				1,
-				pool -> true,
+				pool -> {
+					new ForkJoinPoolSaturatedEvent(name).commit();
+					log.warn(
+						"ObservableThreadExecutor ForkJoinPool `{}` saturated " +
+							"— all compensating threads exhausted, " +
+							"allowing current thread to block.",
+						name
+					);
+					return true;
+				},
 				60,
 				TimeUnit.SECONDS
 			);

--- a/evita_engine/src/main/java/io/evitadb/core/executor/ObservableThreadExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/ObservableThreadExecutor.java
@@ -147,7 +147,7 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 				options.minThreadCount(),
 				options.maxThreadCount(),
 				1,
-				null,
+				pool -> true,
 				60,
 				TimeUnit.SECONDS
 			);

--- a/evita_engine/src/main/java/io/evitadb/core/metric/event/system/ForkJoinPoolSaturatedEvent.java
+++ b/evita_engine/src/main/java/io/evitadb/core/metric/event/system/ForkJoinPoolSaturatedEvent.java
@@ -1,0 +1,65 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.metric.event.system;
+
+import io.evitadb.api.observability.annotation.ExportInvocationMetric;
+import io.evitadb.api.observability.annotation.ExportMetricLabel;
+import jdk.jfr.Description;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Event raised when an {@link io.evitadb.core.executor.ObservableThreadExecutor}'s underlying
+ * {@link java.util.concurrent.ForkJoinPool} saturate predicate is triggered, indicating all
+ * compensating threads are exhausted and the current thread is allowed to block instead of
+ * throwing a {@link java.util.concurrent.RejectedExecutionException}.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Name(AbstractSystemEvent.PACKAGE_NAME + ".ObservableThreadExecutorSaturated")
+@Description(
+	"Event raised when an ObservableThreadExecutor's underlying ForkJoinPool saturate predicate " +
+		"is triggered, indicating all compensating threads are exhausted."
+)
+@ExportInvocationMetric(label = "ObservableThreadExecutor ForkJoinPool saturated")
+@Label("ObservableThreadExecutor ForkJoinPool saturated")
+@Getter
+public class ForkJoinPoolSaturatedEvent extends AbstractSystemEvent {
+
+	/**
+	 * The name of the pool that became saturated.
+	 */
+	@Label("Pool name")
+	@Description("Name of the ObservableThreadExecutor pool that became saturated.")
+	@ExportMetricLabel
+	final String poolName;
+
+	public ForkJoinPoolSaturatedEvent(@Nonnull String poolName) {
+		this.poolName = poolName;
+	}
+
+}


### PR DESCRIPTION
## Summary

- Set `ForkJoinPool` saturate predicate from `null` to `pool -> true` in `ObservableThreadExecutor` to prevent `RejectedExecutionException` when compensating threads exceed `maxThreadCount`
- This is a **defensive safety net** — the last blocking call within the pool was already eliminated in 2026.1, so this exception should no longer occur in practice

## Details

When the `ForkJoinPool` runs out of room for compensating threads (spawned when worker threads block on `CompletableFuture.join()`), the default behavior with a `null` saturate predicate is to throw `RejectedExecutionException: Thread limit exceeded replacing blocked worker`. Setting the predicate to `pool -> true` tells the pool to let the current thread block without compensation, allowing tasks to queue up and eventually time out gracefully.

Closes #1117