### PR TITLE
Fix gRPC CDC subscribers not notified on catalog replace/delete

### DIFF
--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeCatalogCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeCatalogCaptureSubscriber.java
@@ -35,6 +35,7 @@ import io.evitadb.externalApi.grpc.generated.GrpcRegisterChangeCatalogCaptureRes
 import io.evitadb.externalApi.grpc.requestResponse.cdc.ChangeCaptureConverter;
 import io.evitadb.utils.IOUtils;
 import io.evitadb.utils.VersionUtils.SemVer;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
 import javax.annotation.Nonnull;
@@ -153,6 +154,17 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 	@Override
 	public void close() {
 		IOUtils.closeQuietly(this.heartBeatTask::close);
+		// signal the gRPC client that the stream was forcibly terminated
+		// (e.g. when the catalog is replaced or deleted while subscribers are listening)
+		try {
+			this.responseObserver.onError(
+				Status.UNAVAILABLE
+					.withDescription("CDC stream has been terminated by the server.")
+					.asRuntimeException()
+			);
+		} catch (Exception ignored) {
+			// stream may already be cancelled by the client — safe to ignore
+		}
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeCatalogCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeCatalogCaptureSubscriber.java
@@ -37,6 +37,7 @@ import io.evitadb.utils.IOUtils;
 import io.evitadb.utils.VersionUtils.SemVer;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -46,6 +47,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.LongSupplier;
 
 import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toGrpcOffsetDateTime;
@@ -68,16 +70,56 @@ import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toGrp
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
  */
+@Slf4j
 public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogCapture>, AutoCloseable {
+	/**
+	 * Flag ensuring the gRPC stream is finalized (via `onError` or `onCompleted`) exactly once
+	 * across all termination paths ({@link #onError}, {@link #onComplete}, {@link #close}).
+	 */
+	private final AtomicBoolean streamFinalized = new AtomicBoolean(false);
+	/**
+	 * The gRPC stream observer used to send responses to the client.
+	 */
 	private final StreamObserver<GrpcRegisterChangeCatalogCaptureResponse> responseObserver;
+	/**
+	 * Future that is completed when the subscription is established, allowing the gRPC cancel
+	 * handler to obtain the subscription reference for cancellation.
+	 */
 	private final CompletableFuture<Subscription> subscriptionFuture;
+	/**
+	 * The semantic version of the connected client, used to adapt the response format
+	 * for backward compatibility. May be null if the client did not report its version.
+	 */
 	private final SemVer clientVersion;
+	/**
+	 * Supplier that provides the current catalog version for heartbeat messages.
+	 */
 	private final LongSupplier versionSupplier;
+	/**
+	 * The Armeria service request context, used to extend the request timeout on activity.
+	 */
 	private final ServiceRequestContext serviceContext;
+	/**
+	 * The original response timeout in milliseconds, used to extend the timeout after each
+	 * message or heartbeat.
+	 */
 	private final long responseTimeoutMillis;
+	/**
+	 * The delay between heartbeat messages in milliseconds — computed as 5 seconds less than
+	 * the response timeout, clamped to [1 second, 5 minutes].
+	 */
 	private final long heartBeatDelay;
+	/**
+	 * Scheduled task that periodically sends heartbeat messages to keep the gRPC stream alive.
+	 */
 	private final DelayedAsyncTask heartBeatTask;
+	/**
+	 * The active subscription from the publisher, set during {@link #onSubscribe(Subscription)}.
+	 */
 	private Subscription subscription;
+	/**
+	 * Monotonically increasing counter for heartbeat message indexing.
+	 */
 	private long index = 0L;
 
 	public ChangeCatalogCaptureSubscriber(
@@ -129,6 +171,9 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 
 	@Override
 	public void onNext(ChangeCatalogCapture item) {
+		if (this.streamFinalized.get()) {
+			return;
+		}
 		this.responseObserver.onNext(
 			GrpcRegisterChangeCatalogCaptureResponse
 				.newBuilder()
@@ -142,13 +187,19 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 
 	@Override
 	public void onError(Throwable throwable) {
-		this.subscriptionFuture.completeExceptionally(throwable);
-		this.responseObserver.onError(throwable);
+		if (this.streamFinalized.compareAndSet(false, true)) {
+			IOUtils.closeQuietly(this.heartBeatTask::close);
+			this.subscriptionFuture.completeExceptionally(throwable);
+			this.responseObserver.onError(throwable);
+		}
 	}
 
 	@Override
 	public void onComplete() {
-		this.responseObserver.onCompleted();
+		if (this.streamFinalized.compareAndSet(false, true)) {
+			IOUtils.closeQuietly(this.heartBeatTask::close);
+			this.responseObserver.onCompleted();
+		}
 	}
 
 	@Override
@@ -156,14 +207,16 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 		IOUtils.closeQuietly(this.heartBeatTask::close);
 		// signal the gRPC client that the stream was forcibly terminated
 		// (e.g. when the catalog is replaced or deleted while subscribers are listening)
-		try {
-			this.responseObserver.onError(
-				Status.UNAVAILABLE
-					.withDescription("CDC stream has been terminated by the server.")
-					.asRuntimeException()
-			);
-		} catch (Exception ignored) {
-			// stream may already be cancelled by the client — safe to ignore
+		if (this.streamFinalized.compareAndSet(false, true)) {
+			try {
+				this.responseObserver.onError(
+					Status.UNAVAILABLE
+						.withDescription("CDC stream has been terminated by the server.")
+						.asRuntimeException()
+				);
+			} catch (Exception ex) {
+				log.debug("Failed to send UNAVAILABLE error to CDC client: {}", ex.getMessage());
+			}
 		}
 	}
 
@@ -175,6 +228,9 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 	 * @return the delay (in milliseconds) until the next heartbeat is scheduled
 	 */
 	private long sendHeartbeat() {
+		if (this.streamFinalized.get()) {
+			return -1L;
+		}
 		final GrpcRegisterChangeCatalogCaptureResponse.Builder response = GrpcRegisterChangeCatalogCaptureResponse
 			.newBuilder();
 		if (this.subscription instanceof ChangeCaptureSubscription ccs) {

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeCatalogCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeCatalogCaptureSubscriber.java
@@ -48,6 +48,7 @@ import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 
 import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toGrpcOffsetDateTime;
@@ -118,9 +119,11 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 	 */
 	private Subscription subscription;
 	/**
-	 * Monotonically increasing counter for heartbeat message indexing.
+	 * Monotonically increasing counter for heartbeat message indexing. Atomic because
+	 * it is accessed from both the publisher thread ({@link #onNext}) and the scheduler
+	 * thread ({@link #sendHeartbeat}) via {@link #buildHeartBeatMessage()}.
 	 */
-	private long index = 0L;
+	private final AtomicLong index = new AtomicLong(0L);
 
 	public ChangeCatalogCaptureSubscriber(
 		@Nonnull Scheduler scheduler,
@@ -184,6 +187,7 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 			);
 		} catch (Exception ex) {
 			log.debug("CDC onNext failed (stream likely finalized concurrently): {}", ex.getMessage());
+			this.subscription.cancel();
 			return;
 		}
 		this.serviceContext.setRequestTimeout(TimeoutMode.EXTEND, Duration.ofMillis(this.responseTimeoutMillis));
@@ -209,10 +213,10 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 
 	@Override
 	public void close() {
-		IOUtils.closeQuietly(this.heartBeatTask::close);
 		// signal the gRPC client that the stream was forcibly terminated
 		// (e.g. when the catalog is replaced or deleted while subscribers are listening)
 		if (this.streamFinalized.compareAndSet(false, true)) {
+			IOUtils.closeQuietly(this.heartBeatTask::close);
 			try {
 				this.responseObserver.onError(
 					Status.UNAVAILABLE
@@ -267,7 +271,7 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 	@Nonnull
 	private GrpcHeartBeat buildHeartBeatMessage() {
 		return GrpcHeartBeat.newBuilder()
-			.setIndex(this.index++)
+			.setIndex(this.index.getAndIncrement())
 			.setTimestamp(toGrpcOffsetDateTime(OffsetDateTime.now()))
 			.setLastObservedVersion(this.versionSupplier.getAsLong())
 			.setMillisToNextHeartbeat(this.heartBeatDelay)

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeCatalogCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeCatalogCaptureSubscriber.java
@@ -174,13 +174,18 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 		if (this.streamFinalized.get()) {
 			return;
 		}
-		this.responseObserver.onNext(
-			GrpcRegisterChangeCatalogCaptureResponse
-				.newBuilder()
-				.setCapture(ChangeCaptureConverter.toGrpcChangeCatalogCapture(item, this.clientVersion))
-				.setResponseType(GrpcCaptureResponseType.CHANGE)
-				.build()
-		);
+		try {
+			this.responseObserver.onNext(
+				GrpcRegisterChangeCatalogCaptureResponse
+					.newBuilder()
+					.setCapture(ChangeCaptureConverter.toGrpcChangeCatalogCapture(item, this.clientVersion))
+					.setResponseType(GrpcCaptureResponseType.CHANGE)
+					.build()
+			);
+		} catch (Exception ex) {
+			log.debug("CDC onNext failed (stream likely finalized concurrently): {}", ex.getMessage());
+			return;
+		}
 		this.serviceContext.setRequestTimeout(TimeoutMode.EXTEND, Duration.ofMillis(this.responseTimeoutMillis));
 		this.subscription.request(1);
 	}
@@ -215,7 +220,7 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 						.asRuntimeException()
 				);
 			} catch (Exception ex) {
-				log.debug("Failed to send UNAVAILABLE error to CDC client: {}", ex.getMessage());
+				log.debug("Failed to send UNAVAILABLE error to CDC client: {}", ex.getMessage(), ex);
 			}
 		}
 	}
@@ -236,12 +241,17 @@ public class ChangeCatalogCaptureSubscriber implements Subscriber<ChangeCatalogC
 		if (this.subscription instanceof ChangeCaptureSubscription ccs) {
 			response.setUuid(toGrpcUuid(ccs.getSubscriptionId()));
 		}
-		this.responseObserver.onNext(
-			response
-				.setResponseType(GrpcCaptureResponseType.HEARTBEAT)
-				.setHeartBeat(buildHeartBeatMessage())
-				.build()
-		);
+		try {
+			this.responseObserver.onNext(
+				response
+					.setResponseType(GrpcCaptureResponseType.HEARTBEAT)
+					.setHeartBeat(buildHeartBeatMessage())
+					.build()
+			);
+		} catch (Exception ex) {
+			log.debug("Heartbeat send failed (stream likely finalized concurrently): {}", ex.getMessage());
+			return -1L;
+		}
 		this.serviceContext.setRequestTimeout(TimeoutMode.EXTEND, Duration.ofMillis(this.responseTimeoutMillis));
 		// plan the next heartbeat at regular interval
 		return 0L;

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeSystemCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeSystemCaptureSubscriber.java
@@ -38,6 +38,7 @@ import io.evitadb.utils.IOUtils;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
@@ -46,6 +47,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.LongSupplier;
 
 import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toGrpcOffsetDateTime;
@@ -61,16 +63,52 @@ import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toGrp
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
  */
+@Slf4j
 @RequiredArgsConstructor
 public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCapture>, AutoCloseable {
+	/**
+	 * Flag ensuring the gRPC stream is finalized (via `onError` or `onCompleted`) exactly once
+	 * across all termination paths ({@link #onError}, {@link #onComplete}, {@link #close}).
+	 */
+	private final AtomicBoolean streamFinalized = new AtomicBoolean(false);
+	/**
+	 * The gRPC stream observer used to send responses to the client.
+	 */
 	private final StreamObserver<GrpcRegisterSystemChangeCaptureResponse> responseObserver;
+	/**
+	 * Future that is completed when the subscription is established, allowing the gRPC cancel
+	 * handler to obtain the subscription reference for cancellation.
+	 */
 	private final CompletableFuture<Subscription> subscriptionFuture;
+	/**
+	 * Supplier that provides the current system version for heartbeat messages.
+	 */
 	private final LongSupplier versionSupplier;
+	/**
+	 * The Armeria service request context, used to extend the request timeout on activity.
+	 */
 	private final ServiceRequestContext serviceContext;
+	/**
+	 * The original response timeout in milliseconds, used to extend the timeout after each
+	 * message or heartbeat.
+	 */
 	private final long responseTimeoutMillis;
+	/**
+	 * The delay between heartbeat messages in milliseconds — computed as 5 seconds less than
+	 * the response timeout, clamped to [1 second, 5 minutes].
+	 */
 	private final long heartBeatDelay;
+	/**
+	 * Scheduled task that periodically sends heartbeat messages to keep the gRPC stream alive.
+	 */
 	private final DelayedAsyncTask heartBeatTask;
+	/**
+	 * The active subscription from the publisher, set during {@link #onSubscribe(Subscription)}.
+	 */
 	private Subscription subscription;
+	/**
+	 * Monotonically increasing counter for heartbeat message indexing.
+	 */
 	private long index = 0L;
 
 	public ChangeSystemCaptureSubscriber(
@@ -120,6 +158,9 @@ public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCap
 
 	@Override
 	public void onNext(ChangeSystemCapture item) {
+		if (this.streamFinalized.get()) {
+			return;
+		}
 		this.responseObserver.onNext(
 			GrpcRegisterSystemChangeCaptureResponse
 				.newBuilder()
@@ -133,27 +174,35 @@ public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCap
 
 	@Override
 	public void onError(Throwable throwable) {
-		this.subscriptionFuture.completeExceptionally(throwable);
-		this.responseObserver.onError(throwable);
+		if (this.streamFinalized.compareAndSet(false, true)) {
+			IOUtils.closeQuietly(this.heartBeatTask::close);
+			this.subscriptionFuture.completeExceptionally(throwable);
+			this.responseObserver.onError(throwable);
+		}
 	}
 
 	@Override
 	public void onComplete() {
-		this.responseObserver.onCompleted();
+		if (this.streamFinalized.compareAndSet(false, true)) {
+			IOUtils.closeQuietly(this.heartBeatTask::close);
+			this.responseObserver.onCompleted();
+		}
 	}
 
 	@Override
 	public void close() {
 		IOUtils.closeQuietly(this.heartBeatTask::close);
 		// signal the gRPC client that the stream was forcibly terminated
-		try {
-			this.responseObserver.onError(
-				Status.UNAVAILABLE
-					.withDescription("CDC stream has been terminated by the server.")
-					.asRuntimeException()
-			);
-		} catch (Exception ignored) {
-			// stream may already be cancelled by the client — safe to ignore
+		if (this.streamFinalized.compareAndSet(false, true)) {
+			try {
+				this.responseObserver.onError(
+					Status.UNAVAILABLE
+						.withDescription("CDC stream has been terminated by the server.")
+						.asRuntimeException()
+				);
+			} catch (Exception ex) {
+				log.debug("Failed to send UNAVAILABLE error to CDC client: {}", ex.getMessage());
+			}
 		}
 	}
 
@@ -165,6 +214,9 @@ public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCap
 	 * @return the delay (in milliseconds) until the next heartbeat is scheduled
 	 */
 	private long sendHeartbeat() {
+		if (this.streamFinalized.get()) {
+			return -1L;
+		}
 		final GrpcRegisterSystemChangeCaptureResponse.Builder response = GrpcRegisterSystemChangeCaptureResponse
 			.newBuilder();
 		if (this.subscription instanceof ChangeCaptureSubscription ccs) {

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeSystemCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeSystemCaptureSubscriber.java
@@ -161,13 +161,18 @@ public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCap
 		if (this.streamFinalized.get()) {
 			return;
 		}
-		this.responseObserver.onNext(
-			GrpcRegisterSystemChangeCaptureResponse
-				.newBuilder()
-				.setCapture(ChangeCaptureConverter.toGrpcChangeSystemCapture(item))
-				.setResponseType(GrpcCaptureResponseType.CHANGE)
-				.build()
-		);
+		try {
+			this.responseObserver.onNext(
+				GrpcRegisterSystemChangeCaptureResponse
+					.newBuilder()
+					.setCapture(ChangeCaptureConverter.toGrpcChangeSystemCapture(item))
+					.setResponseType(GrpcCaptureResponseType.CHANGE)
+					.build()
+			);
+		} catch (Exception ex) {
+			log.debug("CDC onNext failed (stream likely finalized concurrently): {}", ex.getMessage());
+			return;
+		}
 		this.serviceContext.setRequestTimeout(TimeoutMode.EXTEND, Duration.ofMillis(this.responseTimeoutMillis));
 		this.subscription.request(1);
 	}
@@ -201,7 +206,7 @@ public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCap
 						.asRuntimeException()
 				);
 			} catch (Exception ex) {
-				log.debug("Failed to send UNAVAILABLE error to CDC client: {}", ex.getMessage());
+				log.debug("Failed to send UNAVAILABLE error to CDC client: {}", ex.getMessage(), ex);
 			}
 		}
 	}
@@ -222,12 +227,17 @@ public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCap
 		if (this.subscription instanceof ChangeCaptureSubscription ccs) {
 			response.setUuid(toGrpcUuid(ccs.getSubscriptionId()));
 		}
-		this.responseObserver.onNext(
-			response
-				.setResponseType(GrpcCaptureResponseType.HEARTBEAT)
-				.setHeartBeat(buildHeartBeatMessage())
-				.build()
-		);
+		try {
+			this.responseObserver.onNext(
+				response
+					.setResponseType(GrpcCaptureResponseType.HEARTBEAT)
+					.setHeartBeat(buildHeartBeatMessage())
+					.build()
+			);
+		} catch (Exception ex) {
+			log.debug("Heartbeat send failed (stream likely finalized concurrently): {}", ex.getMessage());
+			return -1L;
+		}
 		this.serviceContext.setRequestTimeout(TimeoutMode.EXTEND, Duration.ofMillis(this.responseTimeoutMillis));
 		// plan the next heartbeat at regular interval
 		return 0L;

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeSystemCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeSystemCaptureSubscriber.java
@@ -35,6 +35,7 @@ import io.evitadb.externalApi.grpc.generated.GrpcHeartBeat;
 import io.evitadb.externalApi.grpc.generated.GrpcRegisterSystemChangeCaptureResponse;
 import io.evitadb.externalApi.grpc.requestResponse.cdc.ChangeCaptureConverter;
 import io.evitadb.utils.IOUtils;
+import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import lombok.RequiredArgsConstructor;
 
@@ -144,6 +145,16 @@ public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCap
 	@Override
 	public void close() {
 		IOUtils.closeQuietly(this.heartBeatTask::close);
+		// signal the gRPC client that the stream was forcibly terminated
+		try {
+			this.responseObserver.onError(
+				Status.UNAVAILABLE
+					.withDescription("CDC stream has been terminated by the server.")
+					.asRuntimeException()
+			);
+		} catch (Exception ignored) {
+			// stream may already be cancelled by the client — safe to ignore
+		}
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeSystemCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/services/subscriber/ChangeSystemCaptureSubscriber.java
@@ -48,6 +48,7 @@ import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.Flow.Subscription;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 
 import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toGrpcOffsetDateTime;
@@ -107,9 +108,11 @@ public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCap
 	 */
 	private Subscription subscription;
 	/**
-	 * Monotonically increasing counter for heartbeat message indexing.
+	 * Monotonically increasing counter for heartbeat message indexing. Atomic because
+	 * it is accessed from both the publisher thread ({@link #onNext}) and the scheduler
+	 * thread ({@link #sendHeartbeat}) via {@link #buildHeartBeatMessage()}.
 	 */
-	private long index = 0L;
+	private final AtomicLong index = new AtomicLong(0L);
 
 	public ChangeSystemCaptureSubscriber(
 		@Nonnull Scheduler scheduler,
@@ -171,6 +174,7 @@ public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCap
 			);
 		} catch (Exception ex) {
 			log.debug("CDC onNext failed (stream likely finalized concurrently): {}", ex.getMessage());
+			this.subscription.cancel();
 			return;
 		}
 		this.serviceContext.setRequestTimeout(TimeoutMode.EXTEND, Duration.ofMillis(this.responseTimeoutMillis));
@@ -196,9 +200,9 @@ public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCap
 
 	@Override
 	public void close() {
-		IOUtils.closeQuietly(this.heartBeatTask::close);
 		// signal the gRPC client that the stream was forcibly terminated
 		if (this.streamFinalized.compareAndSet(false, true)) {
+			IOUtils.closeQuietly(this.heartBeatTask::close);
 			try {
 				this.responseObserver.onError(
 					Status.UNAVAILABLE
@@ -253,7 +257,7 @@ public class ChangeSystemCaptureSubscriber implements Subscriber<ChangeSystemCap
 	@Nonnull
 	private GrpcHeartBeat buildHeartBeatMessage() {
 		return GrpcHeartBeat.newBuilder()
-			.setIndex(this.index++)
+			.setIndex(this.index.getAndIncrement())
 			.setTimestamp(toGrpcOffsetDateTime(OffsetDateTime.now()))
 			.setLastObservedVersion(this.versionSupplier.getAsLong())
 			.setMillisToNextHeartbeat(this.heartBeatDelay)


### PR DESCRIPTION
## Summary

- When a catalog is replaced or deleted, `ChangeCatalogCaptureSharedPublisher.close()` cancels all subscriptions, but gRPC subscribers' `close()` only stopped the heartbeat task — the `StreamObserver` was never finalized
- Now `close()` sends `Status.UNAVAILABLE` via `onError()` so clients detect the forced termination immediately instead of hanging until request timeout
- Applied to both `ChangeCatalogCaptureSubscriber` and `ChangeSystemCaptureSubscriber`

Closes #1124