### PR TITLE
Fix CDC activePublishers key collision across catalogs

### DIFF
--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
@@ -52,6 +52,7 @@ import io.evitadb.api.exception.TransactionException;
 import io.evitadb.api.proxy.ProxyFactory;
 import io.evitadb.api.requestResponse.cdc.ChangeCapturePublisher;
 import io.evitadb.api.requestResponse.cdc.ChangeCaptureRequest;
+import io.evitadb.api.requestResponse.cdc.ChangeCatalogCaptureRequest;
 import io.evitadb.api.requestResponse.cdc.ChangeSystemCapture;
 import io.evitadb.api.requestResponse.cdc.ChangeSystemCaptureRequest;
 import io.evitadb.api.requestResponse.data.DevelopmentConstants;
@@ -208,7 +209,7 @@ public class EvitaClient implements EvitaContract {
 	 * {@link CapturePublisherKey} — either a {@link CatalogBoundCaptureKey} (for catalog-level captures)
 	 * or a {@link SystemCaptureKey} (for system-level captures).
 	 */
-	protected final Map<CapturePublisherKey, ClientChangeCapturePublisher<?, ?, ?>> activePublishers = CollectionUtils.createConcurrentHashMap(
+	final Map<CapturePublisherKey, ClientChangeCapturePublisher<?, ?, ?>> activePublishers = CollectionUtils.createConcurrentHashMap(
 		16);
 	/**
 	 * Executor service used for asynchronous operations.

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
@@ -204,9 +204,11 @@ public class EvitaClient implements EvitaContract {
 	 */
 	private final Map<UUID, EvitaSessionContract> activeSessions = CollectionUtils.createConcurrentHashMap(16);
 	/**
-	 * Index of the opened and active {@link ClientChangeCapturePublisher} indexed by their unique {@link ChangeSystemCaptureRequest}.
+	 * Index of the opened and active {@link ClientChangeCapturePublisher} indexed by their unique
+	 * {@link CapturePublisherKey} — either a {@link CatalogBoundCaptureKey} (for catalog-level captures)
+	 * or a {@link SystemCaptureKey} (for system-level captures).
 	 */
-	protected final Map<ChangeCaptureRequest, ClientChangeCapturePublisher<?, ?, ?>> activePublishers = CollectionUtils.createConcurrentHashMap(
+	protected final Map<CapturePublisherKey, ClientChangeCapturePublisher<?, ?, ?>> activePublishers = CollectionUtils.createConcurrentHashMap(
 		16);
 	/**
 	 * Executor service used for asynchronous operations.
@@ -1061,10 +1063,11 @@ public class EvitaClient implements EvitaContract {
 	public ChangeCapturePublisher<ChangeSystemCapture> registerSystemChangeCapture(
 		@Nonnull ChangeSystemCaptureRequest request
 	) {
+		final SystemCaptureKey key = new SystemCaptureKey(request);
 		//noinspection unchecked
 		return (ChangeCapturePublisher<ChangeSystemCapture>) this.activePublishers.compute(
-			request,
-			(theRequest, existingInstance) ->
+			key,
+			(theKey, existingInstance) ->
 				existingInstance == null || existingInstance.isClosed() ?
 					new ClientChangeSystemCaptureProcessor(
 						this.configuration.changeCaptureQueueSize(),
@@ -1073,14 +1076,13 @@ public class EvitaClient implements EvitaContract {
 						subscriber -> executeWithStreamingEvitaService(
 							evitaService -> {
 								evitaService.registerSystemChangeCapture(
-									ChangeCaptureConverter.toGrpcChangeSystemCaptureRequest(
-										(ChangeSystemCaptureRequest) theRequest),
-										subscriber
+									ChangeCaptureConverter.toGrpcChangeSystemCaptureRequest(request),
+									subscriber
 								);
 								return null;
 							}
 							),
-						publisher -> this.activePublishers.remove(theRequest, publisher)
+						publisher -> this.activePublishers.remove(key, publisher)
 					) : existingInstance
 		);
 	}
@@ -1232,6 +1234,38 @@ public class EvitaClient implements EvitaContract {
 				timeout.timeout(), timeout.timeoutUnit()
 			);
 		}
+	}
+
+	/**
+	 * Key type for the {@link #activePublishers} map, ensuring compile-time safety
+	 * while allowing both system-level and catalog-level capture keys.
+	 */
+	sealed interface CapturePublisherKey
+		permits SystemCaptureKey, CatalogBoundCaptureKey {
+	}
+
+	/**
+	 * Key for system-level CDC publishers in the {@link #activePublishers} map.
+	 *
+	 * @param request the original system capture request
+	 */
+	record SystemCaptureKey(
+		@Nonnull ChangeSystemCaptureRequest request
+	) implements CapturePublisherKey {
+	}
+
+	/**
+	 * Key for catalog-level CDC publishers in the {@link #activePublishers} map.
+	 * Binds a {@link ChangeCaptureRequest} to a specific catalog name, preventing
+	 * collisions when two different catalogs issue requests with identical criteria.
+	 *
+	 * @param catalogName the name of the catalog this capture is bound to
+	 * @param request     the original capture request
+	 */
+	record CatalogBoundCaptureKey(
+		@Nonnull String catalogName,
+		@Nonnull ChangeCaptureRequest request
+	) implements CapturePublisherKey {
 	}
 
 }

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
@@ -1264,7 +1264,7 @@ public class EvitaClient implements EvitaContract {
 	 */
 	record CatalogBoundCaptureKey(
 		@Nonnull String catalogName,
-		@Nonnull ChangeCaptureRequest request
+		@Nonnull ChangeCatalogCaptureRequest request
 	) implements CapturePublisherKey {
 	}
 

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientSession.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientSession.java
@@ -545,10 +545,13 @@ public class EvitaClientSession implements EvitaSessionContract {
 	@Nonnull
 	@Override
 	public ChangeCapturePublisher<ChangeCatalogCapture> registerChangeCatalogCapture(@Nonnull ChangeCatalogCaptureRequest request) {
+		final EvitaClient.CatalogBoundCaptureKey key = new EvitaClient.CatalogBoundCaptureKey(
+			this.catalogName, request
+		);
 		//noinspection unchecked
 		return (ChangeCapturePublisher<ChangeCatalogCapture>) this.evita.activePublishers.compute(
-			request,
-			(theRequest, existingInstance) ->
+			key,
+			(theKey, existingInstance) ->
 				existingInstance == null || existingInstance.isClosed() ?
 					new ClientChangeCatalogCaptureProcessor(
 						this.evita.getConfiguration().changeCaptureQueueSize(),
@@ -557,8 +560,7 @@ public class EvitaClientSession implements EvitaSessionContract {
 						subscriber -> {
 							final AsyncCallFunction<EvitaSessionServiceStub, Void> callFunction = evitaService -> {
 								evitaService.registerChangeCatalogCapture(
-									ChangeCaptureConverter.toGrpcChangeCatalogCaptureRequest(
-										(ChangeCatalogCaptureRequest) theRequest),
+									ChangeCaptureConverter.toGrpcChangeCatalogCaptureRequest(request),
 									subscriber
 								);
 								return null;
@@ -574,7 +576,7 @@ public class EvitaClientSession implements EvitaSessionContract {
 								session.executeWithStreamingEvitaSessionService(callFunction);
 							}
 						},
-						publisher -> this.evita.activePublishers.remove(theRequest, publisher)
+						publisher -> this.evita.activePublishers.remove(key, publisher)
 					) : existingInstance
 		);
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadWriteTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadWriteTest.java
@@ -3504,6 +3504,105 @@ class EvitaClientReadWriteTest implements TestConstants, EvitaTestSupport {
 		}
 	}
 
+	@Test
+	@DisplayName("CDC publishers for different catalogs with identical request criteria should be independent")
+	@UseDataSet(EVITA_CLIENT_DATA_SET)
+	void shouldNotLeakCdcEventsBetweenCatalogsWithIdenticalCaptureRequests(EvitaClient evitaClient) {
+		final String catalogA = "testCatalogCdcA";
+		final String catalogB = "testCatalogCdcB";
+
+		try {
+			// create two separate catalogs and make them go live
+			evitaClient.defineCatalog(catalogA);
+			evitaClient.updateCatalog(catalogA, session -> {
+				session.goLiveAndClose();
+				return null;
+			});
+
+			evitaClient.defineCatalog(catalogB);
+			evitaClient.updateCatalog(catalogB, session -> {
+				session.goLiveAndClose();
+				return null;
+			});
+
+			// build identical CDC request criteria for both catalogs
+			final ChangeCatalogCaptureRequest identicalRequest = ChangeCatalogCaptureRequest
+				.builder()
+				.content(ChangeCaptureContent.BODY)
+				.criteria(
+					ChangeCatalogCaptureCriteria
+						.builder()
+						.schemaArea()
+						.build()
+				)
+				.build();
+
+			final MockCatalogChangeCaptureSubscriber subscriberA =
+				new MockCatalogChangeCaptureSubscriber(Integer.MAX_VALUE);
+			final MockCatalogChangeCaptureSubscriber subscriberB =
+				new MockCatalogChangeCaptureSubscriber(Integer.MAX_VALUE);
+
+			// register CDC on catalog A
+			evitaClient.updateCatalog(catalogA, session -> {
+				session.registerChangeCatalogCapture(identicalRequest)
+					.subscribe(subscriberA);
+				return null;
+			});
+
+			// register CDC on catalog B with the same request
+			evitaClient.updateCatalog(catalogB, session -> {
+				session.registerChangeCatalogCapture(identicalRequest)
+					.subscribe(subscriberB);
+				return null;
+			});
+
+			// trigger schema change only in catalog A
+			evitaClient.updateCatalog(catalogA, session -> {
+				session.defineEntitySchema(Entities.BRAND)
+					.updateVia(session);
+				return null;
+			});
+
+			// subscriber A should receive the event
+			assertEquals(
+				1,
+				subscriberA.getEntityCollectionCreated(Entities.BRAND, 10, TimeUnit.SECONDS, 1),
+				"Subscriber on catalog A should receive schema change from catalog A"
+			);
+
+			// subscriber B must NOT receive the event from catalog A
+			assertEquals(
+				0,
+				subscriberB.getEntityCollectionCreated(Entities.BRAND),
+				"Subscriber on catalog B must not receive events from catalog A"
+			);
+
+			// trigger schema change only in catalog B
+			evitaClient.updateCatalog(catalogB, session -> {
+				session.defineEntitySchema(Entities.STORE)
+					.updateVia(session);
+				return null;
+			});
+
+			// subscriber B should receive its own event
+			assertEquals(
+				1,
+				subscriberB.getEntityCollectionCreated(Entities.STORE, 10, TimeUnit.SECONDS, 1),
+				"Subscriber on catalog B should receive schema change from catalog B"
+			);
+
+			// subscriber A must NOT receive the event from catalog B
+			assertEquals(
+				0,
+				subscriberA.getEntityCollectionCreated(Entities.STORE),
+				"Subscriber on catalog A must not receive events from catalog B"
+			);
+		} finally {
+			evitaClient.deleteCatalogIfExists(catalogA);
+			evitaClient.deleteCatalogIfExists(catalogB);
+		}
+	}
+
 	private static class MockCatalogChangeCaptureSubscriberWithHeartBeat extends MockCatalogChangeCaptureSubscriber implements HeartBeatSensor {
 		private final AtomicInteger heartbeatCount = new AtomicInteger(0);
 		private final AtomicReference<Long> firstHeartbeatTime = new AtomicReference<>();


### PR DESCRIPTION
## Summary

- Fix key collision in `EvitaClient.activePublishers` map where two catalogs with identical `ChangeCatalogCaptureRequest` criteria would share the same CDC publisher
- Introduce sealed `CapturePublisherKey` interface with `CatalogBoundCaptureKey` (catalog-scoped) and `SystemCaptureKey` (system-scoped) to restore compile-time type safety
- Eliminate unsafe casts of lambda key parameter by capturing outer `request` variable directly

Closes #1126