### PR TITLE
Fix SelectionFormula assert bug and optimize formula framework

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -39,7 +39,30 @@ Do not write (co)author name or date in the PR request.
   ```
 - Link issues in PR description (e.g., "Closes #1075")
 
-## Review Comments
+## Reviewing a PR
+
+Before writing any review comments, gather the full review history so you don't repeat resolved concerns or ignore prior discussion:
+
+```shell
+# All prior review rounds (who reviewed, state, body)
+gh api repos/FgForrest/evitaDB/pulls/<PR_NUMBER>/reviews
+
+# All review comments including reply threads (in_reply_to_id links replies to parents)
+gh api repos/FgForrest/evitaDB/pulls/<PR_NUMBER>/comments
+
+# Top-level PR conversation comments
+gh api repos/FgForrest/evitaDB/issues/<PR_NUMBER>/comments
+```
+
+Build a threaded view by grouping comments via `in_reply_to_id`. For each thread, read the original complaint **and** all replies/reactions. Take into account:
+
+- Whether the author already addressed or explained a concern in a reply
+- Whether a previous reviewer withdrew, softened, or refined their complaint after discussion
+- Whether a concern from an earlier review round was already fixed in a subsequent commit
+
+Do not raise issues that were already resolved or adequately answered. Focus new review comments on genuinely unaddressed problems.
+
+## Addressing Review Comments
 
 Fetch all unresolved review comments with `gh` CLI and address them one by one (ignore already resolved).
 

--- a/documentation/developer/formula/formula_framework.md
+++ b/documentation/developer/formula/formula_framework.md
@@ -1,0 +1,687 @@
+# Formula framework
+
+Formulas are the computational backbone of evitaDB's query filtering pipeline. Every user query is translated into
+a tree of `Formula` nodes mirroring the original constraint structure. Leaf nodes wrap index bitmaps; inner nodes
+perform set operations (AND, OR, NOT, etc.). Evaluating the root formula produces a `Bitmap` of matching entity
+primary keys — the starting point for sorting, pagination, and extra-result fabrication.
+
+This document covers everything a developer needs to know to write a correct, efficient, and cache-friendly
+`Formula` implementation.
+
+## How formulas fit into the query pipeline
+
+```
+User query
+    │
+    ▼
+QueryPlanner.planQuery()
+    │
+    ├─ 1. Index selection ─── IndexSelectionVisitor picks best EntityIndex(es)
+    │
+    ├─ 2. Filter formula construction
+    │      │
+    │      ├─ FilterByVisitor walks the FilterConstraint tree
+    │      │    └─ For each constraint: looks up FilteringConstraintTranslator → translator.translate() → Formula
+    │      │
+    │      ├─ FormulaPostProcessor pipeline transforms the tree (optimizer, deduplicator, scope injection, …)
+    │      │
+    │      └─ FormulaDeduplicator is always applied last (reuses structurally identical sub-trees)
+    │
+    ├─ 3. Sorter creation ─── OrderByVisitor
+    ├─ 4. Slicer creation ─── pagination configuration
+    └─ 5. Extra result producers ─── ExtraResultPlanningVisitor
+            │
+            ▼
+        QueryPlan(filterFormula, sorters, slicer, producers)
+            │
+            ▼
+QueryPlan.execute()
+    ├─ filterFormula.initialize(executionContext)
+    ├─ Bitmap result = filterFormula.compute()        ◄── lazy, memoized evaluation
+    ├─ Sorters sort & slice the bitmap
+    ├─ ExtraResultProducers fabricate facets, histograms, hierarchy stats, …
+    └─ Entity bodies fetched for final page → EvitaResponse
+```
+
+**Key design properties:**
+
+- **Two-phase architecture** — planning builds the formula tree (cheap); execution evaluates it (lazy, memoized).
+- **Translator pattern** — `FilterByVisitor` holds a static map
+  `FilterConstraint class → FilteringConstraintTranslator`. Each translator converts exactly one constraint type
+  into one or more `Formula` nodes. This is the primary extension point for new filter constraints.
+- **Post-processing pipeline** — after the raw tree is built, registered `FormulaPostProcessor` instances transform
+  it. The `FormulaOptimizer` prunes dead branches; the `FormulaDeduplicator` collapses structurally identical
+  sub-trees so that memoized results are shared.
+- **Result flow** — the root `Bitmap` is consumed by sorters (for ordering), by extra-result producers
+  (for counts), and by the entity fetcher (for the final page). The formula tree itself is also traversed by
+  extra-result producers (e.g., facet-summary needs to locate `UserFilterFormula` nodes).
+
+### Relevant source files
+
+| Component                     | Path                                                                                     |
+|-------------------------------|------------------------------------------------------------------------------------------|
+| `Formula` interface           | `evita_engine/…/query/algebra/Formula.java`                                              |
+| `AbstractFormula`             | `evita_engine/…/query/algebra/AbstractFormula.java`                                      |
+| `AbstractCacheableFormula`    | `evita_engine/…/query/algebra/AbstractCacheableFormula.java`                              |
+| `FilterByVisitor`             | `evita_engine/…/query/filter/FilterByVisitor.java`                                       |
+| `FilteringConstraintTranslator` | `evita_engine/…/query/filter/translator/FilteringConstraintTranslator.java`            |
+| `QueryPlanner`                | `evita_engine/…/query/QueryPlanner.java`                                                 |
+| `QueryPlan`                   | `evita_engine/…/query/QueryPlan.java`                                                    |
+| `FormulaOptimizer`            | `evita_engine/…/query/filter/FormulaOptimizer.java`                                      |
+| `FormulaDeduplicator`         | `evita_engine/…/query/filter/FormulaDeduplicator.java`                                   |
+| Base formulas (AND, OR, …)    | `evita_engine/…/query/algebra/base/`                                                     |
+| Cache system                  | `evita_engine/…/cache/`                                                                  |
+
+## Anatomy of a formula
+
+> **Performance notice:** The formula framework is the most performance-sensitive part of the engine — every
+> query evaluation walks the formula tree, and hot formulas are evaluated millions of times per second. All
+> implementations **must**:
+>
+> - **Avoid Java streams** — write index-based loops instead; streams allocate iterator objects, lambda
+>   capture objects and intermediate arrays on every invocation.
+> - **Avoid unnecessary autoboxing** — use primitive arrays (`int[]`, `long[]`) and primitive-typed local
+>   variables; never pass primitives through generic (`Object`-based) APIs such as `Objects.hash()`.
+> - **Minimize memory allocations** — reuse shared constants (e.g., `EmptyBitmap.INSTANCE`,
+>   `EMPTY_FORMULA_ARRAY`), pre-size collections and `StringBuilder` instances, and prefer stack-local
+>   computation over temporary object creation.
+
+
+### Inheritance hierarchy
+
+```
+TransactionalDataRelatedStructure          ◄── cost / hash / transactional-id contract
+    └── Formula                            ◄── compute(), accept(), getCloneWithInnerFormulas(), …
+        └── AbstractFormula                ◄── memoization, hash computation, default cost model
+            └── AbstractCacheableFormula   ◄── computation callback for cache integration
+```
+
+Choose your base class based on the formula's role:
+
+| Base class                   | When to use                                                        |
+|------------------------------|--------------------------------------------------------------------|
+| `AbstractCacheableFormula`   | Formula produces a bitmap result that can be stored in the cache.  |
+| `AbstractFormula`            | Formula is a decorator/marker or carries side-data that must not be flattened into a cached bitmap. |
+
+Additionally, implement marker interfaces as needed:
+
+| Interface                   | Effect                                                                   |
+|-----------------------------|--------------------------------------------------------------------------|
+| `CacheableFormula`          | Enables cache promotion (automatically satisfied when extending `AbstractCacheableFormula`). |
+| `NonCacheableFormula`       | Prevents this formula **and all ancestors** from being cached (upward poisoning). |
+| `NonCacheableFormulaScope`  | Prevents **all children** from being cached (downward blocking); formula itself may still be cached. |
+| `ChildrenDependentFormula`  | Formula is meaningless without children — optimizer drops it when all children are pruned. |
+
+### Lifecycle
+
+1. **Construction** — set formula-specific fields, call `initFields(innerFormulas)`.
+2. **Initialization** — `initialize(QueryExecutionContext)` propagates the execution context down the tree.
+   Hash and estimated cost are already available after `initFields()`.
+3. **Post-processing** — zero or more `FormulaPostProcessor` visitors may clone/restructure the tree.
+4. **Computation** — `compute()` is called on the root, which recursively evaluates the tree. Results are
+   memoized per node.
+5. **Cache analysis** — `FormulaCacheVisitor` may instrument the tree with computation callbacks for the
+   `CacheSupervisor`.
+6. **Cleanup** — `clearMemory()` resets memoized results and cost caches; structural hash and transactional
+   IDs are *not* reset.
+
+## Writing a new formula: step by step
+
+### 1. Choose a unique class ID
+
+Every concrete formula class must return a unique `long` constant from `getClassId()`. This constant:
+
+- **must not change** over time for the same class,
+- **must not be inherited** from a superclass,
+- **must be different** for every leaf class.
+
+It is a critical component of the structural hash.
+
+```java
+private static final long CLASS_ID = -7493244674442362190L;
+
+@Override
+protected long getClassId() {
+    return CLASS_ID;
+}
+```
+
+### 2. Implement the constructor
+
+Call `initFields(innerFormulas)` at the end of the constructor, after all formula-specific fields are set.
+Validate preconditions with `Assert.isTrue()`.
+
+```java
+public MyFormula(@Nonnull Formula innerFormula, @Nonnull String attributeKey) {
+    super(null); // no computation callback (or pass one for cacheable formulas)
+    Assert.notNull(attributeKey, "Attribute key must not be null!");
+    this.attributeKey = attributeKey;
+    this.initFields(innerFormula);
+}
+```
+
+For cacheable formulas with bitmap-based inputs, provide a secondary constructor accepting `Bitmap[]`:
+
+```java
+public MyFormula(long indexTransactionId, @Nonnull Bitmap... bitmaps) {
+    super(null);
+    this.indexTransactionId = new long[]{indexTransactionId};
+    this.bitmaps = bitmaps;
+    this.initFields(); // no inner formulas
+}
+```
+
+### 3. Implement `computeInternal()`
+
+This is the core computation. It is called exactly once per formula lifetime (result is memoized by
+`AbstractFormula.compute()`).
+
+```java
+@Nonnull
+@Override
+protected Bitmap computeInternal() {
+    // For bitmap-based mode:
+    if (this.bitmaps != null) {
+        return RoaringBitmapBackedBitmap.and(this.bitmaps);
+    }
+    // For formula-based mode:
+    final Bitmap[] results = new Bitmap[innerFormulas.length];
+    for (int i = 0; i < innerFormulas.length; i++) {
+        results[i] = innerFormulas[i].compute();
+    }
+    return RoaringBitmapBackedBitmap.and(results);
+}
+```
+
+**Rules:**
+
+- Return `EmptyBitmap.INSTANCE` for empty results — never allocate a new empty bitmap.
+- For AND-like operations, sort children by estimated cost and short-circuit on empty intermediate results.
+- For OR-like operations, all children must be evaluated (no short-circuit).
+- Never call `compute()` during construction, `initFields()`, or cost estimation — it triggers the full
+  evaluation chain.
+
+### 4. Implement `getCloneWithInnerFormulas()`
+
+Used by `FormulaCloner` to rebuild the tree after transformation. Must preserve **all formula-specific state**
+while replacing inner formulas.
+
+```java
+@Nonnull
+@Override
+public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {
+    Assert.isTrue(innerFormulas.length == 1, "Expected exactly one inner formula!");
+    return new MyFormula(innerFormulas[0], this.attributeKey);
+}
+```
+
+**Rules:**
+
+- Preserve all configuration fields (attribute keys, price contexts, locales, …).
+- Do **not** preserve memoized results or cost caches.
+- Handle edge cases for container formulas:
+  - 0 children → return `EmptyFormula.INSTANCE`
+  - 1 child → return the child directly (optimization)
+  - 2+ children → return a new formula instance
+
+### 5. Implement the cost model
+
+Each formula exposes three cost levels:
+
+| Method               | When available        | Purpose                                            |
+|----------------------|-----------------------|----------------------------------------------------|
+| `getEstimatedCost()` | After `initFields()`  | Cheap upfront estimate for index selection ranking. |
+| `getCost()`          | After `compute()`     | Exact cost for cache ROI calculation.              |
+| `getOperationCost()` | Always                | Per-element multiplier, constant per formula type. |
+
+#### `getOperationCost()`
+
+Return a constant reflecting the relative expense of this operation. Benchmark against a no-op copy:
+
+| Formula type    | Operation cost | Rationale                           |
+|-----------------|----------------|-------------------------------------|
+| `EmptyFormula`  | `0`            | No computation at all.              |
+| `ConstantFormula` | `1`          | Trivial bitmap return.              |
+| `AndFormula`    | `9`            | Efficient bitmap intersection.      |
+| `NotFormula`    | `9`            | Bitmap subtraction.                 |
+| `OrFormula`     | `13`           | More expensive union.               |
+| `DisentangleFormula` | `2130`    | Element-level deduplication.        |
+| `JoinFormula`   | `2560`         | Expensive merge with duplicates.    |
+
+These values were derived from the JMH benchmark in
+`evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/FormulaCostMeasurement.java`.
+When introducing a new formula, add a corresponding benchmark method to that class, run the suite,
+and calibrate `getOperationCost()` relative to the existing results (COST 1 ≈ 1 mil. ops/s).
+
+#### `getEstimatedCardinality()`
+
+Returns a rough cardinality estimate of the result without triggering computation.
+
+**Important:** the estimate must respect the **worst-case scenario** — it should return an upper bound on the
+expected result size rather than an optimistic or average guess. The cost model multiplies
+`getOperationCost() × getEstimatedCardinality()` to produce the upfront cost estimate. An underestimate can cause
+the planner to pick a more expensive execution path (e.g., choosing a larger index when a smaller one would suffice).
+
+Conventions (each returning the worst-case upper bound):
+
+- **AND-like** (intersection) → return `min` of children's cardinalities (worst case: everything matches
+  the smallest input).
+- **OR-like** (union) → return `sum` of children's cardinalities (worst case: no overlap between children).
+- **NOT-like** (subtraction) → return the cardinality of the base (subtracted-from) formula (worst case:
+  nothing is subtracted).
+- **Wrapper/decorator** → delegate to the single child.
+- **Bitmap-based leaf** → return `bitmap.size()`.
+
+#### Overriding `getEstimatedBaseCost()`
+
+If the formula has internal data beyond inner formulas (e.g., a control bitmap in `DisentangleFormula`), override
+this to include its cost. Default is `0L`.
+
+### 6. Implement hashing
+
+#### `includeAdditionalHash(LongHashFunction)`
+
+Return a hash covering formula-specific state that affects `compute()` output but is **not** already covered by
+inner formula hashes. Inner formulas are implicitly included — do not hash them here.
+
+```java
+@Override
+protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
+    return hashFunction.hashChars(this.attributeKey);
+}
+```
+
+For bitmap-based formulas, hash the bitmap transactional IDs:
+
+```java
+@Override
+protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
+    if (this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
+        return hashFunction.hashLongs(this.indexTransactionId);
+    }
+    final long[] ids = new long[this.bitmaps.length];
+    int idx = 0;
+    for (Bitmap bitmap : this.bitmaps) {
+        if (bitmap instanceof TransactionalLayerProducer<?, ?> tlp) {
+            ids[idx++] = tlp.getId();
+        }
+    }
+    final long[] result = idx == ids.length ? ids : Arrays.copyOf(ids, idx);
+    Arrays.sort(result);
+    return hashFunction.hashLongs(result);
+}
+```
+
+#### `isFormulaOrderSignificant()`
+
+Override and return `true` only for non-commutative operations (e.g., `NotFormula` where `A NOT B ≠ B NOT A`).
+When `false` (default), inner formula hashes are sorted before structural hash computation, ensuring
+`A AND B` and `B AND A` produce the same hash.
+
+### 7. Implement transactional ID gathering
+
+#### Why transactional IDs matter
+
+Every bitmap at the leaf of a formula tree originates from an index data structure. Each index instance carries
+a **transactional ID** — a monotonically increasing version number that changes whenever a write transaction
+modifies the underlying data. The distinct, sorted set of transactional IDs gathered from all leaf bitmaps is
+hashed into a single `transactionalIdHash` that becomes a **key component of the cache key** (see
+[Cache keys](#cache-keys)).
+
+When a query arrives, the cache looks up a cached record by the formula's structural hash and then **compares
+the stored `transactionalIdHash` against the current formula's `transactionalIdHash`**. If any source index has
+moved to a new version (i.e., a transaction committed new data), the transactional IDs change, the hash changes,
+and the cache correctly returns a miss — preventing stale results from being served. Without correct transactional
+ID gathering, the cache layer would have no way to distinguish a formula built on old data from one built on
+current data, and could silently return outdated results.
+
+In short: transactional IDs are the cache **freshness guarantee**. Getting them wrong means either stale cache
+hits (IDs missing → hash doesn't change when data does) or unnecessary cache misses (extra IDs included → hash
+changes too often).
+
+#### Implementation
+
+Override `gatherBitmapIdsInternal()` if the formula wraps bitmaps directly (rather than delegating to inner
+formulas). The default implementation recursively gathers IDs from inner formulas — this is correct for formulas
+whose computation depends solely on their children's results.
+
+```java
+@Nonnull
+@Override
+protected long[] gatherBitmapIdsInternal() {
+    if (this.bitmaps == null) {
+        return super.gatherBitmapIdsInternal();
+    }
+    if (this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
+        return this.indexTransactionId; // use aggregate ID to avoid excessive allocation
+    }
+    final long[] ids = new long[this.bitmaps.length];
+    int idx = 0;
+    for (Bitmap bitmap : this.bitmaps) {
+        if (bitmap instanceof TransactionalLayerProducer<?, ?> tlp) {
+            ids[idx++] = tlp.getId();
+        }
+    }
+    return idx == ids.length ? ids : Arrays.copyOf(ids, idx);
+}
+```
+
+The `EXCESSIVE_HIGH_CARDINALITY` threshold (100) triggers a fallback to the index-level transactional ID instead
+of enumerating individual bitmap IDs — this avoids excessive memory allocation in `CacheEden`.
+
+### 8. String representation
+
+Implement `toString()` for tree printing and optionally override `toStringVerbose()` for detailed diagnostics:
+
+```java
+@Override
+public String toString() {
+    return "MY_OP[" + attributeKey + "]";
+}
+
+@Nonnull
+@Override
+public String toStringVerbose() {
+    return toString() + " → " + (memoizedResult == null ? "?" : memoizedResult.size()) + " records";
+}
+```
+
+## Hash computation in depth
+
+The structural hash uniquely identifies a formula tree's **logical shape**. Two formula trees that would always
+produce the same result from the same data should have the same hash.
+
+```
+hash = xxHash(
+    classId,
+    isFormulaOrderSignificant()
+        ? [innerFormula₁.hash, innerFormula₂.hash, …]                  // ordered
+        : sort([innerFormula₁.hash, innerFormula₂.hash, …]),           // canonical order
+    includeAdditionalHash()
+)
+```
+
+The **transactional ID hash** identifies the *data sources* the formula depends on. It is computed from the
+distinct, sorted array of `TransactionalLayerCreator.getId()` values gathered from all bitmaps:
+
+```
+transactionalIdHash = xxHash(distinct(sort(gatherTransactionalIds())))
+```
+
+Both hashes are computed once during `initFields()` and are immutable for the formula's lifetime.
+`clearMemory()` does **not** reset them.
+
+### Hash function
+
+All hash computation uses `LongHashFunction.xx3()` (xxHash, zero-allocation), obtained from
+`CacheSupervisor.createHashFunction()`.
+
+## Caching mechanism
+
+### Overview
+
+evitaDB uses a two-stage cache — **CacheAnteroom** (observation) and **CacheEden** (storage) — to memoize
+expensive formula sub-trees across queries.
+
+```
+Formula tree
+    │
+    ▼
+FormulaCacheVisitor traverses tree
+    │
+    ├─ Is formula CacheableFormula?
+    ├─ Is estimatedCost ≥ minimalComplexityThreshold?
+    ├─ Not inside NonCacheableFormulaScope?
+    ├─ No NonCacheableFormula descendant?
+    │
+    ▼
+CacheAnteroom.register()
+    │
+    ├─ Cache hit in CacheEden? ──────────────────────► Return cached FlattenedFormula
+    │     (transactionalIdHash must match)
+    │
+    └─ Cache miss → create instrumented clone
+         via getCloneWithComputationCallback()
+         │
+         ▼
+    Query executes, formula.compute() fires
+         │
+         ▼
+    Callback records costToPerformanceRatio + sizeEstimate
+    as CacheRecordAdept in CacheAnteroom
+         │
+         ▼
+    Periodic evaluation (when anteroom fills or timer fires)
+         │
+         ▼
+CacheEden.evaluateAdepts()
+    ├─ Merge adepts + existing cached records
+    ├─ Sort by spaceToPerformanceRatio (descending)
+    ├─ Promote top candidates within memory budget
+    └─ Evict cold records (unused for ≥ 3 evaluation intervals)
+```
+
+### Cache keys
+
+The cache uses a **three-level key**:
+
+1. **Record key** — `xxHash(catalogName, entityType, formula.getHash())` — scopes cache entries
+   per catalog and entity type.
+2. **Structural hash** (`formula.getHash()`) — identifies the formula tree shape. Same query structure
+   → same hash.
+3. **Transactional ID hash** (`formula.getTransactionalIdHash()`) — validates freshness. If the underlying
+   data changed (transaction committed), the transactional IDs change, the hash changes, and the cached
+   entry is a miss.
+
+### Cache record lifecycle
+
+| State             | Description                                                              |
+|-------------------|--------------------------------------------------------------------------|
+| **Adept**         | Candidate in anteroom; usage count being tracked.                        |
+| **Promoted**      | Moved to CacheEden; awaiting first computation to capture payload.       |
+| **Initialized**   | Payload (`FlattenedFormula`) stored; future queries return it directly.   |
+| **Cooling**       | In cache but unused for consecutive evaluation intervals.                |
+| **Evicted**       | Removed after `≥ 3` unused intervals or exceeded memory budget.          |
+
+### Cache invalidation
+
+Invalidation is **automatic and transactional**:
+
+1. A write transaction modifies an entity → the affected index bitmap gets a new transactional layer ID.
+2. On the next read query, the formula is reconstructed with new transactional IDs.
+3. `CacheEden.getCachedRecord()` compares `cachedRecord.transactionalIdHash` vs `formula.transactionalIdHash`.
+4. Mismatch → cache miss → formula is re-evaluated → new result may be promoted.
+
+There is no explicit invalidation API. `clearMemory()` on a formula resets its memoized result but does not
+interact with the cache system.
+
+### NonCacheableFormula vs NonCacheableFormulaScope
+
+These two marker interfaces control caching in opposite directions:
+
+| Interface                  | Direction  | Effect                                                                    |
+|----------------------------|------------|---------------------------------------------------------------------------|
+| `NonCacheableFormula`      | ↑ Upward   | Prevents this formula **and all ancestors** from being cached.            |
+| `NonCacheableFormulaScope` | ↓ Downward | Prevents **all descendants** from being cached; formula itself may still be cached. |
+
+**Example**: `UserFilterFormula` implements **both**. The facet-summary extra-result producer needs to locate
+and inspect the user-filter sub-tree in its original form. Replacing any part of it with a flattened cached
+payload would break that traversal.
+
+### toSerializableFormula()
+
+When a formula is promoted, `toSerializableFormula(formulaHash, hashFunction)` is called to materialize the
+computation result into a lightweight `CachePayloadHeader`. The default implementation in
+`AbstractCacheableFormula` produces a `FlattenedFormula`:
+
+```java
+new FlattenedFormula(
+    formulaHash,
+    getTransactionalIdHash(),
+    distinct(sort(gatherTransactionalIds())),
+    compute()  // already memoized
+)
+```
+
+Specialized variants exist for price-filtered queries that must preserve side-data:
+
+- `FlattenedFormulaWithFilteredPrices` — adds `FilteredPriceRecords` + `PriceEvaluationContext`.
+- `FlattenedFormulaWithFilteredOutRecords` — tracks filtered-out entity IDs.
+- `FlattenedFormulaWithFilteredPricesAndFilteredOutRecords` — combined.
+
+If your formula carries side-data that downstream consumers need (sorters, extra-result producers), you must
+either override `toSerializableFormula()` to include that data, or mark the formula as `NonCacheableFormula`.
+
+### Cache configuration
+
+| Parameter                       | Purpose                                                    |
+|---------------------------------|------------------------------------------------------------|
+| `cacheSizeInBytes`              | Total cache memory budget (default ~1 GB).                 |
+| `anteroomRecordCount`           | Buffer size before triggering evaluation.                  |
+| `minimalComplexityThreshold`    | Minimum `getEstimatedCost()` for cache candidacy.          |
+| `minimalUsageThreshold`         | Minimum usage count before promotion is considered.        |
+| `reevaluateEachSeconds`         | Evaluation interval (default 60 s).                        |
+
+Single records larger than 1 MB (`MAX_BUFFER_SIZE`) are rejected.
+
+### Read-only session requirement
+
+Caching is active **only for read-only sessions**. Write sessions bypass the cache entirely because they may
+contain client-specific uncommitted modifications.
+
+## Visitor pattern
+
+`FormulaVisitor` is the traversal mechanism for formula trees. The key design choice: **traversal is
+visitor-driven**. `Formula.accept(visitor)` delegates to `visitor.visit(formula)` but does **not** recurse
+into children. The visitor decides whether and how to recurse.
+
+This gives visitors full control over:
+
+- Depth-first vs breadth-first traversal
+- Early termination
+- Selective sub-tree skipping
+
+### FormulaPostProcessor
+
+`FormulaPostProcessor` extends `FormulaVisitor` and adds `getPostProcessedFormula()` which returns the
+transformed tree after traversal. Usage:
+
+```java
+FormulaPostProcessor processor = new MyPostProcessor();
+rootFormula.accept(processor);                          // traverse + transform
+Formula result = processor.getPostProcessedFormula();   // retrieve result (resets state)
+```
+
+Post-processors are registered during filter translation via `FilterByVisitor.registerFormulaPostProcessor()`
+and are applied in order by `FilterByVisitor.constructFinalFormula()`. The `FormulaDeduplicator` is always
+applied last.
+
+### Key visitor implementations
+
+| Visitor                           | Purpose                                              |
+|-----------------------------------|------------------------------------------------------|
+| `FormulaCloner`                   | Rebuilds formula tree with selective mutations.       |
+| `FormulaOptimizer`                | Prunes empty branches, unwraps redundant containers.  |
+| `FormulaDeduplicator`             | Collapses duplicate sub-trees for memoization reuse.  |
+| `FormulaCacheVisitor`             | Instruments cacheable formulas with callbacks.        |
+| `FormulaLocator` (`FormulaFinder`)| Finds formula nodes by type in the tree.             |
+| `PrettyPrintingFormulaVisitor`    | Serializes tree as human-readable text.              |
+
+## Testing a new formula
+
+Formula tests live in `evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/`.
+
+### Setting up test data
+
+Create bitmaps with `ArrayBitmap` and wrap them in `ConstantFormula` for formula-based tests:
+
+```java
+private static final long INDEX_TRANSACTION_ID = 1L;
+
+// Direct bitmap mode
+new AndFormula(INDEX_TRANSACTION_ID,
+    new ArrayBitmap(1, 3, 4, 5, 8),
+    new ArrayBitmap(1, 2, 4, 8)
+);
+
+// Formula-wrapping mode
+new AndFormula(
+    new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 3, 4, 5, 8))),
+    new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 4, 8)))
+);
+```
+
+### Result verification
+
+Always verify `compute()` result using `getArray()`:
+
+```java
+assertArrayEquals(
+    new int[]{1, 4},
+    formula.compute().getArray()
+);
+```
+
+### What to test
+
+| Aspect                     | How to test                                                                       |
+|----------------------------|-----------------------------------------------------------------------------------|
+| **Computation correctness** | Verify `compute().getArray()` against expected primary keys.                     |
+| **Empty inputs**           | Test with empty bitmaps, single-element sets, fully overlapping sets.             |
+| **Edge cases**             | Non-overlapping sets, single child, maximum cardinality.                          |
+| **Memoization**            | `assertSame(formula.compute(), formula.compute())` — same object reference.       |
+| **clearMemory()**          | After reset, `compute()` must produce the same result (fresh evaluation).         |
+| **Cloning**                | `getCloneWithInnerFormulas()` must preserve behavior: `assertArrayEquals(original.compute().getArray(), clone.compute().getArray())`. |
+| **Hash determinism**       | `assertEquals(formula.getHash(), identicalFormula.getHash())`.                    |
+| **Hash sensitivity**       | Different configuration → different hash.                                         |
+| **Cardinality estimate**   | Verify `getEstimatedCardinality()` returns sensible bounds.                       |
+| **Cost ordering**          | `getEstimatedCost()` must be less than or equal to `getCost()` for typical inputs.|
+| **Semantic equivalence**   | When testing optimizers: `assertArrayEquals(original.compute().getArray(), optimized.compute().getArray())`. |
+| **Tree structure**         | Use `assertInstanceOf` and `getInnerFormulas()` to verify post-processed trees.   |
+| **Cache behavior**         | Use `FormulaCacheVisitor.analyse()` with a `CacheAnteroom` to verify registration.|
+
+### Initialization in tests
+
+Formulas require initialization before hash/cost methods work. Use `TestQueryExecutionContext` or create a
+minimal context:
+
+```java
+formula.initialize(new TestQueryExecutionContext(entitySchema, query));
+```
+
+For simple computation-only tests, `compute()` works without initialization — but `getHash()`,
+`getEstimatedCost()`, and `gatherTransactionalIds()` will throw if `initFields()` has not been called.
+
+## Common anti-patterns
+
+| Anti-pattern                                             | Correct approach                                         |
+|----------------------------------------------------------|----------------------------------------------------------|
+| Calling `compute()` during construction or cost estimation | Use cardinality estimates; compute is lazy and expensive. |
+| Allocating new empty bitmaps                             | Return `EmptyBitmap.INSTANCE`.                           |
+| Forgetting to preserve state in `getCloneWithInnerFormulas()` | Clone **all** configuration fields.                  |
+| Not validating constructor arguments                     | Use `Assert.isTrue()` / `Assert.notNull()`.              |
+| Inheriting `getClassId()` from a superclass              | Each leaf class must define its own unique constant.      |
+| Hashing inner formulas in `includeAdditionalHash()`      | Inner formulas are already included — hash only additional state. |
+| Using `new StringBuilder()` without capacity             | Always estimate capacity: `new StringBuilder(64)`.       |
+| Using `Objects.hash()` with primitives                   | Use `31 * result + Type.hashCode(primitive)`.            |
+| Using Java streams in hot paths                          | Write index-based `for` loops — streams allocate iterators, lambdas, and intermediate arrays per call. |
+| Unnecessary autoboxing (`int` → `Integer`)               | Use primitive arrays and primitive-typed locals; avoid generic APIs that force boxing. |
+| Allocating temporary objects in `compute()` loops        | Pre-size arrays, reuse shared constants, prefer stack-local computation. |
+
+## Summary checklist for a new formula
+
+- [ ] Extends `AbstractFormula` or `AbstractCacheableFormula`
+- [ ] Implements marker interfaces as appropriate (`CacheableFormula`, `NonCacheableFormula`,
+  `ChildrenDependentFormula`, …)
+- [ ] Unique `CLASS_ID` constant returned from `getClassId()`
+- [ ] Constructor validates preconditions and calls `initFields()` last
+- [ ] `computeInternal()` returns correct bitmap, uses `EmptyBitmap.INSTANCE` for empty results
+- [ ] `getCloneWithInnerFormulas()` preserves all configuration, handles 0/1/N children edge cases
+- [ ] `getOperationCost()` returns a meaningful constant
+- [ ] `getEstimatedCardinality()` returns a sensible estimate (min for AND, sum for OR, delegate for wrappers)
+- [ ] `includeAdditionalHash()` covers formula-specific state (not inner formulas)
+- [ ] `isFormulaOrderSignificant()` returns `true` if operation is non-commutative
+- [ ] `gatherBitmapIdsInternal()` overridden if formula wraps bitmaps directly
+- [ ] `toString()` and optionally `toStringVerbose()` implemented
+- [ ] If cacheable: `toSerializableFormula()` preserves any side-data needed by downstream consumers
+- [ ] Tests cover computation correctness, edge cases, memoization, cloning, hash determinism, and cost ordering

--- a/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormula.java
@@ -40,7 +40,13 @@ import java.io.Serial;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class FlattenedFormula extends CachePayloadHeader implements Formula {
+	/**
+	 * Serial version UID for serialization compatibility.
+	 */
 	@Serial private static final long serialVersionUID = -1183017816058041094L;
+	/**
+	 * Empty formula array constant reused when returning inner formulas of this leaf formula.
+	 */
 	private static final Formula[] EMPTY_FORMULAS = Formula.EMPTY_FORMULA_ARRAY;
 	/**
 	 * Memoized result of the original formula.

--- a/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormulaWithFilteredOutRecords.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormulaWithFilteredOutRecords.java
@@ -51,6 +51,9 @@ import java.math.BigDecimal;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class FlattenedFormulaWithFilteredOutRecords extends FlattenedFormula implements PriceTerminationFormula, Formula {
+	/**
+	 * Serial version UID for serialization compatibility.
+	 */
 	@Serial private static final long serialVersionUID = -1357022866282833762L;
 	/**
 	 * Records that has been filtered out by the original formula.

--- a/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormulaWithFilteredPrices.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormulaWithFilteredPrices.java
@@ -45,7 +45,13 @@ import java.io.Serial;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class FlattenedFormulaWithFilteredPrices extends FlattenedFormula implements FilteredPriceRecordAccessor, Formula {
+	/**
+	 * Estimated in-memory size of a single price record used for memory consumption calculations.
+	 */
 	public static final int PRICE_RECORD_SIZE = MemoryMeasuringConstants.INT_SIZE * 2 + MemoryMeasuringConstants.BYTE_SIZE * 2;
+	/**
+	 * Serial version UID for serialization compatibility.
+	 */
 	@Serial private static final long serialVersionUID = 29711505428272096L;
 	/**
 	 * Contains information about price records leading to a computed result.

--- a/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormulaWithFilteredPricesAndFilteredOutRecords.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cache/payload/FlattenedFormulaWithFilteredPricesAndFilteredOutRecords.java
@@ -54,6 +54,9 @@ import java.math.BigDecimal;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class FlattenedFormulaWithFilteredPricesAndFilteredOutRecords extends FlattenedFormula implements FilteredPriceRecordAccessor, PriceTerminationFormula, Formula {
+	/**
+	 * Serial version UID for serialization compatibility.
+	 */
 	@Serial private static final long serialVersionUID = -6052882250380556441L;
 	/**
 	 * Contains information about price records leading to a computed result.

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractCacheableFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractCacheableFormula.java
@@ -29,19 +29,21 @@ import net.openhft.hashing.LongHashFunction;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.function.Consumer;
 
 import static java.util.Optional.ofNullable;
 
 /**
- * AbstractCacheableFormula is abstract ancestor for all {@link Formula} that produce int based bitmaps as their
- * result and that are suitable for caching. We need to stick to primitive types in order to perform fast. That's why
+ * AbstractCacheableFormula is an abstract ancestor for all {@link Formula} that produce int based bitmaps as their
+ * result and that are suitable for caching. We need to stick to primitive types to perform fast. That's why
  * we need to maintain this type of formula.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public abstract class AbstractCacheableFormula extends AbstractFormula implements CacheableFormula {
+	/**
+	 * Callback invoked after the formula result is computed, allowing the cache supervisor to record the computation.
+	 */
 	protected final Consumer<CacheableFormula> computationCallback;
 
 	protected AbstractCacheableFormula(@Nullable Consumer<CacheableFormula> computationCallback) {
@@ -69,10 +71,7 @@ public abstract class AbstractCacheableFormula extends AbstractFormula implement
 		return new FlattenedFormula(
 			formulaHash,
 			getTransactionalIdHash(),
-			Arrays.stream(gatherTransactionalIds())
-				.distinct()
-				.sorted()
-				.toArray(),
+			AbstractFormula.sortAndDeduplicateLongArray(gatherTransactionalIds()),
 			compute()
 		);
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractCacheableFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractCacheableFormula.java
@@ -71,7 +71,7 @@ public abstract class AbstractCacheableFormula extends AbstractFormula implement
 		return new FlattenedFormula(
 			formulaHash,
 			getTransactionalIdHash(),
-			AbstractFormula.sortAndDeduplicateLongArray(gatherTransactionalIds()),
+			gatherTransactionalIds(),
 			compute()
 		);
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
@@ -51,6 +51,10 @@ import java.util.List;
  */
 public abstract class AbstractFormula implements Formula {
 	/**
+	 * Shared empty array returned by {@link #computeSortedConjunctionBitmaps(List)} on short-circuit.
+	 */
+	protected static final RoaringBitmap[] EMPTY_ROARING_BITMAP_ARRAY = new RoaringBitmap[0];
+	/**
 	 * Execution context from initialization phase.
 	 */
 	protected QueryExecutionContext executionContext;
@@ -113,10 +117,8 @@ public abstract class AbstractFormula implements Formula {
 		}
 		this.hash = HASH_FUNCTION.hashLongs(hashArray);
 
-		this.transactionalIds = gatherBitmapIdsInternal();
-		this.transactionalIdHash = HASH_FUNCTION.hashLongs(
-			sortAndDeduplicateLongArray(this.transactionalIds)
-		);
+		this.transactionalIds = sortAndDeduplicateLongArray(gatherBitmapIdsInternal());
+		this.transactionalIdHash = HASH_FUNCTION.hashLongs(this.transactionalIds);
 		this.estimatedCost = getEstimatedCostInternal();
 	}
 
@@ -386,7 +388,7 @@ public abstract class AbstractFormula implements Formula {
 		for (int i = 0; i < sortedFormulas.size(); i++) {
 			final Bitmap computedBitmap = sortedFormulas.get(i).compute();
 			if (computedBitmap.isEmpty()) {
-				return new RoaringBitmap[0];
+				return EMPTY_ROARING_BITMAP_ARRAY;
 			}
 			theBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(computedBitmap);
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
@@ -231,15 +231,15 @@ public abstract class AbstractFormula implements Formula {
 	 */
 	@Nonnull
 	protected long[] gatherBitmapIdsInternal() {
-		// pre-compute total length to avoid resizing
+		final long[][] allIds = new long[this.innerFormulas.length][];
 		int totalLength = 0;
-		for (final Formula formula : this.innerFormulas) {
-			totalLength += formula.gatherTransactionalIds().length;
+		for (int i = 0; i < this.innerFormulas.length; i++) {
+			allIds[i] = this.innerFormulas[i].gatherTransactionalIds();
+			totalLength += allIds[i].length;
 		}
 		final long[] result = new long[totalLength];
 		int offset = 0;
-		for (final Formula innerFormula : this.innerFormulas) {
-			final long[] ids = innerFormula.gatherTransactionalIds();
+		for (final long[] ids : allIds) {
 			System.arraycopy(ids, 0, result, offset, ids.length);
 			offset += ids.length;
 		}
@@ -261,7 +261,10 @@ public abstract class AbstractFormula implements Formula {
 			for (Formula innerFormula : this.innerFormulas) {
 				costs = Math.addExact(costs, innerFormula.getEstimatedCost());
 			}
-			return getEstimatedBaseCost() + getOperationCost() * getEstimatedCardinality() + costs;
+			return Math.addExact(
+				Math.addExact(getEstimatedBaseCost(), Math.multiplyExact(getOperationCost(), getEstimatedCardinality())),
+				costs
+			);
 		} catch (ArithmeticException ex) {
 			return Long.MAX_VALUE;
 		}
@@ -428,7 +431,7 @@ public abstract class AbstractFormula implements Formula {
 		for (final Formula innerFormula : sortedFormulas) {
 			final Bitmap innerResult = innerFormula.compute();
 			cost += innerFormula.getCost() + innerResult.size() * operationCost;
-			if (innerResult == EmptyBitmap.INSTANCE) {
+			if (innerResult.isEmpty()) {
 				break;
 			}
 		}
@@ -447,7 +450,7 @@ public abstract class AbstractFormula implements Formula {
 		long costToPerformance = 0L;
 		for (final Formula innerFormula : sortedFormulas) {
 			final Bitmap innerResult = innerFormula.compute();
-			if (innerResult == EmptyBitmap.INSTANCE) {
+			if (innerResult.isEmpty()) {
 				break;
 			}
 			costToPerformance += innerFormula.getCostToPerformanceRatio();

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
@@ -257,7 +257,7 @@ public abstract class AbstractFormula implements Formula {
 	 */
 	protected long getEstimatedCostInternal() {
 		try {
-			long costs = getEstimatedBaseCost();
+			long costs = 0L;
 			for (Formula innerFormula : this.innerFormulas) {
 				costs = Math.addExact(costs, innerFormula.getEstimatedCost());
 			}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
@@ -384,8 +384,9 @@ public abstract class AbstractFormula implements Formula {
 	 */
 	@Nonnull
 	protected static RoaringBitmap[] computeSortedConjunctionBitmaps(@Nonnull List<Formula> sortedFormulas) {
-		final RoaringBitmap[] theBitmaps = new RoaringBitmap[sortedFormulas.size()];
-		for (int i = 0; i < sortedFormulas.size(); i++) {
+		final int size = sortedFormulas.size();
+		final RoaringBitmap[] theBitmaps = new RoaringBitmap[size];
+		for (int i = 0; i < size; i++) {
 			final Bitmap computedBitmap = sortedFormulas.get(i).compute();
 			if (computedBitmap.isEmpty()) {
 				return EMPTY_ROARING_BITMAP_ARRAY;

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/AbstractFormula.java
@@ -26,18 +26,22 @@ package io.evitadb.core.query.algebra;
 import io.evitadb.core.cache.CacheSupervisor;
 import io.evitadb.core.query.QueryExecutionContext;
 import io.evitadb.core.query.algebra.utils.visitor.PrettyPrintingFormulaVisitor;
-import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
 import io.evitadb.core.transaction.memory.TransactionalLayerCreator;
+import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
+import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.bitmap.EmptyBitmap;
+import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import io.evitadb.utils.Assert;
 import lombok.Getter;
 import net.openhft.hashing.LongHashFunction;
+import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * This abstract {@link Formula} implementation contains shared logic for all formulas. All formulas are strongly advised
@@ -51,11 +55,11 @@ public abstract class AbstractFormula implements Formula {
 	 */
 	protected QueryExecutionContext executionContext;
 	/**
-	 * Contains array of inner formulas.
+	 * Contains an array of inner formulas.
 	 */
 	@Getter protected Formula[] innerFormulas;
 	/**
-	 * Contains memoized result once {@link #computeInternal()} is invoked for the first time. Additional calls of
+	 * Contains a memoized result once {@link #computeInternal()} is invoked for the first time. Additional calls of
 	 * {@link Formula#compute()} will return this memoized result without paying the computational costs
 	 */
 	@Nullable protected Bitmap memoizedResult;
@@ -80,7 +84,7 @@ public abstract class AbstractFormula implements Formula {
 	 */
 	private long[] transactionalIds;
 	/**
-	 * Contains memoized value of {@link #gatherTransactionalIds()} computed hash.
+	 * Contains memoized value of {@link #getTransactionalIdHash()} method.
 	 */
 	private Long transactionalIdHash;
 
@@ -94,23 +98,24 @@ public abstract class AbstractFormula implements Formula {
 	 */
 	protected void initFields(@Nonnull Formula... innerFormulas) {
 		this.innerFormulas = innerFormulas;
-		final LongStream formulaHashStream = Arrays.stream(innerFormulas)
-			.mapToLong(TransactionalDataRelatedStructure::getHash);
-		this.hash = HASH_FUNCTION.hashLongs(
-			Stream.of(
-					LongStream.of(getClassId()),
-					isFormulaOrderSignificant() ? formulaHashStream : formulaHashStream.sorted(),
-					LongStream.of(includeAdditionalHash(HASH_FUNCTION))
-				)
-				.flatMapToLong(it -> it)
-				.toArray()
-		);
+
+		// build hash array: [classId, innerFormulaHashes..., additionalHash]
+		final int formulaCount = innerFormulas.length;
+		final long[] hashArray = new long[formulaCount + 2];
+		hashArray[0] = getClassId();
+		for (int i = 0; i < formulaCount; i++) {
+			hashArray[i + 1] = innerFormulas[i].getHash();
+		}
+		hashArray[formulaCount + 1] = includeAdditionalHash(HASH_FUNCTION);
+		if (!isFormulaOrderSignificant()) {
+			// sort only the inner formula hash portion [1, formulaCount+1)
+			Arrays.sort(hashArray, 1, formulaCount + 1);
+		}
+		this.hash = HASH_FUNCTION.hashLongs(hashArray);
+
 		this.transactionalIds = gatherBitmapIdsInternal();
 		this.transactionalIdHash = HASH_FUNCTION.hashLongs(
-			Arrays.stream(this.transactionalIds)
-				.distinct()
-				.sorted()
-				.toArray()
+			sortAndDeduplicateLongArray(this.transactionalIds)
 		);
 		this.estimatedCost = getEstimatedCostInternal();
 	}
@@ -211,6 +216,8 @@ public abstract class AbstractFormula implements Formula {
 	 * combinations like: A AND B, B AND A which produce same result, but would have different hashes if we dont reorder
 	 * the inner formula hashes. On the contrary the formula A NOT B cannot be reordered to B NOT A, because these
 	 * expressions produce different output.
+	 *
+	 * @return `true` if the order of inner formulas affects the result, `false` otherwise
 	 */
 	protected boolean isFormulaOrderSignificant() {
 		return false;
@@ -219,19 +226,34 @@ public abstract class AbstractFormula implements Formula {
 	/**
 	 * Returns {@link TransactionalLayerCreator#getId()} of all bitmaps used by this formula. Should any of those ids
 	 * become obsolete the formula is also obsolete. The returned array may contain duplicates and may not be sorted.
+	 *
+	 * @return array of transactional bitmap ids collected from all inner formulas
 	 */
 	@Nonnull
 	protected long[] gatherBitmapIdsInternal() {
-		return Arrays.stream(this.innerFormulas)
-			.flatMapToLong(it -> LongStream.of(it.gatherTransactionalIds()))
-			.toArray();
+		// pre-compute total length to avoid resizing
+		int totalLength = 0;
+		for (final Formula formula : this.innerFormulas) {
+			totalLength += formula.gatherTransactionalIds().length;
+		}
+		final long[] result = new long[totalLength];
+		int offset = 0;
+		for (final Formula innerFormula : this.innerFormulas) {
+			final long[] ids = innerFormula.gatherTransactionalIds();
+			System.arraycopy(ids, 0, result, offset, ids.length);
+			offset += ids.length;
+		}
+		return result;
 	}
 
 	/**
 	 * Estimated cost of the operation based on formula structure without paying the price for real computation
-	 * of the results. That's why the result number is only rough estimate. Default implementation is sum of bitmap
-	 * sizes of referenced bitmaps multiplied by known {@link #getOperationCost()} of this operation.
-	 * This method doesn't trigger formula computation.
+	 * of the results. Default implementation computes:
+	 * `getEstimatedBaseCost() + getOperationCost() * getEstimatedCardinality() + sum(innerFormula.getEstimatedCost())`
+	 * — i.e. the base cost of this formula's own data, plus the per-element operation cost scaled by estimated output
+	 * cardinality, plus the recursive cost of all inner formulas. Returns {@link Long#MAX_VALUE} on arithmetic overflow.
+	 *
+	 * @return estimated cost of this formula tree, or {@link Long#MAX_VALUE} on overflow
 	 */
 	protected long getEstimatedCostInternal() {
 		try {
@@ -246,9 +268,11 @@ public abstract class AbstractFormula implements Formula {
 	}
 
 	/**
-	 * Returns estimated computation complexity cost for computation that covers all additional internal data that
-	 * affect the output of {@link Formula#compute()} method and are not part {@link #getInnerFormulas()}.
-	 * The {@link #getInnerFormulas()} are implicitly part of the hash and should not be covered by this method.
+	 * Returns estimated computation complexity cost that covers additional internal data affecting
+	 * the output of {@link Formula#compute()} beyond {@link #getInnerFormulas()}. Inner formulas are accounted for
+	 * separately in {@link #getEstimatedCostInternal()} and should not be included here. Defaults to zero.
+	 *
+	 * @return base cost contribution from this formula's own data (excluding inner formulas)
 	 */
 	protected long getEstimatedBaseCost() {
 		return 0L;
@@ -259,6 +283,9 @@ public abstract class AbstractFormula implements Formula {
 	 * additional internal data that affect the output of {@link Formula#compute()} method and are not part
 	 * {@link #getInnerFormulas()}. The {@link #getInnerFormulas()} are implicitly part of the hash and should not be
 	 * covered by this method.
+	 *
+	 * @param hashFunction the hash function to use for computing the hash
+	 * @return hash value covering this formula's additional internal state
 	 */
 	protected abstract long includeAdditionalHash(@Nonnull LongHashFunction hashFunction);
 
@@ -266,35 +293,193 @@ public abstract class AbstractFormula implements Formula {
 	 * Returns a long constant, that uniquely distinguishes this class from the others. The number must not change in
 	 * time for the same class. The number must not be inherited from the superclasses and must be implemented and return
 	 * different numbers for each "leaf class". This number is important part of {@link #getHash()} method.
+	 *
+	 * @return unique class identifier constant
 	 */
 	protected abstract long getClassId();
 
 	/**
-	 * Cost of the operation based on computation result. Default implementation is sum of bitmap sizes of referenced
-	 * bitmaps multiplied by known {@link #getOperationCost()} of this operation. This method triggers formula computation.
+	 * Actual cost of the operation based on computed results. Default implementation computes:
+	 * `sum(innerFormula.getCost()) + sum(innerFormula.compute().size()) * getOperationCost()`
+	 * — i.e. the recursive cost of all inner formulas plus the total number of elements processed scaled by
+	 * this operation's cost. This method triggers formula computation.
+	 *
+	 * @return actual cost of this formula tree based on computed results
 	 */
 	protected long getCostInternal() {
-		return Arrays.stream(this.innerFormulas).mapToLong(TransactionalDataRelatedStructure::getCost).sum() +
-			Arrays.stream(this.innerFormulas)
-				.map(Formula::compute)
-				.mapToLong(Bitmap::size)
-				.sum() * getOperationCost();
+		long costSum = 0;
+		long sizeSum = 0;
+		for (final Formula innerFormula : this.innerFormulas) {
+			costSum += innerFormula.getCost();
+			sizeSum += innerFormula.compute().size();
+		}
+		return costSum + sizeSum * getOperationCost();
 	}
 
 	/**
-	 * Returns cost to performance ratio. Default implementation is sums cost to performance ratio of all inner formulas
-	 * and adds ratio of this operation that is computed as ration of its cost to output bitmap size. I.e. when large
-	 * bitmap is greatly reduced to a small one, this ratio gets bigger and thus caching output of this formula saves
-	 * more resources than caching outputs of formulas with lesser ratio.
+	 * Returns cost-to-performance ratio. Default implementation sums the cost-to-performance ratio of all inner
+	 * formulas and adds the ratio of this operation computed as `getCost() / compute().size()`. When a large bitmap
+	 * is greatly reduced to a small one, this ratio grows — caching such a formula saves more resources than caching
+	 * formulas with a lower ratio.
+	 *
+	 * @return accumulated cost-to-performance ratio for this formula and its children
 	 */
 	protected long getCostToPerformanceInternal() {
-		return Arrays.stream(this.innerFormulas)
-			.mapToLong(TransactionalDataRelatedStructure::getCostToPerformanceRatio)
-			.sum() + (getCost() / Math.max(1, compute().size()));
+		long sum = 0;
+		for (final Formula innerFormula : this.innerFormulas) {
+			sum += innerFormula.getCostToPerformanceRatio();
+		}
+		return sum + (getCost() / Math.max(1, compute().size()));
+	}
+
+	/**
+	 * Sorts the given long array in place and removes duplicate values, returning the deduplicated result.
+	 * The input array is sorted as a side effect. Callers that need the original order must clone before calling.
+	 *
+	 * @param input the array to sort and deduplicate (modified in place)
+	 * @return the deduplicated array — either the same instance or a trimmed copy
+	 */
+	@Nonnull
+	protected static long[] sortAndDeduplicateLongArray(@Nonnull long[] input) {
+		if (input.length <= 1) {
+			return input;
+		}
+		Arrays.sort(input);
+		int unique = 1;
+		for (int i = 1; i < input.length; i++) {
+			if (input[i] != input[i - 1]) {
+				input[unique++] = input[i];
+			}
+		}
+		return unique == input.length ? input : Arrays.copyOf(input, unique);
+	}
+
+	/**
+	 * Sorts the given formulas by their {@link TransactionalDataRelatedStructure#getEstimatedCost()} in ascending
+	 * order, returning an immutable list. Used by conjunction formulas to evaluate cheapest formulas first and
+	 * short-circuit on empty results.
+	 *
+	 * @param formulas the formulas to sort (not modified — a copy is made)
+	 * @return immutable list of formulas sorted by ascending estimated cost
+	 */
+	@Nonnull
+	protected static List<Formula> sortFormulasByComplexity(@Nonnull Formula[] formulas) {
+		final Formula[] sorted = new Formula[formulas.length];
+		System.arraycopy(formulas, 0, sorted, 0, formulas.length);
+		Arrays.sort(sorted, Comparator.comparingLong(TransactionalDataRelatedStructure::getEstimatedCost));
+		return List.of(sorted);
+	}
+
+	/**
+	 * Computes {@link RoaringBitmap} results from pre-sorted formulas, short-circuiting and returning an empty array
+	 * as soon as any formula produces an empty result.
+	 *
+	 * @param sortedFormulas formulas sorted by ascending estimated cost
+	 * @return array of computed bitmaps, or an empty array if any formula yields an empty result
+	 */
+	@Nonnull
+	protected static RoaringBitmap[] computeSortedConjunctionBitmaps(@Nonnull List<Formula> sortedFormulas) {
+		final RoaringBitmap[] theBitmaps = new RoaringBitmap[sortedFormulas.size()];
+		for (int i = 0; i < sortedFormulas.size(); i++) {
+			final Bitmap computedBitmap = sortedFormulas.get(i).compute();
+			if (computedBitmap.isEmpty()) {
+				return new RoaringBitmap[0];
+			}
+			theBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(computedBitmap);
+		}
+		return theBitmaps;
+	}
+
+	/**
+	 * Computes the conjunction (AND) of the given {@link RoaringBitmap} array, returning
+	 * {@link EmptyBitmap#INSTANCE} if any bitmap is empty or if the array itself is empty.
+	 *
+	 * @param bitmaps the bitmaps to intersect
+	 * @return the intersection result, or {@link EmptyBitmap#INSTANCE} if the result is empty
+	 */
+	@Nonnull
+	protected static Bitmap computeConjunctionResult(@Nonnull RoaringBitmap[] bitmaps) {
+		if (bitmaps.length == 0) {
+			return EmptyBitmap.INSTANCE;
+		}
+		for (final RoaringBitmap bitmap : bitmaps) {
+			if (bitmap.isEmpty()) {
+				return EmptyBitmap.INSTANCE;
+			}
+		}
+		final Bitmap theResult;
+		if (bitmaps.length == 1) {
+			theResult = new BaseBitmap(bitmaps[0]);
+		} else {
+			theResult = RoaringBitmapBackedBitmap.and(bitmaps);
+		}
+		return theResult.isEmpty() ? EmptyBitmap.INSTANCE : theResult;
+	}
+
+	/**
+	 * Computes the cost of a conjunction operation over pre-sorted formulas, short-circuiting on empty results.
+	 *
+	 * @param sortedFormulas formulas sorted by ascending estimated cost
+	 * @param operationCost  per-element cost of the conjunction operation
+	 * @return accumulated cost, stopping early if any formula produces an empty result
+	 */
+	protected static long computeSortedConjunctionCost(@Nonnull List<Formula> sortedFormulas, long operationCost) {
+		long cost = 0L;
+		for (final Formula innerFormula : sortedFormulas) {
+			final Bitmap innerResult = innerFormula.compute();
+			cost += innerFormula.getCost() + innerResult.size() * operationCost;
+			if (innerResult == EmptyBitmap.INSTANCE) {
+				break;
+			}
+		}
+		return cost;
+	}
+
+	/**
+	 * Computes the accumulated cost-to-performance ratio of a conjunction operation over pre-sorted formulas,
+	 * short-circuiting on empty results. Callers should add their own
+	 * `getCost() / Math.max(1, compute().size())` tail term.
+	 *
+	 * @param sortedFormulas formulas sorted by ascending estimated cost
+	 * @return accumulated cost-to-performance ratio from inner formulas
+	 */
+	protected static long computeSortedConjunctionCostToPerformance(@Nonnull List<Formula> sortedFormulas) {
+		long costToPerformance = 0L;
+		for (final Formula innerFormula : sortedFormulas) {
+			final Bitmap innerResult = innerFormula.compute();
+			if (innerResult == EmptyBitmap.INSTANCE) {
+				break;
+			}
+			costToPerformance += innerFormula.getCostToPerformanceRatio();
+		}
+		return costToPerformance;
+	}
+
+	/**
+	 * Returns the minimum {@link Formula#getEstimatedCardinality()} across the given inner formulas — the correct
+	 * worst-case estimate for conjunction (AND) formulas, since an intersection cannot exceed the smallest input.
+	 *
+	 * @param innerFormulas the formulas to examine
+	 * @return the smallest estimated cardinality, or zero if the array is empty
+	 */
+	protected static int getMinEstimatedCardinality(@Nonnull Formula[] innerFormulas) {
+		if (innerFormulas.length == 0) {
+			return 0;
+		}
+		int min = innerFormulas[0].getEstimatedCardinality();
+		for (int i = 1; i < innerFormulas.length; i++) {
+			final int cardinality = innerFormulas[i].getEstimatedCardinality();
+			if (cardinality < min) {
+				min = cardinality;
+			}
+		}
+		return min;
 	}
 
 	/**
 	 * Internal (not cached) computation operation of this formula.
+	 *
+	 * @return bitmap representing the raw computed result
 	 */
 	@Nonnull
 	protected abstract Bitmap computeInternal();

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/Formula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/Formula.java
@@ -40,35 +40,47 @@ import javax.annotation.Nonnull;
  *
  * Formula {@link #compute()} produces the result of the equation. Formula can estimate its computational cost by
  * calling {@link #getEstimatedCost()} or more exactly by calling {@link #getCost()} that involves result computation.
- * There costs are derived from {@link #getOperationCost()} that was measured by performance tests on random numbers
+ * These costs are derived from {@link #getOperationCost()} that was measured by performance tests on random numbers
  * and the amount of data processed by the formula.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public interface Formula extends TransactionalDataRelatedStructure, PrettyPrintable {
 
+	/**
+	 * Reusable empty array of formulas to avoid unnecessary allocations.
+	 */
 	Formula[] EMPTY_FORMULA_ARRAY = new Formula[0];
 
 	/**
 	 * Traverses formula tree with passed visitor.
+	 *
+	 * @param visitor the visitor to accept
 	 */
 	void accept(@Nonnull FormulaVisitor visitor);
 
 	/**
 	 * Computes product of this formula. The result is cached so multiple calls on this method will pay the cost only
 	 * for the first time.
+	 *
+	 * @return bitmap representing the computed result of this formula
 	 */
 	@Nonnull
 	Bitmap compute();
 
 	/**
 	 * Returns copy of this formula with replaced inner formulas.
+	 *
+	 * @param innerFormulas the new inner formulas to use in the cloned formula
+	 * @return a new formula instance of the same type with the given inner formulas
 	 */
 	@Nonnull
 	Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas);
 
 	/**
 	 * Returns inner formulas this formula {@link #compute()} builds upon.
+	 *
+	 * @return array of child formulas (may be empty for leaf formulas)
 	 */
 	@Nonnull
 	Formula[] getInnerFormulas();
@@ -76,6 +88,8 @@ public interface Formula extends TransactionalDataRelatedStructure, PrettyPrinta
 	/**
 	 * Returns the cardinality estimate of {@link #compute()} method without really computing the result. The estimate
 	 * will not be precise but differs between AND/OR relations and helps us to compute {@link #getEstimatedCost()}.
+	 *
+	 * @return estimated number of elements in the result bitmap
 	 */
 	int getEstimatedCardinality();
 
@@ -86,6 +100,8 @@ public interface Formula extends TransactionalDataRelatedStructure, PrettyPrinta
 
 	/**
 	 * Prints information about the formula in a user-friendly way in verbose mode.
+	 *
+	 * @return verbose human-readable representation of this formula
 	 */
 	@Nonnull
 	String toStringVerbose();

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/attribute/AttributeFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/attribute/AttributeFormula.java
@@ -56,7 +56,13 @@ import static io.evitadb.api.query.QueryConstraints.entityFetch;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class AttributeFormula extends AbstractFormula implements ChildrenDependentFormula, RequirementsDefiner {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 4944486926494447594L;
+	/**
+	 * Error message thrown when the formula does not contain exactly one inner formula.
+	 */
 	public static final String ERROR_SINGLE_FORMULA_EXPECTED = "Exactly one inner formula is expected!";
 	/**
 	 * Contains TRUE if the attribute targets the global attribute schema and thus global attribute index.

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AbstractBitmapCacheableFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AbstractBitmapCacheableFormula.java
@@ -105,7 +105,7 @@ public abstract class AbstractBitmapCacheableFormula extends AbstractCacheableFo
 		if (this.indexTransactionId != null && this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
 			System.arraycopy(this.indexTransactionId, 0, result, 0, this.indexTransactionId.length);
 			pos = this.indexTransactionId.length;
-		} else {
+		} else if (this.bitmaps.length <= EXCESSIVE_HIGH_CARDINALITY) {
 			for (final Bitmap bitmap : this.bitmaps) {
 				if (bitmap instanceof TransactionalLayerProducer) {
 					result[pos++] = ((TransactionalLayerProducer<?, ?>) bitmap).getId();

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AbstractBitmapCacheableFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AbstractBitmapCacheableFormula.java
@@ -25,6 +25,7 @@ package io.evitadb.core.query.algebra.base;
 
 import io.evitadb.core.query.algebra.AbstractCacheableFormula;
 import io.evitadb.core.query.algebra.CacheableFormula;
+import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import io.evitadb.index.bitmap.Bitmap;
 import net.openhft.hashing.LongHashFunction;
@@ -96,7 +97,7 @@ public abstract class AbstractBitmapCacheableFormula extends AbstractCacheableFo
 			}
 		}
 		int innerIdCount = 0;
-		for (final io.evitadb.core.query.algebra.Formula formula : this.innerFormulas) {
+		for (final Formula formula : this.innerFormulas) {
 			innerIdCount += formula.gatherTransactionalIds().length;
 		}
 		final long[] result = new long[bitmapIdCount + innerIdCount];
@@ -111,7 +112,7 @@ public abstract class AbstractBitmapCacheableFormula extends AbstractCacheableFo
 				}
 			}
 		}
-		for (final io.evitadb.core.query.algebra.Formula innerFormula : this.innerFormulas) {
+		for (final Formula innerFormula : this.innerFormulas) {
 			final long[] ids = innerFormula.gatherTransactionalIds();
 			System.arraycopy(ids, 0, result, pos, ids.length);
 			pos += ids.length;

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AbstractBitmapCacheableFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AbstractBitmapCacheableFormula.java
@@ -88,7 +88,11 @@ public abstract class AbstractBitmapCacheableFormula extends AbstractCacheableFo
 		// estimate capacity: bitmap IDs + inner formula IDs
 		int bitmapIdCount;
 		if (this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
-			bitmapIdCount = this.indexTransactionId == null ? 0 : this.indexTransactionId.length;
+			Assert.isPremiseValid(
+				this.indexTransactionId != null,
+				"High-cardinality bitmaps require a non-null indexTransactionId!"
+			);
+			bitmapIdCount = this.indexTransactionId.length;
 		} else {
 			bitmapIdCount = 0;
 			for (final Bitmap bitmap : this.bitmaps) {
@@ -104,15 +108,9 @@ public abstract class AbstractBitmapCacheableFormula extends AbstractCacheableFo
 		final long[] result = new long[bitmapIdCount + innerIdCount];
 		int pos = 0;
 		if (this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
-			Assert.isPremiseValid(
-				this.indexTransactionId != null,
-				"High-cardinality bitmaps require a non-null indexTransactionId!"
-			);
-		}
-		if (this.indexTransactionId != null && this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
 			System.arraycopy(this.indexTransactionId, 0, result, 0, this.indexTransactionId.length);
 			pos = this.indexTransactionId.length;
-		} else if (this.bitmaps.length <= EXCESSIVE_HIGH_CARDINALITY) {
+		} else {
 			for (final Bitmap bitmap : this.bitmaps) {
 				if (bitmap instanceof TransactionalLayerProducer) {
 					result[pos++] = ((TransactionalLayerProducer<?, ?>) bitmap).getId();

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AbstractBitmapCacheableFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AbstractBitmapCacheableFormula.java
@@ -1,0 +1,142 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.base;
+
+import io.evitadb.core.query.algebra.AbstractCacheableFormula;
+import io.evitadb.core.query.algebra.CacheableFormula;
+import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.index.bitmap.Bitmap;
+import net.openhft.hashing.LongHashFunction;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+/**
+ * Abstract ancestor for cacheable formulas that can operate on raw {@link Bitmap} operands in addition to composed
+ * inner formulas. Consolidates the shared bitmap-related fields ({@link #bitmaps}, {@link #indexTransactionId})
+ * and common methods ({@link #getBitmaps()}, {@link #includeAdditionalHash(LongHashFunction)},
+ * {@link #gatherBitmapIdsInternal()}) used by {@link AndFormula} and {@link OrFormula}.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+public abstract class AbstractBitmapCacheableFormula extends AbstractCacheableFormula {
+	/**
+	 * Shared empty array returned by {@link #getBitmaps()} when no bitmap operands are present.
+	 */
+	private static final Bitmap[] EMPTY_BITMAP_ARRAY = new Bitmap[0];
+
+	/**
+	 * Raw bitmap operands this formula operates on. May be `null` when the formula operates solely on inner formulas.
+	 */
+	protected final Bitmap[] bitmaps;
+	/**
+	 * Pre-computed transactional IDs for the {@link #bitmaps} array, used as a fast-path substitute when the number
+	 * of bitmaps exceeds {@link #EXCESSIVE_HIGH_CARDINALITY} to avoid iterating all bitmaps one-by-one.
+	 */
+	protected final long[] indexTransactionId;
+
+	protected AbstractBitmapCacheableFormula(
+		@Nullable Consumer<CacheableFormula> computationCallback,
+		@Nullable long[] indexTransactionId,
+		@Nullable Bitmap[] bitmaps
+	) {
+		super(computationCallback);
+		this.bitmaps = bitmaps;
+		this.indexTransactionId = indexTransactionId;
+	}
+
+	/**
+	 * Returns the raw bitmap operands of this formula, or an empty array if this formula operates solely on inner
+	 * formulas.
+	 */
+	@Nonnull
+	public Bitmap[] getBitmaps() {
+		return this.bitmaps == null ? EMPTY_BITMAP_ARRAY : this.bitmaps;
+	}
+
+	@Nonnull
+	@Override
+	protected long[] gatherBitmapIdsInternal() {
+		if (this.bitmaps == null) {
+			return super.gatherBitmapIdsInternal();
+		}
+		// estimate capacity: bitmap IDs + inner formula IDs
+		int bitmapIdCount;
+		if (this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
+			bitmapIdCount = this.indexTransactionId == null ? 0 : this.indexTransactionId.length;
+		} else {
+			bitmapIdCount = 0;
+			for (final Bitmap bitmap : this.bitmaps) {
+				if (bitmap instanceof TransactionalLayerProducer) {
+					bitmapIdCount++;
+				}
+			}
+		}
+		int innerIdCount = 0;
+		for (final io.evitadb.core.query.algebra.Formula formula : this.innerFormulas) {
+			innerIdCount += formula.gatherTransactionalIds().length;
+		}
+		final long[] result = new long[bitmapIdCount + innerIdCount];
+		int pos = 0;
+		if (this.indexTransactionId != null && this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
+			System.arraycopy(this.indexTransactionId, 0, result, 0, this.indexTransactionId.length);
+			pos = this.indexTransactionId.length;
+		} else {
+			for (final Bitmap bitmap : this.bitmaps) {
+				if (bitmap instanceof TransactionalLayerProducer) {
+					result[pos++] = ((TransactionalLayerProducer<?, ?>) bitmap).getId();
+				}
+			}
+		}
+		for (final io.evitadb.core.query.algebra.Formula innerFormula : this.innerFormulas) {
+			final long[] ids = innerFormula.gatherTransactionalIds();
+			System.arraycopy(ids, 0, result, pos, ids.length);
+			pos += ids.length;
+		}
+		return pos == result.length ? result : Arrays.copyOf(result, pos);
+	}
+
+	@Override
+	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
+		if (this.bitmaps == null) {
+			return 0L;
+		} else {
+			final long[] hashes = new long[this.bitmaps.length];
+			for (int i = 0; i < this.bitmaps.length; i++) {
+				if (this.bitmaps[i] instanceof TransactionalLayerProducer) {
+					hashes[i] = ((TransactionalLayerProducer<?, ?>) this.bitmaps[i]).getId();
+				} else {
+					// this shouldn't happen for long arrays - these are expected to be always linked to transactional
+					// bitmaps located in indexes and represented by "transactional id"
+					hashes[i] = hashFunction.hashInts(this.bitmaps[i].getArray());
+				}
+			}
+			Arrays.sort(hashes);
+			return hashFunction.hashLongs(hashes);
+		}
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AbstractBitmapCacheableFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AbstractBitmapCacheableFormula.java
@@ -27,6 +27,7 @@ import io.evitadb.core.query.algebra.AbstractCacheableFormula;
 import io.evitadb.core.query.algebra.CacheableFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.utils.Assert;
 import io.evitadb.index.bitmap.Bitmap;
 import net.openhft.hashing.LongHashFunction;
 
@@ -102,6 +103,12 @@ public abstract class AbstractBitmapCacheableFormula extends AbstractCacheableFo
 		}
 		final long[] result = new long[bitmapIdCount + innerIdCount];
 		int pos = 0;
+		if (this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
+			Assert.isPremiseValid(
+				this.indexTransactionId != null,
+				"High-cardinality bitmaps require a non-null indexTransactionId!"
+			);
+		}
 		if (this.indexTransactionId != null && this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
 			System.arraycopy(this.indexTransactionId, 0, result, 0, this.indexTransactionId.length);
 			pos = this.indexTransactionId.length;

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
@@ -132,13 +132,16 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 		);
 	}
 
+	@Override
+	public void clearMemory() {
+		super.clearMemory();
+		this.sortedFormulasByComplexity = null;
+	}
+
 	@Nonnull
 	@Override
 	protected long[] gatherBitmapIdsInternal() {
-		if (this.bitmaps == null) {
-			return sortAndDeduplicateLongArray(super.gatherBitmapIdsInternal());
-		}
-		return super.gatherBitmapIdsInternal();
+		return sortAndDeduplicateLongArray(super.gatherBitmapIdsInternal());
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
@@ -23,18 +23,16 @@
 
 package io.evitadb.core.query.algebra.base;
 
-import io.evitadb.core.query.algebra.AbstractCacheableFormula;
+import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.CacheableFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
-import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
-import net.openhft.hashing.LongHashFunction;
 import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
@@ -44,10 +42,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
-
-import static java.util.Optional.ofNullable;
 
 /**
  * And formula will perform boolean conjunction (AND) on multiple bitmaps at once.
@@ -63,43 +57,36 @@ import static java.util.Optional.ofNullable;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class AndFormula extends AbstractCacheableFormula {
+public class AndFormula extends AbstractBitmapCacheableFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 2754438812730972016L;
-	private static final Bitmap[] EMPTY_BITMAP_ARRAY = new Bitmap[0];
-	private final Bitmap[] bitmaps;
-	private final long[] indexTransactionId;
+	/**
+	 * Lazily initialized list of inner formulas sorted by their estimated cost (cheapest first) to allow
+	 * short-circuit evaluation during AND computation.
+	 */
 	private List<Formula> sortedFormulasByComplexity;
 
 	AndFormula(@Nonnull Consumer<CacheableFormula> computationCallback, @Nonnull Formula[] innerFormulas, long[] indexTransactionId, @Nullable Bitmap[] bitmaps) {
-		super(computationCallback);
+		super(computationCallback, indexTransactionId, bitmaps);
 		Assert.isTrue(
 			innerFormulas.length > 1 || Objects.requireNonNull(bitmaps).length > 1,
 			"And formula has no sense with " + innerFormulas.length + " inner formulas / bitmaps!"
 		);
-		this.bitmaps = bitmaps;
-		this.indexTransactionId = indexTransactionId;
 		this.initFields(innerFormulas);
 	}
 
 	public AndFormula(@Nonnull Formula... innerFormulas) {
-		super(null);
+		super(null, null, null);
 		Assert.isTrue(innerFormulas.length > 1, "And formula has no sense with " + innerFormulas.length + " inner formulas!");
-		this.bitmaps = null;
-		this.indexTransactionId = null;
 		this.initFields(innerFormulas);
 	}
 
 	public AndFormula(long[] indexTransactionId, @Nonnull Bitmap... bitmaps) {
-		super(null);
+		super(null, indexTransactionId, bitmaps);
 		Assert.isTrue(bitmaps.length > 1, "And formula has no sense with " + bitmaps.length + " inner bitmaps!");
-		this.bitmaps = bitmaps;
-		this.indexTransactionId = indexTransactionId;
 		this.initFields();
-	}
-
-	@Nonnull
-	public Bitmap[] getBitmaps() {
-		return this.bitmaps == null ? EMPTY_BITMAP_ARRAY : this.bitmaps;
 	}
 
 	@Nonnull
@@ -117,9 +104,29 @@ public class AndFormula extends AbstractCacheableFormula {
 	@Override
 	public int getEstimatedCardinality() {
 		if (this.bitmaps == null) {
-			return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).min().orElse(0);
+			if (this.innerFormulas.length == 0) {
+				return 0;
+			}
+			int min = this.innerFormulas[0].getEstimatedCardinality();
+			for (int i = 1; i < this.innerFormulas.length; i++) {
+				final int cardinality = this.innerFormulas[i].getEstimatedCardinality();
+				if (cardinality < min) {
+					min = cardinality;
+				}
+			}
+			return min;
 		} else {
-			return Arrays.stream(this.bitmaps).mapToInt(Bitmap::size).min().orElse(0);
+			if (this.bitmaps.length == 0) {
+				return 0;
+			}
+			int min = this.bitmaps[0].size();
+			for (int i = 1; i < this.bitmaps.length; i++) {
+				final int size = this.bitmaps[i].size();
+				if (size < min) {
+					min = size;
+				}
+			}
+			return min;
 		}
 	}
 
@@ -141,51 +148,38 @@ public class AndFormula extends AbstractCacheableFormula {
 
 	@Nonnull
 	@Override
-	public long[] gatherBitmapIdsInternal() {
+	protected long[] gatherBitmapIdsInternal() {
 		if (this.bitmaps == null) {
-			return Arrays.stream(this.innerFormulas)
-				.flatMapToLong(it -> LongStream.of(it.gatherTransactionalIds()))
-				.distinct()
-				.toArray();
-		} else {
-			return LongStream.concat(
-					this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY ?
-						LongStream.of(this.indexTransactionId) :
-						Arrays.stream(this.bitmaps)
-							.filter(TransactionalLayerProducer.class::isInstance)
-							.mapToLong(it -> ((TransactionalLayerProducer<?, ?>) it).getId()),
-					Arrays.stream(this.innerFormulas).flatMapToLong(it -> LongStream.of(it.gatherTransactionalIds()))
-				)
-				.toArray();
+			// collect all transactional IDs from inner formulas, then deduplicate
+			final long[] collected = super.gatherBitmapIdsInternal();
+			Arrays.sort(collected);
+			int unique = 0;
+			for (int i = 0; i < collected.length; i++) {
+				if (i == 0 || collected[i] != collected[i - 1]) {
+					collected[unique++] = collected[i];
+				}
+			}
+			return unique == collected.length ? collected : Arrays.copyOf(collected, unique);
 		}
+		return super.gatherBitmapIdsInternal();
 	}
 
 	@Override
 	protected long getEstimatedBaseCost() {
-		return ofNullable(this.bitmaps)
-			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).min().orElse(0L) * getOperationCost())
-			.orElseGet(super::getEstimatedBaseCost);
-	}
-
-	@Override
-	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
 		if (this.bitmaps == null) {
-			return 0L;
-		} else {
-			return hashFunction.hashLongs(
-				Arrays.stream(this.bitmaps).mapToLong(it -> {
-						if (it instanceof TransactionalLayerProducer) {
-							return ((TransactionalLayerProducer<?, ?>) it).getId();
-						} else {
-							// this shouldn't happen for long arrays - these are expected to be always linked to transactional
-							// bitmaps located in indexes and represented by "transactional id"
-							return hashFunction.hashInts(it.getArray());
-						}
-					})
-					.sorted()
-					.toArray()
-			);
+			return super.getEstimatedBaseCost();
 		}
+		if (this.bitmaps.length == 0) {
+			return 0L;
+		}
+		long min = this.bitmaps[0].size();
+		for (int i = 1; i < this.bitmaps.length; i++) {
+			final long size = this.bitmaps[i].size();
+			if (size < min) {
+				min = size;
+			}
+		}
+		return min * getOperationCost();
 	}
 
 	@Override
@@ -195,45 +189,43 @@ public class AndFormula extends AbstractCacheableFormula {
 
 	@Override
 	protected long getCostInternal() {
-		return ofNullable(this.bitmaps)
-			.map(it -> {
-				long cost = 0L;
-				for (Bitmap bitmap : this.bitmaps) {
-					if (bitmap == EmptyBitmap.INSTANCE) {
-						break;
-					}
-					cost += bitmap.size() * getOperationCost();
+		if (this.bitmaps != null) {
+			long cost = 0L;
+			for (final Bitmap bitmap : this.bitmaps) {
+				if (bitmap == EmptyBitmap.INSTANCE) {
+					break;
 				}
-				return cost;
-			})
-			.orElseGet(() -> {
-				long cost = 0L;
-				for (Formula innerFormula : this.sortedFormulasByComplexity) {
-					final Bitmap innerResult = innerFormula.compute();
-					cost += innerFormula.getCost() + innerResult.size() * getOperationCost();
-					if (innerResult == EmptyBitmap.INSTANCE) {
-						break;
-					}
+				cost += bitmap.size() * getOperationCost();
+			}
+			return cost;
+		} else {
+			long cost = 0L;
+			for (final Formula innerFormula : this.sortedFormulasByComplexity) {
+				final Bitmap innerResult = innerFormula.compute();
+				cost += innerFormula.getCost() + innerResult.size() * getOperationCost();
+				if (innerResult == EmptyBitmap.INSTANCE) {
+					break;
 				}
-				return cost;
-			});
+			}
+			return cost;
+		}
 	}
 
 	@Override
 	protected long getCostToPerformanceInternal() {
-		return ofNullable(this.bitmaps)
-			.map(it -> getCost() / Math.max(1, compute().size()))
-			.orElseGet(() -> {
-				long costToPerformance = 0L;
-				for (Formula innerFormula : this.sortedFormulasByComplexity) {
-					final Bitmap innerResult = innerFormula.compute();
-					if (innerResult == EmptyBitmap.INSTANCE) {
-						break;
-					}
-					costToPerformance += innerFormula.getCostToPerformanceRatio();
+		if (this.bitmaps != null) {
+			return getCost() / Math.max(1, compute().size());
+		} else {
+			long costToPerformance = 0L;
+			for (final Formula innerFormula : this.sortedFormulasByComplexity) {
+				final Bitmap innerResult = innerFormula.compute();
+				if (innerResult == EmptyBitmap.INSTANCE) {
+					break;
 				}
-				return costToPerformance + getCost() / Math.max(1, compute().size());
-			});
+				costToPerformance += innerFormula.getCostToPerformanceRatio();
+			}
+			return costToPerformance + getCost() / Math.max(1, compute().size());
+		}
 	}
 
 	@Nonnull
@@ -241,7 +233,16 @@ public class AndFormula extends AbstractCacheableFormula {
 	protected Bitmap computeInternal() {
 		final Bitmap theResult;
 		final RoaringBitmap[] theBitmaps = getRoaringBitmaps();
-		if (theBitmaps.length == 0 || Arrays.stream(theBitmaps).anyMatch(RoaringBitmap::isEmpty)) {
+		boolean hasEmpty = theBitmaps.length == 0;
+		if (!hasEmpty) {
+			for (final RoaringBitmap theBitmap : theBitmaps) {
+				if (theBitmap.isEmpty()) {
+					hasEmpty = true;
+					break;
+				}
+			}
+		}
+		if (hasEmpty) {
 			theResult = EmptyBitmap.INSTANCE;
 		} else if (theBitmaps.length == 1) {
 			theResult = new BaseBitmap(theBitmaps[0]);
@@ -256,7 +257,15 @@ public class AndFormula extends AbstractCacheableFormula {
 		if (ArrayUtils.isEmpty(this.bitmaps)) {
 			return "AND";
 		} else {
-			return "AND: " + Arrays.stream(this.bitmaps).map(Bitmap::toString).collect(Collectors.joining(", "));
+			final StringBuilder sb = new StringBuilder((this.bitmaps.length << 4) + 8);
+			sb.append("AND: ");
+			for (int i = 0; i < this.bitmaps.length; i++) {
+				if (i > 0) {
+					sb.append(", ");
+				}
+				sb.append(this.bitmaps[i].toString());
+			}
+			return sb.toString();
 		}
 	}
 
@@ -266,34 +275,34 @@ public class AndFormula extends AbstractCacheableFormula {
 
 	@Nonnull
 	private RoaringBitmap[] getRoaringBitmaps() {
-		return ofNullable(this.bitmaps)
-			.map(it -> Arrays
-				.stream(it)
-				.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-				.toArray(RoaringBitmap[]::new)
-			)
-			.orElseGet(
-				() -> {
-					if (this.sortedFormulasByComplexity == null) {
-						this.sortedFormulasByComplexity = Arrays.stream(getInnerFormulas())
-							.sorted(Comparator.comparingLong(TransactionalDataRelatedStructure::getEstimatedCost))
-							.toList();
-					}
-					final RoaringBitmap[] theBitmaps = new RoaringBitmap[this.sortedFormulasByComplexity.size()];
-					// go from the cheapest formula to the more expensive and compute one by one
-					for (int i = 0; i < this.sortedFormulasByComplexity.size(); i++) {
-						final Formula formula = this.sortedFormulasByComplexity.get(i);
-						final Bitmap computedBitmap = formula.compute();
-						// if you encounter formula that returns nothing immediately return nothing - hence AND
-						if (computedBitmap.isEmpty()) {
-							return new RoaringBitmap[0];
-						} else {
-							theBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(computedBitmap);
-						}
-					}
-					return theBitmaps;
+		if (this.bitmaps != null) {
+			final RoaringBitmap[] result = new RoaringBitmap[this.bitmaps.length];
+			for (int i = 0; i < this.bitmaps.length; i++) {
+				result[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(this.bitmaps[i]);
+			}
+			return result;
+		} else {
+			if (this.sortedFormulasByComplexity == null) {
+				final Formula[] formulas = getInnerFormulas();
+				final Formula[] sorted = new Formula[formulas.length];
+				System.arraycopy(formulas, 0, sorted, 0, formulas.length);
+				Arrays.sort(sorted, Comparator.comparingLong(TransactionalDataRelatedStructure::getEstimatedCost));
+				this.sortedFormulasByComplexity = List.of(sorted);
+			}
+			final RoaringBitmap[] theBitmaps = new RoaringBitmap[this.sortedFormulasByComplexity.size()];
+			// go from the cheapest formula to the more expensive and compute one by one
+			for (int i = 0; i < this.sortedFormulasByComplexity.size(); i++) {
+				final Formula formula = this.sortedFormulasByComplexity.get(i);
+				final Bitmap computedBitmap = formula.compute();
+				// if you encounter formula that returns nothing immediately return nothing - hence AND
+				if (computedBitmap.isEmpty()) {
+					return new RoaringBitmap[0];
+				} else {
+					theBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(computedBitmap);
 				}
-			);
+			}
+			return theBitmaps;
+		}
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
@@ -157,6 +157,8 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 	@Override
 	protected long getCostInternal() {
 		if (this.bitmaps != null) {
+			// bitmaps are iterated in array order — short-circuit on empty is a best-effort
+			// optimization; callers are expected to filter empties during construction
 			long cost = 0L;
 			for (final Bitmap bitmap : this.bitmaps) {
 				if (bitmap.isEmpty()) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
@@ -149,17 +149,11 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 		if (this.bitmaps == null) {
 			return super.getEstimatedBaseCost();
 		}
-		if (this.bitmaps.length == 0) {
-			return 0L;
+		long sum = 0L;
+		for (final Bitmap bitmap : this.bitmaps) {
+			sum += bitmap.size();
 		}
-		long min = this.bitmaps[0].size();
-		for (int i = 1; i < this.bitmaps.length; i++) {
-			final long size = this.bitmaps[i].size();
-			if (size < min) {
-				min = size;
-			}
-		}
-		return min * getOperationCost();
+		return sum;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
@@ -146,7 +146,11 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 		for (final Bitmap bitmap : this.bitmaps) {
 			sum += bitmap.size();
 		}
-		return sum;
+		// multiply by operation cost: baseCost represents the full work on direct bitmap data
+		// (scanning all elements and applying the AND operation to each). Without this multiplier,
+		// the estimated cost would fall below actual cost because `getEstimatedCardinality()` returns
+		// `min` (output bound), which underestimates the total per-element work of `sum * opCost`.
+		return sum * getOperationCost();
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
@@ -27,7 +27,6 @@ import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.CacheableFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.index.bitmap.Bitmap;
-import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
@@ -138,12 +137,6 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 		this.sortedFormulasByComplexity = null;
 	}
 
-	@Nonnull
-	@Override
-	protected long[] gatherBitmapIdsInternal() {
-		return sortAndDeduplicateLongArray(super.gatherBitmapIdsInternal());
-	}
-
 	@Override
 	protected long getEstimatedBaseCost() {
 		if (this.bitmaps == null) {
@@ -166,13 +159,16 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 		if (this.bitmaps != null) {
 			long cost = 0L;
 			for (final Bitmap bitmap : this.bitmaps) {
-				if (bitmap == EmptyBitmap.INSTANCE) {
+				if (bitmap.isEmpty()) {
 					break;
 				}
 				cost += bitmap.size() * getOperationCost();
 			}
 			return cost;
 		} else {
+			if (this.sortedFormulasByComplexity == null) {
+				this.sortedFormulasByComplexity = sortFormulasByComplexity(getInnerFormulas());
+			}
 			return computeSortedConjunctionCost(this.sortedFormulasByComplexity, getOperationCost());
 		}
 	}
@@ -182,6 +178,9 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 		if (this.bitmaps != null) {
 			return getCost() / Math.max(1, compute().size());
 		} else {
+			if (this.sortedFormulasByComplexity == null) {
+				this.sortedFormulasByComplexity = sortFormulasByComplexity(getInnerFormulas());
+			}
 			return computeSortedConjunctionCostToPerformance(this.sortedFormulasByComplexity)
 				+ getCost() / Math.max(1, compute().size());
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/AndFormula.java
@@ -26,8 +26,6 @@ package io.evitadb.core.query.algebra.base;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.CacheableFormula;
 import io.evitadb.core.query.algebra.Formula;
-import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
-import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
@@ -37,8 +35,6 @@ import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -104,17 +100,7 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 	@Override
 	public int getEstimatedCardinality() {
 		if (this.bitmaps == null) {
-			if (this.innerFormulas.length == 0) {
-				return 0;
-			}
-			int min = this.innerFormulas[0].getEstimatedCardinality();
-			for (int i = 1; i < this.innerFormulas.length; i++) {
-				final int cardinality = this.innerFormulas[i].getEstimatedCardinality();
-				if (cardinality < min) {
-					min = cardinality;
-				}
-			}
-			return min;
+			return getMinEstimatedCardinality(this.innerFormulas);
 		} else {
 			if (this.bitmaps.length == 0) {
 				return 0;
@@ -150,16 +136,7 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 	@Override
 	protected long[] gatherBitmapIdsInternal() {
 		if (this.bitmaps == null) {
-			// collect all transactional IDs from inner formulas, then deduplicate
-			final long[] collected = super.gatherBitmapIdsInternal();
-			Arrays.sort(collected);
-			int unique = 0;
-			for (int i = 0; i < collected.length; i++) {
-				if (i == 0 || collected[i] != collected[i - 1]) {
-					collected[unique++] = collected[i];
-				}
-			}
-			return unique == collected.length ? collected : Arrays.copyOf(collected, unique);
+			return sortAndDeduplicateLongArray(super.gatherBitmapIdsInternal());
 		}
 		return super.gatherBitmapIdsInternal();
 	}
@@ -199,15 +176,7 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 			}
 			return cost;
 		} else {
-			long cost = 0L;
-			for (final Formula innerFormula : this.sortedFormulasByComplexity) {
-				final Bitmap innerResult = innerFormula.compute();
-				cost += innerFormula.getCost() + innerResult.size() * getOperationCost();
-				if (innerResult == EmptyBitmap.INSTANCE) {
-					break;
-				}
-			}
-			return cost;
+			return computeSortedConjunctionCost(this.sortedFormulasByComplexity, getOperationCost());
 		}
 	}
 
@@ -216,40 +185,15 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 		if (this.bitmaps != null) {
 			return getCost() / Math.max(1, compute().size());
 		} else {
-			long costToPerformance = 0L;
-			for (final Formula innerFormula : this.sortedFormulasByComplexity) {
-				final Bitmap innerResult = innerFormula.compute();
-				if (innerResult == EmptyBitmap.INSTANCE) {
-					break;
-				}
-				costToPerformance += innerFormula.getCostToPerformanceRatio();
-			}
-			return costToPerformance + getCost() / Math.max(1, compute().size());
+			return computeSortedConjunctionCostToPerformance(this.sortedFormulasByComplexity)
+				+ getCost() / Math.max(1, compute().size());
 		}
 	}
 
 	@Nonnull
 	@Override
 	protected Bitmap computeInternal() {
-		final Bitmap theResult;
-		final RoaringBitmap[] theBitmaps = getRoaringBitmaps();
-		boolean hasEmpty = theBitmaps.length == 0;
-		if (!hasEmpty) {
-			for (final RoaringBitmap theBitmap : theBitmaps) {
-				if (theBitmap.isEmpty()) {
-					hasEmpty = true;
-					break;
-				}
-			}
-		}
-		if (hasEmpty) {
-			theResult = EmptyBitmap.INSTANCE;
-		} else if (theBitmaps.length == 1) {
-			theResult = new BaseBitmap(theBitmaps[0]);
-		} else {
-			theResult = RoaringBitmapBackedBitmap.and(theBitmaps);
-		}
-		return theResult.isEmpty() ? EmptyBitmap.INSTANCE : theResult;
+		return computeConjunctionResult(getRoaringBitmaps());
 	}
 
 	@Override
@@ -283,25 +227,9 @@ public class AndFormula extends AbstractBitmapCacheableFormula {
 			return result;
 		} else {
 			if (this.sortedFormulasByComplexity == null) {
-				final Formula[] formulas = getInnerFormulas();
-				final Formula[] sorted = new Formula[formulas.length];
-				System.arraycopy(formulas, 0, sorted, 0, formulas.length);
-				Arrays.sort(sorted, Comparator.comparingLong(TransactionalDataRelatedStructure::getEstimatedCost));
-				this.sortedFormulasByComplexity = List.of(sorted);
+				this.sortedFormulasByComplexity = sortFormulasByComplexity(getInnerFormulas());
 			}
-			final RoaringBitmap[] theBitmaps = new RoaringBitmap[this.sortedFormulasByComplexity.size()];
-			// go from the cheapest formula to the more expensive and compute one by one
-			for (int i = 0; i < this.sortedFormulasByComplexity.size(); i++) {
-				final Formula formula = this.sortedFormulasByComplexity.get(i);
-				final Bitmap computedBitmap = formula.compute();
-				// if you encounter formula that returns nothing immediately return nothing - hence AND
-				if (computedBitmap.isEmpty()) {
-					return new RoaringBitmap[0];
-				} else {
-					theBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(computedBitmap);
-				}
-			}
-			return theBitmaps;
+			return computeSortedConjunctionBitmaps(this.sortedFormulasByComplexity);
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/ConstantFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/ConstantFormula.java
@@ -40,8 +40,17 @@ import javax.annotation.Nonnull;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class ConstantFormula extends AbstractFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 2713157071360876502L;
+	/**
+	 * Reusable empty long array returned when the delegate bitmap has no transactional identity.
+	 */
 	private static final long[] EMPTY_LONG_ARRAY = new long[0];
+	/**
+	 * Bitmap of entity primary keys that this constant formula directly returns as its result.
+	 */
 	@Getter private final Bitmap delegate;
 
 	public ConstantFormula(@Nonnull Bitmap delegate) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
@@ -41,7 +41,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.PrimitiveIterator.OfInt;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 /**
@@ -291,7 +290,7 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 				? this.mainBitmap.iterator()
 				: this.innerFormulas[0].compute().iterator();
 			int number;
-			final AtomicInteger controlNumberRef = new AtomicInteger(END_OF_STREAM);
+			final int[] controlNumberRef = {END_OF_STREAM};
 			while ((number = computeNextInt(mainIt, controlIt, controlNumberRef)) != END_OF_STREAM) {
 				writer.add(number);
 			}
@@ -303,24 +302,24 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 		PRIVATE METHODS
 	 */
 
-	private static int computeNextInt(OfInt mainIt, OfInt controlIt, AtomicInteger controlNumberRef) {
+	private static int computeNextInt(OfInt mainIt, OfInt controlIt, int[] controlNumberRef) {
 		if (mainIt.hasNext()) {
 			do {
 				final int nextNumberAdept = mainIt.next();
-				if (!controlIt.hasNext() && controlNumberRef.get() == END_OF_STREAM) {
+				if (!controlIt.hasNext() && controlNumberRef[0] == END_OF_STREAM) {
 					return nextNumberAdept;
 				}
-				while (controlIt.hasNext() && (controlNumberRef.get() == END_OF_STREAM || controlNumberRef.get() < nextNumberAdept)) {
-					controlNumberRef.set(controlIt.next());
+				while (controlIt.hasNext() && (controlNumberRef[0] == END_OF_STREAM || controlNumberRef[0] < nextNumberAdept)) {
+					controlNumberRef[0] = controlIt.next();
 				}
 
-				if (nextNumberAdept == controlNumberRef.get()) {
+				if (nextNumberAdept == controlNumberRef[0]) {
 					// swallow in control list and repeat
 					if (mainIt.hasNext()) {
 						if (controlIt.hasNext()) {
-							controlNumberRef.set(controlIt.next());
+							controlNumberRef[0] = controlIt.next();
 						} else {
-							controlNumberRef.set(END_OF_STREAM);
+							controlNumberRef[0] = END_OF_STREAM;
 						}
 					} else {
 						return END_OF_STREAM;

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
@@ -40,15 +40,9 @@ import org.roaringbitmap.RoaringBitmapWriter;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
-
-import static java.util.Optional.ofNullable;
 
 /**
  * Disentangle formula accepts two bitmaps of numbers and produces bitmap of numbers, that are present in first array
@@ -81,9 +75,21 @@ import static java.util.Optional.ofNullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class DisentangleFormula extends AbstractCacheableFormula implements CacheablePriceFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractCacheableFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -3805332683683704679L;
+	/**
+	 * Sentinel value indicating that a bitmap iterator has been fully exhausted.
+	 */
 	private static final int END_OF_STREAM = -1;
+	/**
+	 * Primary bitmap whose elements are iterated and conditionally included in the result.
+	 */
 	private final Bitmap mainBitmap;
+	/**
+	 * Control bitmap whose elements are used to exclude matching entries from the main bitmap.
+	 */
 	private final Bitmap controlBitmap;
 
 	public DisentangleFormula(@Nonnull Formula mainBitmap, @Nonnull Formula controlBitmap) {
@@ -119,13 +125,31 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 	@Nonnull
 	@Override
 	public long[] gatherBitmapIdsInternal() {
-		return LongStream.concat(
-				Stream.of(this.mainBitmap, this.controlBitmap)
-					.filter(TransactionalLayerProducer.class::isInstance)
-					.mapToLong(it -> ((TransactionalLayerProducer<?, ?>) it).getId()),
-				Arrays.stream(this.innerFormulas).flatMapToLong(it -> LongStream.of(it.gatherTransactionalIds()))
-			)
-			.toArray();
+		int bitmapIdCount = 0;
+		if (this.mainBitmap instanceof TransactionalLayerProducer) {
+			bitmapIdCount++;
+		}
+		if (this.controlBitmap instanceof TransactionalLayerProducer) {
+			bitmapIdCount++;
+		}
+		int innerIdCount = 0;
+		for (int i = 0; i < this.innerFormulas.length; i++) {
+			innerIdCount += this.innerFormulas[i].gatherTransactionalIds().length;
+		}
+		final long[] result = new long[bitmapIdCount + innerIdCount];
+		int pos = 0;
+		if (this.mainBitmap instanceof TransactionalLayerProducer) {
+			result[pos++] = ((TransactionalLayerProducer<?, ?>) this.mainBitmap).getId();
+		}
+		if (this.controlBitmap instanceof TransactionalLayerProducer) {
+			result[pos++] = ((TransactionalLayerProducer<?, ?>) this.controlBitmap).getId();
+		}
+		for (int i = 0; i < this.innerFormulas.length; i++) {
+			final long[] ids = this.innerFormulas[i].gatherTransactionalIds();
+			System.arraycopy(ids, 0, result, pos, ids.length);
+			pos += ids.length;
+		}
+		return pos == result.length ? result : Arrays.copyOf(result, pos);
 	}
 
 	@Override
@@ -146,7 +170,7 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 	@Override
 	protected long getEstimatedBaseCost() {
 		if (this.mainBitmap != null && this.controlBitmap != null) {
-			return Stream.of(this.mainBitmap, this.controlBitmap).mapToLong(Bitmap::size).sum();
+			return (long) this.mainBitmap.size() + (long) this.controlBitmap.size();
 		} else {
 			return super.getEstimatedBaseCost();
 		}
@@ -159,20 +183,34 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 
 	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
-		return hashFunction.hashLongs(
-			Stream.of(this.mainBitmap, this.controlBitmap)
-				.filter(Objects::nonNull)
-				.mapToLong(it -> {
-					if (it instanceof TransactionalLayerProducer) {
-						return ((TransactionalLayerProducer<?, ?>) it).getId();
-					} else {
-						// this shouldn't happen for long arrays - these are expected to be always linked to transactional
-						// bitmaps located in indexes and represented by "transactional id"
-						return hashFunction.hashInts(it.getArray());
-					}
-				})
-				.toArray()
-		);
+		int count = 0;
+		if (this.mainBitmap != null) {
+			count++;
+		}
+		if (this.controlBitmap != null) {
+			count++;
+		}
+		final long[] hashes = new long[count];
+		int pos = 0;
+		if (this.mainBitmap != null) {
+			if (this.mainBitmap instanceof TransactionalLayerProducer) {
+				hashes[pos++] = ((TransactionalLayerProducer<?, ?>) this.mainBitmap).getId();
+			} else {
+				// this shouldn't happen for long arrays - these are expected to be always linked to transactional
+				// bitmaps located in indexes and represented by "transactional id"
+				hashes[pos++] = hashFunction.hashInts(this.mainBitmap.getArray());
+			}
+		}
+		if (this.controlBitmap != null) {
+			if (this.controlBitmap instanceof TransactionalLayerProducer) {
+				hashes[pos++] = ((TransactionalLayerProducer<?, ?>) this.controlBitmap).getId();
+			} else {
+				// this shouldn't happen for long arrays - these are expected to be always linked to transactional
+				// bitmaps located in indexes and represented by "transactional id"
+				hashes[pos++] = hashFunction.hashInts(this.controlBitmap.getArray());
+			}
+		}
+		return hashFunction.hashLongs(hashes);
 	}
 
 	@Override
@@ -188,7 +226,7 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 	@Override
 	protected long getCostInternal() {
 		if (this.mainBitmap != null && this.controlBitmap != null) {
-			return Stream.of(this.mainBitmap, this.controlBitmap).mapToLong(Bitmap::size).sum();
+			return (long) this.mainBitmap.size() + (long) this.controlBitmap.size();
 		} else {
 			return super.getCostInternal();
 		}
@@ -228,7 +266,7 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 	@Override
 	public String toStringVerbose() {
 		if (this.mainBitmap != null && this.controlBitmap != null) {
-			return "DISENTANGLE: " + Stream.of(this.mainBitmap, this.controlBitmap).map(Bitmap::toString).collect(Collectors.joining(", "));
+			return "DISENTANGLE: " + this.mainBitmap.toString() + ", " + this.controlBitmap.toString();
 		} else {
 			return "DISENTANGLE";
 		}
@@ -238,14 +276,20 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 	@Override
 	protected Bitmap computeInternal() {
 		final RoaringBitmapWriter<RoaringBitmap> writer = RoaringBitmapBackedBitmap.buildWriter();
-		final OfInt controlIt = ofNullable(this.controlBitmap).map(Bitmap::iterator).orElseGet(() -> this.innerFormulas[1].compute().iterator());
+		final OfInt controlIt = this.controlBitmap != null
+			? this.controlBitmap.iterator()
+			: this.innerFormulas[1].compute().iterator();
 		if (!controlIt.hasNext()) {
-			final OfInt mainIt = ofNullable(this.mainBitmap).map(Bitmap::iterator).orElseGet(() -> this.innerFormulas[0].compute().iterator());
+			final OfInt mainIt = this.mainBitmap != null
+				? this.mainBitmap.iterator()
+				: this.innerFormulas[0].compute().iterator();
 			while (mainIt.hasNext()) {
 				writer.add(mainIt.next());
 			}
 		} else {
-			final OfInt mainIt = ofNullable(this.mainBitmap).map(Bitmap::iterator).orElseGet(() -> this.innerFormulas[0].compute().iterator());
+			final OfInt mainIt = this.mainBitmap != null
+				? this.mainBitmap.iterator()
+				: this.innerFormulas[0].compute().iterator();
 			int number;
 			final AtomicInteger controlNumberRef = new AtomicInteger(END_OF_STREAM);
 			while ((number = computeNextInt(mainIt, controlIt, controlNumberRef)) != END_OF_STREAM) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
@@ -124,7 +124,7 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 
 	@Nonnull
 	@Override
-	public long[] gatherBitmapIdsInternal() {
+	protected long[] gatherBitmapIdsInternal() {
 		int bitmapIdCount = 0;
 		if (this.mainBitmap instanceof TransactionalLayerProducer) {
 			bitmapIdCount++;

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/EmptyFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/EmptyFormula.java
@@ -37,7 +37,13 @@ import javax.annotation.Nonnull;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class EmptyFormula extends AbstractFormula {
+	/**
+	 * Singleton instance representing an empty result set with no matching records.
+	 */
 	public static final EmptyFormula INSTANCE = new EmptyFormula();
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 7864590390866911682L;
 
 	private EmptyFormula() {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
@@ -37,13 +37,7 @@ import net.openhft.hashing.LongHashFunction;
 import org.roaringbitmap.IntIterator;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
-import java.util.Objects;
 import java.util.PriorityQueue;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.Optional.ofNullable;
 
 /**
  * This formula produces bitmap with possible duplicated record ids but still maintaining ascending order.
@@ -60,9 +54,21 @@ import static java.util.Optional.ofNullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class JoinFormula extends AbstractFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 1167849768781680098L;
+	/**
+	 * Sentinel value indicating that a bitmap iterator has been fully exhausted.
+	 */
 	private static final int END_OF_STREAM = -1;
+	/**
+	 * Transaction id of the index from which the bitmaps originate, used for cache invalidation.
+	 */
 	private final long[] indexTransactionId;
+	/**
+	 * Array of bitmaps to be merged into a single bitmap preserving duplicates in ascending order.
+	 */
 	private final Bitmap[] bitmaps;
 
 	/**
@@ -145,16 +151,30 @@ public class JoinFormula extends AbstractFormula {
 
 	@Nonnull
 	private static IntIterator[] getImmutableRoaringBitmapIterators(@Nonnull Bitmap[] bitmaps) {
-		return Arrays.stream(bitmaps)
-			.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-			.map(it -> it.getBatchIterator().asIntIterator(new int[256]))
-			.toArray(IntIterator[]::new);
+		final IntIterator[] iterators = new IntIterator[bitmaps.length];
+		for (int i = 0; i < bitmaps.length; i++) {
+			iterators[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(bitmaps[i])
+				.getBatchIterator().asIntIterator(new int[256]);
+		}
+		return iterators;
 	}
 
 	public JoinFormula(long indexTransactionId, @Nonnull Bitmap... bitmaps) {
-		this.bitmaps = Arrays.stream(bitmaps)
-			.filter(it -> !(it instanceof EmptyBitmap))
-			.toArray(Bitmap[]::new);
+		// filter out empty bitmaps without stream allocation
+		int nonEmptyCount = 0;
+		for (Bitmap bitmap : bitmaps) {
+			if (!(bitmap instanceof EmptyBitmap)) {
+				nonEmptyCount++;
+			}
+		}
+		final Bitmap[] filtered = new Bitmap[nonEmptyCount];
+		int idx = 0;
+		for (Bitmap bitmap : bitmaps) {
+			if (!(bitmap instanceof EmptyBitmap)) {
+				filtered[idx++] = bitmap;
+			}
+		}
+		this.bitmaps = filtered;
 		Assert.isTrue(this.bitmaps.length > 1, "Join formula has to have at least two bitmaps - otherwise use EmptyFormula.INSTANCE or just the bitmap itself.");
 		this.indexTransactionId = new long[]{indexTransactionId};
 		this.initFields();
@@ -172,13 +192,30 @@ public class JoinFormula extends AbstractFormula {
 
 	@Override
 	public String toString() {
-		return "JOIN: " + Arrays.stream(this.bitmaps).map(it -> String.valueOf(it.size())).collect(Collectors.joining(", ")) + " primary keys";
+		final StringBuilder sb = new StringBuilder(64);
+		sb.append("JOIN: ");
+		for (int i = 0; i < this.bitmaps.length; i++) {
+			if (i > 0) {
+				sb.append(", ");
+			}
+			sb.append(this.bitmaps[i].size());
+		}
+		sb.append(" primary keys");
+		return sb.toString();
 	}
 
 	@Nonnull
 	@Override
 	public String toStringVerbose() {
-		return "JOIN: " + Arrays.stream(this.bitmaps).map(Bitmap::toString).collect(Collectors.joining(", "));
+		final StringBuilder sb = new StringBuilder(128);
+		sb.append("JOIN: ");
+		for (int i = 0; i < this.bitmaps.length; i++) {
+			if (i > 0) {
+				sb.append(", ");
+			}
+			sb.append(this.bitmaps[i]);
+		}
+		return sb.toString();
 	}
 
 	@Nonnull
@@ -189,7 +226,11 @@ public class JoinFormula extends AbstractFormula {
 
 	@Override
 	public int getEstimatedCardinality() {
-		return Arrays.stream(this.bitmaps).mapToInt(Bitmap::size).sum();
+		int sum = 0;
+		for (Bitmap bitmap : this.bitmaps) {
+			sum += bitmap.size();
+		}
+		return sum;
 	}
 
 	@Override
@@ -208,10 +249,20 @@ public class JoinFormula extends AbstractFormula {
 		if (this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
 			return this.indexTransactionId;
 		} else {
-			return Stream.of(this.bitmaps)
-				.filter(TransactionalLayerProducer.class::isInstance)
-				.mapToLong(it -> ((TransactionalLayerProducer<?, ?>) it).getId())
-				.toArray();
+			int count = 0;
+			for (Bitmap bitmap : this.bitmaps) {
+				if (bitmap instanceof TransactionalLayerProducer) {
+					count++;
+				}
+			}
+			final long[] ids = new long[count];
+			int idx = 0;
+			for (Bitmap bitmap : this.bitmaps) {
+				if (bitmap instanceof TransactionalLayerProducer) {
+					ids[idx++] = ((TransactionalLayerProducer<?, ?>) bitmap).getId();
+				}
+			}
+			return ids;
 		}
 	}
 
@@ -230,7 +281,17 @@ public class JoinFormula extends AbstractFormula {
 
 	@Override
 	protected long getEstimatedBaseCost() {
-		return Arrays.stream(this.bitmaps).mapToLong(Bitmap::size).min().orElse(0L);
+		if (this.bitmaps.length == 0) {
+			return 0L;
+		}
+		long min = Long.MAX_VALUE;
+		for (Bitmap bitmap : this.bitmaps) {
+			final long size = bitmap.size();
+			if (size < min) {
+				min = size;
+			}
+		}
+		return min;
 	}
 
 	@Override
@@ -238,20 +299,26 @@ public class JoinFormula extends AbstractFormula {
 		if (this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
 			return hashFunction.hashLongs(this.indexTransactionId);
 		} else {
-			return hashFunction.hashLongs(
-				Stream.of(this.bitmaps)
-					.filter(Objects::nonNull)
-					.mapToLong(it -> {
-						if (it instanceof TransactionalLayerProducer) {
-							return ((TransactionalLayerProducer<?, ?>) it).getId();
-						} else {
-							// this shouldn't happen for long arrays - these are expected to be always linked to transactional
-							// bitmaps located in indexes and represented by "transactional id"
-							return hashFunction.hashInts(it.getArray());
-						}
-					})
-					.toArray()
-			);
+			int count = 0;
+			for (Bitmap bitmap : this.bitmaps) {
+				if (bitmap != null) {
+					count++;
+				}
+			}
+			final long[] hashes = new long[count];
+			int idx = 0;
+			for (Bitmap bitmap : this.bitmaps) {
+				if (bitmap != null) {
+					if (bitmap instanceof TransactionalLayerProducer) {
+						hashes[idx++] = ((TransactionalLayerProducer<?, ?>) bitmap).getId();
+					} else {
+						// this shouldn't happen for long arrays - these are expected to be always linked to transactional
+						// bitmaps located in indexes and represented by "transactional id"
+						hashes[idx++] = hashFunction.hashInts(bitmap.getArray());
+					}
+				}
+			}
+			return hashFunction.hashLongs(hashes);
 		}
 	}
 
@@ -262,9 +329,14 @@ public class JoinFormula extends AbstractFormula {
 
 	@Override
 	protected long getCostInternal() {
-		return ofNullable(this.bitmaps)
-			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).sum())
-			.orElseGet(super::getCostInternal);
+		if (this.bitmaps != null) {
+			long sum = 0L;
+			for (Bitmap bitmap : this.bitmaps) {
+				sum += bitmap.size();
+			}
+			return sum;
+		}
+		return super.getCostInternal();
 	}
 
 	/*

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
@@ -299,23 +299,15 @@ public class JoinFormula extends AbstractFormula {
 		if (this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
 			return hashFunction.hashLongs(this.indexTransactionId);
 		} else {
-			int count = 0;
-			for (Bitmap bitmap : this.bitmaps) {
-				if (bitmap != null) {
-					count++;
-				}
-			}
-			final long[] hashes = new long[count];
-			int idx = 0;
-			for (Bitmap bitmap : this.bitmaps) {
-				if (bitmap != null) {
-					if (bitmap instanceof TransactionalLayerProducer) {
-						hashes[idx++] = ((TransactionalLayerProducer<?, ?>) bitmap).getId();
-					} else {
-						// this shouldn't happen for long arrays - these are expected to be always linked to transactional
-						// bitmaps located in indexes and represented by "transactional id"
-						hashes[idx++] = hashFunction.hashInts(bitmap.getArray());
-					}
+			final long[] hashes = new long[this.bitmaps.length];
+			for (int i = 0; i < this.bitmaps.length; i++) {
+				final Bitmap bitmap = this.bitmaps[i];
+				if (bitmap instanceof TransactionalLayerProducer) {
+					hashes[i] = ((TransactionalLayerProducer<?, ?>) bitmap).getId();
+				} else {
+					// this shouldn't happen for long arrays - these are expected to be always linked to transactional
+					// bitmaps located in indexes and represented by "transactional id"
+					hashes[i] = hashFunction.hashInts(bitmap.getArray());
 				}
 			}
 			return hashFunction.hashLongs(hashes);
@@ -329,7 +321,7 @@ public class JoinFormula extends AbstractFormula {
 
 	@Override
 	protected long getCostInternal() {
-		if (this.bitmaps != null) {
+		if (this.bitmaps.length > 0) {
 			long sum = 0L;
 			for (Bitmap bitmap : this.bitmaps) {
 				sum += bitmap.size();

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
@@ -281,17 +281,11 @@ public class JoinFormula extends AbstractFormula {
 
 	@Override
 	protected long getEstimatedBaseCost() {
-		if (this.bitmaps.length == 0) {
-			return 0L;
+		long sum = 0L;
+		for (final Bitmap bitmap : this.bitmaps) {
+			sum += bitmap.size();
 		}
-		long min = Long.MAX_VALUE;
-		for (Bitmap bitmap : this.bitmaps) {
-			final long size = bitmap.size();
-			if (size < min) {
-				min = size;
-			}
-		}
-		return min;
+		return sum;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
@@ -37,11 +37,7 @@ import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
 
 /**
  * And formula will perform boolean negation (NOT) on two bitmaps: superset and subtracted one
@@ -57,8 +53,17 @@ import java.util.stream.Stream;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class NotFormula extends AbstractCacheableFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractCacheableFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -588386855739382284L;
+	/**
+	 * Bitmap of entity primary keys to subtract from the superset (used when formula is constructed from raw bitmaps).
+	 */
 	private final Bitmap subtractedBitmap;
+	/**
+	 * Bitmap of entity primary keys representing the superset from which subtracted keys are removed.
+	 */
 	private final Bitmap supersetBitmap;
 
 	protected NotFormula(@Nonnull Consumer<CacheableFormula> computationCallback, @Nonnull Formula subtractedFormula, @Nonnull Formula supersetFormula) {
@@ -133,7 +138,7 @@ public class NotFormula extends AbstractCacheableFormula {
 	@Override
 	public String toString() {
 		if (this.subtractedBitmap != null && this.supersetBitmap != null) {
-			return "NOT: " + Stream.of(this.subtractedBitmap, this.supersetBitmap).map(Bitmap::toString).collect(Collectors.joining(", "));
+			return "NOT: " + this.subtractedBitmap + ", " + this.supersetBitmap;
 		} else {
 			return "NOT";
 		}
@@ -147,13 +152,19 @@ public class NotFormula extends AbstractCacheableFormula {
 	@Nonnull
 	@Override
 	public long[] gatherBitmapIdsInternal() {
-		return LongStream.concat(
-				Stream.of(this.subtractedBitmap, this.supersetBitmap)
-					.filter(TransactionalLayerProducer.class::isInstance)
-					.mapToLong(it -> ((TransactionalLayerProducer<?, ?>) it).getId()),
-				Arrays.stream(this.innerFormulas).flatMapToLong(it -> LongStream.of(it.gatherTransactionalIds()))
-			)
-			.toArray();
+		if (this.subtractedBitmap != null && this.supersetBitmap != null) {
+			int idx = 0;
+			final long[] ids = new long[2];
+			if (this.subtractedBitmap instanceof TransactionalLayerProducer<?, ?> tlp) {
+				ids[idx++] = tlp.getId();
+			}
+			if (this.supersetBitmap instanceof TransactionalLayerProducer<?, ?> tlp) {
+				ids[idx++] = tlp.getId();
+			}
+			return idx == ids.length ? ids : Arrays.copyOf(ids, idx);
+		} else {
+			return super.gatherBitmapIdsInternal();
+		}
 	}
 
 	@Override
@@ -174,7 +185,7 @@ public class NotFormula extends AbstractCacheableFormula {
 	@Override
 	protected long getEstimatedBaseCost() {
 		if (this.supersetBitmap != null && this.subtractedBitmap != null) {
-			return Stream.of(this.supersetBitmap, this.subtractedBitmap).mapToLong(Bitmap::size).sum();
+			return (long) this.supersetBitmap.size() + (long) this.subtractedBitmap.size();
 		} else {
 			return super.getEstimatedBaseCost();
 		}
@@ -182,20 +193,23 @@ public class NotFormula extends AbstractCacheableFormula {
 
 	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
-		return hashFunction.hashLongs(
-			Stream.of(this.subtractedBitmap, this.supersetBitmap)
-				.filter(Objects::nonNull)
-				.mapToLong(it -> {
-					if (it instanceof TransactionalLayerProducer) {
-						return ((TransactionalLayerProducer<?, ?>) it).getId();
-					} else {
-						// this shouldn't happen for long arrays - these are expected to be always linked to transactional
-						// bitmaps located in indexes and represented by "transactional id"
-						return hashFunction.hashInts(it.getArray());
-					}
-				})
-				.toArray()
-		);
+		int idx = 0;
+		final long[] hashes = new long[2];
+		if (this.subtractedBitmap != null) {
+			hashes[idx++] = this.subtractedBitmap instanceof TransactionalLayerProducer<?, ?> tlp
+				? tlp.getId()
+				// this shouldn't happen for long arrays - these are expected to be always linked to transactional
+				// bitmaps located in indexes and represented by "transactional id"
+				: hashFunction.hashInts(this.subtractedBitmap.getArray());
+		}
+		if (this.supersetBitmap != null) {
+			hashes[idx++] = this.supersetBitmap instanceof TransactionalLayerProducer<?, ?> tlp
+				? tlp.getId()
+				// this shouldn't happen for long arrays - these are expected to be always linked to transactional
+				// bitmaps located in indexes and represented by "transactional id"
+				: hashFunction.hashInts(this.supersetBitmap.getArray());
+		}
+		return hashFunction.hashLongs(idx == hashes.length ? hashes : Arrays.copyOf(hashes, idx));
 	}
 
 	@Override
@@ -206,7 +220,7 @@ public class NotFormula extends AbstractCacheableFormula {
 	@Override
 	protected long getCostInternal() {
 		if (this.supersetBitmap != null && this.subtractedBitmap != null) {
-			return Stream.of(this.supersetBitmap, this.subtractedBitmap).mapToLong(Bitmap::size).sum();
+			return (long) this.supersetBitmap.size() + (long) this.subtractedBitmap.size();
 		} else {
 			final Bitmap supersetBitmap = getSupersetFormula().compute();
 			if (supersetBitmap.isEmpty()) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
@@ -40,7 +40,7 @@ import java.util.Arrays;
 import java.util.function.Consumer;
 
 /**
- * And formula will perform boolean negation (NOT) on two bitmaps: superset and subtracted one
+ * Not formula will perform boolean negation (NOT) on two bitmaps: superset and subtracted one
  * Example input:
  *
  * superset:   [   2, 3, 4, 5, 8]

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
@@ -151,7 +151,7 @@ public class NotFormula extends AbstractCacheableFormula {
 
 	@Nonnull
 	@Override
-	public long[] gatherBitmapIdsInternal() {
+	protected long[] gatherBitmapIdsInternal() {
 		if (this.subtractedBitmap != null && this.supersetBitmap != null) {
 			int idx = 0;
 			final long[] ids = new long[2];
@@ -168,7 +168,7 @@ public class NotFormula extends AbstractCacheableFormula {
 	}
 
 	@Override
-	public long getEstimatedCostInternal() {
+	protected long getEstimatedCostInternal() {
 		if (this.subtractedBitmap != null && this.supersetBitmap != null) {
 			try {
 				long costs = this.subtractedBitmap.size();

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/OrFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/OrFormula.java
@@ -114,8 +114,8 @@ public class OrFormula extends AbstractBitmapCacheableFormula {
 			return super.getEstimatedBaseCost();
 		}
 		long sum = 0L;
-		for (int i = 0; i < this.bitmaps.length; i++) {
-			sum += this.bitmaps[i].size();
+		for (final Bitmap bitmap : this.bitmaps) {
+			sum += bitmap.size();
 		}
 		return sum;
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/OrFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/OrFormula.java
@@ -148,10 +148,10 @@ public class OrFormula extends AbstractBitmapCacheableFormula {
 			return super.getCostInternal();
 		}
 		long sum = 0L;
-		for (int i = 0; i < this.bitmaps.length; i++) {
-			sum += this.bitmaps[i].size();
+		for (final Bitmap bitmap : this.bitmaps) {
+			sum += bitmap.size();
 		}
-		return sum;
+		return sum * getOperationCost();
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/OrFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/OrFormula.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
- * And formula will perform boolean disjunction (OR) on multiple bitmaps at once.
+ * Or formula will perform boolean disjunction (OR) on multiple bitmaps at once.
  * Example input:
  *
  * [1,    3, 4, 5, 8]

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/OrFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/OrFormula.java
@@ -23,28 +23,21 @@
 
 package io.evitadb.core.query.algebra.base;
 
-import io.evitadb.core.query.algebra.AbstractCacheableFormula;
+import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.CacheableFormula;
 import io.evitadb.core.query.algebra.Formula;
-import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
-import net.openhft.hashing.LongHashFunction;
 import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
-
-import static java.util.Optional.ofNullable;
 
 /**
  * And formula will perform boolean disjunction (OR) on multiple bitmaps at once.
@@ -60,42 +53,31 @@ import static java.util.Optional.ofNullable;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-public class OrFormula extends AbstractCacheableFormula {
+public class OrFormula extends AbstractBitmapCacheableFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -7493244674442362190L;
-	private static final Bitmap[] EMPTY_BITMAP_ARRAY = new Bitmap[0];
-	private final Bitmap[] bitmaps;
-	private final long[] indexTransactionId;
 
 	OrFormula(@Nonnull Consumer<CacheableFormula> computationCallback, @Nonnull Formula[] innerFormulas, long[] indexTransactionId, @Nullable Bitmap[] bitmaps) {
-		super(computationCallback);
+		super(computationCallback, indexTransactionId, bitmaps);
 		Assert.isTrue(
 			innerFormulas.length > 1 || Objects.requireNonNull(bitmaps).length > 1,
 			"Or formula has no sense with " + innerFormulas.length + " inner formulas / bitmaps!"
 		);
-		this.bitmaps = bitmaps;
-		this.indexTransactionId = indexTransactionId;
 		this.initFields(innerFormulas);
 	}
 
 	public OrFormula(@Nonnull Formula... innerFormulas) {
-		super(null);
+		super(null, null, null);
 		Assert.isTrue(innerFormulas.length > 1, "Or formula has no sense with " + innerFormulas.length + " inner formulas!");
-		this.bitmaps = null;
-		this.indexTransactionId = null;
 		this.initFields(innerFormulas);
 	}
 
 	public OrFormula(long[] indexTransactionId, @Nonnull Bitmap... bitmaps) {
-		super(null);
+		super(null, indexTransactionId, bitmaps);
 		Assert.isTrue(bitmaps.length > 1, "Or formula has no sense with " + bitmaps.length + " inner bitmaps!");
-		this.bitmaps = bitmaps;
-		this.indexTransactionId = indexTransactionId;
 		this.initFields();
-	}
-
-	@Nonnull
-	public Bitmap[] getBitmaps() {
-		return this.bitmaps == null ? EMPTY_BITMAP_ARRAY : this.bitmaps;
 	}
 
 	@Nonnull
@@ -126,59 +108,32 @@ public class OrFormula extends AbstractCacheableFormula {
 		);
 	}
 
-	@Nonnull
-	@Override
-	public long[] gatherBitmapIdsInternal() {
-		if (this.bitmaps == null) {
-			return Arrays.stream(this.innerFormulas)
-				.flatMapToLong(it -> LongStream.of(it.gatherTransactionalIds()))
-				.toArray();
-		} else {
-			return LongStream.concat(
-				this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY ?
-					LongStream.of(this.indexTransactionId) :
-					Arrays.stream(this.bitmaps)
-						.filter(TransactionalLayerProducer.class::isInstance)
-						.mapToLong(it -> ((TransactionalLayerProducer<?, ?>) it).getId()),
-				Arrays.stream(this.innerFormulas).flatMapToLong(it -> LongStream.of(it.gatherTransactionalIds()))
-			).toArray();
-		}
-	}
-
 	@Override
 	protected long getEstimatedBaseCost() {
-		return ofNullable(this.bitmaps)
-			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).sum())
-			.orElseGet(super::getEstimatedBaseCost);
+		if (this.bitmaps == null) {
+			return super.getEstimatedBaseCost();
+		}
+		long sum = 0L;
+		for (int i = 0; i < this.bitmaps.length; i++) {
+			sum += this.bitmaps[i].size();
+		}
+		return sum;
 	}
 
 	@Override
 	public int getEstimatedCardinality() {
 		if (this.bitmaps == null) {
-			return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).sum();
+			int sum = 0;
+			for (int i = 0; i < this.innerFormulas.length; i++) {
+				sum += this.innerFormulas[i].getEstimatedCardinality();
+			}
+			return sum;
 		} else {
-			return Arrays.stream(this.bitmaps).mapToInt(Bitmap::size).sum();
-		}
-	}
-
-	@Override
-	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
-		if (this.bitmaps == null) {
-			return 0L;
-		} else {
-			return hashFunction.hashLongs(
-				Arrays.stream(this.bitmaps).mapToLong(it -> {
-						if (it instanceof TransactionalLayerProducer) {
-							return ((TransactionalLayerProducer<?, ?>) it).getId();
-						} else {
-							// this shouldn't happen for long arrays - these are expected to be always linked to transactional
-							// bitmaps located in indexes and represented by "transactional id"
-							return hashFunction.hashInts(it.getArray());
-						}
-					})
-					.sorted()
-					.toArray()
-			);
+			int sum = 0;
+			for (int i = 0; i < this.bitmaps.length; i++) {
+				sum += this.bitmaps[i].size();
+			}
+			return sum;
 		}
 	}
 
@@ -189,9 +144,14 @@ public class OrFormula extends AbstractCacheableFormula {
 
 	@Override
 	protected long getCostInternal() {
-		return ofNullable(this.bitmaps)
-			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).sum())
-			.orElseGet(super::getCostInternal);
+		if (this.bitmaps == null) {
+			return super.getCostInternal();
+		}
+		long sum = 0L;
+		for (int i = 0; i < this.bitmaps.length; i++) {
+			sum += this.bitmaps[i].size();
+		}
+		return sum;
 	}
 
 	@Override
@@ -199,7 +159,15 @@ public class OrFormula extends AbstractCacheableFormula {
 		if (ArrayUtils.isEmpty(this.bitmaps)) {
 			return "OR";
 		} else {
-			return "OR: " + Arrays.stream(this.bitmaps).map(Bitmap::toString).collect(Collectors.joining(", "));
+			final StringBuilder sb = new StringBuilder(this.bitmaps.length * 16 + 8);
+			sb.append("OR: ");
+			for (int i = 0; i < this.bitmaps.length; i++) {
+				if (i > 0) {
+					sb.append(", ");
+				}
+				sb.append(this.bitmaps[i].toString());
+			}
+			return sb.toString();
 		}
 	}
 
@@ -224,17 +192,20 @@ public class OrFormula extends AbstractCacheableFormula {
 
 	@Nonnull
 	private RoaringBitmap[] getRoaringBitmaps() {
-		return ofNullable(this.bitmaps)
-			.map(it -> Arrays
-				.stream(it).map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-				.toArray(RoaringBitmap[]::new)
-			)
-			.orElseGet(
-				() -> Arrays.stream(getInnerFormulas())
-					.map(Formula::compute)
-					.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-					.toArray(RoaringBitmap[]::new)
-			);
+		if (this.bitmaps != null) {
+			final RoaringBitmap[] result = new RoaringBitmap[this.bitmaps.length];
+			for (int i = 0; i < this.bitmaps.length; i++) {
+				result[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(this.bitmaps[i]);
+			}
+			return result;
+		} else {
+			final Formula[] formulas = getInnerFormulas();
+			final RoaringBitmap[] result = new RoaringBitmap[formulas.length];
+			for (int i = 0; i < formulas.length; i++) {
+				result[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(formulas[i].compute());
+			}
+			return result;
+		}
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/deferred/DeferredFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/deferred/DeferredFormula.java
@@ -40,7 +40,13 @@ import java.util.function.Supplier;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class DeferredFormula extends AbstractFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 8831456737770154017L;
+	/**
+	 * Supplier providing the lazily computed bitmap result of this deferred formula.
+	 */
 	protected final BitmapSupplier retrieveLambda;
 
 	public DeferredFormula(@Nonnull BitmapSupplier retrieveLambda) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/deferred/FormulaWrapper.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/deferred/FormulaWrapper.java
@@ -39,9 +39,21 @@ import java.util.function.BiFunction;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2023
  */
 public class FormulaWrapper implements BitmapSupplier {
+	/**
+	 * The delegate formula whose computation is wrapped by this supplier.
+	 */
 	private final Formula formula;
+	/**
+	 * Lambda invoked on the first call to {@link #get()} to compute and memoize the bitmap result.
+	 */
 	private final BiFunction<QueryExecutionContext, Formula, Bitmap> firstInvocation;
+	/**
+	 * Execution context from initialization phase.
+	 */
 	private QueryExecutionContext executionContext;
+	/**
+	 * Memoized bitmap result computed by {@link #firstInvocation}, `null` until first access.
+	 */
 	private Bitmap computed;
 
 	public FormulaWrapper(

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/CombinedFacetFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/CombinedFacetFormula.java
@@ -30,21 +30,24 @@ import io.evitadb.core.query.algebra.base.OrFormula;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
+import io.evitadb.utils.Assert;
 import net.openhft.hashing.LongHashFunction;
 import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
 
 /**
  * This formula has almost identical implementation as {@link OrFormula} but it accepts only set of
- * {@link Formula} as a children and allows containing even single child (on the contrary to the {@link OrFormula}).
- * The formula envelopes both AND joined facet formulas and OR joined facet formulas and allows to distinguish between
- * them and so that newly added formulas for clone can target proper container in this formula.
+ * {@link Formula} as a child and allows containing even single child (on the contrary to the {@link OrFormula}).
+ * The formula envelops both AND joined facet formulas and OR joined facet formulas and allows to distinguish between
+ * them and so that newly added formulas for clone can target the proper container in this formula.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class CombinedFacetFormula extends AbstractFormula implements NonCacheableFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 523840934350100709L;
 
 	public CombinedFacetFormula(@Nonnull Formula andFormula, @Nonnull Formula orFormula) {
@@ -58,6 +61,10 @@ public class CombinedFacetFormula extends AbstractFormula implements NonCacheabl
 	@Nonnull
 	@Override
 	public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {
+		Assert.isPremiseValid(
+			innerFormulas.length == 2,
+			"CombinedFacetFormula requires exactly 2 inner formulas (AND + OR), but got " + innerFormulas.length + "."
+		);
 		return new CombinedFacetFormula(innerFormulas);
 	}
 
@@ -76,20 +83,22 @@ public class CombinedFacetFormula extends AbstractFormula implements NonCacheabl
 
 	@Override
 	public int getEstimatedCardinality() {
-		return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).sum();
+		int sum = 0;
+		for (Formula innerFormula : this.innerFormulas) {
+			sum += innerFormula.getEstimatedCardinality();
+		}
+		return sum;
 	}
 
 	@Nonnull
 	@Override
 	protected Bitmap computeInternal() {
-		return new BaseBitmap(
-			RoaringBitmap.or(
-				Arrays.stream(getInnerFormulas())
-					.map(Formula::compute)
-					.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-					.toArray(RoaringBitmap[]::new)
-			)
-		);
+		final Formula[] formulas = getInnerFormulas();
+		final RoaringBitmap[] roaringBitmaps = new RoaringBitmap[formulas.length];
+		for (int i = 0; i < formulas.length; i++) {
+			roaringBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(formulas[i].compute());
+		}
+		return new BaseBitmap(RoaringBitmap.or(roaringBitmaps));
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
@@ -129,7 +129,11 @@ public class FacetGroupAndFormula extends AbstractFormula implements FacetGroupF
 		for (final Bitmap bitmap : this.bitmaps) {
 			sum += bitmap.size();
 		}
-		return sum;
+		// multiply by operation cost: baseCost represents the full work on direct bitmap data
+		// (scanning all elements and applying the AND operation to each). Without this multiplier,
+		// the estimated cost would fall below actual cost because `getEstimatedCardinality()` returns
+		// `min` (output bound), which underestimates the total per-element work of `sum * opCost`.
+		return sum * getOperationCost();
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
@@ -125,17 +125,11 @@ public class FacetGroupAndFormula extends AbstractFormula implements FacetGroupF
 
 	@Override
 	protected long getEstimatedBaseCost() {
-		if (this.bitmaps.length == 0) {
-			return 0L;
-		}
-		long min = Long.MAX_VALUE;
+		long sum = 0L;
 		for (final Bitmap bitmap : this.bitmaps) {
-			final long size = bitmap.size();
-			if (size < min) {
-				min = size;
-			}
+			sum += bitmap.size();
 		}
-		return min;
+		return sum;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
@@ -187,13 +187,10 @@ public class FacetGroupAndFormula extends AbstractFormula implements FacetGroupF
 
 	@Override
 	protected long getCostInternal() {
-		if (this.bitmaps != null) {
-			long sum = 0L;
-			for (Bitmap bitmap : this.bitmaps) {
-				sum += bitmap.size();
-			}
-			return sum;
+		long sum = 0L;
+		for (Bitmap bitmap : this.bitmaps) {
+			sum += bitmap.size();
 		}
-		return super.getCostInternal();
+		return sum;
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
@@ -125,11 +125,17 @@ public class FacetGroupAndFormula extends AbstractFormula implements FacetGroupF
 
 	@Override
 	protected long getEstimatedBaseCost() {
-		long sum = 0L;
-		for (Bitmap bitmap : this.bitmaps) {
-			sum += bitmap.size();
+		if (this.bitmaps.length == 0) {
+			return 0L;
 		}
-		return sum;
+		long min = Long.MAX_VALUE;
+		for (final Bitmap bitmap : this.bitmaps) {
+			final long size = bitmap.size();
+			if (size < min) {
+				min = size;
+			}
+		}
+		return min;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
@@ -125,43 +125,26 @@ public class FacetGroupAndFormula extends AbstractFormula implements FacetGroupF
 
 	@Override
 	protected long getEstimatedBaseCost() {
-		if (this.bitmaps != null) {
-			long sum = 0L;
-			for (Bitmap bitmap : this.bitmaps) {
-				sum += bitmap.size();
-			}
-			return sum;
+		long sum = 0L;
+		for (Bitmap bitmap : this.bitmaps) {
+			sum += bitmap.size();
 		}
-		return super.getEstimatedBaseCost();
+		return sum;
 	}
 
 	@Override
 	public int getEstimatedCardinality() {
-		if (this.bitmaps == null) {
-			if (this.innerFormulas.length == 0) {
-				return 0;
-			}
-			int min = Integer.MAX_VALUE;
-			for (Formula innerFormula : this.innerFormulas) {
-				final int cardinality = innerFormula.getEstimatedCardinality();
-				if (cardinality < min) {
-					min = cardinality;
-				}
-			}
-			return min;
-		} else {
-			if (this.bitmaps.length == 0) {
-				return 0;
-			}
-			int min = Integer.MAX_VALUE;
-			for (Bitmap bitmap : this.bitmaps) {
-				final int size = bitmap.size();
-				if (size < min) {
-					min = size;
-				}
-			}
-			return min;
+		if (this.bitmaps.length == 0) {
+			return 0;
 		}
+		int min = Integer.MAX_VALUE;
+		for (Bitmap bitmap : this.bitmaps) {
+			final int size = bitmap.size();
+			if (size < min) {
+				min = size;
+			}
+		}
+		return min;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
@@ -188,9 +188,9 @@ public class FacetGroupAndFormula extends AbstractFormula implements FacetGroupF
 	@Override
 	protected long getCostInternal() {
 		long sum = 0L;
-		for (Bitmap bitmap : this.bitmaps) {
+		for (final Bitmap bitmap : this.bitmaps) {
 			sum += bitmap.size();
 		}
-		return sum;
+		return sum * getOperationCost();
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupAndFormula.java
@@ -39,11 +39,6 @@ import org.roaringbitmap.RoaringBitmap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
-import static java.util.Optional.ofNullable;
 
 /**
  * This formula has almost identical implementation as {@link AndFormula} but it accepts only set of
@@ -54,6 +49,9 @@ import static java.util.Optional.ofNullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class FacetGroupAndFormula extends AbstractFormula implements FacetGroupFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 7601098585679511784L;
 	/**
 	 * Contains {@link FacetHaving#getReferenceName()} of the facet that is targeted by this formula.
@@ -106,72 +104,97 @@ public class FacetGroupAndFormula extends AbstractFormula implements FacetGroupF
 
 	@Override
 	public String toString() {
-		final StringBuilder sb = new StringBuilder("FACET " + this.referenceName + " AND (" + ofNullable(this.facetGroupId).map(Object::toString).orElse("-") + " - " + this.facetIds.toString() + "): ");
-		for (int i = 0; i < this.bitmaps.length; i++) {
-			final Bitmap bitmap = this.bitmaps[i];
-			sb.append(" ↦ ").append(bitmap.size());
-			if (i + 1 < this.facetIds.size()) {
-				sb.append(", ");
-			}
-		}
-		return sb.append(" primary keys").toString();
+		return FacetGroupFormula.toStringRepresentation("AND", this.referenceName, this.facetGroupId, this.facetIds, this.bitmaps);
 	}
 
 	@Nonnull
 	@Override
 	public String toStringVerbose() {
-		final StringBuilder sb = new StringBuilder("FACET " + this.referenceName + " AND (" + ofNullable(this.facetGroupId).map(Object::toString).orElse("-") + " - " + this.facetIds.toString() + "): ");
-		for (int i = 0; i < this.bitmaps.length; i++) {
-			final Bitmap bitmap = this.bitmaps[i];
-			sb.append(" ↦ ").append(bitmap.toString());
-			if (i + 1 < this.facetIds.size()) {
-				sb.append(", ");
-			}
-		}
-		return sb.toString();
+		return FacetGroupFormula.toStringVerboseRepresentation("AND", this.referenceName, this.facetGroupId, this.facetIds, this.bitmaps);
 	}
 
 	@Nonnull
 	@Override
 	protected Bitmap computeInternal() {
-		return RoaringBitmapBackedBitmap.and(
-			Arrays.stream(this.bitmaps)
-				.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-				.toArray(RoaringBitmap[]::new)
-		);
+		final RoaringBitmap[] roaringBitmaps = new RoaringBitmap[this.bitmaps.length];
+		for (int i = 0; i < this.bitmaps.length; i++) {
+			roaringBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(this.bitmaps[i]);
+		}
+		return RoaringBitmapBackedBitmap.and(roaringBitmaps);
 	}
 
 	@Override
 	protected long getEstimatedBaseCost() {
-		return ofNullable(this.bitmaps)
-			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).sum())
-			.orElseGet(super::getEstimatedBaseCost);
+		if (this.bitmaps != null) {
+			long sum = 0L;
+			for (Bitmap bitmap : this.bitmaps) {
+				sum += bitmap.size();
+			}
+			return sum;
+		}
+		return super.getEstimatedBaseCost();
 	}
 
 	@Override
 	public int getEstimatedCardinality() {
 		if (this.bitmaps == null) {
-			return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).min().orElse(0);
+			if (this.innerFormulas.length == 0) {
+				return 0;
+			}
+			int min = Integer.MAX_VALUE;
+			for (Formula innerFormula : this.innerFormulas) {
+				final int cardinality = innerFormula.getEstimatedCardinality();
+				if (cardinality < min) {
+					min = cardinality;
+				}
+			}
+			return min;
 		} else {
-			return Arrays.stream(this.bitmaps).mapToInt(Bitmap::size).min().orElse(0);
+			if (this.bitmaps.length == 0) {
+				return 0;
+			}
+			int min = Integer.MAX_VALUE;
+			for (Bitmap bitmap : this.bitmaps) {
+				final int size = bitmap.size();
+				if (size < min) {
+					min = size;
+				}
+			}
+			return min;
 		}
 	}
 
 	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
-		return hashFunction.hashLongs(
-			Stream.of(
-					LongStream.of(hashFunction.hashChars(this.referenceName)),
-					this.facetGroupId == null ? LongStream.empty() : LongStream.of(this.facetGroupId),
-					StreamSupport.stream(this.facetIds.spliterator(), false).mapToLong(it -> it),
-					Arrays.stream(this.bitmaps)
-						.filter(TransactionalBitmap.class::isInstance)
-						.mapToLong(it -> ((TransactionalBitmap) it).getId())
-						.sorted()
-				)
-				.flatMapToLong(it -> it)
-				.toArray()
-		);
+		// count transactional bitmaps for pre-sizing
+		int transactionalCount = 0;
+		for (Bitmap bitmap : this.bitmaps) {
+			if (bitmap instanceof TransactionalBitmap) {
+				transactionalCount++;
+			}
+		}
+		// 1 (referenceName hash) + groupId (0 or 1) + facetIds count + transactional bitmap count
+		final int groupIdSize = this.facetGroupId == null ? 0 : 1;
+		final long[] hashes = new long[1 + groupIdSize + this.facetIds.size() + transactionalCount];
+		int idx = 0;
+		hashes[idx++] = hashFunction.hashChars(this.referenceName);
+		if (this.facetGroupId != null) {
+			hashes[idx++] = this.facetGroupId;
+		}
+		for (int facetId : this.facetIds) {
+			hashes[idx++] = facetId;
+		}
+		// collect transactional bitmap ids into a temporary array for sorting
+		final long[] txIds = new long[transactionalCount];
+		int txIdx = 0;
+		for (Bitmap bitmap : this.bitmaps) {
+			if (bitmap instanceof TransactionalBitmap) {
+				txIds[txIdx++] = ((TransactionalBitmap) bitmap).getId();
+			}
+		}
+		Arrays.sort(txIds);
+		System.arraycopy(txIds, 0, hashes, idx, txIds.length);
+		return hashFunction.hashLongs(hashes);
 	}
 
 	@Override
@@ -181,8 +204,13 @@ public class FacetGroupAndFormula extends AbstractFormula implements FacetGroupF
 
 	@Override
 	protected long getCostInternal() {
-		return ofNullable(this.bitmaps)
-			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).sum())
-			.orElseGet(super::getCostInternal);
+		if (this.bitmaps != null) {
+			long sum = 0L;
+			for (Bitmap bitmap : this.bitmaps) {
+				sum += bitmap.size();
+			}
+			return sum;
+		}
+		return super.getCostInternal();
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupFormula.java
@@ -48,12 +48,74 @@ import static java.util.Optional.ofNullable;
 
 /**
  * Interface marks all {@link Formula} that resolve facet filtering. This interface allows locating appropriate formulas
- * in the tree when {@link FacetStatisticsDepth#IMPACT} is requested to be computed and original requirements needs to
- * be altered in order to compute alternative searches.
+ * in the tree when {@link FacetStatisticsDepth#IMPACT} is requested to be computed and original requirements need to
+ * be altered to compute alternative searches.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public interface FacetGroupFormula extends NonCacheableFormula {
+
+	/**
+	 * Returns a compact string representation of a facet group formula showing per-facet bitmap sizes.
+	 *
+	 * @param operator     the logical operator name (e.g. "AND", "OR")
+	 * @param referenceName the reference name targeting the facet
+	 * @param facetGroupId the facet group id shared among all facets, or null if ungrouped
+	 * @param facetIds     bitmap of requested facet ids
+	 * @param bitmaps      array of bitmaps matching the requested facet ids
+	 * @return formatted string with bitmap sizes
+	 */
+	@Nonnull
+	static String toStringRepresentation(
+		@Nonnull String operator,
+		@Nonnull String referenceName,
+		@Nullable Integer facetGroupId,
+		@Nonnull Bitmap facetIds,
+		@Nonnull Bitmap[] bitmaps
+	) {
+		final String groupIdStr = facetGroupId == null ? "-" : facetGroupId.toString();
+		final StringBuilder sb = new StringBuilder(64);
+		sb.append("FACET ").append(referenceName).append(' ').append(operator)
+			.append(" (").append(groupIdStr).append(" - ").append(facetIds).append("): ");
+		for (int i = 0; i < bitmaps.length; i++) {
+			sb.append(" ↦ ").append(bitmaps[i].size());
+			if (i + 1 < facetIds.size()) {
+				sb.append(", ");
+			}
+		}
+		return sb.append(" primary keys").toString();
+	}
+
+	/**
+	 * Returns a verbose string representation of a facet group formula showing full bitmap contents.
+	 *
+	 * @param operator     the logical operator name (e.g. "AND", "OR")
+	 * @param referenceName the reference name targeting the facet
+	 * @param facetGroupId the facet group id shared among all facets, or null if ungrouped
+	 * @param facetIds     bitmap of requested facet ids
+	 * @param bitmaps      array of bitmaps matching the requested facet ids
+	 * @return formatted string with full bitmap contents
+	 */
+	@Nonnull
+	static String toStringVerboseRepresentation(
+		@Nonnull String operator,
+		@Nonnull String referenceName,
+		@Nullable Integer facetGroupId,
+		@Nonnull Bitmap facetIds,
+		@Nonnull Bitmap[] bitmaps
+	) {
+		final String groupIdStr = facetGroupId == null ? "-" : facetGroupId.toString();
+		final StringBuilder sb = new StringBuilder(128);
+		sb.append("FACET ").append(referenceName).append(' ').append(operator)
+			.append(" (").append(groupIdStr).append(" - ").append(facetIds).append("): ");
+		for (int i = 0; i < bitmaps.length; i++) {
+			sb.append(" ↦ ").append(bitmaps[i]);
+			if (i + 1 < facetIds.size()) {
+				sb.append(", ");
+			}
+		}
+		return sb.toString();
+	}
 
 	/**
 	 * Method merges two {@link FacetGroupFormula} of the same type related to same group id into the one.

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
@@ -190,9 +190,9 @@ public class FacetGroupOrFormula extends AbstractFormula implements FacetGroupFo
 	@Override
 	protected long getCostInternal() {
 		long sum = 0L;
-		for (Bitmap bitmap : this.bitmaps) {
+		for (final Bitmap bitmap : this.bitmaps) {
 			sum += bitmap.size();
 		}
-		return sum;
+		return sum * getOperationCost();
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
@@ -189,13 +189,10 @@ public class FacetGroupOrFormula extends AbstractFormula implements FacetGroupFo
 
 	@Override
 	protected long getCostInternal() {
-		if (this.bitmaps != null) {
-			long sum = 0L;
-			for (Bitmap bitmap : this.bitmaps) {
-				sum += bitmap.size();
-			}
-			return sum;
+		long sum = 0L;
+		for (Bitmap bitmap : this.bitmaps) {
+			sum += bitmap.size();
 		}
-		return super.getCostInternal();
+		return sum;
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
@@ -133,31 +133,20 @@ public class FacetGroupOrFormula extends AbstractFormula implements FacetGroupFo
 
 	@Override
 	protected long getEstimatedBaseCost() {
-		if (this.bitmaps != null) {
-			long sum = 0L;
-			for (Bitmap bitmap : this.bitmaps) {
-				sum += bitmap.size();
-			}
-			return sum;
+		long sum = 0L;
+		for (Bitmap bitmap : this.bitmaps) {
+			sum += bitmap.size();
 		}
-		return super.getEstimatedBaseCost();
+		return sum;
 	}
 
 	@Override
 	public int getEstimatedCardinality() {
-		if (this.bitmaps == null) {
-			int sum = 0;
-			for (Formula innerFormula : this.innerFormulas) {
-				sum += innerFormula.getEstimatedCardinality();
-			}
-			return sum;
-		} else {
-			int sum = 0;
-			for (Bitmap bitmap : this.bitmaps) {
-				sum += bitmap.size();
-			}
-			return sum;
+		int sum = 0;
+		for (Bitmap bitmap : this.bitmaps) {
+			sum += bitmap.size();
 		}
+		return sum;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetGroupOrFormula.java
@@ -41,11 +41,6 @@ import org.roaringbitmap.RoaringBitmap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
-import static java.util.Optional.ofNullable;
 
 /**
  * This formula has almost identical implementation as {@link OrFormula} but it accepts only set of
@@ -56,6 +51,9 @@ import static java.util.Optional.ofNullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class FacetGroupOrFormula extends AbstractFormula implements FacetGroupFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 2720865649065325701L;
 
 	/**
@@ -108,29 +106,13 @@ public class FacetGroupOrFormula extends AbstractFormula implements FacetGroupFo
 
 	@Override
 	public String toString() {
-		final StringBuilder sb = new StringBuilder("FACET " + this.referenceName + " OR (" + ofNullable(this.facetGroupId).map(Object::toString).orElse("-") + " - " + this.facetIds.toString() + "): ");
-		for (int i = 0; i < this.bitmaps.length; i++) {
-			final Bitmap bitmap = this.bitmaps[i];
-			sb.append(" ↦ ").append(bitmap.size());
-			if (i + 1 < this.facetIds.size()) {
-				sb.append(", ");
-			}
-		}
-		return sb.append(" primary keys").toString();
+		return FacetGroupFormula.toStringRepresentation("OR", this.referenceName, this.facetGroupId, this.facetIds, this.bitmaps);
 	}
 
 	@Nonnull
 	@Override
 	public String toStringVerbose() {
-		final StringBuilder sb = new StringBuilder("FACET " + this.referenceName + " OR (" + ofNullable(this.facetGroupId).map(Object::toString).orElse("-") + " - " + this.facetIds.toString() + "): ");
-		for (int i = 0; i < this.bitmaps.length; i++) {
-			final Bitmap bitmap = this.bitmaps[i];
-			sb.append(" ↦ ").append(bitmap.toString());
-			if (i + 1 < this.facetIds.size()) {
-				sb.append(", ");
-			}
-		}
-		return sb.toString();
+		return FacetGroupFormula.toStringVerboseRepresentation("OR", this.referenceName, this.facetGroupId, this.facetIds, this.bitmaps);
 	}
 
 	@Nonnull
@@ -141,47 +123,74 @@ public class FacetGroupOrFormula extends AbstractFormula implements FacetGroupFo
 		} else if (this.bitmaps.length == 1) {
 			return this.bitmaps[0];
 		} else {
-			return new BaseBitmap(
-				RoaringBitmap.or(
-					Arrays.stream(this.bitmaps)
-						.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-						.toArray(RoaringBitmap[]::new)
-				)
-			);
+			final RoaringBitmap[] roaringBitmaps = new RoaringBitmap[this.bitmaps.length];
+			for (int i = 0; i < this.bitmaps.length; i++) {
+				roaringBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(this.bitmaps[i]);
+			}
+			return new BaseBitmap(RoaringBitmap.or(roaringBitmaps));
 		}
 	}
 
 	@Override
 	protected long getEstimatedBaseCost() {
-		return ofNullable(this.bitmaps)
-			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).sum())
-			.orElseGet(super::getEstimatedBaseCost);
+		if (this.bitmaps != null) {
+			long sum = 0L;
+			for (Bitmap bitmap : this.bitmaps) {
+				sum += bitmap.size();
+			}
+			return sum;
+		}
+		return super.getEstimatedBaseCost();
 	}
 
 	@Override
 	public int getEstimatedCardinality() {
 		if (this.bitmaps == null) {
-			return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).sum();
+			int sum = 0;
+			for (Formula innerFormula : this.innerFormulas) {
+				sum += innerFormula.getEstimatedCardinality();
+			}
+			return sum;
 		} else {
-			return Arrays.stream(this.bitmaps).mapToInt(Bitmap::size).sum();
+			int sum = 0;
+			for (Bitmap bitmap : this.bitmaps) {
+				sum += bitmap.size();
+			}
+			return sum;
 		}
 	}
 
 	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
-		return hashFunction.hashLongs(
-			Stream.of(
-					LongStream.of(hashFunction.hashChars(this.referenceName)),
-					this.facetGroupId == null ? LongStream.empty() : LongStream.of(this.facetGroupId),
-					StreamSupport.stream(this.facetIds.spliterator(), false).mapToLong(it -> it),
-					Arrays.stream(this.bitmaps)
-						.filter(TransactionalBitmap.class::isInstance)
-						.mapToLong(it -> ((TransactionalBitmap) it).getId())
-						.sorted()
-				)
-				.flatMapToLong(it -> it)
-				.toArray()
-		);
+		// count transactional bitmaps for pre-sizing
+		int transactionalCount = 0;
+		for (Bitmap bitmap : this.bitmaps) {
+			if (bitmap instanceof TransactionalBitmap) {
+				transactionalCount++;
+			}
+		}
+		// 1 (referenceName hash) + groupId (0 or 1) + facetIds count + transactional bitmap count
+		final int groupIdSize = this.facetGroupId == null ? 0 : 1;
+		final long[] hashes = new long[1 + groupIdSize + this.facetIds.size() + transactionalCount];
+		int idx = 0;
+		hashes[idx++] = hashFunction.hashChars(this.referenceName);
+		if (this.facetGroupId != null) {
+			hashes[idx++] = this.facetGroupId;
+		}
+		for (int facetId : this.facetIds) {
+			hashes[idx++] = facetId;
+		}
+		// collect transactional bitmap ids into a temporary array for sorting
+		final long[] txIds = new long[transactionalCount];
+		int txIdx = 0;
+		for (Bitmap bitmap : this.bitmaps) {
+			if (bitmap instanceof TransactionalBitmap) {
+				txIds[txIdx++] = ((TransactionalBitmap) bitmap).getId();
+			}
+		}
+		Arrays.sort(txIds);
+		System.arraycopy(txIds, 0, hashes, idx, txIds.length);
+		return hashFunction.hashLongs(hashes);
 	}
 
 	@Override
@@ -191,8 +200,13 @@ public class FacetGroupOrFormula extends AbstractFormula implements FacetGroupFo
 
 	@Override
 	protected long getCostInternal() {
-		return ofNullable(this.bitmaps)
-			.map(it -> Arrays.stream(it).mapToLong(Bitmap::size).sum())
-			.orElseGet(super::getCostInternal);
+		if (this.bitmaps != null) {
+			long sum = 0L;
+			for (Bitmap bitmap : this.bitmaps) {
+				sum += bitmap.size();
+			}
+			return sum;
+		}
+		return super.getCostInternal();
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormula.java
@@ -80,6 +80,12 @@ public class ScopeContainerFormula extends AbstractCacheableFormula {
 	}
 
 	@Override
+	public void clearMemory() {
+		super.clearMemory();
+		this.sortedFormulasByComplexity = null;
+	}
+
+	@Override
 	public int getEstimatedCardinality() {
 		return getMinEstimatedCardinality(this.innerFormulas);
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormula.java
@@ -106,12 +106,6 @@ public class ScopeContainerFormula extends AbstractCacheableFormula {
 		);
 	}
 
-	@Nonnull
-	@Override
-	protected long[] gatherBitmapIdsInternal() {
-		return sortAndDeduplicateLongArray(super.gatherBitmapIdsInternal());
-	}
-
 	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
 		return 0L;

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormula.java
@@ -118,11 +118,17 @@ public class ScopeContainerFormula extends AbstractCacheableFormula {
 
 	@Override
 	protected long getCostInternal() {
+		if (this.sortedFormulasByComplexity == null) {
+			this.sortedFormulasByComplexity = sortFormulasByComplexity(getInnerFormulas());
+		}
 		return computeSortedConjunctionCost(this.sortedFormulasByComplexity, getOperationCost());
 	}
 
 	@Override
 	protected long getCostToPerformanceInternal() {
+		if (this.sortedFormulasByComplexity == null) {
+			this.sortedFormulasByComplexity = sortFormulasByComplexity(getInnerFormulas());
+		}
 		return computeSortedConjunctionCostToPerformance(this.sortedFormulasByComplexity)
 			+ getCost() / Math.max(1, compute().size());
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormula.java
@@ -27,23 +27,16 @@ import io.evitadb.core.query.algebra.AbstractCacheableFormula;
 import io.evitadb.core.query.algebra.CacheableFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.AndFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.filter.translator.behavioral.FilterInScopeTranslator.InScopeFormulaPostProcessor;
-import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
 import io.evitadb.dataType.Scope;
-import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
-import io.evitadb.index.bitmap.EmptyBitmap;
-import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import lombok.Getter;
 import net.openhft.hashing.LongHashFunction;
-import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.LongStream;
 
 /**
  * This formula has almost identical implementation as {@link AndFormula} but it accepts only set of
@@ -54,12 +47,22 @@ import java.util.stream.LongStream;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
 public class ScopeContainerFormula extends AbstractCacheableFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractCacheableFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -5387565378948662756L;
 	/**
 	 * The scope that is used to filter the data.
 	 */
 	@Getter private final Scope scope;
+	/**
+	 * Array of transactional ids of the indexes that were used to build this formula, used for cache invalidation.
+	 */
 	private final long[] indexTransactionId;
+	/**
+	 * Lazily initialized list of inner formulas sorted by their estimated cost in ascending order, used to
+	 * short-circuit AND evaluation starting from the cheapest formula.
+	 */
 	private List<Formula> sortedFormulasByComplexity;
 
 	public ScopeContainerFormula(@Nonnull Consumer<CacheableFormula> computationCallback, @Nonnull Scope scope, @Nonnull Formula[] innerFormulas, @Nonnull long[] indexTransactionId) {
@@ -78,7 +81,7 @@ public class ScopeContainerFormula extends AbstractCacheableFormula {
 
 	@Override
 	public int getEstimatedCardinality() {
-		return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).min().orElse(0);
+		return getMinEstimatedCardinality(this.innerFormulas);
 	}
 
 	@Override
@@ -100,10 +103,7 @@ public class ScopeContainerFormula extends AbstractCacheableFormula {
 	@Nonnull
 	@Override
 	public long[] gatherBitmapIdsInternal() {
-		return Arrays.stream(this.innerFormulas)
-			.flatMapToLong(it -> LongStream.of(it.gatherTransactionalIds()))
-			.distinct()
-			.toArray();
+		return sortAndDeduplicateLongArray(super.gatherBitmapIdsInternal());
 	}
 
 	@Override
@@ -118,43 +118,22 @@ public class ScopeContainerFormula extends AbstractCacheableFormula {
 
 	@Override
 	protected long getCostInternal() {
-		long cost = 0L;
-		for (Formula innerFormula : this.sortedFormulasByComplexity) {
-			final Bitmap innerResult = innerFormula.compute();
-			cost += innerFormula.getCost() + innerResult.size() * getOperationCost();
-			if (innerResult == EmptyBitmap.INSTANCE) {
-				break;
-			}
-		}
-		return cost;
+		return computeSortedConjunctionCost(this.sortedFormulasByComplexity, getOperationCost());
 	}
 
 	@Override
 	protected long getCostToPerformanceInternal() {
-		long costToPerformance = 0L;
-		for (Formula innerFormula : this.sortedFormulasByComplexity) {
-			final Bitmap innerResult = innerFormula.compute();
-			if (innerResult == EmptyBitmap.INSTANCE) {
-				break;
-			}
-			costToPerformance += innerFormula.getCostToPerformanceRatio();
-		}
-		return costToPerformance + getCost() / Math.max(1, compute().size());
+		return computeSortedConjunctionCostToPerformance(this.sortedFormulasByComplexity)
+			+ getCost() / Math.max(1, compute().size());
 	}
 
 	@Nonnull
 	@Override
 	protected Bitmap computeInternal() {
-		final Bitmap theResult;
-		final RoaringBitmap[] theBitmaps = getRoaringBitmaps();
-		if (theBitmaps.length == 0 || Arrays.stream(theBitmaps).anyMatch(RoaringBitmap::isEmpty)) {
-			theResult = EmptyBitmap.INSTANCE;
-		} else if (theBitmaps.length == 1) {
-			theResult = new BaseBitmap(theBitmaps[0]);
-		} else {
-			theResult = RoaringBitmapBackedBitmap.and(theBitmaps);
+		if (this.sortedFormulasByComplexity == null) {
+			this.sortedFormulasByComplexity = sortFormulasByComplexity(getInnerFormulas());
 		}
-		return theResult.isEmpty() ? EmptyBitmap.INSTANCE : theResult;
+		return computeConjunctionResult(computeSortedConjunctionBitmaps(this.sortedFormulasByComplexity));
 	}
 
 	@Override
@@ -165,33 +144,10 @@ public class ScopeContainerFormula extends AbstractCacheableFormula {
 	@Nonnull
 	@Override
 	public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {
+		if (innerFormulas.length == 0) {
+			return EmptyFormula.INSTANCE;
+		}
 		return new ScopeContainerFormula(this.scope, innerFormulas);
-	}
-
-	/*
-		PRIVATE METHODS
-	 */
-
-	@Nonnull
-	private RoaringBitmap[] getRoaringBitmaps() {
-		if (this.sortedFormulasByComplexity == null) {
-			this.sortedFormulasByComplexity = Arrays.stream(getInnerFormulas())
-				.sorted(Comparator.comparingLong(TransactionalDataRelatedStructure::getEstimatedCost))
-				.toList();
-		}
-		final RoaringBitmap[] theBitmaps = new RoaringBitmap[this.sortedFormulasByComplexity.size()];
-		// go from the cheapest formula to the more expensive and compute one by one
-		for (int i = 0; i < this.sortedFormulasByComplexity.size(); i++) {
-			final Formula formula = this.sortedFormulasByComplexity.get(i);
-			final Bitmap computedBitmap = formula.compute();
-			// if you encounter formula that returns nothing immediately return nothing - hence AND
-			if (computedBitmap.isEmpty()) {
-				return new RoaringBitmap[0];
-			} else {
-				theBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(computedBitmap);
-			}
-		}
-		return theBitmaps;
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormula.java
@@ -108,7 +108,7 @@ public class ScopeContainerFormula extends AbstractCacheableFormula {
 
 	@Nonnull
 	@Override
-	public long[] gatherBitmapIdsInternal() {
+	protected long[] gatherBitmapIdsInternal() {
 		return sortAndDeduplicateLongArray(super.gatherBitmapIdsInternal());
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/UserFilterFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/UserFilterFormula.java
@@ -76,11 +76,17 @@ public class UserFilterFormula extends AbstractFormula implements NonCacheableFo
 
 	@Override
 	protected long getCostInternal() {
+		if (this.sortedFormulasByComplexity == null) {
+			this.sortedFormulasByComplexity = sortFormulasByComplexity(getInnerFormulas());
+		}
 		return computeSortedConjunctionCost(this.sortedFormulasByComplexity, getOperationCost());
 	}
 
 	@Override
 	protected long getCostToPerformanceInternal() {
+		if (this.sortedFormulasByComplexity == null) {
+			this.sortedFormulasByComplexity = sortFormulasByComplexity(getInnerFormulas());
+		}
 		return computeSortedConjunctionCostToPerformance(this.sortedFormulasByComplexity)
 			+ getCost() / Math.max(1, compute().size());
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/UserFilterFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/UserFilterFormula.java
@@ -29,17 +29,11 @@ import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.NonCacheableFormula;
 import io.evitadb.core.query.algebra.NonCacheableFormulaScope;
 import io.evitadb.core.query.algebra.base.AndFormula;
-import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
-import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.index.bitmap.Bitmap;
-import io.evitadb.index.bitmap.EmptyBitmap;
-import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import net.openhft.hashing.LongHashFunction;
-import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -52,7 +46,14 @@ import java.util.List;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class UserFilterFormula extends AbstractFormula implements NonCacheableFormula, NonCacheableFormulaScope {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 6890499931556487481L;
+	/**
+	 * Lazily initialized list of inner formulas sorted by their estimated cost in ascending order, used to
+	 * short-circuit AND evaluation starting from the cheapest formula.
+	 */
 	private List<Formula> sortedFormulasByComplexity;
 
 	public UserFilterFormula(@Nonnull Formula... innerFormulas) {
@@ -62,6 +63,9 @@ public class UserFilterFormula extends AbstractFormula implements NonCacheableFo
 	@Nonnull
 	@Override
 	public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {
+		if (innerFormulas.length == 0) {
+			return EmptyFormula.INSTANCE;
+		}
 		return new UserFilterFormula(innerFormulas);
 	}
 
@@ -72,48 +76,27 @@ public class UserFilterFormula extends AbstractFormula implements NonCacheableFo
 
 	@Override
 	protected long getCostInternal() {
-		long cost = 0L;
-		for (Formula innerFormula : this.sortedFormulasByComplexity) {
-			final Bitmap innerResult = innerFormula.compute();
-			cost += innerFormula.getCost() + innerResult.size() * getOperationCost();
-			if (innerResult == EmptyBitmap.INSTANCE) {
-				break;
-			}
-		}
-		return cost;
+		return computeSortedConjunctionCost(this.sortedFormulasByComplexity, getOperationCost());
 	}
 
 	@Override
 	protected long getCostToPerformanceInternal() {
-		long costToPerformance = 0L;
-		for (Formula innerFormula : this.sortedFormulasByComplexity) {
-			final Bitmap innerResult = innerFormula.compute();
-			if (innerResult == EmptyBitmap.INSTANCE) {
-				break;
-			}
-			costToPerformance += innerFormula.getCostToPerformanceRatio();
-		}
-		return costToPerformance + getCost() / Math.max(1, compute().size());
+		return computeSortedConjunctionCostToPerformance(this.sortedFormulasByComplexity)
+			+ getCost() / Math.max(1, compute().size());
 	}
 
 	@Nonnull
 	@Override
 	protected Bitmap computeInternal() {
-		final Bitmap theResult;
-		final RoaringBitmap[] theBitmaps = getRoaringBitmaps();
-		if (theBitmaps.length == 0 || Arrays.stream(theBitmaps).anyMatch(RoaringBitmap::isEmpty)) {
-			theResult = EmptyBitmap.INSTANCE;
-		} else if (theBitmaps.length == 1) {
-			theResult = new BaseBitmap(theBitmaps[0]);
-		} else {
-			theResult = RoaringBitmapBackedBitmap.and(theBitmaps);
+		if (this.sortedFormulasByComplexity == null) {
+			this.sortedFormulasByComplexity = sortFormulasByComplexity(getInnerFormulas());
 		}
-		return theResult.isEmpty() ? EmptyBitmap.INSTANCE : theResult;
+		return computeConjunctionResult(computeSortedConjunctionBitmaps(this.sortedFormulasByComplexity));
 	}
 
 	@Override
 	public int getEstimatedCardinality() {
-		return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).min().orElse(0);
+		return getMinEstimatedCardinality(this.innerFormulas);
 	}
 
 	@Override
@@ -131,29 +114,4 @@ public class UserFilterFormula extends AbstractFormula implements NonCacheableFo
 		return CLASS_ID;
 	}
 
-	/*
-		PRIVATE METHODS
-	 */
-
-	@Nonnull
-	private RoaringBitmap[] getRoaringBitmaps() {
-		if (this.sortedFormulasByComplexity == null) {
-			this.sortedFormulasByComplexity = Arrays.stream(getInnerFormulas())
-				.sorted(Comparator.comparingLong(TransactionalDataRelatedStructure::getEstimatedCost))
-				.toList();
-		}
-		final RoaringBitmap[] theBitmaps = new RoaringBitmap[this.sortedFormulasByComplexity.size()];
-		// go from the cheapest formula to the more expensive and compute one by one
-		for (int i = 0; i < this.sortedFormulasByComplexity.size(); i++) {
-			final Formula formula = this.sortedFormulasByComplexity.get(i);
-			final Bitmap computedBitmap = formula.compute();
-			// if you encounter formula that returns nothing immediately return nothing - hence AND
-			if (computedBitmap.isEmpty()) {
-				return new RoaringBitmap[0];
-			} else {
-				theBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(computedBitmap);
-			}
-		}
-		return theBitmaps;
-	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/UserFilterFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/UserFilterFormula.java
@@ -60,6 +60,12 @@ public class UserFilterFormula extends AbstractFormula implements NonCacheableFo
 		this.initFields(innerFormulas);
 	}
 
+	@Override
+	public void clearMemory() {
+		super.clearMemory();
+		this.sortedFormulasByComplexity = null;
+	}
+
 	@Nonnull
 	@Override
 	public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/hierarchy/HierarchyFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/hierarchy/HierarchyFormula.java
@@ -46,7 +46,13 @@ import javax.annotation.Nonnull;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2023
  */
 public class HierarchyFormula extends AbstractFormula implements ChildrenDependentFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -7910610363796304904L;
+	/**
+	 * Error message thrown when the formula does not contain exactly one inner formula.
+	 */
 	public static final String ERROR_SINGLE_FORMULA_EXPECTED = "Exactly one inner formula is expected!";
 
 	public HierarchyFormula(@Nonnull Formula innerFormula) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/infra/SkipFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/infra/SkipFormula.java
@@ -39,8 +39,17 @@ import javax.annotation.Nonnull;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class SkipFormula extends AbstractFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -8329967861689590212L;
+	/**
+	 * Singleton instance of this placeholder formula shared across the entire query engine.
+	 */
 	public static final SkipFormula INSTANCE = new SkipFormula();
+	/**
+	 * Error message thrown when any computational method is called on this placeholder formula.
+	 */
 	private static final String ERROR_CANNOT_BE_USED = "This formula is not expected to be used whatsoever!";
 
 	private SkipFormula() {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/locale/LocaleFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/locale/LocaleFormula.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.core.query.algebra.locale;
 
+import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.attribute.AttributeFormula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.filter.translator.entity.EntityLocaleEqualsTranslator;
@@ -38,6 +39,9 @@ import javax.annotation.Nonnull;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2023
  */
 public class LocaleFormula extends ConstantFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 6877689619565475680L;
 
 	public LocaleFormula(@Nonnull Bitmap delegate) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/EntityFilteringFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/EntityFilteringFormula.java
@@ -50,6 +50,9 @@ import javax.annotation.Nullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class EntityFilteringFormula extends AbstractFormula implements RequirementsDefiner, FilteredPriceRecordAccessor {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -1887923944737482575L;
 	/**
 	 * Contains a simple text, that would be used in an error message if the entities are not prefetched and computation

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/MultipleEntityFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/MultipleEntityFormula.java
@@ -46,8 +46,17 @@ import javax.annotation.Nonnull;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class MultipleEntityFormula extends AbstractFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 7381005856920907843L;
+	/**
+	 * Contains the bitmap of virtual entity primary keys that were translated from entity references.
+	 */
 	@Getter private final Bitmap directEntityReferences;
+	/**
+	 * Contains the transactional ids of the bitmaps that contributed to this formula for cache invalidation.
+	 */
 	private final long[] transactionalIds;
 
 	public MultipleEntityFormula(@Nonnull long[] transactionalIds, @Nonnull Bitmap directEntityReferences) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/PrefetchFormulaVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/PrefetchFormulaVisitor.java
@@ -45,7 +45,7 @@ import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -82,7 +82,7 @@ public class PrefetchFormulaVisitor implements FormulaVisitor, FormulaPostProces
 	/**
 	 * Contains all bitmaps of entity ids found in conjunctive scope of the formula.
 	 */
-	@Nonnull private final List<Bitmap> conjunctiveEntityIds = new LinkedList<>();
+	@Nonnull private final List<Bitmap> conjunctiveEntityIds = new ArrayList<>(16);
 	/**
 	 * Contains set of entity primary keys (masked by {@link QueryPlanningContext#translateEntityReference(EntityReferenceContract...)}
 	 * that needs to be prefetched.
@@ -150,7 +150,11 @@ public class PrefetchFormulaVisitor implements FormulaVisitor, FormulaPostProces
 			final Bitmap conjunctiveEntities = getConjunctiveEntities();
 			requirements = requirements == null ? getRequirements() : requirements;
 			// does the prefetch pay off?
-			if (requirements != null && getExpectedComputationalCosts() > this.queryContext.estimatePrefetchCost(conjunctiveEntities.size(), requirements)) {
+			if (
+				requirements != null
+					&& getExpectedComputationalCosts()
+					> this.queryContext.estimatePrefetchCost(conjunctiveEntities.size(), requirements)
+			) {
 				if (entitiesToPrefetch == null) {
 					entitiesToPrefetch = conjunctiveEntities;
 				} else {
@@ -167,15 +171,17 @@ public class PrefetchFormulaVisitor implements FormulaVisitor, FormulaPostProces
 						ReducedEntityIndex.class.isAssignableFrom(this.targetIndexes.getIndexType()),
 						"Only reduced entity indexes are supported"
 					);
+					final List<?> indexes = this.targetIndexes.getIndexes();
+					final RoaringBitmap[] indexBitmaps = new RoaringBitmap[indexes.size()];
+					for (int i = 0; i < indexes.size(); i++) {
+						indexBitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(
+							((ReducedEntityIndex) indexes.get(i)).getAllPrimaryKeys()
+						);
+					}
 					entitiesToPrefetch = RoaringBitmapBackedBitmap.and(
 						new RoaringBitmap[]{
 							RoaringBitmapBackedBitmap.getRoaringBitmap(entitiesToPrefetch),
-							RoaringBitmap.or(
-								this.targetIndexes.getIndexes().stream()
-									.map(index -> ((ReducedEntityIndex) index).getAllPrimaryKeys())
-									.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-									.toArray(RoaringBitmap[]::new)
-							)
+							RoaringBitmap.or(indexBitmaps)
 						}
 					);
 				}
@@ -255,16 +261,18 @@ public class PrefetchFormulaVisitor implements FormulaVisitor, FormulaPostProces
 	 */
 	@Nonnull
 	private Bitmap getConjunctiveEntities() {
-		return this.estimatedBitmapCardinality <= BITMAP_SIZE_THRESHOLD ?
-			this.conjunctiveEntityIds.stream()
-				.reduce((bitmapA, bitmapB) -> {
-					final RoaringBitmap roaringBitmapA = RoaringBitmapBackedBitmap.getRoaringBitmap(bitmapA);
-					final RoaringBitmap roaringBitmapB = RoaringBitmapBackedBitmap.getRoaringBitmap(bitmapB);
-					return new BaseBitmap(
-						RoaringBitmap.and(roaringBitmapA, roaringBitmapB)
-					);
-				})
-				.orElse(EmptyBitmap.INSTANCE) : EmptyBitmap.INSTANCE;
+		if (this.estimatedBitmapCardinality > BITMAP_SIZE_THRESHOLD || this.conjunctiveEntityIds.isEmpty()) {
+			return EmptyBitmap.INSTANCE;
+		}
+		Bitmap result = this.conjunctiveEntityIds.get(0);
+		for (int i = 1; i < this.conjunctiveEntityIds.size(); i++) {
+			final RoaringBitmap roaringBitmapA = RoaringBitmapBackedBitmap.getRoaringBitmap(result);
+			final RoaringBitmap roaringBitmapB = RoaringBitmapBackedBitmap.getRoaringBitmap(
+				this.conjunctiveEntityIds.get(i)
+			);
+			result = new BaseBitmap(RoaringBitmap.and(roaringBitmapA, roaringBitmapB));
+		}
+		return result;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/SelectionFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/SelectionFormula.java
@@ -67,6 +67,9 @@ import java.util.Optional;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class SelectionFormula extends AbstractFormula implements ChildrenDependentFormula, FilteredPriceRecordAccessor, FilteredOutPriceRecordAccessor, RequirementsDefiner {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 3311110127363103780L;
 	/**
 	 * Contains the alternative computation based on entity contents filtering.

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/SelectionFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/prefetch/SelectionFormula.java
@@ -90,7 +90,7 @@ public class SelectionFormula extends AbstractFormula implements ChildrenDepende
 	@Nullable private Long prefetchEstimatedCost;
 
 	public SelectionFormula(@Nonnull Formula delegate, @Nonnull EntityToBitmapFilter alternative) {
-		Assert.notNull(!(delegate instanceof SkipFormula), "The delegate formula cannot be a skip formula!");
+		Assert.isTrue(!(delegate instanceof SkipFormula), "The delegate formula cannot be a skip formula!");
 		this.alternative = alternative;
 		this.initFields(delegate);
 	}
@@ -206,13 +206,14 @@ public class SelectionFormula extends AbstractFormula implements ChildrenDepende
 				// otherwise collect the filtered records from the delegate
 				.orElseGet(() -> {
 					// collect all FilteredPriceRecordAccessor that were involved in computing delegate result
-					final Formula[] filteredOutRecords = FormulaFinder.findAmongChildren(
-							this, FilteredOutPriceRecordAccessor.class, LookUp.SHALLOW
-						)
-						.stream()
-						.map(FilteredOutPriceRecordAccessor::getCloneWithPricePredicateFilteredOutResults)
-						.toArray(Formula[]::new);
-
+					final Collection<FilteredOutPriceRecordAccessor> accessors = FormulaFinder.findAmongChildren(
+						this, FilteredOutPriceRecordAccessor.class, LookUp.SHALLOW
+					);
+					final Formula[] filteredOutRecords = new Formula[accessors.size()];
+					int index = 0;
+					for (FilteredOutPriceRecordAccessor accessor : accessors) {
+						filteredOutRecords[index++] = accessor.getCloneWithPricePredicateFilteredOutResults();
+					}
 					return FormulaFactory.or(filteredOutRecords);
 				});
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/filteredPriceRecords/FilteredPriceRecords.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/filteredPriceRecords/FilteredPriceRecords.java
@@ -48,7 +48,6 @@ import org.roaringbitmap.RoaringBitmapWriter;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -78,9 +77,17 @@ public interface FilteredPriceRecords extends Serializable {
 	FilteredPriceRecords EMPTY = new ResolvedFilteredPriceRecords();
 
 	/**
-	 * Method collects all {@link FilteredPriceRecords} from all inner formulas of `parentFormula` tree that implement
-	 * {@link FilteredPriceRecordAccessor} interface. All those objects are aggregated and reduced to single instance
-	 * of {@link FilteredPriceRecords} that represents all of them.
+	 * Collects all {@link FilteredPriceRecords} from {@link FilteredPriceRecordAccessor} nodes
+	 * found in the `parentFormula` tree and reduces them into a single {@link FilteredPriceRecords}
+	 * instance. When `narrowToEntityIds` is provided, only prices linked to those entities are
+	 * retained. The result may be a {@link ResolvedFilteredPriceRecords},
+	 * {@link LazyEvaluatedEntityPriceRecords}, or a {@link CombinedPriceRecords} depending on
+	 * the mix of accessor types found.
+	 *
+	 * @param parentFormula     root of the formula tree to search for price record accessors
+	 * @param narrowToEntityIds optional bitmap to restrict results to specific entity primary keys
+	 * @param context           current query execution context
+	 * @return aggregated price records covering all accessors in the formula tree
 	 */
 	@Nonnull
 	static FilteredPriceRecords createFromFormulas(
@@ -93,11 +100,19 @@ public interface FilteredPriceRecords extends Serializable {
 			parentFormula, FilteredPriceRecordAccessor.class, LookUp.SHALLOW
 		);
 
-		final List<FilteredPriceRecords> filteredPriceRecords = filteredPriceRecordAccessors
-			.stream()
-			.map(it -> it.getFilteredPriceRecords(context))
-			.map(it -> it instanceof NonResolvedFilteredPriceRecords ? ((NonResolvedFilteredPriceRecords) it).toResolvedFilteredPriceRecords() : it)
-			.toList();
+		final List<FilteredPriceRecords> filteredPriceRecords;
+		{
+			final FilteredPriceRecords[] arr = new FilteredPriceRecords[filteredPriceRecordAccessors.size()];
+			int idx = 0;
+			for (FilteredPriceRecordAccessor accessor : filteredPriceRecordAccessors) {
+				FilteredPriceRecords records = accessor.getFilteredPriceRecords(context);
+				if (records instanceof NonResolvedFilteredPriceRecords) {
+					records = ((NonResolvedFilteredPriceRecords) records).toResolvedFilteredPriceRecords();
+				}
+				arr[idx++] = records;
+			}
+			filteredPriceRecords = List.of(arr);
+		}
 
 		// there are no filtered price accessors or narrowed bitmap produces no output
 		if (filteredPriceRecords.isEmpty() || (narrowToEntityIds != null && narrowToEntityIds.isEmpty())) {
@@ -134,17 +149,41 @@ public interface FilteredPriceRecords extends Serializable {
 		}
 	}
 
+	/**
+	 * Extracts all {@link PriceListAndCurrencyPriceIndex} references from accessors whose
+	 * {@link FilteredPriceRecords} are {@link LazyEvaluatedEntityPriceRecords} and merges them
+	 * into a single {@link LazyEvaluatedEntityPriceRecords} instance. Returns empty if none
+	 * of the accessors use lazy evaluation.
+	 *
+	 * @param filteredPriceRecordAccessors accessors to inspect for lazy price records
+	 * @param context                     current query execution context
+	 * @return combined lazy price records, or empty if no lazy records found
+	 */
 	@Nonnull
 	private static Optional<LazyEvaluatedEntityPriceRecords> getLazyEvaluatedEntityPriceRecords(
 		@Nonnull Collection<FilteredPriceRecordAccessor> filteredPriceRecordAccessors,
 		@Nonnull QueryExecutionContext context
 	) {
-		final PriceListAndCurrencyPriceIndex<?, ?>[] priceIndexes = filteredPriceRecordAccessors.stream()
-			.map(it -> it.getFilteredPriceRecords(context))
-			.filter(LazyEvaluatedEntityPriceRecords.class::isInstance)
-			.map(LazyEvaluatedEntityPriceRecords.class::cast)
-			.flatMap(it -> Arrays.stream(it.getPriceIndexes()))
-			.toArray(PriceListAndCurrencyPriceIndex[]::new);
+		// cache results to avoid calling getFilteredPriceRecords twice per accessor
+		final FilteredPriceRecords[] cachedRecords = new FilteredPriceRecords[filteredPriceRecordAccessors.size()];
+		int totalIndexCount = 0;
+		int idx = 0;
+		for (FilteredPriceRecordAccessor accessor : filteredPriceRecordAccessors) {
+			final FilteredPriceRecords records = accessor.getFilteredPriceRecords(context);
+			cachedRecords[idx++] = records;
+			if (records instanceof LazyEvaluatedEntityPriceRecords lazy) {
+				totalIndexCount += lazy.getPriceIndexes().length;
+			}
+		}
+		final PriceListAndCurrencyPriceIndex<?, ?>[] priceIndexes = new PriceListAndCurrencyPriceIndex[totalIndexCount];
+		int offset = 0;
+		for (final FilteredPriceRecords cachedRecord : cachedRecords) {
+			if (cachedRecord instanceof LazyEvaluatedEntityPriceRecords lazy) {
+				final PriceListAndCurrencyPriceIndex<?, ?>[] indexes = lazy.getPriceIndexes();
+				System.arraycopy(indexes, 0, priceIndexes, offset, indexes.length);
+				offset += indexes.length;
+			}
+		}
 		return ArrayUtils.isEmpty(priceIndexes) ?
 			empty() :
 			of(
@@ -154,6 +193,16 @@ public interface FilteredPriceRecords extends Serializable {
 			);
 	}
 
+	/**
+	 * Filters resolved price records to only include prices whose entity primary key is present
+	 * in `narrowToEntityIds`. Iterates over the narrowing bitmap in batches via
+	 * {@link SharedBufferPool} and looks up matching prices through {@link PriceRecordLookup}.
+	 *
+	 * @param narrowToEntityIds    bitmap of entity primary keys to retain
+	 * @param filteredPriceRecords all collected price records (only resolved ones are examined)
+	 * @param requirePriceFound    when true, asserts that every entity id maps to at least one price
+	 * @return resolved price records narrowed to matching entities, or empty if no resolved records exist
+	 */
 	@Nonnull
 	private static Optional<ResolvedFilteredPriceRecords> getNarrowedResolvedFilteredPriceRecords(
 		@Nonnull Bitmap narrowToEntityIds,
@@ -167,22 +216,36 @@ public interface FilteredPriceRecords extends Serializable {
 				RoaringBitmapBackedBitmap.getRoaringBitmap(narrowToEntityIds).getBatchIterator(),
 				buffer
 			);
-			final PriceRecordLookup[] priceRecordIterators = filteredPriceRecords.stream()
-				.filter(ResolvedFilteredPriceRecords.class::isInstance)
-				.map(FilteredPriceRecords::getPriceRecordsLookup)
-				.toArray(PriceRecordLookup[]::new);
+			int lookupCount = 0;
+			for (FilteredPriceRecords priceRecord : filteredPriceRecords) {
+				if (priceRecord instanceof ResolvedFilteredPriceRecords) {
+					lookupCount++;
+				}
+			}
+			final PriceRecordLookup[] priceRecordIterators = new PriceRecordLookup[lookupCount];
+			int lookupIdx = 0;
+			for (FilteredPriceRecords filteredPriceRecord : filteredPriceRecords) {
+				if (filteredPriceRecord instanceof ResolvedFilteredPriceRecords) {
+					priceRecordIterators[lookupIdx++] = filteredPriceRecord.getPriceRecordsLookup();
+				}
+			}
 			if (ArrayUtils.isEmpty(priceRecordIterators)) {
 				resolvedFilteredPriceRecords = empty();
 			} else {
-				final CompositeObjectArray<PriceRecordContract> narrowedPrices = new CompositeObjectArray<>(PriceRecordContract.class, false);
+				final CompositeObjectArray<PriceRecordContract> narrowedPrices =
+					new CompositeObjectArray<>(PriceRecordContract.class, false);
 				while (filteredPriceIdsIterator.hasNext()) {
 					final int[] batch = filteredPriceIdsIterator.nextBatch();
-					final int lastExpectedEntity = filteredPriceIdsIterator.getPeek() > 0 ? batch[filteredPriceIdsIterator.getPeek() - 1] : -1;
+					final int lastExpectedEntity = filteredPriceIdsIterator.getPeek() > 0
+						? batch[filteredPriceIdsIterator.getPeek() - 1]
+						: -1;
 					for (int i = 0; i < filteredPriceIdsIterator.getPeek(); i++) {
 						int narrowedPriceId = batch[i];
 						boolean anyPriceFound = false;
 						for (PriceRecordLookup it : priceRecordIterators) {
-							anyPriceFound = it.forEachPriceOfEntity(narrowedPriceId, lastExpectedEntity, narrowedPrices::add);
+							anyPriceFound = it.forEachPriceOfEntity(
+								narrowedPriceId, lastExpectedEntity, narrowedPrices::add
+							);
 							if (anyPriceFound) {
 								break;
 							}
@@ -206,17 +269,32 @@ public interface FilteredPriceRecords extends Serializable {
 		}
 	}
 
+	/**
+	 * Merges all {@link ResolvedFilteredPriceRecords} from the given list into a single instance
+	 * by concatenating their price record arrays. Non-resolved records are skipped.
+	 *
+	 * @param filteredPriceRecords all collected price records to merge
+	 * @return merged resolved price records, or empty if none of the records are resolved
+	 */
 	@Nonnull
-	private static Optional<ResolvedFilteredPriceRecords> getResolvedFilteredPriceRecords(List<FilteredPriceRecords> filteredPriceRecords) {
-		final Optional<ResolvedFilteredPriceRecords> resolvedFilteredPriceRecords;
-		final PriceRecordContract[] priceRecords = ArrayUtils.mergeArrays(
-			filteredPriceRecords.stream()
-				.filter(ResolvedFilteredPriceRecords.class::isInstance)
-				.map(ResolvedFilteredPriceRecords.class::cast)
-				.map(ResolvedFilteredPriceRecords::getPriceRecords)
-				.toArray(PriceRecordContract[][]::new)
-		);
-		resolvedFilteredPriceRecords = ArrayUtils.isEmpty(priceRecords) ?
+	private static Optional<ResolvedFilteredPriceRecords> getResolvedFilteredPriceRecords(
+		@Nonnull List<FilteredPriceRecords> filteredPriceRecords
+	) {
+		int resolvedCount = 0;
+		for (FilteredPriceRecords priceRecord : filteredPriceRecords) {
+			if (priceRecord instanceof ResolvedFilteredPriceRecords) {
+				resolvedCount++;
+			}
+		}
+		final PriceRecordContract[][] arrays = new PriceRecordContract[resolvedCount][];
+		int arrIdx = 0;
+		for (FilteredPriceRecords filteredPriceRecord : filteredPriceRecords) {
+			if (filteredPriceRecord instanceof ResolvedFilteredPriceRecords resolved) {
+				arrays[arrIdx++] = resolved.getPriceRecords();
+			}
+		}
+		final PriceRecordContract[] priceRecords = ArrayUtils.mergeArrays(arrays);
+		return ArrayUtils.isEmpty(priceRecords) ?
 			empty() :
 			of(
 				new ResolvedFilteredPriceRecords(
@@ -224,16 +302,18 @@ public interface FilteredPriceRecords extends Serializable {
 					SortingForm.NOT_SORTED
 				)
 			);
-		return resolvedFilteredPriceRecords;
 	}
 
 	/**
-	 * Method collects all prices from list of passed `filteredPriceRecordAccessors`, reduces them to a subset which
-	 * {@link PriceRecordContract#entityPrimaryKey()} matches the `filterTo` bitmap and returns thre result wrapped
-	 * in {@link FilteredPriceRecordsLookupResult} divided into two parts:
+	 * Collects prices from `filteredPriceRecordAccessors` and retains only those whose
+	 * {@link PriceRecordContract#entityPrimaryKey()} is present in `filterTo`. The result
+	 * is split into two parts: an array of matched price records and a bitmap of entity ids
+	 * that had no associated price.
 	 *
-	 * - array of prices that match passed entities
-	 * - the rest of entity ids that were not matched to any price
+	 * @param filteredPriceRecordAccessors accessors providing price records to filter
+	 * @param filterTo                    bitmap of entity primary keys to match against
+	 * @param context                     current query execution context
+	 * @return lookup result containing matched prices and unmatched entity ids
 	 */
 	@Nonnull
 	static FilteredPriceRecordsLookupResult collectFilteredPriceRecordsFromPriceRecordAccessors(
@@ -242,10 +322,11 @@ public interface FilteredPriceRecords extends Serializable {
 		@Nonnull QueryExecutionContext context
 	) {
 		final CompositeObjectArray<PriceRecordContract> collectedPriceRecords = new CompositeObjectArray<>(PriceRecordContract.class, false);
-		final List<PriceRecordLookup> priceRecordIterators = filteredPriceRecordAccessors
-			.stream()
-			.map(it -> it.getFilteredPriceRecords(context).getPriceRecordsLookup())
-			.toList();
+		final PriceRecordLookup[] priceRecordIterators = new PriceRecordLookup[filteredPriceRecordAccessors.size()];
+		int prIdx = 0;
+		for (FilteredPriceRecordAccessor accessor : filteredPriceRecordAccessors) {
+			priceRecordIterators[prIdx++] = accessor.getFilteredPriceRecords(context).getPriceRecordsLookup();
+		}
 
 		final int[] buffer = SharedBufferPool.INSTANCE.obtain();
 		try {
@@ -330,7 +411,11 @@ public interface FilteredPriceRecords extends Serializable {
 		 * @param priceConsumer      lambda that accepts the {@link PriceRecordContract} of the price that
 		 *                           links to the `entityPk`
 		 */
-		boolean forEachPriceOfEntity(int entityPk, int lastExpectedEntity, @Nonnull Consumer<PriceRecordContract> priceConsumer);
+		boolean forEachPriceOfEntity(
+			int entityPk,
+			int lastExpectedEntity,
+			@Nonnull Consumer<PriceRecordContract> priceConsumer
+		);
 
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/innerRecordHandling/PriceHandlingContainerFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/innerRecordHandling/PriceHandlingContainerFormula.java
@@ -44,6 +44,9 @@ import javax.annotation.Nonnull;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class PriceHandlingContainerFormula extends AbstractFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -8703919997870820964L;
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIdContainerFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIdContainerFormula.java
@@ -49,6 +49,9 @@ import javax.annotation.Nonnull;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class PriceIdContainerFormula extends AbstractFormula implements PriceIndexProvidingFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -1448590239158197683L;
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIndexContainerFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIndexContainerFormula.java
@@ -49,6 +49,9 @@ import java.util.function.Consumer;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class PriceIndexContainerFormula extends AbstractCacheableFormula implements PriceIndexProvidingFormula, Formula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 1785319770058715404L;
 
 	/**
@@ -74,7 +77,7 @@ public class PriceIndexContainerFormula extends AbstractCacheableFormula impleme
 	public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {
 		Assert.isPremiseValid(innerFormulas.length == 1, "Expected exactly single delegate inner formula!");
 		return new PriceIndexContainerFormula(
-			this.priceIndex, getDelegate()
+			this.priceIndex, innerFormulas[0]
 		);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/priceIndex/PriceListCombinationFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/priceIndex/PriceListCombinationFormula.java
@@ -25,6 +25,7 @@ package io.evitadb.core.query.algebra.price.priceIndex;
 
 import io.evitadb.core.cache.payload.FlattenedFormula;
 import io.evitadb.core.cache.payload.FlattenedFormulaWithFilteredPrices;
+import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.CacheableFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.NotFormula;
@@ -37,7 +38,6 @@ import net.openhft.hashing.LongHashFunction;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.function.Consumer;
 
 /**
@@ -72,9 +72,21 @@ import java.util.function.Consumer;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class PriceListCombinationFormula extends NotFormula implements CacheablePriceFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -379304706891548493L;
+	/**
+	 * Name of the price list whose entity ids are subtracted from the superset formula result.
+	 */
 	@Getter private final Serializable subtractedPriceListName;
+	/**
+	 * Name of the price list whose entity ids form the superset formula result.
+	 */
 	@Getter private final Serializable priceListName;
+	/**
+	 * Price evaluation context carrying information about price lists and currency used for price evaluation.
+	 */
 	@Getter private final PriceEvaluationContext priceEvaluationContext;
 
 	public PriceListCombinationFormula(@Nonnull Serializable subtractedPriceListName, @Nonnull Serializable priceListName, @Nonnull PriceEvaluationContext priceEvaluationContext, @Nonnull Formula subtractedFormula, @Nonnull Formula supersetFormula) {
@@ -94,14 +106,12 @@ public class PriceListCombinationFormula extends NotFormula implements Cacheable
 	@Override
 	public FlattenedFormula toSerializableFormula(long formulaHash, @Nonnull LongHashFunction hashFunction) {
 		final Bitmap computationalResult = compute();
+		final long[] sortedDistinctIds = sortAndDeduplicateLongArray(gatherTransactionalIds());
 		// by this time computation result should be already memoized
 		return new FlattenedFormulaWithFilteredPrices(
 			formulaHash,
 			getTransactionalIdHash(),
-			Arrays.stream(gatherTransactionalIds())
-				.distinct()
-				.sorted()
-				.toArray(),
+			sortedDistinctIds,
 			computationalResult,
 			FilteredPriceRecords.createFromFormulas(this, computationalResult, this.executionContext),
 			this.priceEvaluationContext
@@ -145,4 +155,5 @@ public class PriceListCombinationFormula extends NotFormula implements Cacheable
 	public String toString() {
 		return "WITH PRICE IN " + this.priceListName + " WHEN NO PRICE EXISTS IN " + this.subtractedPriceListName;
 	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/LowestPriceTerminationFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/LowestPriceTerminationFormula.java
@@ -63,7 +63,6 @@ import org.roaringbitmap.RoaringBitmapWriter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Objects;
@@ -81,7 +80,13 @@ import java.util.function.Predicate;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class LowestPriceTerminationFormula extends AbstractCacheableFormula implements FilteredPriceRecordAccessor, PriceTerminationFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -4905806490462655316L;
+	/**
+	 * Default predicate that accepts all price records without any filtering.
+	 */
 	private static final Predicate<PriceRecordContract> ALL_MATCHING_PREDICATE = priceContract -> true;
 
 	/**
@@ -270,13 +275,11 @@ public class LowestPriceTerminationFormula extends AbstractCacheableFormula impl
 
 	@Override
 	public FlattenedFormula toSerializableFormula(long formulaHash, @Nonnull LongHashFunction hashFunction) {
+		final long[] sortedDistinctIds = sortAndDeduplicateLongArray(gatherTransactionalIds());
 		return new FlattenedFormulaWithFilteredPricesAndFilteredOutRecords(
 			formulaHash,
 			getTransactionalIdHash(),
-			Arrays.stream(gatherTransactionalIds())
-				.distinct()
-				.sorted()
-				.toArray(),
+			sortedDistinctIds,
 			compute(),
 			getFilteredPriceRecords(this.executionContext),
 			Objects.requireNonNull(getRecordsFilteredOutByPredicate()),
@@ -311,11 +314,12 @@ public class LowestPriceTerminationFormula extends AbstractCacheableFormula impl
 				getDelegate(), FilteredPriceRecordAccessor.class, LookUp.SHALLOW
 			);
 			// collect price iterators ordered by price list importance
-			final PriceRecordLookup[] priceRecordIterators = filteredPriceRecordAccessors
-				.stream()
-				.map(it -> it.getFilteredPriceRecords(this.executionContext))
-				.map(FilteredPriceRecords::getPriceRecordsLookup)
-				.toArray(PriceRecordLookup[]::new);
+			final PriceRecordLookup[] priceRecordIterators = new PriceRecordLookup[filteredPriceRecordAccessors.size()];
+			int idx = 0;
+			for (FilteredPriceRecordAccessor accessor : filteredPriceRecordAccessors) {
+				priceRecordIterators[idx++] = accessor.getFilteredPriceRecords(this.executionContext)
+					.getPriceRecordsLookup();
+			}
 			// create array for the lowest prices by entity
 			final CompositeObjectArray<PriceRecordContract> priceRecordsFunnel = new CompositeObjectArray<>(PriceRecordContract.class, false);
 			// create helper associative index for looking up index of the lowest price by entity id in the priceRecordsFunnel
@@ -407,7 +411,11 @@ public class LowestPriceTerminationFormula extends AbstractCacheableFormula impl
 
 	@Override
 	public int getEstimatedCardinality() {
-		return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).sum();
+		int sum = 0;
+		for (int i = 0; i < this.innerFormulas.length; i++) {
+			sum += this.innerFormulas[i].getEstimatedCardinality();
+		}
+		return sum;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PlainPriceTerminationFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PlainPriceTerminationFormula.java
@@ -45,6 +45,9 @@ import javax.annotation.Nullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class PlainPriceTerminationFormula extends AbstractFormula implements PriceTerminationFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -6690961703571256783L;
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PlainPriceTerminationFormulaWithPriceFilter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PlainPriceTerminationFormulaWithPriceFilter.java
@@ -59,7 +59,6 @@ import org.roaringbitmap.RoaringBitmapWriter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -75,6 +74,9 @@ import java.util.function.Consumer;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class PlainPriceTerminationFormulaWithPriceFilter extends AbstractCacheableFormula implements FilteredPriceRecordAccessor, PriceTerminationFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -2971377943765598548L;
 
 	/**
@@ -151,9 +153,9 @@ public class PlainPriceTerminationFormulaWithPriceFilter extends AbstractCacheab
 	}
 
 	@Override
-	public void initialize(@Nonnull QueryExecutionContext executionContextt) {
-		getDelegate().initialize(this.executionContext);
-		super.initialize(this.executionContext);
+	public void initialize(@Nonnull QueryExecutionContext executionContext) {
+		getDelegate().initialize(executionContext);
+		super.initialize(executionContext);
 	}
 
 	@Nonnull
@@ -210,13 +212,11 @@ public class PlainPriceTerminationFormulaWithPriceFilter extends AbstractCacheab
 
 	@Override
 	public FlattenedFormula toSerializableFormula(long formulaHash, @Nonnull LongHashFunction hashFunction) {
+		final long[] sortedDistinctIds = sortAndDeduplicateLongArray(gatherTransactionalIds());
 		return new FlattenedFormulaWithFilteredPricesAndFilteredOutRecords(
 			formulaHash,
 			getTransactionalIdHash(),
-			Arrays.stream(gatherTransactionalIds())
-				.distinct()
-				.sorted()
-				.toArray(),
+			sortedDistinctIds,
 			compute(),
 			getFilteredPriceRecords(this.executionContext),
 			Objects.requireNonNull(getRecordsFilteredOutByPredicate()),
@@ -251,11 +251,12 @@ public class PlainPriceTerminationFormulaWithPriceFilter extends AbstractCacheab
 				getDelegate(), FilteredPriceRecordAccessor.class, LookUp.SHALLOW
 			);
 			// collect price iterators ordered by price list importance
-			final PriceRecordLookup[] priceRecordIterators = filteredPriceRecordAccessors
-				.stream()
-				.map(it -> it.getFilteredPriceRecords(this.executionContext))
-				.map(FilteredPriceRecords::getPriceRecordsLookup)
-				.toArray(PriceRecordLookup[]::new);
+			final PriceRecordLookup[] priceRecordIterators = new PriceRecordLookup[filteredPriceRecordAccessors.size()];
+			int idx = 0;
+			for (FilteredPriceRecordAccessor accessor : filteredPriceRecordAccessors) {
+				priceRecordIterators[idx++] = accessor.getFilteredPriceRecords(this.executionContext)
+					.getPriceRecordsLookup();
+			}
 
 			// create array for the lowest prices by entity
 			final CompositeObjectArray<PriceRecordContract> priceRecordsFunnel = new CompositeObjectArray<>(PriceRecordContract.class, false);
@@ -324,7 +325,11 @@ public class PlainPriceTerminationFormulaWithPriceFilter extends AbstractCacheab
 
 	@Override
 	public int getEstimatedCardinality() {
-		return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).sum();
+		int sum = 0;
+		for (int i = 0; i < this.innerFormulas.length; i++) {
+			sum += this.innerFormulas[i].getEstimatedCardinality();
+		}
+		return sum;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PriceEvaluationContext.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PriceEvaluationContext.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
-import java.util.stream.LongStream;
 
 import static java.time.LocalDateTime.ofEpochSecond;
 
@@ -92,13 +91,11 @@ public record PriceEvaluationContext(
 	 * {@link #hashCode()} and is targeted to be used in cache key.
 	 */
 	public long computeHash(@Nonnull LongHashFunction hashFunction) {
-		return hashFunction.hashLongs(
-			LongStream.concat(
-					LongStream.of(this.validIn),
-					Arrays.stream(this.targetPriceIndexes)
-						.mapToLong(it -> hashFunction.hashChars(it.toString()))
-				)
-				.toArray()
-		);
+		final long[] hashes = new long[1 + this.targetPriceIndexes.length];
+		hashes[0] = this.validIn;
+		for (int i = 0; i < this.targetPriceIndexes.length; i++) {
+			hashes[i + 1] = hashFunction.hashChars(this.targetPriceIndexes[i].toString());
+		}
+		return hashFunction.hashLongs(hashes);
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PriceFilteringEnvelopeContainer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PriceFilteringEnvelopeContainer.java
@@ -43,9 +43,6 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Currency;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
 
 /**
  * Formula container that behaves exactly as {@link OrFormula}, but carries information about price lists, currency and
@@ -55,10 +52,25 @@ import java.util.stream.Stream;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
 public class PriceFilteringEnvelopeContainer extends AbstractCacheableFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -1722354238488401487L;
+	/**
+	 * Array of price list names used as filter criteria for the enclosed price formulas.
+	 */
 	@Nullable @Getter private final String[] priceLists;
+	/**
+	 * Currency used as filter criteria for the enclosed price formulas.
+	 */
 	@Nullable @Getter private final Currency currency;
+	/**
+	 * Date and time used to filter prices by their validity period.
+	 */
 	@Nullable @Getter private final OffsetDateTime validIn;
+	/**
+	 * Callback operator invoked when the formula computation result is available for caching.
+	 */
 	@Nullable Consumer<CacheableFormula> selfOperator;
 
 	public PriceFilteringEnvelopeContainer(
@@ -101,7 +113,11 @@ public class PriceFilteringEnvelopeContainer extends AbstractCacheableFormula {
 
 	@Override
 	public int getEstimatedCardinality() {
-		return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).sum();
+		int sum = 0;
+		for (int i = 0; i < this.innerFormulas.length; i++) {
+			sum += this.innerFormulas[i].getEstimatedCardinality();
+		}
+		return sum;
 	}
 
 	@Override
@@ -124,9 +140,18 @@ public class PriceFilteringEnvelopeContainer extends AbstractCacheableFormula {
 	@Nonnull
 	@Override
 	public long[] gatherBitmapIdsInternal() {
-		return Arrays.stream(this.innerFormulas)
-			.flatMapToLong(it -> LongStream.of(it.gatherTransactionalIds()))
-			.toArray();
+		int totalLength = 0;
+		for (int i = 0; i < this.innerFormulas.length; i++) {
+			totalLength += this.innerFormulas[i].gatherTransactionalIds().length;
+		}
+		final long[] result = new long[totalLength];
+		int offset = 0;
+		for (int i = 0; i < this.innerFormulas.length; i++) {
+			final long[] ids = this.innerFormulas[i].gatherTransactionalIds();
+			System.arraycopy(ids, 0, result, offset, ids.length);
+			offset += ids.length;
+		}
+		return result;
 	}
 
 	@Override
@@ -157,14 +182,10 @@ public class PriceFilteringEnvelopeContainer extends AbstractCacheableFormula {
 	@Override
 	public String toString() {
 		return "PRICE FILTER CONTAINER - OR (" +
-			Stream.of(
-					(this.priceLists == null ? "" : Arrays.toString(this.priceLists)) +
-						(this.currency == null ? "" : this.currency.getCurrencyCode()) +
-						(this.validIn == null ? "" : this.validIn)
-				)
-				.filter(it -> !it.isEmpty())
-				.collect(Collectors.joining(", "))
-			+ ")";
+			(this.priceLists == null ? "" : Arrays.toString(this.priceLists)) +
+			(this.currency == null ? "" : this.currency.getCurrencyCode()) +
+			(this.validIn == null ? "" : this.validIn) +
+			")";
 	}
 
 	/*
@@ -173,10 +194,12 @@ public class PriceFilteringEnvelopeContainer extends AbstractCacheableFormula {
 
 	@Nonnull
 	private RoaringBitmap[] getRoaringBitmaps() {
-		return Arrays.stream(getInnerFormulas())
-			.map(Formula::compute)
-			.map(RoaringBitmapBackedBitmap::getRoaringBitmap)
-			.toArray(RoaringBitmap[]::new);
+		final Formula[] formulas = getInnerFormulas();
+		final RoaringBitmap[] bitmaps = new RoaringBitmap[formulas.length];
+		for (int i = 0; i < formulas.length; i++) {
+			bitmaps[i] = RoaringBitmapBackedBitmap.getRoaringBitmap(formulas[i].compute());
+		}
+		return bitmaps;
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PriceFilteringEnvelopeContainer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PriceFilteringEnvelopeContainer.java
@@ -137,23 +137,6 @@ public class PriceFilteringEnvelopeContainer extends AbstractCacheableFormula {
 		);
 	}
 
-	@Nonnull
-	@Override
-	public long[] gatherBitmapIdsInternal() {
-		int totalLength = 0;
-		for (int i = 0; i < this.innerFormulas.length; i++) {
-			totalLength += this.innerFormulas[i].gatherTransactionalIds().length;
-		}
-		final long[] result = new long[totalLength];
-		int offset = 0;
-		for (int i = 0; i < this.innerFormulas.length; i++) {
-			final long[] ids = this.innerFormulas[i].gatherTransactionalIds();
-			System.arraycopy(ids, 0, result, offset, ids.length);
-			offset += ids.length;
-		}
-		return result;
-	}
-
 	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
 		return 0L;

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PriceFilteringEnvelopeContainer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/PriceFilteringEnvelopeContainer.java
@@ -53,7 +53,7 @@ import java.util.function.Consumer;
  */
 public class PriceFilteringEnvelopeContainer extends AbstractCacheableFormula {
 	/**
-	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 * Unique identifier of this formula used in {@link AbstractCacheableFormula#getClassId()} for hash computation.
 	 */
 	private static final long CLASS_ID = -1722354238488401487L;
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/SumPriceTerminationFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/termination/SumPriceTerminationFormula.java
@@ -65,7 +65,6 @@ import org.roaringbitmap.RoaringBitmapWriter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -84,7 +83,13 @@ import java.util.function.ToIntFunction;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class SumPriceTerminationFormula extends AbstractCacheableFormula implements FilteredPriceRecordAccessor, PriceTerminationFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 8387802561001219891L;
+	/**
+	 * Default predicate that accepts all price records without any filtering and reports zero missing component price.
+	 */
 	private static final SumPredicate<PriceRecordContract> ALL_MATCHING_PREDICATE = new SumPredicate<>() {
 		@Override
 		public int getMissingComponentsPrice(@Nonnull IntCollection includedInnerRecordIds) {
@@ -295,13 +300,11 @@ public class SumPriceTerminationFormula extends AbstractCacheableFormula impleme
 
 	@Override
 	public FlattenedFormula toSerializableFormula(long formulaHash, @Nonnull LongHashFunction hashFunction) {
+		final long[] sortedDistinctIds = sortAndDeduplicateLongArray(gatherTransactionalIds());
 		return new FlattenedFormulaWithFilteredPricesAndFilteredOutRecords(
 			formulaHash,
 			getTransactionalIdHash(),
-			Arrays.stream(gatherTransactionalIds())
-				.distinct()
-				.sorted()
-				.toArray(),
+			sortedDistinctIds,
 			compute(),
 			getFilteredPriceRecords(this.executionContext),
 			Objects.requireNonNull(getRecordsFilteredOutByPredicate()),
@@ -338,11 +341,12 @@ public class SumPriceTerminationFormula extends AbstractCacheableFormula impleme
 			// create array for the virtual - cumulated prices
 			final CompositeObjectArray<PriceRecordContract> priceRecordsFunnel = new CompositeObjectArray<>(PriceRecordContract.class, false);
 			// collect price iterators ordered by price list importance
-			final PriceRecordLookup[] priceRecordIterators = filteredPriceRecordAccessors
-				.stream()
-				.map(it -> it.getFilteredPriceRecords(this.executionContext))
-				.map(FilteredPriceRecords::getPriceRecordsLookup)
-				.toArray(PriceRecordLookup[]::new);
+			final PriceRecordLookup[] priceRecordIterators = new PriceRecordLookup[filteredPriceRecordAccessors.size()];
+			int idx = 0;
+			for (FilteredPriceRecordAccessor accessor : filteredPriceRecordAccessors) {
+				priceRecordIterators[idx++] = accessor.getFilteredPriceRecords(this.executionContext)
+					.getPriceRecordsLookup();
+			}
 			// create helper associative index for looking up index of the appropriate price by entity id in the priceRecordsFunnel
 			final IntObjectMap<PriceRecordContract> entityInnerRecordPrice = new IntObjectHashMap<>();
 			// create new roaring bitmap builder
@@ -443,7 +447,11 @@ public class SumPriceTerminationFormula extends AbstractCacheableFormula impleme
 
 	@Override
 	public int getEstimatedCardinality() {
-		return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).sum();
+		int sum = 0;
+		for (int i = 0; i < this.innerFormulas.length; i++) {
+			sum += this.innerFormulas[i].getEstimatedCardinality();
+		}
+		return sum;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/translate/PriceIdToEntityIdTranslateFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/translate/PriceIdToEntityIdTranslateFormula.java
@@ -27,6 +27,7 @@ import io.evitadb.core.cache.payload.FlattenedFormula;
 import io.evitadb.core.cache.payload.FlattenedFormulaWithFilteredPrices;
 import io.evitadb.core.query.QueryExecutionContext;
 import io.evitadb.core.query.algebra.AbstractCacheableFormula;
+import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.CacheableFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.price.CacheablePriceFormula;
@@ -70,6 +71,9 @@ import java.util.function.Consumer;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class PriceIdToEntityIdTranslateFormula extends AbstractCacheableFormula implements FilteredPriceRecordAccessor, CacheablePriceFormula, Formula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -8575853054010280485L;
 
 	/**
@@ -121,13 +125,11 @@ public class PriceIdToEntityIdTranslateFormula extends AbstractCacheableFormula 
 
 	@Override
 	public FlattenedFormula toSerializableFormula(long formulaHash, @Nonnull LongHashFunction hashFunction) {
+		final long[] sortedDistinctIds = sortAndDeduplicateLongArray(gatherTransactionalIds());
 		return new FlattenedFormulaWithFilteredPrices(
 			formulaHash,
 			getTransactionalIdHash(),
-			Arrays.stream(gatherTransactionalIds())
-				.distinct()
-				.sorted()
-				.toArray(),
+			sortedDistinctIds,
 			compute(),
 			getFilteredPriceRecords(this.executionContext),
 			getPriceEvaluationContext()
@@ -140,12 +142,12 @@ public class PriceIdToEntityIdTranslateFormula extends AbstractCacheableFormula 
 			getDelegate(), PriceIdContainerFormula.class, LookUp.SHALLOW
 		);
 
-		return new PriceEvaluationContext(
-			null,
-			priceIdFormulas.stream()
-				.map(it -> it.getPriceIndex().getPriceIndexKey())
-				.toArray(PriceIndexKey[]::new)
-		);
+		final PriceIndexKey[] keys = new PriceIndexKey[priceIdFormulas.size()];
+		int idx = 0;
+		for (PriceIdContainerFormula formula : priceIdFormulas) {
+			keys[idx++] = formula.getPriceIndex().getPriceIndexKey();
+		}
+		return new PriceEvaluationContext(null, keys);
 	}
 
 	@Override
@@ -239,7 +241,11 @@ public class PriceIdToEntityIdTranslateFormula extends AbstractCacheableFormula 
 
 	@Override
 	public int getEstimatedCardinality() {
-		return Arrays.stream(this.innerFormulas).mapToInt(Formula::getEstimatedCardinality).sum();
+		int sum = 0;
+		for (int i = 0; i < this.innerFormulas.length; i++) {
+			sum += this.innerFormulas[i].getEstimatedCardinality();
+		}
+		return sum;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferenceOwnerTranslatingFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferenceOwnerTranslatingFormula.java
@@ -53,7 +53,13 @@ import java.util.function.IntFunction;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class ReferenceOwnerTranslatingFormula extends AbstractFormula implements ChildrenDependentFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 6841111737856593641L;
+	/**
+	 * Error message thrown when {@link #getCloneWithInnerFormulas(Formula...)} receives more than one inner formula.
+	 */
 	public static final String ERROR_SINGLE_FORMULA_EXPECTED = "Exactly one inner formula is expected!";
 	/**
 	 * Contains the transactional id of the {@link GlobalEntityIndex} of the referenced entity. Because we need to be

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferenceOwnerTranslatingFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferenceOwnerTranslatingFormula.java
@@ -56,7 +56,7 @@ public class ReferenceOwnerTranslatingFormula extends AbstractFormula implements
 	/**
 	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
 	 */
-	private static final long CLASS_ID = 6841111737856593641L;
+	private static final long CLASS_ID = 3838085621297258621L;
 	/**
 	 * Error message thrown when {@link #getCloneWithInnerFormulas(Formula...)} receives more than one inner formula.
 	 */

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormula.java
@@ -68,7 +68,13 @@ import java.util.function.UnaryOperator;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class ReferencedEntityIndexPrimaryKeyTranslatingFormula extends AbstractFormula implements ChildrenDependentFormula {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = 6841111737856593641L;
+	/**
+	 * Error message thrown when {@link #getCloneWithInnerFormulas(Formula...)} receives more than one inner formula.
+	 */
 	public static final String ERROR_SINGLE_FORMULA_EXPECTED = "Exactly one inner formula is expected!";
 	/**
 	 * Optional union bitmap of all referenced entity primary keys that are allowed to participate

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/FormulaFactory.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/FormulaFactory.java
@@ -33,25 +33,46 @@ import io.evitadb.core.query.algebra.base.NotFormula;
 import io.evitadb.core.query.algebra.base.OrFormula;
 import io.evitadb.dataType.array.CompositeObjectArray;
 import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
 import java.util.function.Supplier;
 
 /**
- * Formula factory class contains static helper methods for creating basic boolean containers for set of formulas
- * that automatically adapt to the count and type of passed inner constraints (i.e. long vs. integer type).
+ * Static factory for creating boolean formula containers ({@link OrFormula}, {@link AndFormula}, {@link NotFormula})
+ * that automatically simplify the result based on the number and type of inner formulas:
+ *
+ * - **zero** children → {@link EmptyFormula#INSTANCE}
+ * - **one** child → the child itself (no wrapping container)
+ * - **multiple** children → the appropriate boolean container with nested same-type containers flattened
+ *
+ * The {@link #or(Supplier, Formula...)} overload additionally handles {@link FutureNotFormula} post-processing
+ * and eagerly merges all-{@link ConstantFormula} inputs into a single {@link ConstantFormula} via RoaringBitmap OR.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class FormulaFactory {
 
 	/**
-	 * Creates boolean OR query for passed `innerFormulas`. If the array is empty, it returns `emptyFormula`.
-	 * If array contains exactly one inner formula, only this formula is returned, otherwise OR formula container
-	 * either for integer or long type is created and returned.
+	 * Creates a disjunction (OR) over `innerFormulas` with special handling for negation and constant folding.
+	 *
+	 * Processing order:
+	 *
+	 * 1. empty array → {@link EmptyFormula#INSTANCE}
+	 * 2. single formula → returned as-is
+	 * 3. first element is {@link FutureNotFormula} → delegates to
+	 *    {@link FutureNotFormula#postProcess(Formula[], EnclosingContainerRelation, Supplier)} to compose
+	 *    the final {@link NotFormula}
+	 * 4. all elements are {@link ConstantFormula} or {@link EmptyFormula} → eagerly computes the bitmap union
+	 *    via {@link RoaringBitmap#or(RoaringBitmap...)} and returns a single {@link ConstantFormula}
+	 * 5. otherwise → wraps in {@link OrFormula}
+	 *
+	 * @param superSetFormulaSupplier supplies the superset formula used by {@link FutureNotFormula} post-processing
+	 *                                when the negation has no positive sibling to serve as superset
+	 * @param innerFormulas           formulas to combine with logical OR
+	 * @return simplified formula representing the disjunction
 	 */
 	@Nonnull
 	public static Formula or(@Nonnull Supplier<Formula> superSetFormulaSupplier, @Nonnull Formula... innerFormulas) {
@@ -67,18 +88,34 @@ public class FormulaFactory {
 			);
 		} else {
 			/* this check and transformation enables prefetching for simple cases */
-			if (Arrays.stream(innerFormulas).allMatch(it -> it instanceof ConstantFormula || it instanceof EmptyFormula)) {
-				final RoaringBitmap[] bitmaps = Arrays.stream(innerFormulas)
-					.filter(ConstantFormula.class::isInstance)
-					.map(ConstantFormula.class::cast)
-					.map(ConstantFormula::getDelegate)
-					.map(
-						it -> it instanceof RoaringBitmapBackedBitmap rbbb ?
+			boolean allConstantOrEmpty = true;
+			for (final Formula value : innerFormulas) {
+				if (!(value instanceof ConstantFormula || value instanceof EmptyFormula)) {
+					allConstantOrEmpty = false;
+					break;
+				}
+			}
+			if (allConstantOrEmpty) {
+				// count ConstantFormula instances first to pre-size the array
+				int constantCount = 0;
+				for (final Formula formula : innerFormulas) {
+					if (formula instanceof ConstantFormula) {
+						constantCount++;
+					}
+				}
+				final RoaringBitmap[] bitmaps = new RoaringBitmap[constantCount];
+				int idx = 0;
+				for (final Formula innerFormula : innerFormulas) {
+					if (innerFormula instanceof ConstantFormula constantFormula) {
+						final Bitmap delegate = constantFormula.getDelegate();
+						bitmaps[idx++] = delegate instanceof RoaringBitmapBackedBitmap rbbb ?
 							rbbb.getRoaringBitmap() :
-							RoaringBitmap.bitmapOf(it.getArray())
-					)
-					.toArray(RoaringBitmap[]::new);
-				return bitmaps.length == 0 ? EmptyFormula.INSTANCE : new ConstantFormula(new BaseBitmap(RoaringBitmap.or(bitmaps)));
+							RoaringBitmap.bitmapOf(delegate.getArray());
+					}
+				}
+				return bitmaps.length == 0
+					? EmptyFormula.INSTANCE
+					: new ConstantFormula(new BaseBitmap(RoaringBitmap.or(bitmaps)));
 			} else {
 				return new OrFormula(innerFormulas);
 			}
@@ -86,9 +123,12 @@ public class FormulaFactory {
 	}
 
 	/**
-	 * Creates boolean OR query for passed `innerFormulas`. If the array is empty, it returns `emptyFormula`.
-	 * If array contains exactly one inner formula, only this formula is returned, otherwise OR formula container
-	 * either for integer or long type is created and returned.
+	 * Creates a disjunction (OR) over `innerFormulas` with automatic flattening of nested {@link OrFormula}
+	 * containers via {@link #getMergedOrFormulas(Formula...)}. Returns {@link EmptyFormula#INSTANCE} for an empty
+	 * array and the single element for a one-element array.
+	 *
+	 * @param innerFormulas formulas to combine with logical OR
+	 * @return simplified formula representing the disjunction
 	 */
 	@Nonnull
 	public static Formula or(@Nonnull Formula... innerFormulas) {
@@ -103,9 +143,12 @@ public class FormulaFactory {
 	}
 
 	/**
-	 * Creates boolean AND query for passed `innerFormulas`. If the array is empty, it returns `emptyFormula`.
-	 * If array contains exactly one inner formula, only this formula is returned, otherwise AND formula container
-	 * either for integer or long type is created and returned.
+	 * Creates a conjunction (AND) over `innerFormulas` with automatic flattening of nested {@link AndFormula}
+	 * containers via {@link #getMergedAndFormulas(Formula...)}. Returns {@link EmptyFormula#INSTANCE} for an empty
+	 * array and the single element for a one-element array.
+	 *
+	 * @param innerFormulas formulas to combine with logical AND
+	 * @return simplified formula representing the conjunction
 	 */
 	@Nonnull
 	public static Formula and(@Nonnull Formula... innerFormulas) {
@@ -120,7 +163,11 @@ public class FormulaFactory {
 	}
 
 	/**
-	 * Creates boolean NOT query for passed formulas, either for integer or long type.
+	 * Creates a {@link NotFormula} that subtracts the `subtracted` bitmap from the `superSet` bitmap.
+	 *
+	 * @param subtracted the formula whose results are removed from the superset
+	 * @param superSet   the formula providing the base set to subtract from
+	 * @return a {@link NotFormula} representing `superSet \ subtracted`
 	 */
 	@Nonnull
 	public static Formula not(@Nonnull Formula subtracted, @Nonnull Formula superSet) {
@@ -130,17 +177,23 @@ public class FormulaFactory {
 	}
 
 	/**
-	 * Iterates over formulas and if OR formula is found it gets unwrapped and inner formulas are propagated to the same
-	 * level as other formulas. We expect that the result would be wrapped into an OR container and by this unwrapping
-	 * we would need to compute only one OR product and not two or more separate ones.
+	 * Flattens nested {@link OrFormula} containers so that a single OR product is computed instead of multiple
+	 * nested ones. Each encountered {@link OrFormula} has its children and any additional {@link OrFormula#getBitmaps()
+	 * bitmaps} (wrapped as {@link ConstantFormula}) promoted to the same level as sibling formulas.
+	 *
+	 * @param formulas the input formulas that may contain nested {@link OrFormula} instances
+	 * @return a flat array with nested OR formulas unwrapped
 	 */
 	@Nonnull
 	private static Formula[] getMergedOrFormulas(@Nonnull Formula... formulas) {
 		final CompositeObjectArray<Formula> mergedFormulas = new CompositeObjectArray<>(Formula.class);
 		for (Formula innerFormula : formulas) {
-			if (innerFormula instanceof OrFormula) {
+			if (innerFormula instanceof OrFormula orFormula) {
 				mergedFormulas.addAll(innerFormula.getInnerFormulas(), 0, innerFormula.getInnerFormulas().length);
-				Arrays.stream(((OrFormula) innerFormula).getBitmaps()).map(ConstantFormula::new).forEach(mergedFormulas::add);
+				final Bitmap[] bitmaps = orFormula.getBitmaps();
+				for (final Bitmap bitmap : bitmaps) {
+					mergedFormulas.add(new ConstantFormula(bitmap));
+				}
 			} else {
 				mergedFormulas.add(innerFormula);
 			}
@@ -149,17 +202,23 @@ public class FormulaFactory {
 	}
 
 	/**
-	 * Iterates over formulas and if AND formula is found it gets unwrapped and inner formulas are propagated to the same
-	 * level as other formulas. We expect that the result would be wrapped into an AND container and by this unwrapping
-	 * we would need to compute only one AND product and not two and more separate ones.
+	 * Flattens nested {@link AndFormula} containers so that a single AND product is computed instead of multiple
+	 * nested ones. Each encountered {@link AndFormula} has its children and any additional {@link AndFormula#getBitmaps()
+	 * bitmaps} (wrapped as {@link ConstantFormula}) promoted to the same level as sibling formulas.
+	 *
+	 * @param formulas the input formulas that may contain nested {@link AndFormula} instances
+	 * @return a flat array with nested AND formulas unwrapped
 	 */
 	@Nonnull
 	private static Formula[] getMergedAndFormulas(@Nonnull Formula... formulas) {
 		final CompositeObjectArray<Formula> mergedFormulas = new CompositeObjectArray<>(Formula.class);
 		for (Formula innerFormula : formulas) {
-			if (innerFormula instanceof AndFormula) {
+			if (innerFormula instanceof AndFormula andFormula) {
 				mergedFormulas.addAll(innerFormula.getInnerFormulas(), 0, innerFormula.getInnerFormulas().length);
-				Arrays.stream(((AndFormula) innerFormula).getBitmaps()).map(ConstantFormula::new).forEach(mergedFormulas::add);
+				final Bitmap[] bitmaps = andFormula.getBitmaps();
+				for (final Bitmap bitmap : bitmaps) {
+					mergedFormulas.add(new ConstantFormula(bitmap));
+				}
 			} else {
 				mergedFormulas.add(innerFormula);
 			}
@@ -167,6 +226,9 @@ public class FormulaFactory {
 		return mergedFormulas.toArray();
 	}
 
+	/**
+	 * Utility class — not instantiable.
+	 */
 	private FormulaFactory() {
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
@@ -31,7 +31,6 @@ import lombok.Getter;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayDeque;
-import java.util.Arrays;
 import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
@@ -121,7 +120,12 @@ public class FormulaCloner implements FormulaVisitor {
 	 * Returns true if all parents match the passed predicate.
 	 */
 	public boolean allParentsMatch(@Nonnull Predicate<Formula> formulaTester) {
-		return this.parents.stream().allMatch(formulaTester);
+		for (Formula parent : this.parents) {
+			if (!formulaTester.test(parent)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**
@@ -148,8 +152,15 @@ public class FormulaCloner implements FormulaVisitor {
 				this.parents.pop();
 				final SubTree subTree = popContext(this.treeStack);
 				final Set<Formula> updatedChildren = subTree.getChildren();
-				final boolean childrenHaveNotChanged = updatedChildren.size() == formula.getInnerFormulas().length &&
-					Arrays.stream(formula.getInnerFormulas()).allMatch(updatedChildren::contains);
+				boolean childrenHaveNotChanged = updatedChildren.size() == formula.getInnerFormulas().length;
+				if (childrenHaveNotChanged) {
+					for (Formula innerFormula : formula.getInnerFormulas()) {
+						if (!updatedChildren.contains(innerFormula)) {
+							childrenHaveNotChanged = false;
+							break;
+						}
+					}
+				}
 
 				if (childrenHaveNotChanged) {
 					// use entire formula tree block
@@ -238,7 +249,7 @@ public class FormulaCloner implements FormulaVisitor {
 	 * Default implementation of {@link SubTree} contract used in the formula cloner.
 	 */
 	private static class DefaultSubTree implements SubTree {
-		@Getter private final Set<Formula> children = new LinkedHashSet<>();
+		@Getter private final Set<Formula> children = new LinkedHashSet<>(16);
 
 		@Override
 		public void add(@Nonnull Formula formula) {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/base/AndFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/base/AndFormulaTest.java
@@ -23,87 +23,325 @@
 
 package io.evitadb.core.query.algebra.base;
 
+import io.evitadb.core.query.algebra.CacheableFormula;
+import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.dataType.array.CompositeIntArray;
 import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import javax.annotation.Nonnull;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * This test verifies contract of {@link AndFormula}.
+ * Tests for {@link AndFormula} verifying boolean conjunction (AND) computation, memoization,
+ * cloning, hashing and cost estimation.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
+@DisplayName("AndFormula — boolean conjunction")
 class AndFormulaTest {
 
-	public static final long[] INDEX_TRANSACTION_ID = {1L};
+	private static final long[] INDEX_TRANSACTION_ID = {1L};
 
-	@Test
-	void shouldApplyBooleanAnd() {
-		assertArrayEquals(
-			new int[]{1, 4},
-			new AndFormula(
+	@Nested
+	@DisplayName("Computation correctness")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should intersect three overlapping bitmaps")
+		void shouldApplyBooleanAnd() {
+			assertArrayEquals(
+				new int[]{1, 4},
+				new AndFormula(
+					INDEX_TRANSACTION_ID,
+					new ArrayBitmap(1, 3, 4, 5, 8),
+					new ArrayBitmap(1, 2, 4, 8),
+					new ArrayBitmap(1, 2, 3, 4, 5)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should intersect three overlapping formulas")
+		void shouldApplyBooleanAndWithFormula() {
+			final AndFormula andFormula = new AndFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 3, 4, 5, 8))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 4, 8))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5)))
+			);
+			assertArrayEquals(
+				new int[]{1, 4},
+				andFormula.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return empty when no elements are common")
+		void shouldApplyBooleanAndOnNonOverlappingCollections() {
+			assertArrayEquals(
+				new int[0],
+				new AndFormula(
+					INDEX_TRANSACTION_ID,
+					new ArrayBitmap(1, 3, 5, 7, 9, 11),
+					new ArrayBitmap(3, 4, 5, 6, 7),
+					new ArrayBitmap(10, 11, 1)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return empty for two empty bitmaps")
+		void shouldReturnNothingForEmptyBitmaps() {
+			assertArrayEquals(
+				new int[0],
+				new AndFormula(
+					INDEX_TRANSACTION_ID,
+					new ArrayBitmap(),
+					new ArrayBitmap()
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return empty when one bitmap is empty")
+		void shouldReturnNothingForEmptyAndFullBitmap() {
+			assertArrayEquals(
+				new int[0],
+				new AndFormula(
+					INDEX_TRANSACTION_ID,
+					new ArrayBitmap(1, 3, 4, 5, 8),
+					new ArrayBitmap(),
+					new ArrayBitmap(1, 2, 3, 4, 5)
+				)
+					.compute().getArray()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Memoization")
+	class MemoizationTest {
+
+		@Test
+		@DisplayName("should return same instance on repeated compute calls")
+		void shouldReturnSameInstanceOnRepeatedCompute() {
+			final AndFormula formula = new AndFormula(
 				INDEX_TRANSACTION_ID,
-				new ArrayBitmap(1, 3, 4, 5, 8),
-				new ArrayBitmap(1, 2, 4, 8),
-				new ArrayBitmap(1, 2, 3, 4, 5)
-			)
-				.compute().getArray()
-		);
+				new ArrayBitmap(1, 2, 3),
+				new ArrayBitmap(2, 3, 4)
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
+
+		@Test
+		@DisplayName("should return same instance on repeated compute calls with formula children")
+		void shouldReturnSameInstanceOnRepeatedComputeWithFormulas() {
+			final AndFormula formula = new AndFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 3, 4)))
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
 	}
 
-	@Test
-	void shouldApplyBooleanAndWithFormula() {
-		final AndFormula andFormula = new AndFormula(
-			new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 3, 4, 5, 8))),
-			new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 4, 8))),
-			new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5)))
-		);
-		assertArrayEquals(
-			new int[]{1, 4},
-			andFormula.compute().getArray()
-		);
-	}
+	@Nested
+	@DisplayName("Clear memory")
+	class ClearMemoryTest {
 
-	@Test
-	void shouldApplyBooleanAndOnNonOverlappingCollections() {
-		assertArrayEquals(
-			new int[0],
-			new AndFormula(
+		@Test
+		@DisplayName("should recompute equal result after clearMemory")
+		void shouldRecomputeEqualResultAfterClearMemory() {
+			final AndFormula formula = new AndFormula(
 				INDEX_TRANSACTION_ID,
-				new ArrayBitmap(1, 3, 5, 7, 9, 11),
-				new ArrayBitmap(3, 4, 5, 6, 7),
-				new ArrayBitmap(10, 11, 1)
-			)
-				.compute().getArray()
-		);
+				new ArrayBitmap(1, 2, 3),
+				new ArrayBitmap(2, 3, 4)
+			);
+
+			final Bitmap first = formula.compute();
+			formula.clearMemory();
+			final Bitmap second = formula.compute();
+
+			assertNotSame(first, second);
+			assertArrayEquals(first.getArray(), second.getArray());
+		}
 	}
 
-	@Test
-	void shouldReturnNothingForEmptyBitmaps() {
-		assertArrayEquals(
-			new int[0],
-			new AndFormula(
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should return EmptyFormula when cloned with zero children")
+		void shouldReturnEmptyFormulaWhenClonedWithZeroChildren() {
+			final AndFormula original = new AndFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 3)))
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas();
+
+			assertSame(EmptyFormula.INSTANCE, clone);
+		}
+
+		@Test
+		@DisplayName("should return the single child directly when cloned with one child")
+		void shouldReturnSingleChildWhenClonedWithOneChild() {
+			final ConstantFormula child = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3)));
+			final AndFormula original = new AndFormula(
+				child,
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 3)))
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas(child);
+
+			assertSame(child, clone);
+		}
+
+		@Test
+		@DisplayName("should return new AndFormula preserving computation when cloned with two+ children")
+		void shouldReturnNewAndFormulaWhenClonedWithMultipleChildren() {
+			final ConstantFormula childA = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3)));
+			final ConstantFormula childB = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 3, 4)));
+			final AndFormula original = new AndFormula(childA, childB);
+
+			final Formula clone = original.getCloneWithInnerFormulas(childA, childB);
+
+			assertInstanceOf(AndFormula.class, clone);
+			assertArrayEquals(original.compute().getArray(), clone.compute().getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically-constructed formulas")
+		void shouldProduceIdenticalHashForIdenticalFormulas() {
+			final long hashA = createAndFormula(1, 2, 3, 4).getHash();
+			final long hashB = createAndFormula(1, 2, 3, 4).getHash();
+
+			assertEquals(hashA, hashB);
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different children")
+		void shouldProduceDifferentHashForDifferentChildren() {
+			final long hashA = createAndFormula(1, 2, 3).getHash();
+			final long hashB = createAndFormula(4, 5, 6).getHash();
+
+			assertNotEquals(hashA, hashB);
+		}
+
+		@Test
+		@DisplayName("should produce same hash when children are reordered (order-insignificant)")
+		void shouldProduceSameHashWhenChildrenReordered() {
+			final ConstantFormula childA = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3)));
+			final ConstantFormula childB = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(4, 5, 6)));
+
+			final long hashAB = new AndFormula(childA, childB).getHash();
+			final long hashBA = new AndFormula(childB, childA).getHash();
+
+			assertEquals(hashAB, hashBA);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should return minimum cardinality across bitmaps")
+		void shouldReturnMinCardinalityForBitmaps() {
+			final AndFormula formula = new AndFormula(
 				INDEX_TRANSACTION_ID,
-				new ArrayBitmap(),
-				new ArrayBitmap()
-			)
-				.compute().getArray()
-		);
+				new ArrayBitmap(1, 2, 3, 4, 5),
+				new ArrayBitmap(2, 3),
+				new ArrayBitmap(1, 2, 3, 4)
+			);
+
+			assertEquals(2, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should return minimum cardinality across formula children")
+		void shouldReturnMinCardinalityForFormulas() {
+			final AndFormula formula = new AndFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 3)))
+			);
+
+			assertEquals(2, formula.getEstimatedCardinality());
+		}
 	}
 
-	@Test
-	void shouldReturnNothingForEmptyAndFullBitmap() {
-		assertArrayEquals(
-			new int[0],
-			new AndFormula(
+	@Nested
+	@DisplayName("Cost ordering")
+	class CostOrderingTest {
+
+		@Test
+		@DisplayName("should have non-negative estimated and actual cost with estimated being an upper bound")
+		void shouldHaveNonNegativeCostsWithEstimatedAsUpperBound() {
+			final AndFormula formula = new AndFormula(
 				INDEX_TRANSACTION_ID,
-				new ArrayBitmap(1, 3, 4, 5, 8),
-				new ArrayBitmap(),
-				new ArrayBitmap(1, 2, 3, 4, 5)
-			)
-				.compute().getArray()
-		);
+				new ArrayBitmap(1, 2, 3, 4, 5),
+				new ArrayBitmap(2, 3, 4)
+			);
+
+			final long estimatedCost = formula.getEstimatedCost();
+			formula.compute();
+			final long actualCost = formula.getCost();
+
+			assertTrue(estimatedCost >= 0, "Estimated cost should be non-negative, was: " + estimatedCost);
+			assertTrue(actualCost >= 0, "Actual cost should be non-negative, was: " + actualCost);
+			assertTrue(
+				estimatedCost >= actualCost,
+				"Estimated cost " + estimatedCost + " should be >= actual cost " + actualCost
+			);
+		}
 	}
 
+	@Nested
+	@DisplayName("Cache behavior")
+	class CacheBehaviorTest {
+
+		@Test
+		@DisplayName("should implement CacheableFormula")
+		void shouldImplementCacheableFormula() {
+			final AndFormula formula = new AndFormula(
+				INDEX_TRANSACTION_ID,
+				new ArrayBitmap(1, 2),
+				new ArrayBitmap(2, 3)
+			);
+
+			assertInstanceOf(CacheableFormula.class, formula);
+		}
+	}
+
+	/**
+	 * Creates an {@link AndFormula} from two bitmap-based children for hash testing: one bitmap
+	 * holds the supplied values, the other holds a fixed reference set.
+	 */
+	@Nonnull
+	private static AndFormula createAndFormula(int... values) {
+		return new AndFormula(
+			new ConstantFormula(new ArrayBitmap(new CompositeIntArray(values))),
+			new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5, 6)))
+		);
+	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/base/DisentangleFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/base/DisentangleFormulaTest.java
@@ -23,129 +23,353 @@
 
 package io.evitadb.core.query.algebra.base;
 
+import io.evitadb.core.query.algebra.CacheableFormula;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.price.CacheablePriceFormula;
 import io.evitadb.dataType.array.CompositeIntArray;
 import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.EmptyBitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import javax.annotation.Nonnull;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * This test verifies contract of {@link DisentangleFormula}.
+ * Tests for {@link DisentangleFormula} verifying index-aware duplicate removal,
+ * memoization, cloning, hashing and cost estimation.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
+@DisplayName("DisentangleFormula — index-aware duplicate removal")
 class DisentangleFormulaTest {
 
-	@Test
-	void shouldReturnAllNumbersExceptSingleInControlArray() {
-		assertDistinctArray(
-			new int[] {1, 2, 4},
-			new int[] {1, 2, 3, 4},
-			new int[] {3}
-		);
+	@Nested
+	@DisplayName("Computation correctness")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should remove single matching element from main array")
+		void shouldReturnAllNumbersExceptSingleInControlArray() {
+			assertDistinctArray(
+				new int[]{1, 2, 4},
+				new int[]{1, 2, 3, 4},
+				new int[]{3}
+			);
+		}
+
+		@Test
+		@DisplayName("should remove matching elements and collapse duplicates")
+		void shouldReturnAllNumbersExceptThoseInControlArray() {
+			assertDistinctArray(
+				new int[]{1, 3, 4},
+				new int[]{1, 2, 3, 3, 4},
+				new int[]{2, 3}
+			);
+		}
+
+		@Test
+		@DisplayName("should not change main when control has only greater numbers")
+		void shouldReturnMainListWithoutChangeWhenThereIsOnlyGreaterNumbersInControlList() {
+			assertDistinctArray(
+				new int[]{1, 2, 3, 4, 5},
+				new int[]{1, 2, 3, 4, 5},
+				new int[]{6, 7, 8}
+			);
+		}
+
+		@Test
+		@DisplayName("should not change main when control has only lesser numbers")
+		void shouldReturnMainListWithoutChangeWhenThereIsOnlyLesserNumbersInControlList() {
+			assertDistinctArray(
+				new int[]{6, 7, 8},
+				new int[]{6, 7, 8},
+				new int[]{1, 2, 3, 4, 5}
+			);
+		}
+
+		@Test
+		@DisplayName("should return main unchanged when control is empty")
+		void shouldReturnMainListWhenControlListIsEmpty() {
+			assertDistinctArray(
+				new int[]{6, 7, 8},
+				new int[]{6, 7, 8},
+				new int[0]
+			);
+		}
+
+		@Test
+		@DisplayName("should return empty when main is empty")
+		void shouldReturnEmptyMainListWhenMainListIsEmpty() {
+			assertDistinctArray(
+				new int[0],
+				new int[0],
+				new int[]{6, 7, 8}
+			);
+		}
+
+		@Test
+		@DisplayName("should remove matching elements by index position")
+		void shouldReturnMainListWithDistinctNumbersOnlyWhenThereIsMatchInControlList() {
+			assertDistinctArray(
+				new int[]{1, 7},
+				new int[]{1, 4, 6, 7},
+				new int[]{2, 4, 6, 8}
+			);
+		}
+
+		@Test
+		@DisplayName("should handle duplicates in both main and control arrays")
+		void shouldReturnMainListWithDistinctNumbersAndDuplicatesOnlyWhenThereIsMatchInControlList() {
+			assertDistinctArray(
+				new int[]{1, 4, 7},
+				new int[]{1, 4, 4, 6, 6, 7},
+				new int[]{2, 4, 6, 6, 6, 8}
+			);
+		}
+
+		@Test
+		@DisplayName("should return empty for two empty bitmaps")
+		void shouldReturnNothingForEmptyBitmaps() {
+			assertArrayEquals(
+				new int[0],
+				new DisentangleFormula(
+					EmptyBitmap.INSTANCE,
+					EmptyBitmap.INSTANCE
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return empty when main is empty and control is non-empty")
+		void shouldReturnFullBitmapForEmptyAndFullBitmap() {
+			assertArrayEquals(
+				new int[0],
+				new DisentangleFormula(
+					EmptyBitmap.INSTANCE,
+					new ArrayBitmap(new CompositeIntArray(3, 3, 6, 9, 12))
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return full main when control is empty")
+		void shouldReturnEmptyBitmapForEmptyControlBitmapAndFullMainBitmap() {
+			assertArrayEquals(
+				new int[]{3, 6, 9, 12},
+				new DisentangleFormula(
+					new ArrayBitmap(new CompositeIntArray(3, 3, 6, 9, 12)),
+					EmptyBitmap.INSTANCE
+				)
+					.compute().getArray()
+			);
+		}
 	}
 
-	@Test
-	void shouldReturnAllNumbersExceptThoseInControlArray() {
-		assertDistinctArray(
-			new int[] {1, 3, 4},
-			new int[] {1, 2, 3, 3, 4},
-			new int[] {2, 3}
-		);
+	@Nested
+	@DisplayName("Memoization")
+	class MemoizationTest {
+
+		@Test
+		@DisplayName("should return same instance on repeated compute calls")
+		void shouldReturnSameInstanceOnRepeatedCompute() {
+			final DisentangleFormula formula = new DisentangleFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4)),
+				new ArrayBitmap(new CompositeIntArray(2, 3))
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
+
+		@Test
+		@DisplayName("should return same instance on repeated compute calls with formula children")
+		void shouldReturnSameInstanceOnRepeatedComputeWithFormulas() {
+			final DisentangleFormula formula = new DisentangleFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 3)))
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
 	}
 
-	@Test
-	void shouldReturnMainListWithoutChangeWhenThereIsOnlyGreaterNumbersInControlList() {
-		assertDistinctArray(
-			new int[] {1, 2, 3, 4, 5},
-			new int[] {1, 2, 3, 4, 5},
-			new int[] {6, 7, 8}
-		);
+	@Nested
+	@DisplayName("Clear memory")
+	class ClearMemoryTest {
+
+		@Test
+		@DisplayName("should recompute equal result after clearMemory")
+		void shouldRecomputeEqualResultAfterClearMemory() {
+			final DisentangleFormula formula = new DisentangleFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4)),
+				new ArrayBitmap(new CompositeIntArray(2, 3))
+			);
+
+			final Bitmap first = formula.compute();
+			formula.clearMemory();
+			final Bitmap second = formula.compute();
+
+			assertNotSame(first, second);
+			assertArrayEquals(first.getArray(), second.getArray());
+		}
 	}
 
-	@Test
-	void shouldReturnMainListWithoutChangeWhenThereIsOnlyLesserNumbersInControlList() {
-		assertDistinctArray(
-			new int[] {6, 7, 8},
-			new int[] {6, 7, 8},
-			new int[] {1, 2, 3, 4, 5}
-		);
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should return new DisentangleFormula preserving computation when cloned")
+		void shouldReturnNewFormulaWhenCloned() {
+			final ConstantFormula main = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4)));
+			final ConstantFormula control = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 3)));
+			final DisentangleFormula original = new DisentangleFormula(main, control);
+
+			final Formula clone = original.getCloneWithInnerFormulas(main, control);
+
+			assertInstanceOf(DisentangleFormula.class, clone);
+			assertArrayEquals(original.compute().getArray(), clone.compute().getArray());
+		}
 	}
 
-	@Test
-	void shouldReturnMainListWhenControlListIsEmpty() {
-		assertDistinctArray(
-			new int[] {6, 7, 8},
-			new int[] {6, 7, 8},
-			new int[0]
-		);
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically-constructed formulas")
+		void shouldProduceIdenticalHashForIdenticalFormulas() {
+			final long hashA = createDisentangleFormula(
+				new int[]{1, 2, 3, 4}, new int[]{2, 3}
+			).getHash();
+			final long hashB = createDisentangleFormula(
+				new int[]{1, 2, 3, 4}, new int[]{2, 3}
+			).getHash();
+
+			assertEquals(hashA, hashB);
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different children")
+		void shouldProduceDifferentHashForDifferentChildren() {
+			final long hashA = createDisentangleFormula(
+				new int[]{1, 2, 3, 4}, new int[]{2, 3}
+			).getHash();
+			final long hashB = createDisentangleFormula(
+				new int[]{5, 6, 7, 8}, new int[]{6, 7}
+			).getHash();
+
+			assertNotEquals(hashA, hashB);
+		}
+
+		@Test
+		@DisplayName("should produce different hash when main and control are swapped (order-significant)")
+		void shouldProduceDifferentHashWhenArgumentsSwapped() {
+			final ConstantFormula childA = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3)));
+			final ConstantFormula childB = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 3, 4, 5)));
+
+			final long hashAB = new DisentangleFormula(childA, childB).getHash();
+			final long hashBA = new DisentangleFormula(childB, childA).getHash();
+
+			assertNotEquals(hashAB, hashBA);
+		}
 	}
 
-	@Test
-	void shouldReturnEmptyMainListWhenMainListIsEmpty() {
-		assertDistinctArray(
-			new int[0],
-			new int[0],
-			new int[] {6, 7, 8}
-		);
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should return main bitmap cardinality for bitmap-based construction")
+		void shouldReturnMainCardinalityForBitmaps() {
+			final DisentangleFormula formula = new DisentangleFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5)),
+				new ArrayBitmap(new CompositeIntArray(2, 3))
+			);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should return main formula cardinality for formula-based construction")
+		void shouldReturnMainCardinalityForFormulas() {
+			final DisentangleFormula formula = new DisentangleFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 3)))
+			);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
 	}
 
-	@Test
-	void shouldReturnMainListWithDistinctNumbersOnlyWhenThereIsMatchInControlList() {
-		assertDistinctArray(
-			new int[] {1, 7},
-			new int[] {1, 4, 6, 7},
-			new int[] {2, 4, 6, 8}
-		);
+	@Nested
+	@DisplayName("Cost ordering")
+	class CostOrderingTest {
+
+		@Test
+		@DisplayName("should have non-negative estimated and actual cost with estimated being an upper bound")
+		void shouldHaveNonNegativeCostsWithEstimatedAsUpperBound() {
+			final DisentangleFormula formula = new DisentangleFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5)),
+				new ArrayBitmap(new CompositeIntArray(2, 3, 4))
+			);
+
+			final long estimatedCost = formula.getEstimatedCost();
+			formula.compute();
+			final long actualCost = formula.getCost();
+
+			assertTrue(estimatedCost >= 0, "Estimated cost should be non-negative, was: " + estimatedCost);
+			assertTrue(actualCost >= 0, "Actual cost should be non-negative, was: " + actualCost);
+			assertTrue(
+				estimatedCost >= actualCost,
+				"Estimated cost " + estimatedCost + " should be >= actual cost " + actualCost
+			);
+		}
 	}
 
-	@Test
-	void shouldReturnMainListWithDistinctNumbersAndDuplicatesOnlyWhenThereIsMatchInControlList() {
-		assertDistinctArray(
-			new int[] {1, 4, 7},
-			new int[] {1, 4, 4, 6, 6, 7},
-			new int[] {2, 4, 6, 6, 6, 8}
-		);
+	@Nested
+	@DisplayName("Cache behavior")
+	class CacheBehaviorTest {
+
+		@Test
+		@DisplayName("should implement CacheableFormula")
+		void shouldImplementCacheableFormula() {
+			final DisentangleFormula formula = new DisentangleFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2)),
+				new ArrayBitmap(new CompositeIntArray(2, 3))
+			);
+
+			assertInstanceOf(CacheableFormula.class, formula);
+		}
+
+		@Test
+		@DisplayName("should implement CacheablePriceFormula")
+		void shouldImplementCacheablePriceFormula() {
+			final DisentangleFormula formula = new DisentangleFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2)),
+				new ArrayBitmap(new CompositeIntArray(2, 3))
+			);
+
+			assertInstanceOf(CacheablePriceFormula.class, formula);
+		}
 	}
 
-	@Test
-	void shouldReturnNothingForEmptyBitmaps() {
-		assertArrayEquals(
-			new int[0],
-			new DisentangleFormula(
-				EmptyBitmap.INSTANCE,
-				EmptyBitmap.INSTANCE
-			)
-				.compute().getArray()
-		);
-	}
-
-	@Test
-	void shouldReturnFullBitmapForEmptyAndFullBitmap() {
-		assertArrayEquals(
-			new int[0],
-			new DisentangleFormula(
-				EmptyBitmap.INSTANCE,
-				new ArrayBitmap(new CompositeIntArray(3, 3, 6, 9, 12))
-			)
-				.compute().getArray()
-		);
-	}
-
-	@Test
-	void shouldReturnEmptyBitmapForEmptyControlBitmapAndFullMainBitmap() {
-		assertArrayEquals(
-			new int[] {3, 6, 9, 12},
-			new DisentangleFormula(
-				new ArrayBitmap(new CompositeIntArray(3, 3, 6, 9, 12)),
-				EmptyBitmap.INSTANCE
-			)
-				.compute().getArray()
-		);
-	}
-
-	private void assertDistinctArray(int[] expectedResult, int[] mainArray, int[] controlArray) {
+	/**
+	 * Asserts that disentangling main against control produces the expected result, testing both
+	 * bitmap-based and formula-based constructors.
+	 */
+	private void assertDistinctArray(@Nonnull int[] expectedResult, @Nonnull int[] mainArray, @Nonnull int[] controlArray) {
 		assertArrayEquals(
 			expectedResult,
 			new DisentangleFormula(
@@ -158,11 +382,25 @@ class DisentangleFormulaTest {
 		assertArrayEquals(
 			expectedResult,
 			new DisentangleFormula(
-				mainArray.length == 0 ? EmptyFormula.INSTANCE : new ConstantFormula(new ArrayBitmap(new CompositeIntArray(mainArray))),
-				controlArray.length == 0 ? EmptyFormula.INSTANCE : new ConstantFormula(new ArrayBitmap(new CompositeIntArray(controlArray)))
+				mainArray.length == 0 ?
+					EmptyFormula.INSTANCE :
+					new ConstantFormula(new ArrayBitmap(new CompositeIntArray(mainArray))),
+				controlArray.length == 0 ?
+					EmptyFormula.INSTANCE :
+					new ConstantFormula(new ArrayBitmap(new CompositeIntArray(controlArray)))
 			)
 				.compute().getArray()
 		);
 	}
 
+	/**
+	 * Creates a {@link DisentangleFormula} from formula-based children for hash testing.
+	 */
+	@Nonnull
+	private static DisentangleFormula createDisentangleFormula(@Nonnull int[] main, @Nonnull int[] control) {
+		return new DisentangleFormula(
+			new ConstantFormula(new ArrayBitmap(new CompositeIntArray(main))),
+			new ConstantFormula(new ArrayBitmap(new CompositeIntArray(control)))
+		);
+	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/base/JoinFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/base/JoinFormulaTest.java
@@ -23,150 +23,315 @@
 
 package io.evitadb.core.query.algebra.base;
 
+import io.evitadb.core.query.algebra.CacheableFormula;
 import io.evitadb.dataType.array.CompositeIntArray;
 import io.evitadb.index.bitmap.ArrayBitmap;
 import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * This test verifies contract of {@link JoinFormula}.
+ * Tests for {@link JoinFormula} verifying duplicate-preserving merge, memoization,
+ * cloning restrictions, hashing and cost estimation.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
+@DisplayName("JoinFormula — duplicate-preserving merge")
 class JoinFormulaTest {
 
-	@Test
-	void shouldApplyBitmapJoin() {
-		assertArrayEquals(
-			new int[]{1, 1, 2, 2, 3, 4, 4, 5, 5},
-			new JoinFormula(
+	@Nested
+	@DisplayName("Computation correctness")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should merge three bitmaps preserving duplicates in sorted order")
+		void shouldApplyBitmapJoin() {
+			assertArrayEquals(
+				new int[]{1, 1, 2, 2, 3, 4, 4, 5, 5},
+				new JoinFormula(
+					1L,
+					new BaseBitmap(1, 2, 3, 4, 5),
+					new BaseBitmap(2, 4),
+					new BaseBitmap(1, 5)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should merge three ArrayBitmap inputs preserving duplicates")
+		void shouldApplyBitmapJoinWithFormula() {
+			assertArrayEquals(
+				new int[]{1, 1, 2, 2, 3, 4, 4, 5, 5},
+				new JoinFormula(
+					1L,
+					new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5)),
+					new ArrayBitmap(new CompositeIntArray(2, 4)),
+					new ArrayBitmap(new CompositeIntArray(1, 5))
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return empty for two empty bitmaps")
+		void shouldReturnNothingForEmptyBitmaps() {
+			assertArrayEquals(
+				new int[0],
+				new JoinFormula(
+					1L,
+					new BaseBitmap(),
+					new BaseBitmap()
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return full bitmap when joined with empty")
+		void shouldReturnFullBitmapForEmptyAndFullBitmap() {
+			assertArrayEquals(
+				new int[]{1, 3, 4, 5, 8},
+				new JoinFormula(
+					1L,
+					new BaseBitmap(1, 3, 4, 5, 8),
+					new BaseBitmap()
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should duplicate common elements when one bitmap is subset of other")
+		void shouldHandleOneBitmapBeingSubsetOfOther() {
+			assertArrayEquals(
+				new int[]{1, 1, 2, 2, 3, 3, 4, 5, 5},
+				new JoinFormula(
+					1L,
+					new BaseBitmap(1, 2, 3, 4, 5),
+					new BaseBitmap(1, 2, 3, 5)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should merge overlapping bitmaps preserving duplicates")
+		void shouldHandleOverlappingBitmaps() {
+			assertArrayEquals(
+				new int[]{1, 1, 2, 3, 4, 5, 5, 7, 8, 8},
+				new JoinFormula(
+					1L,
+					new BaseBitmap(1, 2, 5, 7, 8),
+					new BaseBitmap(1, 3, 4, 5, 8)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should handle first bitmap being considerably smaller")
+		void shouldHandleFirstBitmapConsiderablySmaller() {
+			assertArrayEquals(
+				new int[]{1, 2, 2, 3, 4, 5},
+				new JoinFormula(
+					1L,
+					new BaseBitmap(2),
+					new BaseBitmap(1, 2, 3, 4, 5)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should handle second bitmap being considerably smaller")
+		void shouldHandleSecondBitmapConsiderablySmaller() {
+			assertArrayEquals(
+				new int[]{1, 2, 2, 3, 4, 5},
+				new JoinFormula(
+					1L,
+					new BaseBitmap(1, 2, 3, 4, 5),
+					new BaseBitmap(2)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should concatenate bitmaps with no common elements")
+		void shouldHandleBitmapsHavingNoCommonElements() {
+			assertArrayEquals(
+				new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				new JoinFormula(
+					1L,
+					new BaseBitmap(1, 2, 3, 4, 5),
+					new BaseBitmap(6, 7, 8, 9, 10)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return single bitmap when other is empty")
+		void shouldHandleOneBitmapBeingEmpty() {
+			assertArrayEquals(
+				new int[]{1, 2, 3, 4, 5},
+				new JoinFormula(
+					1L,
+					new BaseBitmap(1, 2, 3, 4, 5),
+					new BaseBitmap()
+				)
+					.compute().getArray()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Memoization")
+	class MemoizationTest {
+
+		@Test
+		@DisplayName("should return same instance on repeated compute calls")
+		void shouldReturnSameInstanceOnRepeatedCompute() {
+			final JoinFormula formula = new JoinFormula(
+				1L,
+				new BaseBitmap(1, 2, 3),
+				new BaseBitmap(2, 3, 4)
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
+	}
+
+	@Nested
+	@DisplayName("Clear memory")
+	class ClearMemoryTest {
+
+		@Test
+		@DisplayName("should recompute equal result after clearMemory")
+		void shouldRecomputeEqualResultAfterClearMemory() {
+			final JoinFormula formula = new JoinFormula(
+				1L,
+				new BaseBitmap(1, 2, 3),
+				new BaseBitmap(2, 3, 4)
+			);
+
+			final Bitmap first = formula.compute();
+			formula.clearMemory();
+			final Bitmap second = formula.compute();
+
+			assertNotSame(first, second);
+			assertArrayEquals(first.getArray(), second.getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should throw UnsupportedOperationException on clone attempt")
+		void shouldThrowOnCloneAttempt() {
+			final JoinFormula formula = new JoinFormula(
+				1L,
+				new BaseBitmap(1, 2, 3),
+				new BaseBitmap(4, 5, 6)
+			);
+
+			assertThrows(
+				UnsupportedOperationException.class,
+				formula::getCloneWithInnerFormulas
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically-constructed formulas")
+		void shouldProduceIdenticalHashForIdenticalFormulas() {
+			final long hashA = new JoinFormula(1L, new BaseBitmap(1, 2, 3), new BaseBitmap(4, 5)).getHash();
+			final long hashB = new JoinFormula(1L, new BaseBitmap(1, 2, 3), new BaseBitmap(4, 5)).getHash();
+
+			assertEquals(hashA, hashB);
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different bitmaps")
+		void shouldProduceDifferentHashForDifferentBitmaps() {
+			final long hashA = new JoinFormula(1L, new BaseBitmap(1, 2, 3), new BaseBitmap(4, 5)).getHash();
+			final long hashB = new JoinFormula(1L, new BaseBitmap(7, 8, 9), new BaseBitmap(4, 5)).getHash();
+
+			assertNotEquals(hashA, hashB);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should return sum of cardinalities across bitmaps")
+		void shouldReturnSumOfCardinalities() {
+			final JoinFormula formula = new JoinFormula(
+				1L,
+				new BaseBitmap(1, 2, 3),
+				new BaseBitmap(4, 5)
+			);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cost ordering")
+	class CostOrderingTest {
+
+		@Test
+		@DisplayName("should have non-negative estimated and actual cost with estimated being an upper bound")
+		void shouldHaveNonNegativeCostsWithEstimatedAsUpperBound() {
+			final JoinFormula formula = new JoinFormula(
 				1L,
 				new BaseBitmap(1, 2, 3, 4, 5),
-				new BaseBitmap(2, 4),
-				new BaseBitmap(1, 5)
-			)
-				.compute().getArray()
-		);
+				new BaseBitmap(3, 4, 5, 6, 7)
+			);
+
+			final long estimatedCost = formula.getEstimatedCost();
+			formula.compute();
+			final long actualCost = formula.getCost();
+
+			assertTrue(estimatedCost >= 0, "Estimated cost should be non-negative, was: " + estimatedCost);
+			assertTrue(actualCost >= 0, "Actual cost should be non-negative, was: " + actualCost);
+			assertTrue(
+				estimatedCost >= actualCost,
+				"Estimated cost " + estimatedCost + " should be >= actual cost " + actualCost
+			);
+		}
 	}
 
-	@Test
-	void shouldApplyBitmapJoinWithFormula() {
-		assertArrayEquals(
-			new int[]{1, 1, 2, 2, 3, 4, 4, 5, 5},
-			new JoinFormula(
+	@Nested
+	@DisplayName("Cache behavior")
+	class CacheBehaviorTest {
+
+		@Test
+		@DisplayName("should NOT implement CacheableFormula")
+		void shouldNotImplementCacheableFormula() {
+			final JoinFormula formula = new JoinFormula(
 				1L,
-				new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5)),
-				new ArrayBitmap(new CompositeIntArray(2, 4)),
-				new ArrayBitmap(new CompositeIntArray(1, 5))
-			)
-				.compute().getArray()
-		);
-	}
+				new BaseBitmap(1, 2),
+				new BaseBitmap(3, 4)
+			);
 
-	@Test
-	void shouldReturnNothingForEmptyBitmaps() {
-		assertArrayEquals(
-			new int[0],
-			new JoinFormula(
-				1L,
-				new BaseBitmap(),
-				new BaseBitmap()
-			)
-				.compute().getArray()
-		);
+			assertFalse(formula instanceof CacheableFormula);
+		}
 	}
-
-	@Test
-	void shouldReturnFullBitmapForEmptyAndFullBitmap() {
-		assertArrayEquals(
-			new int[]{1, 3, 4, 5, 8},
-			new JoinFormula(
-				1L,
-				new BaseBitmap(1, 3, 4, 5, 8),
-				new BaseBitmap()
-			)
-				.compute().getArray()
-		);
-	}
-
-	@Test
-	void shouldHandleOneBitmapBeingSubsetOfOther() {
-		assertArrayEquals(
-			new int[]{1, 1, 2, 2, 3, 3, 4, 5, 5},
-			new JoinFormula(
-				1L,
-				new BaseBitmap(1, 2, 3, 4, 5),
-				new BaseBitmap(1, 2, 3, 5)
-			)
-				.compute().getArray()
-		);
-	}
-
-	@Test
-	void shouldHandleOverlappingBitmaps() {
-		assertArrayEquals(
-			new int[]{1, 1, 2, 3, 4, 5, 5, 7, 8, 8},
-			new JoinFormula(
-				1L,
-				new BaseBitmap(1, 2, 5, 7, 8),
-				new BaseBitmap(1, 3, 4, 5, 8)
-			)
-				.compute().getArray()
-		);
-	}
-
-	@Test
-	void shouldHandleFirstBitmapConsiderablySmaller() {
-		assertArrayEquals(
-			new int[]{1, 2, 2, 3, 4, 5},
-			new JoinFormula(
-				1L,
-				new BaseBitmap(2),
-				new BaseBitmap(1, 2, 3, 4, 5)
-			)
-				.compute().getArray()
-		);
-	}
-
-	@Test
-	void shouldHandleSecondBitmapConsiderablySmaller() {
-		assertArrayEquals(
-			new int[]{1, 2, 2, 3, 4, 5},
-			new JoinFormula(
-				1L,
-				new BaseBitmap(1, 2, 3, 4, 5),
-				new BaseBitmap(2)
-			)
-				.compute().getArray()
-		);
-	}
-
-	@Test
-	void shouldHandleBitmapsHavingNoCommonElements() {
-		assertArrayEquals(
-			new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-			new JoinFormula(
-				1L,
-				new BaseBitmap(1, 2, 3, 4, 5),
-				new BaseBitmap(6, 7, 8, 9, 10)
-			)
-				.compute().getArray()
-		);
-	}
-
-	@Test
-	void shouldHandleOneBitmapBeingEmpty() {
-		assertArrayEquals(
-			new int[]{1, 2, 3, 4, 5},
-			new JoinFormula(
-				1L,
-				new BaseBitmap(1, 2, 3, 4, 5),
-				new BaseBitmap()
-			)
-				.compute().getArray()
-		);
-	}
-
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/base/NotFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/base/NotFormulaTest.java
@@ -23,72 +23,270 @@
 
 package io.evitadb.core.query.algebra.base;
 
+import io.evitadb.core.query.algebra.CacheableFormula;
+import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.dataType.array.CompositeIntArray;
 import io.evitadb.index.bitmap.ArrayBitmap;
 import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import javax.annotation.Nonnull;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * This test verifies contract of {@link NotFormula}.
+ * Tests for {@link NotFormula} verifying boolean negation (NOT) computation, memoization,
+ * cloning, hashing and cost estimation.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
+@DisplayName("NotFormula — boolean negation")
 class NotFormulaTest {
 
-	@Test
-	void shouldApplyBooleanNot() {
-		assertNegatedArray(new int[]{1, 3}, new int[0], new int[]{1, 3});
-		assertNegatedArray(new int[]{6}, new int[]{2, 3, 4}, new int[]{3, 6});
-		assertNegatedArray(new int[]{3, 4}, new int[]{1, 2}, new int[]{1, 2, 3, 4});
-		assertNegatedArray(new int[]{1, 2}, new int[]{3, 4}, new int[]{1, 2, 3, 4});
-		assertNegatedArray(new int[]{1, 4}, new int[]{2, 3}, new int[]{1, 2, 3, 4});
-		assertNegatedArray(new int[]{1, 3}, new int[]{2, 4}, new int[]{1, 2, 3, 4});
-		assertNegatedArray(new int[0], new int[]{1, 2, 3, 4}, new int[]{1, 2, 3, 4});
-		assertNegatedArray(new int[0], new int[]{1, 2, 3, 4, 5, 6}, new int[]{1, 2, 3, 4});
-		assertNegatedArray(new int[]{1, 3, 4}, new int[]{2, 7, 9}, new int[]{1, 2, 3, 4});
-		assertNegatedArray(new int[]{1, 2, 3, 4}, new int[]{7, 9}, new int[]{1, 2, 3, 4});
-		assertNegatedArray(new int[]{3}, new int[]{1, 2, 4, 5, 6, 7}, new int[]{1, 2, 3, 4, 5, 6, 7});
+	@Nested
+	@DisplayName("Computation correctness")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should subtract elements from superset across various cases")
+		void shouldApplyBooleanNot() {
+			assertNegatedArray(new int[]{1, 3}, new int[0], new int[]{1, 3});
+			assertNegatedArray(new int[]{6}, new int[]{2, 3, 4}, new int[]{3, 6});
+			assertNegatedArray(new int[]{3, 4}, new int[]{1, 2}, new int[]{1, 2, 3, 4});
+			assertNegatedArray(new int[]{1, 2}, new int[]{3, 4}, new int[]{1, 2, 3, 4});
+			assertNegatedArray(new int[]{1, 4}, new int[]{2, 3}, new int[]{1, 2, 3, 4});
+			assertNegatedArray(new int[]{1, 3}, new int[]{2, 4}, new int[]{1, 2, 3, 4});
+			assertNegatedArray(new int[0], new int[]{1, 2, 3, 4}, new int[]{1, 2, 3, 4});
+			assertNegatedArray(new int[0], new int[]{1, 2, 3, 4, 5, 6}, new int[]{1, 2, 3, 4});
+			assertNegatedArray(new int[]{1, 3, 4}, new int[]{2, 7, 9}, new int[]{1, 2, 3, 4});
+			assertNegatedArray(new int[]{1, 2, 3, 4}, new int[]{7, 9}, new int[]{1, 2, 3, 4});
+			assertNegatedArray(new int[]{3}, new int[]{1, 2, 4, 5, 6, 7}, new int[]{1, 2, 3, 4, 5, 6, 7});
+		}
+
+		@Test
+		@DisplayName("should return empty for two empty bitmaps")
+		void shouldReturnNothingForEmptyBitmaps() {
+			assertArrayEquals(
+				new int[0],
+				new NotFormula(
+					new BaseBitmap(),
+					new BaseBitmap()
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return empty when superset is empty")
+		void shouldReturnNothingForEmptyAndFullBitmap() {
+			assertArrayEquals(
+				new int[0],
+				new NotFormula(
+					new BaseBitmap(1, 3, 4, 5, 8),
+					new BaseBitmap()
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return all when subtracted is empty")
+		void shouldReturnAllForFullAndEmptyBitmap() {
+			assertArrayEquals(
+				new int[]{1, 3, 4, 5, 8},
+				new NotFormula(
+					new BaseBitmap(),
+					new BaseBitmap(1, 3, 4, 5, 8)
+				)
+					.compute().getArray()
+			);
+		}
 	}
 
-	@Test
-	void shouldReturnNothingForEmptyBitmaps() {
-		assertArrayEquals(
-			new int[0],
-			new NotFormula(
-				new BaseBitmap(),
-				new BaseBitmap()
-			)
-				.compute().getArray()
-		);
+	@Nested
+	@DisplayName("Memoization")
+	class MemoizationTest {
+
+		@Test
+		@DisplayName("should return same instance on repeated compute calls")
+		void shouldReturnSameInstanceOnRepeatedCompute() {
+			final NotFormula formula = new NotFormula(
+				new BaseBitmap(2, 4),
+				new BaseBitmap(1, 2, 3, 4, 5)
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
+
+		@Test
+		@DisplayName("should return same instance on repeated compute calls with formula children")
+		void shouldReturnSameInstanceOnRepeatedComputeWithFormulas() {
+			final NotFormula formula = new NotFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 4))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5)))
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
 	}
 
-	@Test
-	void shouldReturnNothingForEmptyAndFullBitmap() {
-		assertArrayEquals(
-			new int[0],
-			new NotFormula(
-				new BaseBitmap(1, 3, 4, 5, 8),
-				new BaseBitmap()
-			)
-				.compute().getArray()
-		);
+	@Nested
+	@DisplayName("Clear memory")
+	class ClearMemoryTest {
+
+		@Test
+		@DisplayName("should recompute equal result after clearMemory")
+		void shouldRecomputeEqualResultAfterClearMemory() {
+			final NotFormula formula = new NotFormula(
+				new BaseBitmap(2, 4),
+				new BaseBitmap(1, 2, 3, 4, 5)
+			);
+
+			final Bitmap first = formula.compute();
+			formula.clearMemory();
+			final Bitmap second = formula.compute();
+
+			assertNotSame(first, second);
+			assertArrayEquals(first.getArray(), second.getArray());
+		}
 	}
 
-	@Test
-	void shouldReturnAllForFullAndEmptyBitmap() {
-		assertArrayEquals(
-			new int[]{1, 3, 4, 5, 8},
-			new NotFormula(
-				new BaseBitmap(),
-				new BaseBitmap(1, 3, 4, 5, 8)
-			)
-				.compute().getArray()
-		);
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should return new NotFormula preserving computation when cloned")
+		void shouldReturnNewNotFormulaWhenCloned() {
+			final ConstantFormula subtracted = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 4)));
+			final ConstantFormula superset = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5)));
+			final NotFormula original = new NotFormula(subtracted, superset);
+
+			final Formula clone = original.getCloneWithInnerFormulas(subtracted, superset);
+
+			assertInstanceOf(NotFormula.class, clone);
+			assertArrayEquals(original.compute().getArray(), clone.compute().getArray());
+		}
 	}
 
-	private void assertNegatedArray(int[] expectedResult, int[] negatedArray, int[] mainArray) {
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically-constructed formulas")
+		void shouldProduceIdenticalHashForIdenticalFormulas() {
+			final long hashA = createNotFormula(new int[]{2, 4}, new int[]{1, 2, 3, 4, 5}).getHash();
+			final long hashB = createNotFormula(new int[]{2, 4}, new int[]{1, 2, 3, 4, 5}).getHash();
+
+			assertEquals(hashA, hashB);
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different children")
+		void shouldProduceDifferentHashForDifferentChildren() {
+			final long hashA = createNotFormula(new int[]{2, 4}, new int[]{1, 2, 3, 4, 5}).getHash();
+			final long hashB = createNotFormula(new int[]{1, 3}, new int[]{1, 2, 3, 4, 5}).getHash();
+
+			assertNotEquals(hashA, hashB);
+		}
+
+		@Test
+		@DisplayName("should produce different hash when subtracted and superset are swapped (order-significant)")
+		void shouldProduceDifferentHashWhenArgumentsSwapped() {
+			final ConstantFormula childA = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3)));
+			final ConstantFormula childB = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 3, 4, 5)));
+
+			// NOT(A, B) vs NOT(B, A) — order matters
+			final long hashAB = new NotFormula(childA, childB).getHash();
+			final long hashBA = new NotFormula(childB, childA).getHash();
+
+			assertNotEquals(hashAB, hashBA);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should return superset cardinality for bitmap-based construction")
+		void shouldReturnSupersetCardinalityForBitmaps() {
+			final NotFormula formula = new NotFormula(
+				new BaseBitmap(2, 4),
+				new BaseBitmap(1, 2, 3, 4, 5)
+			);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should return superset cardinality for formula-based construction")
+		void shouldReturnSupersetCardinalityForFormulas() {
+			final NotFormula formula = new NotFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2, 4))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5)))
+			);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cost ordering")
+	class CostOrderingTest {
+
+		@Test
+		@DisplayName("should have non-negative estimated and actual cost with estimated being an upper bound")
+		void shouldHaveNonNegativeCostsWithEstimatedAsUpperBound() {
+			final NotFormula formula = new NotFormula(
+				new BaseBitmap(2, 4),
+				new BaseBitmap(1, 2, 3, 4, 5)
+			);
+
+			final long estimatedCost = formula.getEstimatedCost();
+			formula.compute();
+			final long actualCost = formula.getCost();
+
+			assertTrue(estimatedCost >= 0, "Estimated cost should be non-negative, was: " + estimatedCost);
+			assertTrue(actualCost >= 0, "Actual cost should be non-negative, was: " + actualCost);
+			assertTrue(
+				estimatedCost >= actualCost,
+				"Estimated cost " + estimatedCost + " should be >= actual cost " + actualCost
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cache behavior")
+	class CacheBehaviorTest {
+
+		@Test
+		@DisplayName("should implement CacheableFormula")
+		void shouldImplementCacheableFormula() {
+			final NotFormula formula = new NotFormula(
+				new BaseBitmap(2, 4),
+				new BaseBitmap(1, 2, 3, 4, 5)
+			);
+
+			assertInstanceOf(CacheableFormula.class, formula);
+		}
+	}
+
+	/**
+	 * Asserts that NOT(negatedArray, mainArray) produces the expected result, testing both
+	 * bitmap-based and formula-based constructors.
+	 */
+	private void assertNegatedArray(@Nonnull int[] expectedResult, @Nonnull int[] negatedArray, @Nonnull int[] mainArray) {
 		assertArrayEquals(
 			expectedResult,
 			new NotFormula(
@@ -101,11 +299,25 @@ class NotFormulaTest {
 		assertArrayEquals(
 			expectedResult,
 			new NotFormula(
-				negatedArray.length == 0 ? EmptyFormula.INSTANCE : new ConstantFormula(new ArrayBitmap(new CompositeIntArray(negatedArray))),
-				mainArray.length == 0 ? EmptyFormula.INSTANCE : new ConstantFormula(new ArrayBitmap(new CompositeIntArray(mainArray)))
+				negatedArray.length == 0 ?
+					EmptyFormula.INSTANCE :
+					new ConstantFormula(new ArrayBitmap(new CompositeIntArray(negatedArray))),
+				mainArray.length == 0 ?
+					EmptyFormula.INSTANCE :
+					new ConstantFormula(new ArrayBitmap(new CompositeIntArray(mainArray)))
 			)
 				.compute().getArray()
 		);
 	}
 
+	/**
+	 * Creates a {@link NotFormula} from formula-based children for hash testing.
+	 */
+	@Nonnull
+	private static NotFormula createNotFormula(@Nonnull int[] subtracted, @Nonnull int[] superset) {
+		return new NotFormula(
+			new ConstantFormula(new ArrayBitmap(new CompositeIntArray(subtracted))),
+			new ConstantFormula(new ArrayBitmap(new CompositeIntArray(superset)))
+		);
+	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/base/OrFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/base/OrFormulaTest.java
@@ -23,115 +23,354 @@
 
 package io.evitadb.core.query.algebra.base;
 
+import io.evitadb.core.query.algebra.CacheableFormula;
+import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.dataType.array.CompositeIntArray;
 import io.evitadb.index.bitmap.ArrayBitmap;
 import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import javax.annotation.Nonnull;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * This test verifies contract of {@link OrFormula}.
+ * Tests for {@link OrFormula} verifying boolean disjunction (OR) computation, memoization,
+ * cloning, hashing and cost estimation.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
+@DisplayName("OrFormula — boolean disjunction")
 class OrFormulaTest {
+
 	private static final long[] INDEX_TRANSACTION_ID = {1L};
 
-	@Test
-	void shouldApplyBooleanOr() {
-		assertArrayEquals(
-			new int[]{1, 2, 3, 4, 5, 8},
-			new OrFormula(
+	@Nested
+	@DisplayName("Computation correctness")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should union three overlapping bitmaps")
+		void shouldApplyBooleanOr() {
+			assertArrayEquals(
+				new int[]{1, 2, 3, 4, 5, 8},
+				new OrFormula(
+					INDEX_TRANSACTION_ID,
+					new BaseBitmap(1, 3, 4, 5, 8),
+					new BaseBitmap(1, 2, 4, 8),
+					new BaseBitmap(1, 2, 3, 4, 5)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should union three overlapping formulas")
+		void shouldApplyBooleanOrWithFormula() {
+			assertArrayEquals(
+				new int[]{1, 2, 3, 4, 5, 8},
+				new OrFormula(
+					new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 3, 4, 5, 8))),
+					new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 4, 8))),
+					new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5)))
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should deduplicate across bitmaps with shared elements")
+		void shouldConjugateCollectionsOfDuplicateInt() {
+			assertArrayEquals(
+				new int[]{1, 3, 4, 5, 7, 8},
+				new OrFormula(
+					INDEX_TRANSACTION_ID,
+					new BaseBitmap(1, 3, 5),
+					new BaseBitmap(3, 5, 8),
+					new BaseBitmap(3, 4, 5, 7)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return empty for two empty bitmaps")
+		void shouldReturnNothingForEmptyBitmaps() {
+			assertArrayEquals(
+				new int[0],
+				new OrFormula(
+					INDEX_TRANSACTION_ID,
+					new BaseBitmap(),
+					new BaseBitmap()
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should return union when one bitmap is empty")
+		void shouldReturnJoinForEmptyAndFullBitmap() {
+			assertArrayEquals(
+				new int[]{1, 3, 4, 5},
+				new OrFormula(
+					INDEX_TRANSACTION_ID,
+					new BaseBitmap(3, 4),
+					new BaseBitmap(),
+					new BaseBitmap(1, 5)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should union non-overlapping collections")
+		void shouldConjugateNonOverlappingCollections() {
+			assertArrayEquals(
+				new int[]{1, 3, 4, 5, 6, 7, 9, 10, 11, 12},
+				new OrFormula(
+					INDEX_TRANSACTION_ID,
+					new BaseBitmap(1, 3, 5, 7, 9, 11),
+					new BaseBitmap(3, 4, 5, 6, 7),
+					new BaseBitmap(10, 11, 12)
+				)
+					.compute().getArray()
+			);
+		}
+
+		@Test
+		@DisplayName("should deduplicate completely overlapping collections")
+		void shouldConjugateOverlappingCollections() {
+			assertArrayEquals(
+				new int[]{1, 3, 5, 7, 9, 11},
+				new OrFormula(
+					INDEX_TRANSACTION_ID,
+					new BaseBitmap(1, 3, 5, 7, 9, 11),
+					new BaseBitmap(1, 3, 5, 7, 9, 11),
+					new BaseBitmap(1, 3, 5, 7, 9, 11)
+				)
+					.compute().getArray()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Memoization")
+	class MemoizationTest {
+
+		@Test
+		@DisplayName("should return same instance on repeated compute calls")
+		void shouldReturnSameInstanceOnRepeatedCompute() {
+			final OrFormula formula = new OrFormula(
 				INDEX_TRANSACTION_ID,
-				new BaseBitmap(1, 3, 4, 5, 8),
-				new BaseBitmap(1, 2, 4, 8),
-				new BaseBitmap(1, 2, 3, 4, 5)
-			)
-				.compute().getArray()
-		);
+				new BaseBitmap(1, 2, 3),
+				new BaseBitmap(3, 4, 5)
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
+
+		@Test
+		@DisplayName("should return same instance on repeated compute calls with formula children")
+		void shouldReturnSameInstanceOnRepeatedComputeWithFormulas() {
+			final OrFormula formula = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(3, 4, 5)))
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
 	}
 
-	@Test
-	void shouldApplyBooleanOrWithFormula() {
-		assertArrayEquals(
-			new int[]{1, 2, 3, 4, 5, 8},
-			new OrFormula(
-				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 3, 4, 5, 8))),
-				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 4, 8))),
-				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5)))
-			)
-				.compute().getArray()
-		);
-	}
+	@Nested
+	@DisplayName("Clear memory")
+	class ClearMemoryTest {
 
-	@Test
-	void shouldConjugateCollectionsOfDuplicateInt() {
-		assertArrayEquals(
-			new int[]{1, 3, 4, 5, 7, 8},
-			new OrFormula(
+		@Test
+		@DisplayName("should recompute equal result after clearMemory")
+		void shouldRecomputeEqualResultAfterClearMemory() {
+			final OrFormula formula = new OrFormula(
 				INDEX_TRANSACTION_ID,
-				new BaseBitmap(1, 3, 5),
-				new BaseBitmap(3, 5, 8),
-				new BaseBitmap(3, 4, 5, 7)
-			)
-				.compute().getArray()
-		);
+				new BaseBitmap(1, 2, 3),
+				new BaseBitmap(3, 4, 5)
+			);
+
+			final Bitmap first = formula.compute();
+			formula.clearMemory();
+			final Bitmap second = formula.compute();
+
+			assertNotSame(first, second);
+			assertArrayEquals(first.getArray(), second.getArray());
+		}
 	}
 
-	@Test
-	void shouldReturnNothingForEmptyBitmaps() {
-		assertArrayEquals(
-			new int[0],
-			new OrFormula(
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should return EmptyFormula when cloned with zero children")
+		void shouldReturnEmptyFormulaWhenClonedWithZeroChildren() {
+			final OrFormula original = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(3, 4)))
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas();
+
+			assertSame(EmptyFormula.INSTANCE, clone);
+		}
+
+		@Test
+		@DisplayName("should return the single child directly when cloned with one child")
+		void shouldReturnSingleChildWhenClonedWithOneChild() {
+			final ConstantFormula child = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3)));
+			final OrFormula original = new OrFormula(
+				child,
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(4, 5)))
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas(child);
+
+			assertSame(child, clone);
+		}
+
+		@Test
+		@DisplayName("should return new OrFormula preserving computation when cloned with two+ children")
+		void shouldReturnNewOrFormulaWhenClonedWithMultipleChildren() {
+			final ConstantFormula childA = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3)));
+			final ConstantFormula childB = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(3, 4, 5)));
+			final OrFormula original = new OrFormula(childA, childB);
+
+			final Formula clone = original.getCloneWithInnerFormulas(childA, childB);
+
+			assertInstanceOf(OrFormula.class, clone);
+			assertArrayEquals(original.compute().getArray(), clone.compute().getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically-constructed formulas")
+		void shouldProduceIdenticalHashForIdenticalFormulas() {
+			final long hashA = createOrFormula(1, 2, 3).getHash();
+			final long hashB = createOrFormula(1, 2, 3).getHash();
+
+			assertEquals(hashA, hashB);
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different children")
+		void shouldProduceDifferentHashForDifferentChildren() {
+			final long hashA = createOrFormula(1, 2, 3).getHash();
+			final long hashB = createOrFormula(7, 8, 9).getHash();
+
+			assertNotEquals(hashA, hashB);
+		}
+
+		@Test
+		@DisplayName("should produce same hash when children are reordered (order-insignificant)")
+		void shouldProduceSameHashWhenChildrenReordered() {
+			final ConstantFormula childA = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3)));
+			final ConstantFormula childB = new ConstantFormula(new ArrayBitmap(new CompositeIntArray(4, 5, 6)));
+
+			final long hashAB = new OrFormula(childA, childB).getHash();
+			final long hashBA = new OrFormula(childB, childA).getHash();
+
+			assertEquals(hashAB, hashBA);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should return sum of cardinalities across bitmaps")
+		void shouldReturnSumCardinalityForBitmaps() {
+			final OrFormula formula = new OrFormula(
 				INDEX_TRANSACTION_ID,
-				new BaseBitmap(),
-				new BaseBitmap()
-			)
-				.compute().getArray()
-		);
+				new BaseBitmap(1, 2, 3),
+				new BaseBitmap(4, 5)
+			);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should return sum of cardinalities across formula children")
+		void shouldReturnSumCardinalityForFormulas() {
+			final OrFormula formula = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3))),
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(4, 5)))
+			);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
 	}
 
-	@Test
-	void shouldReturnJoinForEmptyAndFullBitmap() {
-		assertArrayEquals(
-			new int[]{1, 3, 4, 5},
-			new OrFormula(
+	@Nested
+	@DisplayName("Cost ordering")
+	class CostOrderingTest {
+
+		@Test
+		@DisplayName("should have non-negative estimated and actual cost with estimated being an upper bound")
+		void shouldHaveNonNegativeCostsWithEstimatedAsUpperBound() {
+			final OrFormula formula = new OrFormula(
 				INDEX_TRANSACTION_ID,
-				new BaseBitmap(3, 4),
-				new BaseBitmap(),
-				new BaseBitmap(1, 5)
-			)
-				.compute().getArray()
-		);
+				new BaseBitmap(1, 2, 3, 4, 5),
+				new BaseBitmap(3, 4, 5, 6, 7)
+			);
+
+			final long estimatedCost = formula.getEstimatedCost();
+			formula.compute();
+			final long actualCost = formula.getCost();
+
+			assertTrue(estimatedCost >= 0, "Estimated cost should be non-negative, was: " + estimatedCost);
+			assertTrue(actualCost >= 0, "Actual cost should be non-negative, was: " + actualCost);
+			assertTrue(
+				estimatedCost >= actualCost,
+				"Estimated cost " + estimatedCost + " should be >= actual cost " + actualCost
+			);
+		}
 	}
 
-	@Test
-	void shouldConjugateNonOverlappingCollections() {
-		assertArrayEquals(
-			new int[]{1, 3, 4, 5, 6, 7, 9, 10, 11, 12},
-			new OrFormula(
+	@Nested
+	@DisplayName("Cache behavior")
+	class CacheBehaviorTest {
+
+		@Test
+		@DisplayName("should implement CacheableFormula")
+		void shouldImplementCacheableFormula() {
+			final OrFormula formula = new OrFormula(
 				INDEX_TRANSACTION_ID,
-				new BaseBitmap(1, 3, 5, 7, 9, 11),
-				new BaseBitmap(3, 4, 5, 6, 7),
-				new BaseBitmap(10, 11, 12)
-			)
-				.compute().getArray()
-		);
+				new BaseBitmap(1, 2),
+				new BaseBitmap(3, 4)
+			);
+
+			assertInstanceOf(CacheableFormula.class, formula);
+		}
 	}
 
-	@Test
-	void shouldConjugateOverlappingCollections() {
-		assertArrayEquals(
-			new int[]{1, 3, 5, 7, 9, 11},
-			new OrFormula(
-				INDEX_TRANSACTION_ID,
-				new BaseBitmap(1, 3, 5, 7, 9, 11),
-				new BaseBitmap(1, 3, 5, 7, 9, 11),
-				new BaseBitmap(1, 3, 5, 7, 9, 11)
-			)
-				.compute().getArray()
+	/**
+	 * Creates an {@link OrFormula} wrapping two constant formulas for hash testing.
+	 */
+	@Nonnull
+	private static OrFormula createOrFormula(int... values) {
+		return new OrFormula(
+			new ConstantFormula(new ArrayBitmap(new CompositeIntArray(values))),
+			new ConstantFormula(new ArrayBitmap(new CompositeIntArray(10, 20, 30)))
 		);
 	}
-
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/facet/CombinedFacetFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/facet/CombinedFacetFormulaTest.java
@@ -1,0 +1,285 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.facet;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link CombinedFacetFormula} verifying computation, memoization, cloning,
+ * hashing, accessor methods and edge case behavior.
+ *
+ * @author evitaDB
+ */
+@DisplayName("CombinedFacetFormula functionality")
+class CombinedFacetFormulaTest {
+
+	@Nested
+	@DisplayName("Computation")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should compute OR of and-formula and or-formula results")
+		void shouldComputeOrOfAndFormulaAndOrFormulaResults() {
+			final ConstantFormula andPart = new ConstantFormula(new ArrayBitmap(10, 20, 30));
+			final ConstantFormula orPart = new ConstantFormula(new ArrayBitmap(30, 40, 50));
+			final CombinedFacetFormula formula = new CombinedFacetFormula(andPart, orPart);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{10, 20, 30, 40, 50}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should compute OR with non-overlapping inputs")
+		void shouldComputeOrWithNonOverlappingInputs() {
+			final ConstantFormula andPart = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+			final ConstantFormula orPart = new ConstantFormula(new ArrayBitmap(4, 5, 6));
+			final CombinedFacetFormula formula = new CombinedFacetFormula(andPart, orPart);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{1, 2, 3, 4, 5, 6}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should compute OR with fully overlapping inputs")
+		void shouldComputeOrWithFullyOverlappingInputs() {
+			final ConstantFormula andPart = new ConstantFormula(new ArrayBitmap(10, 20, 30));
+			final ConstantFormula orPart = new ConstantFormula(new ArrayBitmap(10, 20, 30));
+			final CombinedFacetFormula formula = new CombinedFacetFormula(andPart, orPart);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{10, 20, 30}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should handle empty formula as one of the inputs")
+		void shouldHandleEmptyFormulaAsOneOfTheInputs() {
+			final ConstantFormula nonEmpty = new ConstantFormula(new ArrayBitmap(10, 20));
+			final CombinedFacetFormula formula = new CombinedFacetFormula(
+				EmptyFormula.INSTANCE, nonEmpty
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{10, 20}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return empty result when both inputs are empty")
+		void shouldReturnEmptyResultWhenBothInputsAreEmpty() {
+			final CombinedFacetFormula formula = new CombinedFacetFormula(
+				EmptyFormula.INSTANCE, EmptyFormula.INSTANCE
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertEquals(0, result.size());
+		}
+	}
+
+	@Nested
+	@DisplayName("Accessor methods")
+	class AccessorTest {
+
+		@Test
+		@DisplayName("should return and-formula via getAndFormula")
+		void shouldReturnAndFormulaViaGetAndFormula() {
+			final ConstantFormula andPart = new ConstantFormula(new ArrayBitmap(10));
+			final ConstantFormula orPart = new ConstantFormula(new ArrayBitmap(20));
+			final CombinedFacetFormula formula = new CombinedFacetFormula(andPart, orPart);
+
+			assertSame(andPart, formula.getAndFormula());
+		}
+
+		@Test
+		@DisplayName("should return or-formula via getOrFormula")
+		void shouldReturnOrFormulaViaGetOrFormula() {
+			final ConstantFormula andPart = new ConstantFormula(new ArrayBitmap(10));
+			final ConstantFormula orPart = new ConstantFormula(new ArrayBitmap(20));
+			final CombinedFacetFormula formula = new CombinedFacetFormula(andPart, orPart);
+
+			assertSame(orPart, formula.getOrFormula());
+		}
+
+		@Test
+		@DisplayName("should have exactly two inner formulas")
+		void shouldHaveExactlyTwoInnerFormulas() {
+			final ConstantFormula andPart = new ConstantFormula(new ArrayBitmap(10));
+			final ConstantFormula orPart = new ConstantFormula(new ArrayBitmap(20));
+			final CombinedFacetFormula formula = new CombinedFacetFormula(andPart, orPart);
+
+			assertEquals(2, formula.getInnerFormulas().length);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should create clone with different inner formulas")
+		void shouldCreateCloneWithDifferentInnerFormulas() {
+			final ConstantFormula andPart = new ConstantFormula(new ArrayBitmap(10));
+			final ConstantFormula orPart = new ConstantFormula(new ArrayBitmap(20));
+			final CombinedFacetFormula original = new CombinedFacetFormula(andPart, orPart);
+
+			final ConstantFormula newAndPart = new ConstantFormula(new ArrayBitmap(100));
+			final ConstantFormula newOrPart = new ConstantFormula(new ArrayBitmap(200));
+			final Formula clone = original.getCloneWithInnerFormulas(newAndPart, newOrPart);
+
+			assertInstanceOf(CombinedFacetFormula.class, clone);
+			final CombinedFacetFormula clonedFormula = (CombinedFacetFormula) clone;
+			assertSame(newAndPart, clonedFormula.getAndFormula());
+			assertSame(newOrPart, clonedFormula.getOrFormula());
+		}
+
+		@Test
+		@DisplayName("should not be same instance as original")
+		void shouldNotBeSameInstanceAsOriginal() {
+			final CombinedFacetFormula original = new CombinedFacetFormula(
+				new ConstantFormula(new ArrayBitmap(10)),
+				new ConstantFormula(new ArrayBitmap(20))
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas(
+				new ConstantFormula(new ArrayBitmap(10)),
+				new ConstantFormula(new ArrayBitmap(20))
+			);
+
+			assertNotSame(original, clone);
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed formulas")
+		void shouldProduceIdenticalHashForIdenticallyConstructedFormulas() {
+			final CombinedFacetFormula formulaA = new CombinedFacetFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20)),
+				new ConstantFormula(new ArrayBitmap(30, 40))
+			);
+			final CombinedFacetFormula formulaB = new CombinedFacetFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20)),
+				new ConstantFormula(new ArrayBitmap(30, 40))
+			);
+
+			assertEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different inner formulas")
+		void shouldProduceDifferentHashForDifferentInnerFormulas() {
+			final CombinedFacetFormula formulaA = new CombinedFacetFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20)),
+				new ConstantFormula(new ArrayBitmap(30, 40))
+			);
+			final CombinedFacetFormula formulaB = new CombinedFacetFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20)),
+				new ConstantFormula(new ArrayBitmap(50, 60))
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should estimate cardinality as sum of inner formula cardinalities")
+		void shouldEstimateCardinalityAsSumOfInnerFormulaCardinalities() {
+			final CombinedFacetFormula formula = new CombinedFacetFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20, 30)),
+				new ConstantFormula(new ArrayBitmap(40, 50))
+			);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
+	}
+
+	@Nested
+	@DisplayName("Error handling")
+	class ErrorHandlingTest {
+
+		@Test
+		@DisplayName("should throw when cloned with fewer than two inner formulas")
+		void shouldThrowWhenClonedWithFewerThanTwoInnerFormulas() {
+			final CombinedFacetFormula original = new CombinedFacetFormula(
+				new ConstantFormula(new ArrayBitmap(10)),
+				new ConstantFormula(new ArrayBitmap(20))
+			);
+
+			final GenericEvitaInternalError exception = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> original.getCloneWithInnerFormulas(
+					new ConstantFormula(new ArrayBitmap(100))
+				)
+			);
+
+			assertTrue(
+				exception.getMessage().contains("exactly 2"),
+				"Exception message should mention exactly 2 required formulas, was: " + exception.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("should throw when cloned with more than two inner formulas")
+		void shouldThrowWhenClonedWithMoreThanTwoInnerFormulas() {
+			final CombinedFacetFormula original = new CombinedFacetFormula(
+				new ConstantFormula(new ArrayBitmap(10)),
+				new ConstantFormula(new ArrayBitmap(20))
+			);
+
+			final GenericEvitaInternalError exception = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> original.getCloneWithInnerFormulas(
+					new ConstantFormula(new ArrayBitmap(100)),
+					new ConstantFormula(new ArrayBitmap(200)),
+					new ConstantFormula(new ArrayBitmap(300))
+				)
+			);
+
+			assertTrue(
+				exception.getMessage().contains("exactly 2"),
+				"Exception message should mention exactly 2 required formulas, was: " + exception.getMessage()
+			);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/facet/FacetGroupFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/facet/FacetGroupFormulaTest.java
@@ -24,94 +24,844 @@
 package io.evitadb.core.query.algebra.facet;
 
 import com.esotericsoftware.kryo.util.IntMap;
+import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.exception.EvitaInternalError;
+import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.index.bitmap.ArrayBitmap;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.EmptyBitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import javax.annotation.Nonnull;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * This test verifies behaviour of {@link FacetGroupFormula} interface.
+ * Tests for {@link FacetGroupAndFormula} and {@link FacetGroupOrFormula} verifying
+ * computation, memoization, cloning, hashing, merging and edge case behavior.
  *
- * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
+ * @author evitaDB
  */
+@DisplayName("FacetGroupFormula (And + Or) functionality")
 class FacetGroupFormulaTest {
 
-	@Test
-	void shouldMergeTwoFacetGroupFormulasTogether() {
-		final FacetGroupAndFormula a = new FacetGroupAndFormula(
-			"product", 1,
-			new ArrayBitmap(1, 2, 3),
-			new BaseBitmap(10),
-			new BaseBitmap(11),
-			new BaseBitmap(12)
-		);
+	@Nested
+	@DisplayName("FacetGroupAndFormula computation")
+	class AndComputationTest {
 
-		final FacetGroupAndFormula b = new FacetGroupAndFormula(
-			"product", 1,
-			new ArrayBitmap(3, 4),
-			new BaseBitmap(20),
-			new BaseBitmap(21)
-		);
+		@Test
+		@DisplayName("should compute AND across overlapping bitmaps")
+		void shouldComputeAndAcrossOverlappingBitmaps() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20, 30),
+				new BaseBitmap(20, 30, 40)
+			);
 
-		final FacetGroupAndFormula result = FacetGroupFormula.mergeWith(
-			a, b, (facetIds, bitmaps) -> new FacetGroupAndFormula("product", 1, facetIds, bitmaps)
-		);
+			final Bitmap result = formula.compute();
 
-		assertNotNull(result);
+			assertArrayEquals(new int[]{20, 30}, result.getArray());
+		}
 
-		assertFacetGroupFormulaIs(
-			new int[] {1, 2, 3, 4},
-			new Bitmap[] {
+		@Test
+		@DisplayName("should return empty bitmap for non-overlapping bitmaps")
+		void shouldReturnEmptyBitmapForNonOverlappingBitmaps() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20),
+				new BaseBitmap(30, 40)
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertEquals(0, result.size());
+		}
+
+		@Test
+		@DisplayName("should return single bitmap contents when only one bitmap provided")
+		void shouldReturnSingleBitmapContentsWhenOnlyOneBitmapProvided() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10, 20, 30)
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{10, 20, 30}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return empty bitmap when any input bitmap is empty")
+		void shouldReturnEmptyBitmapWhenAnyInputBitmapIsEmpty() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20, 30),
+				new BaseBitmap()
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertEquals(0, result.size());
+		}
+	}
+
+	@Nested
+	@DisplayName("FacetGroupOrFormula computation")
+	class OrComputationTest {
+
+		@Test
+		@DisplayName("should compute OR across overlapping bitmaps")
+		void shouldComputeOrAcrossOverlappingBitmaps() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20, 30),
+				new BaseBitmap(20, 30, 40)
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{10, 20, 30, 40}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should compute OR across non-overlapping bitmaps")
+		void shouldComputeOrAcrossNonOverlappingBitmaps() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20),
+				new BaseBitmap(30, 40)
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{10, 20, 30, 40}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return single bitmap contents when only one bitmap provided")
+		void shouldReturnSingleBitmapContentsWhenOnlyOneBitmapProvided() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10, 20, 30)
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{10, 20, 30}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return empty bitmap when no bitmaps provided")
+		void shouldReturnEmptyBitmapWhenNoBitmapsProvided() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				EmptyBitmap.INSTANCE
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should handle one empty and one non-empty bitmap")
+		void shouldHandleOneEmptyAndOneNonEmptyBitmap() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20),
+				new BaseBitmap()
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{10, 20}, result.getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Memoization")
+	class MemoizationTest {
+
+		@Test
+		@DisplayName("should return same instance on repeated AND compute calls")
+		void shouldReturnSameInstanceOnRepeatedAndComputeCalls() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10, 20)
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
+
+		@Test
+		@DisplayName("should return same instance on repeated OR compute calls")
+		void shouldReturnSameInstanceOnRepeatedOrComputeCalls() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10, 20)
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
+	}
+
+	@Nested
+	@DisplayName("Clear memory and recomputation")
+	class ClearMemoryTest {
+
+		@Test
+		@DisplayName("should recompute AND after clearMemory and produce equal result")
+		void shouldRecomputeAndAfterClearMemoryAndProduceEqualResult() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20, 30),
+				new BaseBitmap(20, 30, 40)
+			);
+
+			final Bitmap first = formula.compute();
+			final int[] firstArray = first.getArray();
+			formula.clearMemory();
+			final Bitmap second = formula.compute();
+
+			assertNotSame(first, second);
+			assertArrayEquals(firstArray, second.getArray());
+		}
+
+		@Test
+		@DisplayName("should recompute OR after clearMemory and produce equal result")
+		void shouldRecomputeOrAfterClearMemoryAndProduceEqualResult() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20),
+				new BaseBitmap(30, 40)
+			);
+
+			final Bitmap first = formula.compute();
+			final int[] firstArray = first.getArray();
+			formula.clearMemory();
+			final Bitmap second = formula.compute();
+
+			assertNotSame(first, second);
+			assertArrayEquals(firstArray, second.getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should return same AND formula instance since it has no inner formulas")
+		void shouldReturnSameAndFormulaInstanceSinceItHasNoInnerFormulas() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20),
+				new BaseBitmap(30, 40)
+			);
+
+			final Formula clone = formula.getCloneWithInnerFormulas();
+
+			assertSame(formula, clone);
+		}
+
+		@Test
+		@DisplayName("should reject inner formulas for AND formula clone")
+		void shouldRejectInnerFormulasForAndFormulaClone() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+
+			assertThrows(
+				EvitaInvalidUsageException.class,
+				() -> formula.getCloneWithInnerFormulas(
+					new FacetGroupAndFormula("other", 2, new ArrayBitmap(5), new BaseBitmap(50))
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should return same OR formula instance since it has no inner formulas")
+		void shouldReturnSameOrFormulaInstanceSinceItHasNoInnerFormulas() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20),
+				new BaseBitmap(30, 40)
+			);
+
+			final Formula clone = formula.getCloneWithInnerFormulas();
+
+			assertSame(formula, clone);
+		}
+
+		@Test
+		@DisplayName("should reject inner formulas for OR formula clone")
+		void shouldRejectInnerFormulasForOrFormulaClone() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+
+			assertThrows(
+				EvitaInvalidUsageException.class,
+				() -> formula.getCloneWithInnerFormulas(
+					new FacetGroupOrFormula("other", 2, new ArrayBitmap(5), new BaseBitmap(50))
+				)
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed AND formulas")
+		void shouldProduceIdenticalHashForIdenticallyConstructedAndFormulas() {
+			final FacetGroupAndFormula formulaA = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20),
+				new BaseBitmap(30, 40)
+			);
+			final FacetGroupAndFormula formulaB = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20),
+				new BaseBitmap(30, 40)
+			);
+
+			assertEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different reference names")
+		void shouldProduceDifferentHashForDifferentReferenceNames() {
+			final FacetGroupAndFormula formulaA = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+			final FacetGroupAndFormula formulaB = new FacetGroupAndFormula(
+				"category", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different facet group ids")
+		void shouldProduceDifferentHashForDifferentFacetGroupIds() {
+			final FacetGroupAndFormula formulaA = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+			final FacetGroupAndFormula formulaB = new FacetGroupAndFormula(
+				"product", 2,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different facet ids")
+		void shouldProduceDifferentHashForDifferentFacetIds() {
+			final FacetGroupAndFormula formulaA = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+			final FacetGroupAndFormula formulaB = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(2),
+				new BaseBitmap(10)
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hashes for AND vs OR formulas")
+		void shouldProduceDifferentHashesForAndVsOrFormulas() {
+			final FacetGroupAndFormula andFormula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10, 20)
+			);
+			final FacetGroupOrFormula orFormula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10, 20)
+			);
+
+			assertNotEquals(andFormula.getHash(), orFormula.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed OR formulas")
+		void shouldProduceIdenticalHashForIdenticallyConstructedOrFormulas() {
+			final FacetGroupOrFormula formulaA = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20),
+				new BaseBitmap(30, 40)
+			);
+			final FacetGroupOrFormula formulaB = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20),
+				new BaseBitmap(30, 40)
+			);
+
+			assertEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should handle null facet group id in hash")
+		void shouldHandleNullFacetGroupIdInHash() {
+			final FacetGroupAndFormula formulaA = new FacetGroupAndFormula(
+				"product", null,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+			final FacetGroupAndFormula formulaB = new FacetGroupAndFormula(
+				"product", null,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+
+			assertEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for null vs non-null facet group id")
+		void shouldProduceDifferentHashForNullVsNonNullFacetGroupId() {
+			final FacetGroupAndFormula formulaA = new FacetGroupAndFormula(
+				"product", null,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+			final FacetGroupAndFormula formulaB = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("AND should estimate cardinality as minimum of bitmap sizes")
+		void andShouldEstimateCardinalityAsMinimumOfBitmapSizes() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2, 3),
+				new BaseBitmap(10, 20, 30),
+				new BaseBitmap(40, 50),
+				new BaseBitmap(60, 70, 80, 90)
+			);
+
+			assertEquals(2, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("OR should estimate cardinality as sum of bitmap sizes")
+		void orShouldEstimateCardinalityAsSumOfBitmapSizes() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2, 3),
+				new BaseBitmap(10, 20, 30),
+				new BaseBitmap(40, 50),
+				new BaseBitmap(60, 70, 80, 90)
+			);
+
+			assertEquals(9, formula.getEstimatedCardinality());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cost ordering")
+	class CostOrderingTest {
+
+		@Test
+		@DisplayName("AND estimated cost should be a non-negative upper bound of actual cost")
+		void andEstimatedCostShouldBeUpperBoundOfActualCost() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20, 30),
+				new BaseBitmap(20, 30, 40)
+			);
+
+			final long estimatedCost = formula.getEstimatedCost();
+			formula.compute();
+			final long actualCost = formula.getCost();
+
+			assertTrue(estimatedCost >= 0, "Estimated cost should be non-negative, was: " + estimatedCost);
+			assertTrue(actualCost >= 0, "Actual cost should be non-negative, was: " + actualCost);
+			assertTrue(
+				estimatedCost >= actualCost,
+				"Estimated cost (" + estimatedCost + ") should be >= actual cost (" + actualCost + ")"
+			);
+		}
+
+		@Test
+		@DisplayName("OR estimated cost should be a non-negative upper bound of actual cost")
+		void orEstimatedCostShouldBeUpperBoundOfActualCost() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10, 20, 30),
+				new BaseBitmap(20, 30, 40)
+			);
+
+			final long estimatedCost = formula.getEstimatedCost();
+			formula.compute();
+			final long actualCost = formula.getCost();
+
+			assertTrue(estimatedCost >= 0, "Estimated cost should be non-negative, was: " + estimatedCost);
+			assertTrue(actualCost >= 0, "Actual cost should be non-negative, was: " + actualCost);
+			assertTrue(
+				estimatedCost >= actualCost,
+				"Estimated cost (" + estimatedCost + ") should be >= actual cost (" + actualCost + ")"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Merge with")
+	class MergeWithTest {
+
+		@Test
+		@DisplayName("should merge two AND formulas with overlapping facet ids")
+		void shouldMergeTwoAndFormulasWithOverlappingFacetIds() {
+			final FacetGroupAndFormula a = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2, 3),
 				new BaseBitmap(10),
 				new BaseBitmap(11),
-				new BaseBitmap(12, 20),
-				new BaseBitmap(21),
-			},
-			result
-		);
+				new BaseBitmap(12)
+			);
+			final FacetGroupAndFormula b = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(3, 4),
+				new BaseBitmap(20),
+				new BaseBitmap(21)
+			);
+
+			final FacetGroupFormula result = a.mergeWith(b);
+
+			assertInstanceOf(FacetGroupAndFormula.class, result);
+			assertFacetGroupFormulaIs(
+				new int[]{1, 2, 3, 4},
+				new Bitmap[]{
+					new BaseBitmap(10),
+					new BaseBitmap(11),
+					new BaseBitmap(12, 20),
+					new BaseBitmap(21),
+				},
+				(FacetGroupAndFormula) result
+			);
+		}
+
+		@Test
+		@DisplayName("should merge two AND formulas with disjoint facet ids")
+		void shouldMergeTwoAndFormulasWithDisjointFacetIds() {
+			final FacetGroupAndFormula a = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10),
+				new BaseBitmap(20)
+			);
+			final FacetGroupAndFormula b = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(3, 4),
+				new BaseBitmap(30),
+				new BaseBitmap(40)
+			);
+
+			final FacetGroupFormula result = a.mergeWith(b);
+
+			assertInstanceOf(FacetGroupAndFormula.class, result);
+			assertFacetGroupFormulaIs(
+				new int[]{1, 2, 3, 4},
+				new Bitmap[]{
+					new BaseBitmap(10),
+					new BaseBitmap(20),
+					new BaseBitmap(30),
+					new BaseBitmap(40),
+				},
+				(FacetGroupAndFormula) result
+			);
+		}
+
+		@Test
+		@DisplayName("should merge two OR formulas together")
+		void shouldMergeTwoOrFormulasTogether() {
+			final FacetGroupOrFormula a = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10),
+				new BaseBitmap(20)
+			);
+			final FacetGroupOrFormula b = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(3),
+				new BaseBitmap(30)
+			);
+
+			final FacetGroupFormula result = a.mergeWith(b);
+
+			assertInstanceOf(FacetGroupOrFormula.class, result);
+			final FacetGroupOrFormula orResult = (FacetGroupOrFormula) result;
+			assertArrayEquals(new int[]{1, 2, 3}, orResult.getFacetIds().getArray());
+			assertEquals(3, orResult.getBitmaps().length);
+		}
+
+		@Test
+		@DisplayName("should merge two AND formulas via static mergeWith")
+		void shouldMergeTwoFacetGroupFormulasTogetherViaStaticMergeWith() {
+			final FacetGroupAndFormula a = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2, 3),
+				new BaseBitmap(10),
+				new BaseBitmap(11),
+				new BaseBitmap(12)
+			);
+			final FacetGroupAndFormula b = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(3, 4),
+				new BaseBitmap(20),
+				new BaseBitmap(21)
+			);
+
+			final FacetGroupAndFormula result = FacetGroupFormula.mergeWith(
+				a, b, (facetIds, bitmaps) -> new FacetGroupAndFormula("product", 1, facetIds, bitmaps)
+			);
+
+			assertNotNull(result);
+			assertFacetGroupFormulaIs(
+				new int[]{1, 2, 3, 4},
+				new Bitmap[]{
+					new BaseBitmap(10),
+					new BaseBitmap(11),
+					new BaseBitmap(12, 20),
+					new BaseBitmap(21),
+				},
+				result
+			);
+		}
+
+		@Test
+		@DisplayName("should fail to merge when reference names differ")
+		void shouldFailToMergeWhenReferenceNamesDiffer() {
+			assertThrows(
+				EvitaInternalError.class,
+				() -> FacetGroupFormula.mergeWith(
+					new FacetGroupAndFormula("productA", 1, EmptyBitmap.INSTANCE),
+					new FacetGroupAndFormula("productB", 1, EmptyBitmap.INSTANCE),
+					(facetIds, bitmaps) -> new FacetGroupAndFormula("product", 1, facetIds, bitmaps)
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should fail to merge when group ids differ")
+		void shouldFailToMergeWhenGroupIdsDiffer() {
+			assertThrows(
+				EvitaInternalError.class,
+				() -> FacetGroupFormula.mergeWith(
+					new FacetGroupAndFormula("product", 1, EmptyBitmap.INSTANCE),
+					new FacetGroupAndFormula("product", 2, EmptyBitmap.INSTANCE),
+					(facetIds, bitmaps) -> new FacetGroupAndFormula("product", 1, facetIds, bitmaps)
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should fail to merge when one group id is null and the other is not")
+		void shouldFailToMergeWhenOneGroupIdIsNullAndTheOtherIsNot() {
+			assertThrows(
+				EvitaInternalError.class,
+				() -> FacetGroupFormula.mergeWith(
+					new FacetGroupAndFormula("product", null, EmptyBitmap.INSTANCE),
+					new FacetGroupAndFormula("product", 1, EmptyBitmap.INSTANCE),
+					(facetIds, bitmaps) -> new FacetGroupAndFormula("product", 1, facetIds, bitmaps)
+				)
+			);
+		}
 	}
 
-	@Test
-	void shouldFailToMergeTwoFacetGroupFormulasTogetherWhenEntitTypeDiffers() {
-		assertThrows(
-			EvitaInternalError.class,
-			() -> FacetGroupFormula.mergeWith(
-				new FacetGroupAndFormula(
-					"productA", 1,
-					EmptyBitmap.INSTANCE
-				), new FacetGroupAndFormula(
-					"productB", 1,
-					EmptyBitmap.INSTANCE
-				),
-				(facetIds, bitmaps) -> new FacetGroupAndFormula("product", 1, facetIds, bitmaps)
-			)
-		);
-	}
+	@Nested
+	@DisplayName("Edge cases")
+	class EdgeCaseTest {
 
-	@Test
-	void shouldFailToMergeTwoFacetGroupFormulasTogetherWhenGroupIdDiffers() {
-		assertThrows(
-			EvitaInternalError.class,
-			() -> FacetGroupFormula.mergeWith(
-				new FacetGroupAndFormula(
+		@Test
+		@DisplayName("AND should fail when facetIds count does not match bitmaps count")
+		void andShouldFailWhenFacetIdsCountDoesNotMatchBitmapsCount() {
+			assertThrows(
+				EvitaInternalError.class,
+				() -> new FacetGroupAndFormula(
 					"product", 1,
-					EmptyBitmap.INSTANCE
-				), new FacetGroupAndFormula(
-					"product", 2,
-					EmptyBitmap.INSTANCE
-				),
-				(facetIds, bitmaps) -> new FacetGroupAndFormula("product", 1, facetIds, bitmaps)
-			)
-		);
+					new ArrayBitmap(1, 2, 3),
+					new BaseBitmap(10),
+					new BaseBitmap(20)
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("AND should support null facet group id")
+		void andShouldSupportNullFacetGroupId() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", null,
+				new ArrayBitmap(1),
+				new BaseBitmap(10, 20)
+			);
+
+			assertNull(formula.getFacetGroupId());
+			assertArrayEquals(new int[]{10, 20}, formula.compute().getArray());
+		}
+
+		@Test
+		@DisplayName("OR should support null facet group id")
+		void orShouldSupportNullFacetGroupId() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", null,
+				new ArrayBitmap(1),
+				new BaseBitmap(10, 20)
+			);
+
+			assertNull(formula.getFacetGroupId());
+			assertArrayEquals(new int[]{10, 20}, formula.compute().getArray());
+		}
 	}
 
-	private static void assertFacetGroupFormulaIs(int[] facetIds, Bitmap[] bitmaps, FacetGroupAndFormula actualFormula) {
+	@Nested
+	@DisplayName("Operation cost")
+	class OperationCostTest {
+
+		@Test
+		@DisplayName("AND operation cost should be 15")
+		void andOperationCostShouldBe15() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+
+			assertEquals(15, formula.getOperationCost());
+		}
+
+		@Test
+		@DisplayName("OR operation cost should be 11")
+		void orOperationCostShouldBe11() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+
+			assertEquals(11, formula.getOperationCost());
+		}
+	}
+
+	@Nested
+	@DisplayName("String representation")
+	class ToStringTest {
+
+		@Test
+		@DisplayName("AND toString should contain reference name and AND keyword")
+		void andToStringShouldContainReferenceNameAndAndKeyword() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10),
+				new BaseBitmap(20)
+			);
+
+			final String result = formula.toString();
+
+			assertTrue(result.contains("product"));
+			assertTrue(result.contains("AND"));
+		}
+
+		@Test
+		@DisplayName("OR toString should contain reference name and OR keyword")
+		void orToStringShouldContainReferenceNameAndOrKeyword() {
+			final FacetGroupOrFormula formula = new FacetGroupOrFormula(
+				"product", 1,
+				new ArrayBitmap(1, 2),
+				new BaseBitmap(10),
+				new BaseBitmap(20)
+			);
+
+			final String result = formula.toString();
+
+			assertTrue(result.contains("product"));
+			assertTrue(result.contains("OR"));
+		}
+
+		@Test
+		@DisplayName("AND toString should show dash for null group id")
+		void andToStringShouldShowDashForNullGroupId() {
+			final FacetGroupAndFormula formula = new FacetGroupAndFormula(
+				"product", null,
+				new ArrayBitmap(1),
+				new BaseBitmap(10)
+			);
+
+			assertTrue(formula.toString().contains("-"));
+		}
+	}
+
+	/**
+	 * Asserts that the given {@link FacetGroupAndFormula} contains exactly the expected facet ids and bitmaps.
+	 *
+	 * @param facetIds       expected facet ids
+	 * @param bitmaps        expected bitmaps for each facet id
+	 * @param actualFormula  the formula to check
+	 */
+	private static void assertFacetGroupFormulaIs(
+		@Nonnull int[] facetIds,
+		@Nonnull Bitmap[] bitmaps,
+		@Nonnull FacetGroupAndFormula actualFormula
+	) {
 		final Bitmap actualFacetIds = actualFormula.getFacetIds();
 		final Bitmap[] actualBitmaps = actualFormula.getBitmaps();
 
@@ -131,5 +881,4 @@ class FacetGroupFormulaTest {
 
 		assertEquals(expected, actual);
 	}
-
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/facet/ScopeContainerFormulaTest.java
@@ -1,0 +1,315 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.facet;
+
+import io.evitadb.core.query.algebra.CacheableFormula;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.dataType.Scope;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ScopeContainerFormula} verifying AND-like computation, scope metadata,
+ * memoization, cloning, caching, hashing and edge case behavior.
+ *
+ * @author evitaDB
+ */
+@DisplayName("ScopeContainerFormula functionality")
+class ScopeContainerFormulaTest {
+
+	@Nested
+	@DisplayName("Computation")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should compute AND of multiple child formulas")
+		void shouldComputeAndOfMultipleChildFormulas() {
+			final ScopeContainerFormula formula = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(1, 2, 3, 4, 5)),
+				new ConstantFormula(new ArrayBitmap(2, 3, 4, 6)),
+				new ConstantFormula(new ArrayBitmap(3, 4, 7))
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{3, 4}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return empty bitmap for non-overlapping children")
+		void shouldReturnEmptyBitmapForNonOverlappingChildren() {
+			final ScopeContainerFormula formula = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(1, 2)),
+				new ConstantFormula(new ArrayBitmap(3, 4))
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should return single child contents when only one child provided")
+		void shouldReturnSingleChildContentsWhenOnlyOneChildProvided() {
+			final ScopeContainerFormula formula = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(10, 20, 30))
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{10, 20, 30}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return empty bitmap when any child is empty")
+		void shouldReturnEmptyBitmapWhenAnyChildIsEmpty() {
+			final ScopeContainerFormula formula = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(10, 20)),
+				EmptyFormula.INSTANCE
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should return empty bitmap when all children are empty")
+		void shouldReturnEmptyBitmapWhenAllChildrenAreEmpty() {
+			final ScopeContainerFormula formula = new ScopeContainerFormula(
+				Scope.LIVE,
+				EmptyFormula.INSTANCE
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should work with ARCHIVED scope")
+		void shouldWorkWithArchivedScope() {
+			final ScopeContainerFormula formula = new ScopeContainerFormula(
+				Scope.ARCHIVED,
+				new ConstantFormula(new ArrayBitmap(10, 20, 30)),
+				new ConstantFormula(new ArrayBitmap(20, 30, 40))
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{20, 30}, result.getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Scope metadata")
+	class ScopeMetadataTest {
+
+		@Test
+		@DisplayName("should return LIVE scope")
+		void shouldReturnLiveScope() {
+			final ScopeContainerFormula formula = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(10))
+			);
+
+			assertEquals(Scope.LIVE, formula.getScope());
+		}
+
+		@Test
+		@DisplayName("should return ARCHIVED scope")
+		void shouldReturnArchivedScope() {
+			final ScopeContainerFormula formula = new ScopeContainerFormula(
+				Scope.ARCHIVED,
+				new ConstantFormula(new ArrayBitmap(10))
+			);
+
+			assertEquals(Scope.ARCHIVED, formula.getScope());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should create clone preserving scope")
+		void shouldCreateClonePreservingScope() {
+			final ScopeContainerFormula original = new ScopeContainerFormula(
+				Scope.ARCHIVED,
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+
+			final ConstantFormula newChild = new ConstantFormula(new ArrayBitmap(100, 200));
+			final Formula clone = original.getCloneWithInnerFormulas(newChild);
+
+			assertInstanceOf(ScopeContainerFormula.class, clone);
+			final ScopeContainerFormula cloned = (ScopeContainerFormula) clone;
+			assertEquals(Scope.ARCHIVED, cloned.getScope());
+			assertArrayEquals(new int[]{100, 200}, cloned.compute().getArray());
+		}
+
+		@Test
+		@DisplayName("should return EmptyFormula when cloned with zero inner formulas")
+		void shouldReturnEmptyFormulaWhenClonedWithZeroInnerFormulas() {
+			final ScopeContainerFormula original = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas();
+
+			assertSame(EmptyFormula.INSTANCE, clone);
+		}
+
+		@Test
+		@DisplayName("should not be same instance as original")
+		void shouldNotBeSameInstanceAsOriginal() {
+			final ScopeContainerFormula original = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(10))
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas(
+				new ConstantFormula(new ArrayBitmap(10))
+			);
+
+			assertNotSame(original, clone);
+		}
+
+		@Test
+		@DisplayName("should create cacheable clone with computation callback")
+		void shouldCreateCacheableCloneWithComputationCallback() {
+			final ScopeContainerFormula original = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+
+			final boolean[] callbackInvoked = {false};
+			final CacheableFormula clone = original.getCloneWithComputationCallback(
+				formula -> callbackInvoked[0] = true,
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+
+			assertInstanceOf(ScopeContainerFormula.class, clone);
+			final ScopeContainerFormula cloned = (ScopeContainerFormula) clone;
+			assertEquals(Scope.LIVE, cloned.getScope());
+
+			// trigger computation to invoke callback
+			cloned.compute();
+			assertTrue(callbackInvoked[0]);
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed formulas")
+		void shouldProduceIdenticalHashForIdenticallyConstructedFormulas() {
+			final ScopeContainerFormula formulaA = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+			final ScopeContainerFormula formulaB = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+
+			assertEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different inner formulas")
+		void shouldProduceDifferentHashForDifferentInnerFormulas() {
+			final ScopeContainerFormula formulaA = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+			final ScopeContainerFormula formulaB = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(30, 40))
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce same hash for different scopes with same children")
+		void shouldProduceSameHashForDifferentScopesWithSameChildren() {
+			// scope is not part of includeAdditionalHash (returns 0L)
+			final ScopeContainerFormula formulaLive = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+			final ScopeContainerFormula formulaArchived = new ScopeContainerFormula(
+				Scope.ARCHIVED,
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+
+			assertEquals(formulaLive.getHash(), formulaArchived.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should estimate cardinality as minimum of inner formula cardinalities")
+		void shouldEstimateCardinalityAsMinimumOfInnerFormulaCardinalities() {
+			final ScopeContainerFormula formula = new ScopeContainerFormula(
+				Scope.LIVE,
+				new ConstantFormula(new ArrayBitmap(10, 20, 30)),
+				new ConstantFormula(new ArrayBitmap(40, 50))
+			);
+
+			assertEquals(2, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should return zero cardinality for empty formula child")
+		void shouldReturnZeroCardinalityForEmptyFormulaChild() {
+			final ScopeContainerFormula formula = new ScopeContainerFormula(
+				Scope.LIVE,
+				EmptyFormula.INSTANCE
+			);
+
+			assertEquals(0, formula.getEstimatedCardinality());
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/facet/UserFilterFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/facet/UserFilterFormulaTest.java
@@ -1,0 +1,248 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.facet;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link UserFilterFormula} verifying AND-like computation, memoization, cloning,
+ * hashing, interface contracts and edge case behavior.
+ *
+ * @author evitaDB
+ */
+@DisplayName("UserFilterFormula functionality")
+class UserFilterFormulaTest {
+
+	@Nested
+	@DisplayName("Computation")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should compute AND of multiple child formulas")
+		void shouldComputeAndOfMultipleChildFormulas() {
+			final UserFilterFormula formula = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2, 3, 4, 5)),
+				new ConstantFormula(new ArrayBitmap(2, 3, 4, 6)),
+				new ConstantFormula(new ArrayBitmap(3, 4, 7))
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{3, 4}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return empty bitmap for non-overlapping children")
+		void shouldReturnEmptyBitmapForNonOverlappingChildren() {
+			final UserFilterFormula formula = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2)),
+				new ConstantFormula(new ArrayBitmap(3, 4))
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should return single child contents when only one child provided")
+		void shouldReturnSingleChildContentsWhenOnlyOneChildProvided() {
+			final UserFilterFormula formula = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20, 30))
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{10, 20, 30}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return empty bitmap when any child is empty")
+		void shouldReturnEmptyBitmapWhenAnyChildIsEmpty() {
+			final UserFilterFormula formula = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20)),
+				EmptyFormula.INSTANCE
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should return empty bitmap when all children are empty")
+		void shouldReturnEmptyBitmapWhenAllChildrenAreEmpty() {
+			final UserFilterFormula formula = new UserFilterFormula(
+				EmptyFormula.INSTANCE
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should compute AND with two fully overlapping children")
+		void shouldComputeAndWithTwoFullyOverlappingChildren() {
+			final UserFilterFormula formula = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20, 30)),
+				new ConstantFormula(new ArrayBitmap(10, 20, 30))
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{10, 20, 30}, result.getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should create clone with replacement inner formulas")
+		void shouldCreateCloneWithReplacementInnerFormulas() {
+			final UserFilterFormula original = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+
+			final ConstantFormula newChild = new ConstantFormula(new ArrayBitmap(100, 200));
+			final Formula clone = original.getCloneWithInnerFormulas(newChild);
+
+			assertInstanceOf(UserFilterFormula.class, clone);
+			assertNotSame(original, clone);
+			assertArrayEquals(new int[]{100, 200}, clone.compute().getArray());
+		}
+
+		@Test
+		@DisplayName("should return EmptyFormula when cloned with zero inner formulas")
+		void shouldReturnEmptyFormulaWhenClonedWithZeroInnerFormulas() {
+			final UserFilterFormula original = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas();
+
+			assertSame(EmptyFormula.INSTANCE, clone);
+		}
+
+		@Test
+		@DisplayName("should create clone with multiple inner formulas")
+		void shouldCreateCloneWithMultipleInnerFormulas() {
+			final UserFilterFormula original = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(10))
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas(
+				new ConstantFormula(new ArrayBitmap(1, 2, 3)),
+				new ConstantFormula(new ArrayBitmap(2, 3, 4))
+			);
+
+			assertInstanceOf(UserFilterFormula.class, clone);
+			assertArrayEquals(new int[]{2, 3}, clone.compute().getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed formulas")
+		void shouldProduceIdenticalHashForIdenticallyConstructedFormulas() {
+			final UserFilterFormula formulaA = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20)),
+				new ConstantFormula(new ArrayBitmap(30, 40))
+			);
+			final UserFilterFormula formulaB = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20)),
+				new ConstantFormula(new ArrayBitmap(30, 40))
+			);
+
+			assertEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different inner formulas")
+		void shouldProduceDifferentHashForDifferentInnerFormulas() {
+			final UserFilterFormula formulaA = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20))
+			);
+			final UserFilterFormula formulaB = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(30, 40))
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce same hash regardless of child order")
+		void shouldProduceSameHashRegardlessOfChildOrder() {
+			final ConstantFormula childA = new ConstantFormula(new ArrayBitmap(10, 20));
+			final ConstantFormula childB = new ConstantFormula(new ArrayBitmap(30, 40));
+
+			final UserFilterFormula formulaAB = new UserFilterFormula(childA, childB);
+			final UserFilterFormula formulaBA = new UserFilterFormula(childB, childA);
+
+			// AbstractFormula sorts inner formula hashes by default (isFormulaOrderSignificant returns false)
+			assertEquals(formulaAB.getHash(), formulaBA.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should estimate cardinality as minimum of inner formula cardinalities")
+		void shouldEstimateCardinalityAsMinimumOfInnerFormulaCardinalities() {
+			final UserFilterFormula formula = new UserFilterFormula(
+				new ConstantFormula(new ArrayBitmap(10, 20, 30)),
+				new ConstantFormula(new ArrayBitmap(40, 50))
+			);
+
+			assertEquals(2, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should return zero cardinality for empty formula child")
+		void shouldReturnZeroCardinalityForEmptyFormulaChild() {
+			final UserFilterFormula formula = new UserFilterFormula(
+				EmptyFormula.INSTANCE
+			);
+
+			assertEquals(0, formula.getEstimatedCardinality());
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/prefetch/SelectionFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/prefetch/SelectionFormulaTest.java
@@ -1,0 +1,453 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.prefetch;
+
+import io.evitadb.api.query.require.EntityFetchRequire;
+import io.evitadb.core.query.QueryExecutionContext;
+import io.evitadb.core.query.QueryPlanningContext;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.infra.SkipFormula;
+import io.evitadb.dataType.array.CompositeIntArray;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link SelectionFormula} verifying computation delegation, memoization,
+ * cloning, hash behavior, and cost estimation.
+ *
+ * The non-prefetch path (delegate-based computation) is exercised directly. The
+ * prefetch path (alternative filter on prefetched entities) requires a fully wired
+ * `QueryExecutionContext` with real prefetched entities and is documented as a
+ * limitation rather than tested here.
+ *
+ * @author evitaDB
+ */
+@DisplayName("SelectionFormula")
+class SelectionFormulaTest {
+
+	@Nested
+	@DisplayName("Non-prefetch computation")
+	class NonPrefetchComputationTest {
+
+		@Test
+		@DisplayName("should delegate computation to inner formula")
+		void shouldDelegateComputationToInnerFormula() {
+			final ConstantFormula delegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 3, 5, 7))
+			);
+			final SelectionFormula formula = createFormula(delegate);
+			initializeForNonPrefetch(formula);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{1, 3, 5, 7}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should delegate to empty formula and return empty bitmap")
+		void shouldDelegateToEmptyFormulaAndReturnEmptyBitmap() {
+			final SelectionFormula formula = createFormula(EmptyFormula.INSTANCE);
+			initializeForNonPrefetch(formula);
+
+			final Bitmap result = formula.compute();
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should delegate to single-element formula")
+		void shouldDelegateToSingleElementFormula() {
+			final ConstantFormula delegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(42))
+			);
+			final SelectionFormula formula = createFormula(delegate);
+			initializeForNonPrefetch(formula);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{42}, result.getArray());
+			assertEquals(1, result.size());
+		}
+
+		@Test
+		@DisplayName("should delegate to large bitmap formula")
+		void shouldDelegateToLargeBitmapFormula() {
+			final CompositeIntArray array = new CompositeIntArray();
+			for (int i = 1; i <= 1000; i++) {
+				array.add(i);
+			}
+			final ConstantFormula delegate = new ConstantFormula(new ArrayBitmap(array));
+			final SelectionFormula formula = createFormula(delegate);
+			initializeForNonPrefetch(formula);
+
+			final Bitmap result = formula.compute();
+
+			assertEquals(1000, result.size());
+			assertEquals(1, result.getArray()[0]);
+			assertEquals(1000, result.getArray()[999]);
+		}
+	}
+
+	@Nested
+	@DisplayName("Memoization")
+	class MemoizationTest {
+
+		@Test
+		@DisplayName("should return same instance on repeated compute calls")
+		void shouldReturnSameInstanceOnRepeatedComputeCalls() {
+			final ConstantFormula delegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2, 3))
+			);
+			final SelectionFormula formula = createFormula(delegate);
+			initializeForNonPrefetch(formula);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
+
+		@Test
+		@DisplayName("should recompute after clearMemory")
+		void shouldRecomputeAfterClearMemory() {
+			final ConstantFormula delegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(10, 20, 30))
+			);
+			final SelectionFormula formula = createFormula(delegate);
+			initializeForNonPrefetch(formula);
+
+			final Bitmap first = formula.compute();
+			formula.clearMemory();
+			final Bitmap second = formula.compute();
+
+			// result content is identical but memoization was cleared
+			assertArrayEquals(first.getArray(), second.getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should create clone with single inner formula")
+		void shouldCreateCloneWithSingleInnerFormula() {
+			final ConstantFormula originalDelegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2))
+			);
+			final SelectionFormula original = createFormula(originalDelegate);
+
+			final ConstantFormula newDelegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(3, 4))
+			);
+			final Formula clone = original.getCloneWithInnerFormulas(newDelegate);
+
+			assertNotNull(clone);
+			final SelectionFormula clonedSelection = assertInstanceOf(SelectionFormula.class, clone);
+			initializeForNonPrefetch(clonedSelection);
+
+			assertArrayEquals(new int[]{3, 4}, clonedSelection.compute().getArray());
+		}
+
+		@Test
+		@DisplayName("should throw when zero inner formulas provided")
+		void shouldThrowWhenZeroInnerFormulasProvided() {
+			final SelectionFormula formula = createFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1)))
+			);
+
+			assertThrows(
+				Exception.class,
+				() -> formula.getCloneWithInnerFormulas()
+			);
+		}
+
+		@Test
+		@DisplayName("should throw when more than one inner formula provided")
+		void shouldThrowWhenMoreThanOneInnerFormulaProvided() {
+			final SelectionFormula formula = createFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1)))
+			);
+
+			assertThrows(
+				Exception.class,
+				() -> formula.getCloneWithInnerFormulas(
+					new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1))),
+					new ConstantFormula(new ArrayBitmap(new CompositeIntArray(2)))
+				)
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism")
+	class HashDeterminismTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed instances")
+		void shouldProduceIdenticalHashForIdenticallyConstructedInstances() {
+			final ConstantFormula delegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2, 3))
+			);
+			final SelectionFormula first = createFormula(delegate);
+			final SelectionFormula second = createFormula(delegate);
+
+			assertEquals(first.getHash(), second.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce identical transactional id hash for same delegate")
+		void shouldProduceIdenticalTransactionalIdHashForSameDelegate() {
+			final ConstantFormula delegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(5, 10, 15))
+			);
+			final SelectionFormula first = createFormula(delegate);
+			final SelectionFormula second = createFormula(delegate);
+
+			assertEquals(
+				first.getTransactionalIdHash(),
+				second.getTransactionalIdHash()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash sensitivity")
+	class HashSensitivityTest {
+
+		@Test
+		@DisplayName("should produce different hash for different delegates")
+		void shouldProduceDifferentHashForDifferentDelegates() {
+			final SelectionFormula first = createFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1, 2, 3)))
+			);
+			final SelectionFormula second = createFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(4, 5, 6)))
+			);
+
+			assertNotEquals(first.getHash(), second.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash between SelectionFormula and EmptyFormula delegate")
+		void shouldProduceDifferentHashBetweenDifferentDelegateTypes() {
+			final SelectionFormula withConstant = createFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1)))
+			);
+			final SelectionFormula withEmpty = createFormula(EmptyFormula.INSTANCE);
+
+			assertNotEquals(withConstant.getHash(), withEmpty.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality and cost estimates")
+	class CardinalityAndCostEstimatesTest {
+
+		@Test
+		@DisplayName("should delegate estimated cardinality to child formula")
+		void shouldDelegateEstimatedCardinalityToChildFormula() {
+			final ConstantFormula delegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2, 3, 4, 5))
+			);
+			final SelectionFormula formula = createFormula(delegate);
+
+			// without initialization, prefetchEstimatedCardinality is null
+			// → delegates to child's estimated cardinality
+			assertEquals(delegate.getEstimatedCardinality(), formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should return zero estimated cardinality when delegate is empty")
+		void shouldReturnZeroEstimatedCardinalityWhenDelegateIsEmpty() {
+			final SelectionFormula formula = createFormula(EmptyFormula.INSTANCE);
+
+			assertEquals(0, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should delegate estimated cost to child formula when not initialized")
+		void shouldDelegateEstimatedCostToChildFormulaWhenNotInitialized() {
+			final ConstantFormula delegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2, 3))
+			);
+			final SelectionFormula formula = createFormula(delegate);
+
+			// prefetchEstimatedCost is null → delegates to child
+			assertEquals(delegate.getEstimatedCost(), formula.getEstimatedCost());
+		}
+
+		@Test
+		@DisplayName("should return 1 for operation cost")
+		void shouldReturnOneForOperationCost() {
+			final SelectionFormula formula = createFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1)))
+			);
+
+			assertEquals(1L, formula.getOperationCost());
+		}
+	}
+
+	@Nested
+	@DisplayName("Structure")
+	class StructureTest {
+
+		@Test
+		@DisplayName("should expose delegate as first inner formula")
+		void shouldExposeDelegateAsFirstInnerFormula() {
+			final ConstantFormula delegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2))
+			);
+			final SelectionFormula formula = createFormula(delegate);
+
+			assertEquals(1, formula.getInnerFormulas().length);
+			assertSame(delegate, formula.getDelegate());
+			assertSame(delegate, formula.getInnerFormulas()[0]);
+		}
+
+		@Test
+		@DisplayName("should return null entity require when alternative has none")
+		void shouldReturnNullEntityRequireWhenAlternativeHasNone() {
+			final SelectionFormula formula = createFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1)))
+			);
+
+			assertNull(formula.getEntityRequire());
+		}
+
+		@Test
+		@DisplayName("should return descriptive toString")
+		void shouldReturnDescriptiveToString() {
+			final SelectionFormula formula = createFormula(
+				new ConstantFormula(new ArrayBitmap(new CompositeIntArray(1)))
+			);
+
+			assertEquals(
+				"APPLY PREDICATE ON PREFETCHED ENTITIES IF POSSIBLE",
+				formula.toString()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cost ordering")
+	class CostOrderingTest {
+
+		@Test
+		@DisplayName("should satisfy estimatedCost >= delegate estimated cost")
+		void shouldSatisfyEstimatedCostGreaterOrEqualToDelegateEstimatedCost() {
+			final ConstantFormula delegate = new ConstantFormula(
+				new ArrayBitmap(new CompositeIntArray(1, 2, 3))
+			);
+			final SelectionFormula formula = createFormula(delegate);
+
+			// SelectionFormula delegates to child's estimatedCost when no prefetch
+			assertTrue(formula.getEstimatedCost() >= delegate.getEstimatedCost());
+		}
+	}
+
+	@Nested
+	@DisplayName("Construction validation")
+	class ConstructionValidationTest {
+
+		@Test
+		@DisplayName("should reject SkipFormula as delegate")
+		void shouldRejectSkipFormulaAsDelegate() {
+			assertThrows(
+				Exception.class,
+				() -> new SelectionFormula(SkipFormula.INSTANCE, new NoOpEntityToBitmapFilter())
+			);
+		}
+	}
+
+	/**
+	 * Creates a {@link SelectionFormula} with the given delegate and a no-op alternative filter.
+	 *
+	 * @param delegate the delegate formula for the non-prefetch computation path
+	 * @return new selection formula instance
+	 */
+	@Nonnull
+	private static SelectionFormula createFormula(@Nonnull Formula delegate) {
+		return new SelectionFormula(delegate, new NoOpEntityToBitmapFilter());
+	}
+
+	/**
+	 * Initializes the formula with a non-prefetch execution context so that
+	 * `computeInternal()` follows the delegate path. Uses a mock
+	 * `QueryPlanningContext` because constructing a real one requires full
+	 * engine infrastructure.
+	 *
+	 * @param formula the formula to initialize
+	 */
+	private static void initializeForNonPrefetch(@Nonnull SelectionFormula formula) {
+		final QueryExecutionContext context = new QueryExecutionContext(
+			Mockito.mock(QueryPlanningContext.class),
+			false,
+			null,
+			(aClass, sealedEntity) -> {
+				throw new UnsupportedOperationException();
+			}
+		);
+		formula.initialize(context);
+	}
+
+	/**
+	 * Minimal {@link EntityToBitmapFilter} that returns a fixed empty bitmap and
+	 * declares no entity requirements. Used for tests that exercise structural
+	 * behavior rather than actual entity filtering.
+	 */
+	private static class NoOpEntityToBitmapFilter implements EntityToBitmapFilter {
+
+		@Nonnull
+		@Override
+		public Bitmap filter(@Nonnull QueryExecutionContext context) {
+			return new ArrayBitmap();
+		}
+
+		@Nullable
+		@Override
+		public EntityFetchRequire getEntityRequire() {
+			return null;
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/prefetch/SelectionFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/prefetch/SelectionFormulaTest.java
@@ -129,43 +129,6 @@ class SelectionFormulaTest {
 	}
 
 	@Nested
-	@DisplayName("Memoization")
-	class MemoizationTest {
-
-		@Test
-		@DisplayName("should return same instance on repeated compute calls")
-		void shouldReturnSameInstanceOnRepeatedComputeCalls() {
-			final ConstantFormula delegate = new ConstantFormula(
-				new ArrayBitmap(new CompositeIntArray(1, 2, 3))
-			);
-			final SelectionFormula formula = createFormula(delegate);
-			initializeForNonPrefetch(formula);
-
-			final Bitmap first = formula.compute();
-			final Bitmap second = formula.compute();
-
-			assertSame(first, second);
-		}
-
-		@Test
-		@DisplayName("should recompute after clearMemory")
-		void shouldRecomputeAfterClearMemory() {
-			final ConstantFormula delegate = new ConstantFormula(
-				new ArrayBitmap(new CompositeIntArray(10, 20, 30))
-			);
-			final SelectionFormula formula = createFormula(delegate);
-			initializeForNonPrefetch(formula);
-
-			final Bitmap first = formula.compute();
-			formula.clearMemory();
-			final Bitmap second = formula.compute();
-
-			// result content is identical but memoization was cleared
-			assertArrayEquals(first.getArray(), second.getArray());
-		}
-	}
-
-	@Nested
 	@DisplayName("Cloning")
 	class CloningTest {
 
@@ -366,23 +329,6 @@ class SelectionFormulaTest {
 				"APPLY PREDICATE ON PREFETCHED ENTITIES IF POSSIBLE",
 				formula.toString()
 			);
-		}
-	}
-
-	@Nested
-	@DisplayName("Cost ordering")
-	class CostOrderingTest {
-
-		@Test
-		@DisplayName("should satisfy estimatedCost >= delegate estimated cost")
-		void shouldSatisfyEstimatedCostGreaterOrEqualToDelegateEstimatedCost() {
-			final ConstantFormula delegate = new ConstantFormula(
-				new ArrayBitmap(new CompositeIntArray(1, 2, 3))
-			);
-			final SelectionFormula formula = createFormula(delegate);
-
-			// SelectionFormula delegates to child's estimatedCost when no prefetch
-			assertTrue(formula.getEstimatedCost() >= delegate.getEstimatedCost());
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIndexContainerFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIndexContainerFormulaTest.java
@@ -1,0 +1,242 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.price.priceIndex;
+
+import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.dataType.array.CompositeIntArray;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.price.PriceListAndCurrencyPriceIndex;
+import io.evitadb.index.price.PriceListAndCurrencyPriceSuperIndex;
+import io.evitadb.index.price.model.PriceIndexKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Currency;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link PriceIndexContainerFormula} verifying delegation, caching, hashing,
+ * and price index association.
+ *
+ * @author evitaDB
+ */
+@DisplayName("PriceIndexContainerFormula")
+class PriceIndexContainerFormulaTest {
+
+	private static final Currency CZK = Currency.getInstance("CZK");
+	private static final Currency EUR = Currency.getInstance("EUR");
+
+	@Nested
+	@DisplayName("Computation")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should delegate compute to inner formula")
+		void shouldDelegateComputeToInnerFormula() {
+			final PriceIndexContainerFormula formula = createFormula("basic", CZK, 1, 3, 5);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{1, 3, 5}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return delegate reference via getDelegate")
+		void shouldReturnDelegateReferenceViaGetDelegate() {
+			final ConstantFormula delegate = createConstantFormula(2, 4);
+			final PriceIndexContainerFormula formula = new PriceIndexContainerFormula(
+				createPriceIndex("vip", CZK), delegate
+			);
+
+			assertSame(delegate, formula.getDelegate());
+		}
+
+		@Test
+		@DisplayName("should expose price index via getter")
+		void shouldExposePriceIndexViaGetter() {
+			final PriceListAndCurrencyPriceIndex<?, ?> index = createPriceIndex("basic", CZK);
+			final PriceIndexContainerFormula formula = new PriceIndexContainerFormula(
+				index, createConstantFormula(1)
+			);
+
+			assertSame(index, formula.getPriceIndex());
+		}
+	}
+
+	@Nested
+	@DisplayName("Empty inputs")
+	class EmptyInputsTest {
+
+		@Test
+		@DisplayName("should return empty bitmap when wrapping empty formula")
+		void shouldReturnEmptyBitmapWhenWrappingEmptyFormula() {
+			final PriceIndexContainerFormula formula = new PriceIndexContainerFormula(
+				createPriceIndex("basic", CZK), EmptyFormula.INSTANCE
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertEquals(0, result.size());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should preserve price index in clone")
+		void shouldPreservePriceIndexInClone() {
+			final PriceListAndCurrencyPriceIndex<?, ?> index = createPriceIndex("vip", EUR);
+			final PriceIndexContainerFormula original = new PriceIndexContainerFormula(
+				index, createConstantFormula(1, 2)
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas(createConstantFormula(3, 4));
+
+			assertTrue(clone instanceof PriceIndexContainerFormula);
+			final PriceIndexContainerFormula typedClone = (PriceIndexContainerFormula) clone;
+			assertSame(index, typedClone.getPriceIndex());
+		}
+
+		@Test
+		@DisplayName("should use provided inner formula in clone instead of original delegate")
+		void shouldUseProvidedInnerFormulaInCloneInsteadOfOriginalDelegate() {
+			final PriceIndexContainerFormula original = new PriceIndexContainerFormula(
+				createPriceIndex("basic", CZK), createConstantFormula(1, 2, 3)
+			);
+
+			final ConstantFormula newDelegate = createConstantFormula(10, 20);
+			final Formula clone = original.getCloneWithInnerFormulas(newDelegate);
+
+			final PriceIndexContainerFormula typedClone = (PriceIndexContainerFormula) clone;
+			assertSame(newDelegate, typedClone.getDelegate());
+			assertArrayEquals(new int[]{10, 20}, typedClone.compute().getArray());
+			assertArrayEquals(new int[]{1, 2, 3}, original.compute().getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism")
+	class HashDeterminismTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identical construction")
+		void shouldProduceIdenticalHashForIdenticalConstruction() {
+			final PriceIndexContainerFormula a = createFormula("basic", CZK, 1, 2, 3);
+			final PriceIndexContainerFormula b = createFormula("basic", CZK, 1, 2, 3);
+
+			assertEquals(a.getHash(), b.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash sensitivity")
+	class HashSensitivityTest {
+
+		@Test
+		@DisplayName("should produce different hash for different inner data")
+		void shouldProduceDifferentHashForDifferentInnerData() {
+			final long hashA = createFormula("basic", CZK, 1, 2, 3).getHash();
+			final long hashB = createFormula("basic", CZK, 4, 5, 6).getHash();
+
+			assertNotEquals(hashA, hashB);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should delegate cardinality estimate to inner formula")
+		void shouldDelegateCardinalityEstimateToInnerFormula() {
+			final ConstantFormula delegate = createConstantFormula(1, 2, 3, 4, 5);
+			final PriceIndexContainerFormula formula = new PriceIndexContainerFormula(
+				createPriceIndex("basic", CZK), delegate
+			);
+
+			assertEquals(delegate.getEstimatedCardinality(), formula.getEstimatedCardinality());
+		}
+	}
+
+	/**
+	 * Creates a {@link PriceListAndCurrencyPriceSuperIndex} for the given price list and currency.
+	 *
+	 * @param priceList the price list name
+	 * @param currency  the currency
+	 * @return new price index instance
+	 */
+	@Nonnull
+	private static PriceListAndCurrencyPriceIndex<?, ?> createPriceIndex(
+		@Nonnull String priceList,
+		@Nonnull Currency currency
+	) {
+		return new PriceListAndCurrencyPriceSuperIndex(
+			new PriceIndexKey(priceList, currency, PriceInnerRecordHandling.NONE)
+		);
+	}
+
+	/**
+	 * Creates a {@link ConstantFormula} wrapping the given bitmap values.
+	 *
+	 * @param values the bitmap values
+	 * @return new constant formula
+	 */
+	@Nonnull
+	private static ConstantFormula createConstantFormula(int... values) {
+		return new ConstantFormula(new ArrayBitmap(new CompositeIntArray(values)));
+	}
+
+	/**
+	 * Creates a {@link PriceIndexContainerFormula} with the given price list, currency, and bitmap values.
+	 *
+	 * @param priceList the price list name
+	 * @param currency  the currency
+	 * @param values    the bitmap values for the inner constant formula
+	 * @return new formula instance
+	 */
+	@Nonnull
+	private static PriceIndexContainerFormula createFormula(
+		@Nonnull String priceList,
+		@Nonnull Currency currency,
+		int... values
+	) {
+		return new PriceIndexContainerFormula(
+			createPriceIndex(priceList, currency),
+			createConstantFormula(values)
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/priceIndex/PriceListCombinationFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/priceIndex/PriceListCombinationFormulaTest.java
@@ -26,6 +26,7 @@ package io.evitadb.core.query.algebra.price.priceIndex;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.base.NotFormula;
 import io.evitadb.core.query.algebra.price.termination.PriceEvaluationContext;
 import io.evitadb.dataType.array.CompositeIntArray;
@@ -162,8 +163,8 @@ class PriceListCombinationFormulaTest {
 				new int[]{1}, new int[]{1, 2, 3}
 			);
 
-			final ConstantFormula newSubtracted = createConstantFormula(2);
-			final ConstantFormula newSuperset = createConstantFormula(1, 2, 3, 4);
+			final Formula newSubtracted = createConstantFormula(2);
+			final Formula newSuperset = createConstantFormula(1, 2, 3, 4);
 			final Formula clone = original.getCloneWithInnerFormulas(newSubtracted, newSuperset);
 
 			assertInstanceOf(PriceListCombinationFormula.class, clone);
@@ -221,8 +222,8 @@ class PriceListCombinationFormulaTest {
 		@Test
 		@DisplayName("should have different hash than NotFormula with same children")
 		void shouldHaveDifferentHashThanNotFormulaWithSameChildren() {
-			final ConstantFormula subtracted = createConstantFormula(1, 2);
-			final ConstantFormula superset = createConstantFormula(1, 2, 3, 4);
+			final Formula subtracted = createConstantFormula(1, 2);
+			final Formula superset = createConstantFormula(1, 2, 3, 4);
 
 			final long notFormulaHash = new NotFormula(subtracted, superset).getHash();
 			final long priceListComboHash = new PriceListCombinationFormula(
@@ -234,13 +235,17 @@ class PriceListCombinationFormulaTest {
 	}
 
 	/**
-	 * Creates a {@link ConstantFormula} wrapping the given bitmap values.
+	 * Creates a {@link ConstantFormula} wrapping the given bitmap values, or {@link EmptyFormula#INSTANCE}
+	 * when the values array is empty (because {@code ConstantFormula} rejects empty bitmaps).
 	 *
 	 * @param values the bitmap values
-	 * @return new constant formula
+	 * @return new constant formula, or {@link EmptyFormula#INSTANCE} for empty input
 	 */
 	@Nonnull
-	private static ConstantFormula createConstantFormula(int... values) {
+	private static Formula createConstantFormula(int... values) {
+		if (values.length == 0) {
+			return EmptyFormula.INSTANCE;
+		}
 		return new ConstantFormula(new ArrayBitmap(new CompositeIntArray(values)));
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/priceIndex/PriceListCombinationFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/priceIndex/PriceListCombinationFormulaTest.java
@@ -39,11 +39,7 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Nonnull;
 import java.util.Currency;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link PriceListCombinationFormula} verifying NOT-like subtraction semantics,
@@ -68,7 +64,7 @@ class PriceListCombinationFormulaTest {
 		@DisplayName("should subtract entities present in subtracted formula from superset")
 		void shouldSubtractEntitiesPresentInSubtractedFromSuperset() {
 			final PriceListCombinationFormula formula = createFormula(
-				"subtracted", "superset", DEFAULT_CONTEXT,
+				"subtracted", "superset",
 				new int[]{2, 4}, new int[]{1, 2, 3, 4, 5}
 			);
 
@@ -81,7 +77,7 @@ class PriceListCombinationFormulaTest {
 		@DisplayName("should return full superset when subtracted is disjoint")
 		void shouldReturnFullSupersetWhenSubtractedIsDisjoint() {
 			final PriceListCombinationFormula formula = createFormula(
-				"subtracted", "superset", DEFAULT_CONTEXT,
+				"subtracted", "superset",
 				new int[]{10, 20}, new int[]{1, 2, 3}
 			);
 
@@ -94,7 +90,7 @@ class PriceListCombinationFormulaTest {
 		@DisplayName("should return empty when subtracted contains all superset elements")
 		void shouldReturnEmptyWhenSubtractedContainsAllSupersetElements() {
 			final PriceListCombinationFormula formula = createFormula(
-				"subtracted", "superset", DEFAULT_CONTEXT,
+				"subtracted", "superset",
 				new int[]{1, 2, 3, 4, 5}, new int[]{1, 2, 3}
 			);
 
@@ -107,7 +103,7 @@ class PriceListCombinationFormulaTest {
 		@DisplayName("should expose price list names via getters")
 		void shouldExposePriceListNamesViaGetters() {
 			final PriceListCombinationFormula formula = createFormula(
-				"vip", "basic", DEFAULT_CONTEXT,
+				"vip", "basic",
 				new int[]{1}, new int[]{1, 2, 3}
 			);
 
@@ -119,7 +115,7 @@ class PriceListCombinationFormulaTest {
 		@DisplayName("should expose price evaluation context")
 		void shouldExposePriceEvaluationContext() {
 			final PriceListCombinationFormula formula = createFormula(
-				"subtracted", "superset", DEFAULT_CONTEXT,
+				"subtracted", "superset",
 				new int[]{1}, new int[]{1, 2}
 			);
 
@@ -130,7 +126,7 @@ class PriceListCombinationFormulaTest {
 		@DisplayName("should return combined price list names")
 		void shouldReturnCombinedPriceListNames() {
 			final PriceListCombinationFormula formula = createFormula(
-				"vip", "basic", DEFAULT_CONTEXT,
+				"vip", "basic",
 				new int[]{1}, new int[]{1, 2}
 			);
 
@@ -146,11 +142,11 @@ class PriceListCombinationFormulaTest {
 		@DisplayName("should return empty when superset is empty")
 		void shouldReturnEmptyWhenSupersetIsEmpty() {
 			final PriceListCombinationFormula formula = createFormula(
-				"subtracted", "superset", DEFAULT_CONTEXT,
-				new int[]{1, 2}, new int[]{3}
+				"subtracted", "superset",
+				new int[]{1, 2}, new int[]{}
 			);
 
-			assertArrayEquals(new int[]{3}, formula.compute().getArray());
+			assertEquals(0, formula.compute().size());
 		}
 	}
 
@@ -162,7 +158,7 @@ class PriceListCombinationFormulaTest {
 		@DisplayName("should preserve price list names and context in clone")
 		void shouldPreservePriceListNamesAndContextInClone() {
 			final PriceListCombinationFormula original = createFormula(
-				"vip", "basic", DEFAULT_CONTEXT,
+				"vip", "basic",
 				new int[]{1}, new int[]{1, 2, 3}
 			);
 
@@ -170,7 +166,7 @@ class PriceListCombinationFormulaTest {
 			final ConstantFormula newSuperset = createConstantFormula(1, 2, 3, 4);
 			final Formula clone = original.getCloneWithInnerFormulas(newSubtracted, newSuperset);
 
-			assertTrue(clone instanceof PriceListCombinationFormula);
+			assertInstanceOf(PriceListCombinationFormula.class, clone);
 			final PriceListCombinationFormula typedClone = (PriceListCombinationFormula) clone;
 			assertEquals("vip", typedClone.getSubtractedPriceListName());
 			assertEquals("basic", typedClone.getPriceListName());
@@ -186,11 +182,11 @@ class PriceListCombinationFormulaTest {
 		@DisplayName("should produce identical hash for identical construction")
 		void shouldProduceIdenticalHashForIdenticalConstruction() {
 			final PriceListCombinationFormula a = createFormula(
-				"sub", "super", DEFAULT_CONTEXT,
+				"sub", "super",
 				new int[]{1, 2}, new int[]{1, 2, 3}
 			);
 			final PriceListCombinationFormula b = createFormula(
-				"sub", "super", DEFAULT_CONTEXT,
+				"sub", "super",
 				new int[]{1, 2}, new int[]{1, 2, 3}
 			);
 
@@ -206,11 +202,11 @@ class PriceListCombinationFormulaTest {
 		@DisplayName("should produce different hash for different inner data")
 		void shouldProduceDifferentHashForDifferentInnerData() {
 			final long hashA = createFormula(
-				"sub", "super", DEFAULT_CONTEXT,
+				"sub", "super",
 				new int[]{1, 2}, new int[]{1, 2, 3}
 			).getHash();
 			final long hashB = createFormula(
-				"sub", "super", DEFAULT_CONTEXT,
+				"sub", "super",
 				new int[]{4, 5}, new int[]{4, 5, 6}
 			).getHash();
 
@@ -254,7 +250,6 @@ class PriceListCombinationFormulaTest {
 	 *
 	 * @param subtractedName the name of the subtracted price list
 	 * @param supersetName   the name of the superset price list
-	 * @param context        the price evaluation context
 	 * @param subtracted     the values for the subtracted formula
 	 * @param superset       the values for the superset formula
 	 * @return new formula instance
@@ -263,12 +258,12 @@ class PriceListCombinationFormulaTest {
 	private static PriceListCombinationFormula createFormula(
 		@Nonnull String subtractedName,
 		@Nonnull String supersetName,
-		@Nonnull PriceEvaluationContext context,
 		@Nonnull int[] subtracted,
 		@Nonnull int[] superset
 	) {
 		return new PriceListCombinationFormula(
-			subtractedName, supersetName, context,
+			subtractedName, supersetName,
+			PriceListCombinationFormulaTest.DEFAULT_CONTEXT,
 			createConstantFormula(subtracted),
 			createConstantFormula(superset)
 		);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/priceIndex/PriceListCombinationFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/priceIndex/PriceListCombinationFormulaTest.java
@@ -1,0 +1,276 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.price.priceIndex;
+
+import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.NotFormula;
+import io.evitadb.core.query.algebra.price.termination.PriceEvaluationContext;
+import io.evitadb.dataType.array.CompositeIntArray;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.price.model.PriceIndexKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Currency;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link PriceListCombinationFormula} verifying NOT-like subtraction semantics,
+ * caching, hashing, and price list metadata.
+ *
+ * @author evitaDB
+ */
+@DisplayName("PriceListCombinationFormula")
+class PriceListCombinationFormulaTest {
+
+	private static final Currency CZK = Currency.getInstance("CZK");
+	private static final PriceEvaluationContext DEFAULT_CONTEXT = new PriceEvaluationContext(
+		null,
+		new PriceIndexKey("basic", CZK, PriceInnerRecordHandling.NONE)
+	);
+
+	@Nested
+	@DisplayName("Computation")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should subtract entities present in subtracted formula from superset")
+		void shouldSubtractEntitiesPresentInSubtractedFromSuperset() {
+			final PriceListCombinationFormula formula = createFormula(
+				"subtracted", "superset", DEFAULT_CONTEXT,
+				new int[]{2, 4}, new int[]{1, 2, 3, 4, 5}
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{1, 3, 5}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return full superset when subtracted is disjoint")
+		void shouldReturnFullSupersetWhenSubtractedIsDisjoint() {
+			final PriceListCombinationFormula formula = createFormula(
+				"subtracted", "superset", DEFAULT_CONTEXT,
+				new int[]{10, 20}, new int[]{1, 2, 3}
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{1, 2, 3}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return empty when subtracted contains all superset elements")
+		void shouldReturnEmptyWhenSubtractedContainsAllSupersetElements() {
+			final PriceListCombinationFormula formula = createFormula(
+				"subtracted", "superset", DEFAULT_CONTEXT,
+				new int[]{1, 2, 3, 4, 5}, new int[]{1, 2, 3}
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertEquals(0, result.size());
+		}
+
+		@Test
+		@DisplayName("should expose price list names via getters")
+		void shouldExposePriceListNamesViaGetters() {
+			final PriceListCombinationFormula formula = createFormula(
+				"vip", "basic", DEFAULT_CONTEXT,
+				new int[]{1}, new int[]{1, 2, 3}
+			);
+
+			assertEquals("vip", formula.getSubtractedPriceListName());
+			assertEquals("basic", formula.getPriceListName());
+		}
+
+		@Test
+		@DisplayName("should expose price evaluation context")
+		void shouldExposePriceEvaluationContext() {
+			final PriceListCombinationFormula formula = createFormula(
+				"subtracted", "superset", DEFAULT_CONTEXT,
+				new int[]{1}, new int[]{1, 2}
+			);
+
+			assertSame(DEFAULT_CONTEXT, formula.getPriceEvaluationContext());
+		}
+
+		@Test
+		@DisplayName("should return combined price list names")
+		void shouldReturnCombinedPriceListNames() {
+			final PriceListCombinationFormula formula = createFormula(
+				"vip", "basic", DEFAULT_CONTEXT,
+				new int[]{1}, new int[]{1, 2}
+			);
+
+			assertEquals("basic, vip", formula.getCombinedPriceListNames());
+		}
+	}
+
+	@Nested
+	@DisplayName("Empty inputs")
+	class EmptyInputsTest {
+
+		@Test
+		@DisplayName("should return empty when superset is empty")
+		void shouldReturnEmptyWhenSupersetIsEmpty() {
+			final PriceListCombinationFormula formula = createFormula(
+				"subtracted", "superset", DEFAULT_CONTEXT,
+				new int[]{1, 2}, new int[]{3}
+			);
+
+			assertArrayEquals(new int[]{3}, formula.compute().getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should preserve price list names and context in clone")
+		void shouldPreservePriceListNamesAndContextInClone() {
+			final PriceListCombinationFormula original = createFormula(
+				"vip", "basic", DEFAULT_CONTEXT,
+				new int[]{1}, new int[]{1, 2, 3}
+			);
+
+			final ConstantFormula newSubtracted = createConstantFormula(2);
+			final ConstantFormula newSuperset = createConstantFormula(1, 2, 3, 4);
+			final Formula clone = original.getCloneWithInnerFormulas(newSubtracted, newSuperset);
+
+			assertTrue(clone instanceof PriceListCombinationFormula);
+			final PriceListCombinationFormula typedClone = (PriceListCombinationFormula) clone;
+			assertEquals("vip", typedClone.getSubtractedPriceListName());
+			assertEquals("basic", typedClone.getPriceListName());
+			assertSame(DEFAULT_CONTEXT, typedClone.getPriceEvaluationContext());
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism")
+	class HashDeterminismTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identical construction")
+		void shouldProduceIdenticalHashForIdenticalConstruction() {
+			final PriceListCombinationFormula a = createFormula(
+				"sub", "super", DEFAULT_CONTEXT,
+				new int[]{1, 2}, new int[]{1, 2, 3}
+			);
+			final PriceListCombinationFormula b = createFormula(
+				"sub", "super", DEFAULT_CONTEXT,
+				new int[]{1, 2}, new int[]{1, 2, 3}
+			);
+
+			assertEquals(a.getHash(), b.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash sensitivity")
+	class HashSensitivityTest {
+
+		@Test
+		@DisplayName("should produce different hash for different inner data")
+		void shouldProduceDifferentHashForDifferentInnerData() {
+			final long hashA = createFormula(
+				"sub", "super", DEFAULT_CONTEXT,
+				new int[]{1, 2}, new int[]{1, 2, 3}
+			).getHash();
+			final long hashB = createFormula(
+				"sub", "super", DEFAULT_CONTEXT,
+				new int[]{4, 5}, new int[]{4, 5, 6}
+			).getHash();
+
+			assertNotEquals(hashA, hashB);
+		}
+	}
+
+	@Nested
+	@DisplayName("Class ID difference")
+	class ClassIdDifferenceTest {
+
+		@Test
+		@DisplayName("should have different hash than NotFormula with same children")
+		void shouldHaveDifferentHashThanNotFormulaWithSameChildren() {
+			final ConstantFormula subtracted = createConstantFormula(1, 2);
+			final ConstantFormula superset = createConstantFormula(1, 2, 3, 4);
+
+			final long notFormulaHash = new NotFormula(subtracted, superset).getHash();
+			final long priceListComboHash = new PriceListCombinationFormula(
+				"sub", "super", DEFAULT_CONTEXT, subtracted, superset
+			).getHash();
+
+			assertNotEquals(notFormulaHash, priceListComboHash);
+		}
+	}
+
+	/**
+	 * Creates a {@link ConstantFormula} wrapping the given bitmap values.
+	 *
+	 * @param values the bitmap values
+	 * @return new constant formula
+	 */
+	@Nonnull
+	private static ConstantFormula createConstantFormula(int... values) {
+		return new ConstantFormula(new ArrayBitmap(new CompositeIntArray(values)));
+	}
+
+	/**
+	 * Creates a {@link PriceListCombinationFormula} with the given price list names, context,
+	 * and bitmap data for subtracted and superset formulas.
+	 *
+	 * @param subtractedName the name of the subtracted price list
+	 * @param supersetName   the name of the superset price list
+	 * @param context        the price evaluation context
+	 * @param subtracted     the values for the subtracted formula
+	 * @param superset       the values for the superset formula
+	 * @return new formula instance
+	 */
+	@Nonnull
+	private static PriceListCombinationFormula createFormula(
+		@Nonnull String subtractedName,
+		@Nonnull String supersetName,
+		@Nonnull PriceEvaluationContext context,
+		@Nonnull int[] subtracted,
+		@Nonnull int[] superset
+	) {
+		return new PriceListCombinationFormula(
+			subtractedName, supersetName, context,
+			createConstantFormula(subtracted),
+			createConstantFormula(superset)
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/termination/LowestPriceTerminationFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/termination/LowestPriceTerminationFormulaTest.java
@@ -1,0 +1,392 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.price.termination;
+
+import io.evitadb.api.query.require.QueryPriceMode;
+import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.core.query.algebra.CacheableFormula;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.price.predicate.PricePredicate;
+import io.evitadb.core.query.algebra.price.predicate.PriceRecordPredicate;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.price.model.PriceIndexKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.math.BigDecimal;
+import java.util.Currency;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link LowestPriceTerminationFormula} verifying construction, hashing, cloning,
+ * cardinality estimation, and cache behavior.
+ *
+ * Note: full computation tests for `compute()` require a subtree containing
+ * {@link io.evitadb.core.query.algebra.price.FilteredPriceRecordAccessor} implementations
+ * providing price records per entity, which cannot be constructed without mocking.
+ * The contract tests below cover all aspects that don't require actual price record resolution.
+ *
+ * @author evitaDB
+ */
+@DisplayName("LowestPriceTerminationFormula")
+class LowestPriceTerminationFormulaTest {
+
+	private static final Currency CZK = Currency.getInstance("CZK");
+	private static final Currency EUR = Currency.getInstance("EUR");
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed formulas")
+		void shouldProduceIdenticalHashForIdenticalFormulas() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+			final PriceEvaluationContext context = createContext("basic", CZK);
+			final PriceRecordPredicate predicate = PricePredicate.ALL_RECORD_FILTER;
+
+			final LowestPriceTerminationFormula f1 = new LowestPriceTerminationFormula(
+				inner, context, QueryPriceMode.WITH_TAX, predicate
+			);
+			final LowestPriceTerminationFormula f2 = new LowestPriceTerminationFormula(
+				inner, context, QueryPriceMode.WITH_TAX, predicate
+			);
+
+			assertEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different evaluation context")
+		void shouldProduceDifferentHashForDifferentEvaluationContext() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+
+			final LowestPriceTerminationFormula f1 = new LowestPriceTerminationFormula(
+				inner, createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+			final LowestPriceTerminationFormula f2 = new LowestPriceTerminationFormula(
+				inner, createContext("vip", CZK),
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different selling price predicate")
+		void shouldProduceDifferentHashForDifferentSellingPricePredicate() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+			final PriceEvaluationContext context = createContext("basic", CZK);
+
+			final LowestPriceTerminationFormula f1 = new LowestPriceTerminationFormula(
+				inner, context, QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+			final PriceRecordPredicate rangePredicate = new PricePredicate.PriceRecordPredicate(
+				BigDecimal.ONE, BigDecimal.TEN, QueryPriceMode.WITH_TAX, 2
+			);
+			final LowestPriceTerminationFormula f2 = new LowestPriceTerminationFormula(
+				inner, context, QueryPriceMode.WITH_TAX, rangePredicate
+			);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different inner formulas")
+		void shouldProduceDifferentHashForDifferentInnerFormulas() {
+			final PriceEvaluationContext context = createContext("basic", CZK);
+
+			final LowestPriceTerminationFormula f1 = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2)), context,
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+			final LowestPriceTerminationFormula f2 = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(3, 4)), context,
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different currency")
+		void shouldProduceDifferentHashForDifferentCurrency() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+
+			final LowestPriceTerminationFormula f1 = new LowestPriceTerminationFormula(
+				inner, createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+			final LowestPriceTerminationFormula f2 = new LowestPriceTerminationFormula(
+				inner, createContext("basic", EUR),
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should preserve context, price mode, and predicate when cloning")
+		void shouldPreserveAllConfigWhenCloning() {
+			final PriceEvaluationContext context = createContext("vip", EUR);
+			final PriceRecordPredicate predicate = new PricePredicate.PriceRecordPredicate(
+				BigDecimal.ONE, BigDecimal.TEN, QueryPriceMode.WITHOUT_TAX, 2
+			);
+			final LowestPriceTerminationFormula original = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)), context,
+				QueryPriceMode.WITHOUT_TAX, predicate
+			);
+
+			final ConstantFormula newInner = new ConstantFormula(new ArrayBitmap(10, 20));
+			final Formula clone = original.getCloneWithInnerFormulas(newInner);
+
+			assertInstanceOf(LowestPriceTerminationFormula.class, clone);
+			final LowestPriceTerminationFormula typedClone = (LowestPriceTerminationFormula) clone;
+			assertSame(context, typedClone.getPriceEvaluationContext());
+			assertEquals(QueryPriceMode.WITHOUT_TAX, typedClone.getQueryPriceMode());
+			assertSame(predicate, typedClone.getSellingPricePredicate());
+		}
+
+		@Test
+		@DisplayName("should throw when cloning with wrong number of inner formulas")
+		void shouldThrowWhenCloningWithWrongNumberOfInnerFormulas() {
+			final LowestPriceTerminationFormula formula = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertThrows(
+				Exception.class,
+				() -> formula.getCloneWithInnerFormulas(
+					new ConstantFormula(new ArrayBitmap(1)),
+					new ConstantFormula(new ArrayBitmap(2))
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should create clone with computation callback preserving all config")
+		void shouldCreateCloneWithComputationCallbackPreservingAllConfig() {
+			final PriceEvaluationContext context = createContext("basic", CZK);
+			final PriceRecordPredicate predicate = PricePredicate.ALL_RECORD_FILTER;
+			final LowestPriceTerminationFormula original = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)), context,
+				QueryPriceMode.WITH_TAX, predicate
+			);
+
+			final ConstantFormula newInner = new ConstantFormula(new ArrayBitmap(5, 6));
+			final CacheableFormula clone = original.getCloneWithComputationCallback(
+				f -> { /* no-op callback */ }, newInner
+			);
+
+			assertInstanceOf(LowestPriceTerminationFormula.class, clone);
+			final LowestPriceTerminationFormula typedClone = (LowestPriceTerminationFormula) clone;
+			assertSame(context, typedClone.getPriceEvaluationContext());
+			assertEquals(QueryPriceMode.WITH_TAX, typedClone.getQueryPriceMode());
+			assertSame(predicate, typedClone.getSellingPricePredicate());
+		}
+
+		@Test
+		@DisplayName("should create clone with price predicate filtered out results")
+		void shouldCreateCloneWithPricePredicateFilteredOutResults() {
+			// first compute to populate recordsFilteredOutByPredicate
+			final LowestPriceTerminationFormula formula = new LowestPriceTerminationFormula(
+				EmptyFormula.INSTANCE,
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			// trigger computation on empty input - populates filtered out records
+			formula.compute();
+
+			final Formula clone = formula.getCloneWithPricePredicateFilteredOutResults();
+
+			assertInstanceOf(LowestPriceTerminationFormula.class, clone);
+			final LowestPriceTerminationFormula typedClone = (LowestPriceTerminationFormula) clone;
+			// the clone should use ALL_RECORD_FILTER predicate
+			assertSame(PricePredicate.ALL_RECORD_FILTER, typedClone.getSellingPricePredicate());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality and cost")
+	class CardinalityAndCostTest {
+
+		@Test
+		@DisplayName("should delegate estimated cardinality to inner formula")
+		void shouldDelegateEstimatedCardinalityToInnerFormula() {
+			final LowestPriceTerminationFormula formula = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2, 3, 4, 5)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should report operation cost of 18203")
+		void shouldReportOperationCostOf18203() {
+			final LowestPriceTerminationFormula formula = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertEquals(18203, formula.getOperationCost());
+		}
+	}
+
+	@Nested
+	@DisplayName("Contract details")
+	class ContractTest {
+
+		@Test
+		@DisplayName("should return delegate formula via getDelegate")
+		void shouldReturnDelegateFormulaViaGetDelegate() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+			final LowestPriceTerminationFormula formula = new LowestPriceTerminationFormula(
+				inner, createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertSame(inner, formula.getDelegate());
+		}
+
+		@Test
+		@DisplayName("should return exactly one inner formula")
+		void shouldReturnExactlyOneInnerFormula() {
+			final LowestPriceTerminationFormula formula = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertEquals(1, formula.getInnerFormulas().length);
+		}
+
+		@Test
+		@DisplayName("should return predicate's requested predicate")
+		void shouldReturnPredicatesRequestedPredicate() {
+			final PriceRecordPredicate rangePredicate = new PricePredicate.PriceRecordPredicate(
+				BigDecimal.ONE, BigDecimal.TEN, QueryPriceMode.WITH_TAX, 2
+			);
+			final LowestPriceTerminationFormula formula = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX, rangePredicate
+			);
+
+			assertNotNull(formula.getRequestedPredicate());
+		}
+
+		@Test
+		@DisplayName("should produce non-empty toString from predicate")
+		void shouldProduceNonEmptyToString() {
+			final LowestPriceTerminationFormula formula = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertNotNull(formula.toString());
+			assertFalse(formula.toString().isEmpty());
+		}
+
+		@Test
+		@DisplayName("should return empty result when inner formula produces empty bitmap")
+		void shouldReturnEmptyResultWhenInnerFormulaProducesEmptyBitmap() {
+			final LowestPriceTerminationFormula formula = new LowestPriceTerminationFormula(
+				EmptyFormula.INSTANCE,
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertTrue(formula.compute().isEmpty());
+			assertNotNull(formula.getRecordsFilteredOutByPredicate());
+			assertTrue(formula.getRecordsFilteredOutByPredicate().isEmpty());
+		}
+
+		@Test
+		@DisplayName("should store WITH_TAX query price mode")
+		void shouldStoreWithTaxQueryPriceMode() {
+			final LowestPriceTerminationFormula formula = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertEquals(QueryPriceMode.WITH_TAX, formula.getQueryPriceMode());
+		}
+
+		@Test
+		@DisplayName("should store WITHOUT_TAX query price mode")
+		void shouldStoreWithoutTaxQueryPriceMode() {
+			final LowestPriceTerminationFormula formula = new LowestPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITHOUT_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertEquals(QueryPriceMode.WITHOUT_TAX, formula.getQueryPriceMode());
+		}
+	}
+
+	/**
+	 * Creates a {@link PriceEvaluationContext} with a single price index key.
+	 *
+	 * @param priceList the price list name
+	 * @param currency  the currency
+	 * @return configured price evaluation context
+	 */
+	@Nonnull
+	private static PriceEvaluationContext createContext(
+		@Nonnull String priceList,
+		@Nonnull Currency currency
+	) {
+		return new PriceEvaluationContext(
+			null,
+			new PriceIndexKey(priceList, currency, PriceInnerRecordHandling.NONE)
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/termination/PlainPriceTerminationFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/termination/PlainPriceTerminationFormulaTest.java
@@ -1,0 +1,320 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.price.termination;
+
+import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.price.predicate.PriceAmountPredicate;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.price.model.PriceIndexKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Currency;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link PlainPriceTerminationFormula} verifying delegation, hashing, cloning,
+ * and cardinality estimation behavior.
+ *
+ * @author evitaDB
+ */
+@DisplayName("PlainPriceTerminationFormula")
+class PlainPriceTerminationFormulaTest {
+
+	private static final Currency CZK = Currency.getInstance("CZK");
+	private static final Currency EUR = Currency.getInstance("EUR");
+
+	@Nested
+	@DisplayName("Computation")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should delegate compute to inner formula")
+		void shouldDelegateComputeToInnerFormula() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 3, 5, 7));
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				inner, createPriceEvaluationContext("basic", CZK)
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{1, 3, 5, 7}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return empty bitmap when inner formula is empty")
+		void shouldReturnEmptyBitmapWhenInnerFormulaIsEmpty() {
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				EmptyFormula.INSTANCE, createPriceEvaluationContext("basic", CZK)
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should return same reference on repeated compute calls (memoization)")
+		void shouldReturnSameReferenceOnRepeatedComputeCalls() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(10, 20));
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				inner, createPriceEvaluationContext("basic", CZK)
+			);
+
+			final Bitmap first = formula.compute();
+			final Bitmap second = formula.compute();
+
+			assertSame(first, second);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should preserve evaluation context when cloning with new inner formula")
+		void shouldPreserveEvaluationContextWhenCloning() {
+			final PriceEvaluationContext context = createPriceEvaluationContext("vip", EUR);
+			final ConstantFormula originalInner = new ConstantFormula(new ArrayBitmap(1, 2));
+			final PlainPriceTerminationFormula original = new PlainPriceTerminationFormula(
+				originalInner, context
+			);
+
+			final ConstantFormula newInner = new ConstantFormula(new ArrayBitmap(10, 20, 30));
+			final Formula clone = original.getCloneWithInnerFormulas(newInner);
+
+			assertInstanceOf(PlainPriceTerminationFormula.class, clone);
+			final PlainPriceTerminationFormula typedClone = (PlainPriceTerminationFormula) clone;
+			assertSame(context, typedClone.getPriceEvaluationContext());
+			assertArrayEquals(new int[]{10, 20, 30}, typedClone.compute().getArray());
+		}
+
+		@Test
+		@DisplayName("should throw when cloning with wrong number of inner formulas")
+		void shouldThrowWhenCloningWithWrongNumberOfInnerFormulas() {
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				EmptyFormula.INSTANCE, createPriceEvaluationContext("basic", CZK)
+			);
+
+			assertThrows(
+				Exception.class,
+				() -> formula.getCloneWithInnerFormulas(
+					new ConstantFormula(new ArrayBitmap(1)),
+					new ConstantFormula(new ArrayBitmap(2))
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should return self from getCloneWithPricePredicateFilteredOutResults")
+		void shouldReturnSelfFromGetCloneWithPricePredicateFilteredOutResults() {
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2)), createPriceEvaluationContext("basic", CZK)
+			);
+
+			final Formula clone = formula.getCloneWithPricePredicateFilteredOutResults();
+
+			assertSame(formula, clone);
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed formulas")
+		void shouldProduceIdenticalHashForIdenticalFormulas() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+			final PriceEvaluationContext context = createPriceEvaluationContext("basic", CZK);
+
+			final PlainPriceTerminationFormula formula1 = new PlainPriceTerminationFormula(inner, context);
+			final PlainPriceTerminationFormula formula2 = new PlainPriceTerminationFormula(inner, context);
+
+			assertEquals(formula1.getHash(), formula2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different evaluation context")
+		void shouldProduceDifferentHashForDifferentEvaluationContext() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+			final PlainPriceTerminationFormula formula1 = new PlainPriceTerminationFormula(
+				inner, createPriceEvaluationContext("basic", CZK)
+			);
+			final PlainPriceTerminationFormula formula2 = new PlainPriceTerminationFormula(
+				inner, createPriceEvaluationContext("vip", CZK)
+			);
+
+			assertNotEquals(formula1.getHash(), formula2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different currency")
+		void shouldProduceDifferentHashForDifferentCurrency() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+			final PlainPriceTerminationFormula formula1 = new PlainPriceTerminationFormula(
+				inner, createPriceEvaluationContext("basic", CZK)
+			);
+			final PlainPriceTerminationFormula formula2 = new PlainPriceTerminationFormula(
+				inner, createPriceEvaluationContext("basic", EUR)
+			);
+
+			assertNotEquals(formula1.getHash(), formula2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different inner formulas")
+		void shouldProduceDifferentHashForDifferentInnerFormulas() {
+			final PriceEvaluationContext context = createPriceEvaluationContext("basic", CZK);
+			final PlainPriceTerminationFormula formula1 = new PlainPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2, 3)), context
+			);
+			final PlainPriceTerminationFormula formula2 = new PlainPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(4, 5, 6)), context
+			);
+
+			assertNotEquals(formula1.getHash(), formula2.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality and cost")
+	class CardinalityAndCostTest {
+
+		@Test
+		@DisplayName("should delegate estimated cardinality to inner formula")
+		void shouldDelegateEstimatedCardinalityToInnerFormula() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2, 3, 4, 5));
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				inner, createPriceEvaluationContext("basic", CZK)
+			);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should have operation cost of 1")
+		void shouldHaveOperationCostOfOne() {
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)), createPriceEvaluationContext("basic", CZK)
+			);
+
+			assertEquals(1, formula.getOperationCost());
+		}
+
+		@Test
+		@DisplayName("should have non-negative estimated and actual cost with estimated being an upper bound")
+		void shouldHaveNonNegativeCostsWithEstimatedAsUpperBound() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				inner, createPriceEvaluationContext("basic", CZK)
+			);
+
+			final long estimatedCost = formula.getEstimatedCost();
+			// trigger computation to get actual cost
+			formula.compute();
+			final long actualCost = formula.getCost();
+
+			assertTrue(estimatedCost >= 0, "Estimated cost should be non-negative, was: " + estimatedCost);
+			assertTrue(actualCost >= 0, "Actual cost should be non-negative, was: " + actualCost);
+			assertTrue(
+				estimatedCost >= actualCost,
+				"Estimated cost (" + estimatedCost + ") should be >= actual cost (" + actualCost + ")"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Contract details")
+	class ContractTest {
+
+		@Test
+		@DisplayName("should return ALL predicate as requested predicate")
+		void shouldReturnAllPredicateAsRequestedPredicate() {
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)), createPriceEvaluationContext("basic", CZK)
+			);
+
+			assertSame(PriceAmountPredicate.ALL, formula.getRequestedPredicate());
+		}
+
+		@Test
+		@DisplayName("should return delegate formula via getDelegate")
+		void shouldReturnDelegateFormulaViaGetDelegate() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				inner, createPriceEvaluationContext("basic", CZK)
+			);
+
+			assertSame(inner, formula.getDelegate());
+		}
+
+		@Test
+		@DisplayName("should return exactly one inner formula")
+		void shouldReturnExactlyOneInnerFormula() {
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)), createPriceEvaluationContext("basic", CZK)
+			);
+
+			assertEquals(1, formula.getInnerFormulas().length);
+		}
+
+		@Test
+		@DisplayName("should produce non-empty toString")
+		void shouldProduceNonEmptyToString() {
+			final PlainPriceTerminationFormula formula = new PlainPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)), createPriceEvaluationContext("basic", CZK)
+			);
+
+			assertNotNull(formula.toString());
+			assertFalse(formula.toString().isEmpty());
+		}
+	}
+
+	/**
+	 * Creates a {@link PriceEvaluationContext} with a single price index key.
+	 *
+	 * @param priceList the price list name
+	 * @param currency  the currency
+	 * @return configured price evaluation context
+	 */
+	@Nonnull
+	private static PriceEvaluationContext createPriceEvaluationContext(
+		@Nonnull String priceList,
+		@Nonnull Currency currency
+	) {
+		return new PriceEvaluationContext(
+			null,
+			new PriceIndexKey(priceList, currency, PriceInnerRecordHandling.NONE)
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/termination/PlainPriceTerminationFormulaWithPriceFilterTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/termination/PlainPriceTerminationFormulaWithPriceFilterTest.java
@@ -1,0 +1,330 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.price.termination;
+
+import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.core.query.algebra.CacheableFormula;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.price.predicate.PricePredicate;
+import io.evitadb.core.query.algebra.price.predicate.PriceRecordPredicate;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.price.model.PriceIndexKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.math.BigDecimal;
+import java.util.Currency;
+import static io.evitadb.api.query.require.QueryPriceMode.WITH_TAX;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link PlainPriceTerminationFormulaWithPriceFilter} verifying construction, hashing, cloning,
+ * cardinality estimation, and cache behavior.
+ *
+ * Note: full computation tests for `compute()` require a subtree containing
+ * {@link io.evitadb.core.query.algebra.price.FilteredPriceRecordAccessor} implementations,
+ * which cannot be constructed without mocking. The contract tests below cover all aspects
+ * that don't require actual price record resolution.
+ *
+ * @author evitaDB
+ */
+@DisplayName("PlainPriceTerminationFormulaWithPriceFilter")
+class PlainPriceTerminationFormulaWithPriceFilterTest {
+
+	private static final Currency CZK = Currency.getInstance("CZK");
+	private static final Currency EUR = Currency.getInstance("EUR");
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed formulas")
+		void shouldProduceIdenticalHashForIdenticalFormulas() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+			final PriceEvaluationContext context = createContext("basic", CZK);
+			final PriceRecordPredicate predicate = PricePredicate.ALL_RECORD_FILTER;
+
+			final PlainPriceTerminationFormulaWithPriceFilter f1 =
+				new PlainPriceTerminationFormulaWithPriceFilter(inner, context, predicate);
+			final PlainPriceTerminationFormulaWithPriceFilter f2 =
+				new PlainPriceTerminationFormulaWithPriceFilter(inner, context, predicate);
+
+			assertEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different evaluation context")
+		void shouldProduceDifferentHashForDifferentEvaluationContext() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+
+			final PlainPriceTerminationFormulaWithPriceFilter f1 =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					inner, createContext("basic", CZK), PricePredicate.ALL_RECORD_FILTER
+				);
+			final PlainPriceTerminationFormulaWithPriceFilter f2 =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					inner, createContext("vip", CZK), PricePredicate.ALL_RECORD_FILTER
+				);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different price predicate")
+		void shouldProduceDifferentHashForDifferentPricePredicate() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+			final PriceEvaluationContext context = createContext("basic", CZK);
+
+			final PlainPriceTerminationFormulaWithPriceFilter f1 =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					inner, context, PricePredicate.ALL_RECORD_FILTER
+				);
+			final PriceRecordPredicate rangePredicate = new PricePredicate.PriceRecordPredicate(
+				BigDecimal.ONE, BigDecimal.TEN, WITH_TAX, 2
+			);
+			final PlainPriceTerminationFormulaWithPriceFilter f2 =
+				new PlainPriceTerminationFormulaWithPriceFilter(inner, context, rangePredicate);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different inner formulas")
+		void shouldProduceDifferentHashForDifferentInnerFormulas() {
+			final PriceEvaluationContext context = createContext("basic", CZK);
+
+			final PlainPriceTerminationFormulaWithPriceFilter f1 =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					new ConstantFormula(new ArrayBitmap(1, 2)),
+					context, PricePredicate.ALL_RECORD_FILTER
+				);
+			final PlainPriceTerminationFormulaWithPriceFilter f2 =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					new ConstantFormula(new ArrayBitmap(3, 4)),
+					context, PricePredicate.ALL_RECORD_FILTER
+				);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should preserve context and predicate when cloning with new inner formula")
+		void shouldPreserveContextAndPredicateWhenCloning() {
+			final PriceEvaluationContext context = createContext("vip", EUR);
+			final PriceRecordPredicate predicate = new PricePredicate.PriceRecordPredicate(
+				BigDecimal.ONE, BigDecimal.TEN, WITH_TAX, 2
+			);
+			final PlainPriceTerminationFormulaWithPriceFilter original =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					new ConstantFormula(new ArrayBitmap(1)), context, predicate
+				);
+
+			final ConstantFormula newInner = new ConstantFormula(new ArrayBitmap(10, 20));
+			final Formula clone = original.getCloneWithInnerFormulas(newInner);
+
+			assertInstanceOf(PlainPriceTerminationFormulaWithPriceFilter.class, clone);
+			final PlainPriceTerminationFormulaWithPriceFilter typedClone =
+				(PlainPriceTerminationFormulaWithPriceFilter) clone;
+			assertSame(context, typedClone.getPriceEvaluationContext());
+			assertSame(predicate, typedClone.getPricePredicate());
+		}
+
+		@Test
+		@DisplayName("should throw when cloning with wrong number of inner formulas")
+		void shouldThrowWhenCloningWithWrongNumberOfInnerFormulas() {
+			final PlainPriceTerminationFormulaWithPriceFilter formula =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					new ConstantFormula(new ArrayBitmap(1)),
+					createContext("basic", CZK),
+					PricePredicate.ALL_RECORD_FILTER
+				);
+
+			assertThrows(
+				Exception.class,
+				() -> formula.getCloneWithInnerFormulas(
+					new ConstantFormula(new ArrayBitmap(1)),
+					new ConstantFormula(new ArrayBitmap(2))
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should create clone with computation callback preserving context")
+		void shouldCreateCloneWithComputationCallbackPreservingContext() {
+			final PriceEvaluationContext context = createContext("basic", CZK);
+			final PriceRecordPredicate predicate = PricePredicate.ALL_RECORD_FILTER;
+			final PlainPriceTerminationFormulaWithPriceFilter original =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					new ConstantFormula(new ArrayBitmap(1)), context, predicate
+				);
+
+			final ConstantFormula newInner = new ConstantFormula(new ArrayBitmap(5, 6));
+			final CacheableFormula clone = original.getCloneWithComputationCallback(
+				f -> { /* no-op callback */ }, newInner
+			);
+
+			assertInstanceOf(PlainPriceTerminationFormulaWithPriceFilter.class, clone);
+			final PlainPriceTerminationFormulaWithPriceFilter typedClone =
+				(PlainPriceTerminationFormulaWithPriceFilter) clone;
+			assertSame(context, typedClone.getPriceEvaluationContext());
+			assertSame(predicate, typedClone.getPricePredicate());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality and cost")
+	class CardinalityAndCostTest {
+
+		@Test
+		@DisplayName("should delegate estimated cardinality to inner formula")
+		void shouldDelegateEstimatedCardinalityToInnerFormula() {
+			final PlainPriceTerminationFormulaWithPriceFilter formula =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					new ConstantFormula(new ArrayBitmap(1, 2, 3, 4)),
+					createContext("basic", CZK),
+					PricePredicate.ALL_RECORD_FILTER
+				);
+
+			assertEquals(4, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should report operation cost of 3205")
+		void shouldReportOperationCostOf3205() {
+			final PlainPriceTerminationFormulaWithPriceFilter formula =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					new ConstantFormula(new ArrayBitmap(1)),
+					createContext("basic", CZK),
+					PricePredicate.ALL_RECORD_FILTER
+				);
+
+			assertEquals(3205, formula.getOperationCost());
+		}
+	}
+
+	@Nested
+	@DisplayName("Contract details")
+	class ContractTest {
+
+		@Test
+		@DisplayName("should return delegate formula via getDelegate")
+		void shouldReturnDelegateFormulaViaGetDelegate() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+			final PlainPriceTerminationFormulaWithPriceFilter formula =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					inner, createContext("basic", CZK), PricePredicate.ALL_RECORD_FILTER
+				);
+
+			assertSame(inner, formula.getDelegate());
+		}
+
+		@Test
+		@DisplayName("should return exactly one inner formula")
+		void shouldReturnExactlyOneInnerFormula() {
+			final PlainPriceTerminationFormulaWithPriceFilter formula =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					new ConstantFormula(new ArrayBitmap(1)),
+					createContext("basic", CZK),
+					PricePredicate.ALL_RECORD_FILTER
+				);
+
+			assertEquals(1, formula.getInnerFormulas().length);
+		}
+
+		@Test
+		@DisplayName("should return predicate's requested predicate")
+		void shouldReturnPredicatesRequestedPredicate() {
+			final PriceRecordPredicate rangePredicate = new PricePredicate.PriceRecordPredicate(
+				BigDecimal.ONE, BigDecimal.TEN, WITH_TAX, 2
+			);
+			final PlainPriceTerminationFormulaWithPriceFilter formula =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					new ConstantFormula(new ArrayBitmap(1)),
+					createContext("basic", CZK),
+					rangePredicate
+				);
+
+			assertNotNull(formula.getRequestedPredicate());
+		}
+
+		@Test
+		@DisplayName("should produce non-empty toString from predicate")
+		void shouldProduceNonEmptyToString() {
+			final PlainPriceTerminationFormulaWithPriceFilter formula =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					new ConstantFormula(new ArrayBitmap(1)),
+					createContext("basic", CZK),
+					PricePredicate.ALL_RECORD_FILTER
+				);
+
+			assertNotNull(formula.toString());
+			assertFalse(formula.toString().isEmpty());
+		}
+
+		@Test
+		@DisplayName("should return empty result when inner formula produces empty bitmap")
+		void shouldReturnEmptyResultWhenInnerFormulaProducesEmptyBitmap() {
+			// PlainPriceTerminationFormulaWithPriceFilter handles the empty bitmap case
+			// without touching FilteredPriceRecordAccessor, so this path is directly testable
+			final PlainPriceTerminationFormulaWithPriceFilter formula =
+				new PlainPriceTerminationFormulaWithPriceFilter(
+					EmptyFormula.INSTANCE,
+					createContext("basic", CZK),
+					PricePredicate.ALL_RECORD_FILTER
+				);
+
+			assertTrue(formula.compute().isEmpty());
+			assertNotNull(formula.getRecordsFilteredOutByPredicate());
+			assertTrue(formula.getRecordsFilteredOutByPredicate().isEmpty());
+		}
+	}
+
+	/**
+	 * Creates a {@link PriceEvaluationContext} with a single price index key.
+	 *
+	 * @param priceList the price list name
+	 * @param currency  the currency
+	 * @return configured price evaluation context
+	 */
+	@Nonnull
+	private static PriceEvaluationContext createContext(
+		@Nonnull String priceList,
+		@Nonnull Currency currency
+	) {
+		return new PriceEvaluationContext(
+			null,
+			new PriceIndexKey(priceList, currency, PriceInnerRecordHandling.NONE)
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/termination/PriceFilteringEnvelopeContainerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/termination/PriceFilteringEnvelopeContainerTest.java
@@ -1,0 +1,283 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.price.termination;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.dataType.array.CompositeIntArray;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Currency;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link PriceFilteringEnvelopeContainer} verifying OR-like union semantics,
+ * caching, hashing, and metadata propagation.
+ *
+ * @author evitaDB
+ */
+@DisplayName("PriceFilteringEnvelopeContainer")
+class PriceFilteringEnvelopeContainerTest {
+
+	private static final Currency CZK = Currency.getInstance("CZK");
+	private static final OffsetDateTime VALID_IN =
+		OffsetDateTime.of(2025, 1, 15, 12, 0, 0, 0, ZoneOffset.UTC);
+
+	@Nested
+	@DisplayName("Computation")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should compute OR-like union of inner formulas")
+		void shouldComputeOrLikeUnionOfInnerFormulas() {
+			final PriceFilteringEnvelopeContainer formula = createFormula(
+				new String[]{"basic"}, CZK, null,
+				new int[]{1, 3, 5}, new int[]{2, 3, 6}
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{1, 2, 3, 5, 6}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return single formula result when only one inner formula")
+		void shouldReturnSingleFormulaResultWhenOnlyOneInnerFormula() {
+			final PriceFilteringEnvelopeContainer formula = new PriceFilteringEnvelopeContainer(
+				new String[]{"basic"}, CZK, null,
+				createConstantFormula(10, 20, 30)
+			);
+
+			assertArrayEquals(new int[]{10, 20, 30}, formula.compute().getArray());
+		}
+
+		@Test
+		@DisplayName("should expose metadata via getters")
+		void shouldExposeMetadataViaGetters() {
+			final String[] priceLists = {"basic", "vip"};
+			final PriceFilteringEnvelopeContainer formula = new PriceFilteringEnvelopeContainer(
+				priceLists, CZK, VALID_IN,
+				createConstantFormula(1)
+			);
+
+			assertSame(priceLists, formula.getPriceLists());
+			assertSame(CZK, formula.getCurrency());
+			assertSame(VALID_IN, formula.getValidIn());
+		}
+
+		@Test
+		@DisplayName("should handle null metadata gracefully")
+		void shouldHandleNullMetadataGracefully() {
+			final PriceFilteringEnvelopeContainer formula = new PriceFilteringEnvelopeContainer(
+				null, null, null,
+				createConstantFormula(1, 2)
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertArrayEquals(new int[]{1, 2}, result.getArray());
+			assertNull(formula.getPriceLists());
+			assertNull(formula.getCurrency());
+			assertNull(formula.getValidIn());
+		}
+	}
+
+	@Nested
+	@DisplayName("Empty inputs")
+	class EmptyInputsTest {
+
+		@Test
+		@DisplayName("should return empty bitmap when wrapping single empty formula")
+		void shouldReturnEmptyBitmapWhenWrappingSingleEmptyFormula() {
+			final PriceFilteringEnvelopeContainer formula = new PriceFilteringEnvelopeContainer(
+				null, null, null,
+				EmptyFormula.INSTANCE
+			);
+
+			assertEquals(0, formula.compute().size());
+		}
+
+		@Test
+		@DisplayName("should return EmptyFormula when cloned with zero inner formulas")
+		void shouldReturnEmptyFormulaWhenClonedWithZeroInnerFormulas() {
+			final PriceFilteringEnvelopeContainer original = new PriceFilteringEnvelopeContainer(
+				new String[]{"basic"}, CZK, null,
+				createConstantFormula(1)
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas();
+
+			assertSame(EmptyFormula.INSTANCE, clone);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should preserve metadata in clone")
+		void shouldPreserveMetadataInClone() {
+			final String[] priceLists = {"basic"};
+			final PriceFilteringEnvelopeContainer original = new PriceFilteringEnvelopeContainer(
+				priceLists, CZK, VALID_IN,
+				createConstantFormula(1, 2)
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas(createConstantFormula(3, 4));
+
+			assertTrue(clone instanceof PriceFilteringEnvelopeContainer);
+			final PriceFilteringEnvelopeContainer typedClone = (PriceFilteringEnvelopeContainer) clone;
+			assertSame(priceLists, typedClone.getPriceLists());
+			assertSame(CZK, typedClone.getCurrency());
+			assertSame(VALID_IN, typedClone.getValidIn());
+			assertArrayEquals(new int[]{3, 4}, typedClone.compute().getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism")
+	class HashDeterminismTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identical construction")
+		void shouldProduceIdenticalHashForIdenticalConstruction() {
+			final PriceFilteringEnvelopeContainer a = new PriceFilteringEnvelopeContainer(
+				null, null, null,
+				createConstantFormula(1, 2, 3)
+			);
+			final PriceFilteringEnvelopeContainer b = new PriceFilteringEnvelopeContainer(
+				null, null, null,
+				createConstantFormula(1, 2, 3)
+			);
+
+			assertEquals(a.getHash(), b.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce same hash regardless of metadata differences")
+		void shouldProduceSameHashRegardlessOfMetadataDifferences() {
+			// metadata (priceLists, currency, validIn) is NOT included in the hash
+			final ConstantFormula innerFormula = createConstantFormula(1, 2, 3);
+			final long hashA = new PriceFilteringEnvelopeContainer(
+				new String[]{"basic"}, CZK, VALID_IN, innerFormula
+			).getHash();
+			final long hashB = new PriceFilteringEnvelopeContainer(
+				new String[]{"vip"}, Currency.getInstance("EUR"), null, innerFormula
+			).getHash();
+
+			// includeAdditionalHash returns 0, so metadata doesn't affect hash
+			assertEquals(hashA, hashB);
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash sensitivity")
+	class HashSensitivityTest {
+
+		@Test
+		@DisplayName("should produce different hash for different inner data")
+		void shouldProduceDifferentHashForDifferentInnerData() {
+			final long hashA = new PriceFilteringEnvelopeContainer(
+				null, null, null, createConstantFormula(1, 2, 3)
+			).getHash();
+			final long hashB = new PriceFilteringEnvelopeContainer(
+				null, null, null, createConstantFormula(4, 5, 6)
+			).getHash();
+
+			assertNotEquals(hashA, hashB);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should return sum of inner formulas cardinality")
+		void shouldReturnSumOfInnerFormulasCardinality() {
+			final ConstantFormula a = createConstantFormula(1, 2, 3);
+			final ConstantFormula b = createConstantFormula(4, 5);
+			final PriceFilteringEnvelopeContainer formula = new PriceFilteringEnvelopeContainer(
+				null, null, null, a, b
+			);
+
+			assertEquals(
+				a.getEstimatedCardinality() + b.getEstimatedCardinality(),
+				formula.getEstimatedCardinality()
+			);
+		}
+	}
+
+	/**
+	 * Creates a {@link ConstantFormula} wrapping the given bitmap values.
+	 *
+	 * @param values the bitmap values
+	 * @return new constant formula
+	 */
+	@Nonnull
+	private static ConstantFormula createConstantFormula(int... values) {
+		return new ConstantFormula(new ArrayBitmap(new CompositeIntArray(values)));
+	}
+
+	/**
+	 * Creates a {@link PriceFilteringEnvelopeContainer} with two inner constant formulas
+	 * and optional metadata.
+	 *
+	 * @param priceLists the price list names (nullable)
+	 * @param currency   the currency (nullable)
+	 * @param validIn    the validity timestamp (nullable)
+	 * @param valuesA    bitmap values for the first inner formula
+	 * @param valuesB    bitmap values for the second inner formula
+	 * @return new formula instance
+	 */
+	@Nonnull
+	private static PriceFilteringEnvelopeContainer createFormula(
+		@Nullable String[] priceLists,
+		@Nullable Currency currency,
+		@Nullable OffsetDateTime validIn,
+		@Nonnull int[] valuesA,
+		@Nonnull int[] valuesB
+	) {
+		return new PriceFilteringEnvelopeContainer(
+			priceLists, currency, validIn,
+			createConstantFormula(valuesA),
+			createConstantFormula(valuesB)
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/termination/SumPriceTerminationFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/termination/SumPriceTerminationFormulaTest.java
@@ -1,0 +1,362 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.price.termination;
+
+import io.evitadb.api.query.require.QueryPriceMode;
+import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.core.query.algebra.CacheableFormula;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.price.predicate.PricePredicate;
+import io.evitadb.core.query.algebra.price.predicate.PriceRecordPredicate;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.price.model.PriceIndexKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.math.BigDecimal;
+import java.util.Currency;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link SumPriceTerminationFormula} verifying construction, hashing, cloning,
+ * cardinality estimation, and cache behavior.
+ *
+ * Note: full computation tests for `compute()` require a subtree containing
+ * {@link io.evitadb.core.query.algebra.price.FilteredPriceRecordAccessor} implementations
+ * providing price records per entity, which cannot be constructed without mocking.
+ * The contract tests below cover all aspects that don't require actual price record resolution.
+ *
+ * @author evitaDB
+ */
+@DisplayName("SumPriceTerminationFormula")
+class SumPriceTerminationFormulaTest {
+
+	private static final Currency CZK = Currency.getInstance("CZK");
+	private static final Currency EUR = Currency.getInstance("EUR");
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed formulas")
+		void shouldProduceIdenticalHashForIdenticalFormulas() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+			final PriceEvaluationContext context = createContext("basic", CZK);
+			final PriceRecordPredicate predicate = PricePredicate.ALL_RECORD_FILTER;
+
+			final SumPriceTerminationFormula f1 = new SumPriceTerminationFormula(
+				inner, context, QueryPriceMode.WITH_TAX, predicate
+			);
+			final SumPriceTerminationFormula f2 = new SumPriceTerminationFormula(
+				inner, context, QueryPriceMode.WITH_TAX, predicate
+			);
+
+			assertEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different evaluation context")
+		void shouldProduceDifferentHashForDifferentEvaluationContext() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+
+			final SumPriceTerminationFormula f1 = new SumPriceTerminationFormula(
+				inner, createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+			final SumPriceTerminationFormula f2 = new SumPriceTerminationFormula(
+				inner, createContext("vip", CZK),
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different selling price predicate")
+		void shouldProduceDifferentHashForDifferentSellingPricePredicate() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+			final PriceEvaluationContext context = createContext("basic", CZK);
+
+			final SumPriceTerminationFormula f1 = new SumPriceTerminationFormula(
+				inner, context, QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+			final PriceRecordPredicate rangePredicate = new PricePredicate.PriceRecordPredicate(
+				BigDecimal.ONE, BigDecimal.TEN, QueryPriceMode.WITH_TAX, 2
+			);
+			final SumPriceTerminationFormula f2 = new SumPriceTerminationFormula(
+				inner, context, QueryPriceMode.WITH_TAX, rangePredicate
+			);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different inner formulas")
+		void shouldProduceDifferentHashForDifferentInnerFormulas() {
+			final PriceEvaluationContext context = createContext("basic", CZK);
+
+			final SumPriceTerminationFormula f1 = new SumPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2)), context,
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+			final SumPriceTerminationFormula f2 = new SumPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(3, 4)), context,
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different currency")
+		void shouldProduceDifferentHashForDifferentCurrency() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+
+			final SumPriceTerminationFormula f1 = new SumPriceTerminationFormula(
+				inner, createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+			final SumPriceTerminationFormula f2 = new SumPriceTerminationFormula(
+				inner, createContext("basic", EUR),
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should preserve context, price mode, and predicate when cloning")
+		void shouldPreserveAllConfigWhenCloning() {
+			final PriceEvaluationContext context = createContext("vip", EUR);
+			final PriceRecordPredicate predicate = new PricePredicate.PriceRecordPredicate(
+				BigDecimal.ONE, BigDecimal.TEN, QueryPriceMode.WITHOUT_TAX, 2
+			);
+			final SumPriceTerminationFormula original = new SumPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)), context,
+				QueryPriceMode.WITHOUT_TAX, predicate
+			);
+
+			final ConstantFormula newInner = new ConstantFormula(new ArrayBitmap(10, 20));
+			final Formula clone = original.getCloneWithInnerFormulas(newInner);
+
+			assertInstanceOf(SumPriceTerminationFormula.class, clone);
+			final SumPriceTerminationFormula typedClone = (SumPriceTerminationFormula) clone;
+			assertSame(context, typedClone.getPriceEvaluationContext());
+			assertSame(predicate, typedClone.getSellingPricePredicate());
+		}
+
+		@Test
+		@DisplayName("should throw when cloning with wrong number of inner formulas")
+		void shouldThrowWhenCloningWithWrongNumberOfInnerFormulas() {
+			final SumPriceTerminationFormula formula = new SumPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertThrows(
+				Exception.class,
+				() -> formula.getCloneWithInnerFormulas(
+					new ConstantFormula(new ArrayBitmap(1)),
+					new ConstantFormula(new ArrayBitmap(2))
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should create clone with computation callback preserving all config")
+		void shouldCreateCloneWithComputationCallbackPreservingAllConfig() {
+			final PriceEvaluationContext context = createContext("basic", CZK);
+			final PriceRecordPredicate predicate = PricePredicate.ALL_RECORD_FILTER;
+			final SumPriceTerminationFormula original = new SumPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)), context,
+				QueryPriceMode.WITH_TAX, predicate
+			);
+
+			final ConstantFormula newInner = new ConstantFormula(new ArrayBitmap(5, 6));
+			final CacheableFormula clone = original.getCloneWithComputationCallback(
+				f -> { /* no-op callback */ }, newInner
+			);
+
+			assertInstanceOf(SumPriceTerminationFormula.class, clone);
+			final SumPriceTerminationFormula typedClone = (SumPriceTerminationFormula) clone;
+			assertSame(context, typedClone.getPriceEvaluationContext());
+			assertSame(predicate, typedClone.getSellingPricePredicate());
+		}
+
+		@Test
+		@DisplayName("should create clone with price predicate filtered out results")
+		void shouldCreateCloneWithPricePredicateFilteredOutResults() {
+			final SumPriceTerminationFormula formula = new SumPriceTerminationFormula(
+				EmptyFormula.INSTANCE,
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			// trigger computation on empty input - populates filtered out records
+			formula.compute();
+
+			final Formula clone = formula.getCloneWithPricePredicateFilteredOutResults();
+
+			assertInstanceOf(SumPriceTerminationFormula.class, clone);
+			final SumPriceTerminationFormula typedClone = (SumPriceTerminationFormula) clone;
+			assertSame(PricePredicate.ALL_RECORD_FILTER, typedClone.getSellingPricePredicate());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality and cost")
+	class CardinalityAndCostTest {
+
+		@Test
+		@DisplayName("should delegate estimated cardinality to inner formula")
+		void shouldDelegateEstimatedCardinalityToInnerFormula() {
+			final SumPriceTerminationFormula formula = new SumPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2, 3, 4, 5)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should report operation cost of 18077")
+		void shouldReportOperationCostOf18077() {
+			final SumPriceTerminationFormula formula = new SumPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertEquals(18077, formula.getOperationCost());
+		}
+	}
+
+	@Nested
+	@DisplayName("Contract details")
+	class ContractTest {
+
+		@Test
+		@DisplayName("should return delegate formula via getDelegate")
+		void shouldReturnDelegateFormulaViaGetDelegate() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+			final SumPriceTerminationFormula formula = new SumPriceTerminationFormula(
+				inner, createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX, PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertSame(inner, formula.getDelegate());
+		}
+
+		@Test
+		@DisplayName("should return exactly one inner formula")
+		void shouldReturnExactlyOneInnerFormula() {
+			final SumPriceTerminationFormula formula = new SumPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertEquals(1, formula.getInnerFormulas().length);
+		}
+
+		@Test
+		@DisplayName("should return predicate's requested predicate")
+		void shouldReturnPredicatesRequestedPredicate() {
+			final PriceRecordPredicate rangePredicate = new PricePredicate.PriceRecordPredicate(
+				BigDecimal.ONE, BigDecimal.TEN, QueryPriceMode.WITH_TAX, 2
+			);
+			final SumPriceTerminationFormula formula = new SumPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX, rangePredicate
+			);
+
+			assertNotNull(formula.getRequestedPredicate());
+		}
+
+		@Test
+		@DisplayName("should produce non-empty toString from predicate")
+		void shouldProduceNonEmptyToString() {
+			final SumPriceTerminationFormula formula = new SumPriceTerminationFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertNotNull(formula.toString());
+			assertFalse(formula.toString().isEmpty());
+		}
+
+		@Test
+		@DisplayName("should return empty result when inner formula produces empty bitmap")
+		void shouldReturnEmptyResultWhenInnerFormulaProducesEmptyBitmap() {
+			final SumPriceTerminationFormula formula = new SumPriceTerminationFormula(
+				EmptyFormula.INSTANCE,
+				createContext("basic", CZK),
+				QueryPriceMode.WITH_TAX,
+				PricePredicate.ALL_RECORD_FILTER
+			);
+
+			assertTrue(formula.compute().isEmpty());
+			assertNotNull(formula.getRecordsFilteredOutByPredicate());
+			assertTrue(formula.getRecordsFilteredOutByPredicate().isEmpty());
+		}
+	}
+
+	/**
+	 * Creates a {@link PriceEvaluationContext} with a single price index key.
+	 *
+	 * @param priceList the price list name
+	 * @param currency  the currency
+	 * @return configured price evaluation context
+	 */
+	@Nonnull
+	private static PriceEvaluationContext createContext(
+		@Nonnull String priceList,
+		@Nonnull Currency currency
+	) {
+		return new PriceEvaluationContext(
+			null,
+			new PriceIndexKey(priceList, currency, PriceInnerRecordHandling.NONE)
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/translate/PriceIdToEntityIdTranslateFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/translate/PriceIdToEntityIdTranslateFormulaTest.java
@@ -1,0 +1,223 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.price.translate;
+
+import io.evitadb.core.query.algebra.CacheableFormula;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link PriceIdToEntityIdTranslateFormula} verifying construction, hashing, cloning,
+ * cardinality estimation, and cache behavior.
+ *
+ * Note: full computation tests for `compute()` require a subtree containing
+ * {@link io.evitadb.core.query.algebra.price.priceIndex.PriceIdContainerFormula} implementations
+ * with a real {@link io.evitadb.index.price.PriceListAndCurrencyPriceIndex}, which cannot be
+ * constructed without mocking or full index setup. The contract tests below cover all aspects
+ * that don't require actual price record resolution.
+ *
+ * @author evitaDB
+ */
+@DisplayName("PriceIdToEntityIdTranslateFormula")
+class PriceIdToEntityIdTranslateFormulaTest {
+
+	@Nested
+	@DisplayName("Hash determinism and sensitivity")
+	class HashTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed formulas")
+		void shouldProduceIdenticalHashForIdenticalFormulas() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+
+			final PriceIdToEntityIdTranslateFormula f1 = new PriceIdToEntityIdTranslateFormula(inner);
+			final PriceIdToEntityIdTranslateFormula f2 = new PriceIdToEntityIdTranslateFormula(inner);
+
+			assertEquals(f1.getHash(), f2.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different inner formulas")
+		void shouldProduceDifferentHashForDifferentInnerFormulas() {
+			final PriceIdToEntityIdTranslateFormula f1 = new PriceIdToEntityIdTranslateFormula(
+				new ConstantFormula(new ArrayBitmap(1, 2))
+			);
+			final PriceIdToEntityIdTranslateFormula f2 = new PriceIdToEntityIdTranslateFormula(
+				new ConstantFormula(new ArrayBitmap(3, 4))
+			);
+
+			assertNotEquals(f1.getHash(), f2.getHash());
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should create clone with new inner formula")
+		void shouldCreateCloneWithNewInnerFormula() {
+			final ConstantFormula originalInner = new ConstantFormula(new ArrayBitmap(1, 2));
+			final PriceIdToEntityIdTranslateFormula original =
+				new PriceIdToEntityIdTranslateFormula(originalInner);
+
+			final ConstantFormula newInner = new ConstantFormula(new ArrayBitmap(10, 20, 30));
+			final Formula clone = original.getCloneWithInnerFormulas(newInner);
+
+			assertInstanceOf(PriceIdToEntityIdTranslateFormula.class, clone);
+			final PriceIdToEntityIdTranslateFormula typedClone =
+				(PriceIdToEntityIdTranslateFormula) clone;
+			assertSame(newInner, typedClone.getDelegate());
+		}
+
+		@Test
+		@DisplayName("should throw when cloning with wrong number of inner formulas")
+		void shouldThrowWhenCloningWithWrongNumberOfInnerFormulas() {
+			final PriceIdToEntityIdTranslateFormula formula =
+				new PriceIdToEntityIdTranslateFormula(
+					new ConstantFormula(new ArrayBitmap(1))
+				);
+
+			assertThrows(
+				Exception.class,
+				() -> formula.getCloneWithInnerFormulas(
+					new ConstantFormula(new ArrayBitmap(1)),
+					new ConstantFormula(new ArrayBitmap(2))
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should create clone with computation callback")
+		void shouldCreateCloneWithComputationCallback() {
+			final PriceIdToEntityIdTranslateFormula original =
+				new PriceIdToEntityIdTranslateFormula(
+					new ConstantFormula(new ArrayBitmap(1))
+				);
+
+			final ConstantFormula newInner = new ConstantFormula(new ArrayBitmap(5, 6));
+			final CacheableFormula clone = original.getCloneWithComputationCallback(
+				f -> { /* no-op callback */ }, newInner
+			);
+
+			assertInstanceOf(PriceIdToEntityIdTranslateFormula.class, clone);
+			final PriceIdToEntityIdTranslateFormula typedClone =
+				(PriceIdToEntityIdTranslateFormula) clone;
+			assertSame(newInner, typedClone.getDelegate());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality and cost")
+	class CardinalityAndCostTest {
+
+		@Test
+		@DisplayName("should delegate estimated cardinality to inner formula")
+		void shouldDelegateEstimatedCardinalityToInnerFormula() {
+			final PriceIdToEntityIdTranslateFormula formula =
+				new PriceIdToEntityIdTranslateFormula(
+					new ConstantFormula(new ArrayBitmap(1, 2, 3, 4, 5))
+				);
+
+			assertEquals(5, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should report operation cost of 3527")
+		void shouldReportOperationCostOf3527() {
+			final PriceIdToEntityIdTranslateFormula formula =
+				new PriceIdToEntityIdTranslateFormula(
+					new ConstantFormula(new ArrayBitmap(1))
+				);
+
+			assertEquals(3527, formula.getOperationCost());
+		}
+	}
+
+	@Nested
+	@DisplayName("Contract details")
+	class ContractTest {
+
+		@Test
+		@DisplayName("should return delegate formula via getDelegate")
+		void shouldReturnDelegateFormulaViaGetDelegate() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+			final PriceIdToEntityIdTranslateFormula formula =
+				new PriceIdToEntityIdTranslateFormula(inner);
+
+			assertSame(inner, formula.getDelegate());
+		}
+
+		@Test
+		@DisplayName("should return exactly one inner formula")
+		void shouldReturnExactlyOneInnerFormula() {
+			final PriceIdToEntityIdTranslateFormula formula =
+				new PriceIdToEntityIdTranslateFormula(
+					new ConstantFormula(new ArrayBitmap(1))
+				);
+
+			assertEquals(1, formula.getInnerFormulas().length);
+		}
+
+		@Test
+		@DisplayName("should produce fixed toString description")
+		void shouldProduceFixedToStringDescription() {
+			final PriceIdToEntityIdTranslateFormula formula =
+				new PriceIdToEntityIdTranslateFormula(
+					new ConstantFormula(new ArrayBitmap(1))
+				);
+
+			assertEquals("TRANSLATE PRICE ID TO ENTITY ID", formula.toString());
+		}
+
+		@Test
+		@DisplayName("should return empty result when inner formula produces empty bitmap")
+		void shouldReturnEmptyResultWhenInnerFormulaProducesEmptyBitmap() {
+			final PriceIdToEntityIdTranslateFormula formula =
+				new PriceIdToEntityIdTranslateFormula(EmptyFormula.INSTANCE);
+
+			assertTrue(formula.compute().isEmpty());
+		}
+
+		@Test
+		@DisplayName("should return price id bitmap from delegate")
+		void shouldReturnPriceIdBitmapFromDelegate() {
+			final ConstantFormula inner = new ConstantFormula(new ArrayBitmap(100, 200, 300));
+			final PriceIdToEntityIdTranslateFormula formula =
+				new PriceIdToEntityIdTranslateFormula(inner);
+
+			// getPriceIdBitmap delegates to inner formula's compute
+			assertArrayEquals(new int[]{100, 200, 300}, formula.getPriceIdBitmap().getArray());
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/reference/ReferenceOwnerTranslatingFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/reference/ReferenceOwnerTranslatingFormulaTest.java
@@ -1,0 +1,290 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.reference;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.bitmap.EmptyBitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.function.IntFunction;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link ReferenceOwnerTranslatingFormula} verifying computation, memoization,
+ * cloning, hashing, cardinality estimation, and cost behaviour.
+ *
+ * @author evitaDB
+ */
+@DisplayName("ReferenceOwnerTranslatingFormula")
+class ReferenceOwnerTranslatingFormulaTest {
+
+	private static final long TRANSACTIONAL_ID = 42L;
+	private static final int WORST_CARDINALITY = 100;
+
+	/**
+	 * Simple expander that maps each referenced entity PK to a pair of owner PKs:
+	 * `pk -> {pk * 10, pk * 10 + 1}`.
+	 */
+	private static final IntFunction<Bitmap> SIMPLE_EXPANDER =
+		pk -> new BaseBitmap(pk * 10, pk * 10 + 1);
+
+	@Nested
+	@DisplayName("Computation")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should translate single inner PK to expanded owner PKs")
+		void shouldTranslateSingleInnerPkToExpandedOwnerPks() {
+			final ReferenceOwnerTranslatingFormula formula = createFormula(
+				TRANSACTIONAL_ID, WORST_CARDINALITY,
+				new ConstantFormula(new ArrayBitmap(3)),
+				SIMPLE_EXPANDER
+			);
+
+			final Bitmap result = formula.compute();
+
+			// PK 3 -> {30, 31}
+			assertArrayEquals(new int[]{30, 31}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should translate multiple inner PKs and union results")
+		void shouldTranslateMultipleInnerPksAndUnionResults() {
+			final ReferenceOwnerTranslatingFormula formula = createFormula(
+				TRANSACTIONAL_ID, WORST_CARDINALITY,
+				new ConstantFormula(new ArrayBitmap(1, 2, 3)),
+				SIMPLE_EXPANDER
+			);
+
+			final Bitmap result = formula.compute();
+
+			// PK 1 -> {10, 11}, PK 2 -> {20, 21}, PK 3 -> {30, 31}
+			assertArrayEquals(new int[]{10, 11, 20, 21, 30, 31}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should handle overlapping expanded results by producing distinct union")
+		void shouldHandleOverlappingExpandedResultsByProducingDistinctUnion() {
+			// expander that always returns the same bitmap regardless of input
+			final IntFunction<Bitmap> overlappingExpander = pk -> new BaseBitmap(1, 2, 3);
+			final ReferenceOwnerTranslatingFormula formula = createFormula(
+				TRANSACTIONAL_ID, WORST_CARDINALITY,
+				new ConstantFormula(new ArrayBitmap(10, 20)),
+				overlappingExpander
+			);
+
+			final Bitmap result = formula.compute();
+
+			// union of {1,2,3} and {1,2,3} should be {1,2,3}
+			assertArrayEquals(new int[]{1, 2, 3}, result.getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Empty inputs")
+	class EmptyInputsTest {
+
+		@Test
+		@DisplayName("should return EmptyBitmap when inner formula produces empty result")
+		void shouldReturnEmptyBitmapWhenInnerFormulaProducesEmptyResult() {
+			final ReferenceOwnerTranslatingFormula formula = createFormula(
+				TRANSACTIONAL_ID, WORST_CARDINALITY,
+				EmptyFormula.INSTANCE,
+				SIMPLE_EXPANDER
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertSame(EmptyBitmap.INSTANCE, result);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should preserve expander and transactional ID in clone")
+		void shouldPreserveExpanderAndTransactionalIdInClone() {
+			final Formula innerFormula = new ConstantFormula(new ArrayBitmap(4));
+			final ReferenceOwnerTranslatingFormula original = createFormula(
+				TRANSACTIONAL_ID, WORST_CARDINALITY,
+				innerFormula,
+				SIMPLE_EXPANDER
+			);
+
+			final Formula newInner = new ConstantFormula(new ArrayBitmap(7));
+			final Formula clone = original.getCloneWithInnerFormulas(newInner);
+
+			final ReferenceOwnerTranslatingFormula clonedFormula =
+				assertInstanceOf(ReferenceOwnerTranslatingFormula.class, clone);
+
+			// clone should use the new inner formula — PK 7 -> {70, 71}
+			assertArrayEquals(new int[]{70, 71}, clonedFormula.compute().getArray());
+		}
+
+		@Test
+		@DisplayName("should preserve cardinality estimate in clone")
+		void shouldPreserveCardinalityEstimateInClone() {
+			final ReferenceOwnerTranslatingFormula original = createFormula(
+				TRANSACTIONAL_ID, WORST_CARDINALITY,
+				new ConstantFormula(new ArrayBitmap(1)),
+				SIMPLE_EXPANDER
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas(
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			assertEquals(WORST_CARDINALITY, clone.getEstimatedCardinality());
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism")
+	class HashDeterminismTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed formulas")
+		void shouldProduceIdenticalHashForIdenticallyConstructedFormulas() {
+			final ReferenceOwnerTranslatingFormula formulaA = createFormula(
+				TRANSACTIONAL_ID, WORST_CARDINALITY,
+				new ConstantFormula(new ArrayBitmap(1, 2, 3)),
+				SIMPLE_EXPANDER
+			);
+			final ReferenceOwnerTranslatingFormula formulaB = createFormula(
+				TRANSACTIONAL_ID, WORST_CARDINALITY,
+				new ConstantFormula(new ArrayBitmap(1, 2, 3)),
+				SIMPLE_EXPANDER
+			);
+
+			assertEquals(formulaA.getHash(), formulaB.getHash());
+			assertEquals(
+				formulaA.getTransactionalIdHash(),
+				formulaB.getTransactionalIdHash()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash sensitivity")
+	class HashSensitivityTest {
+
+		@Test
+		@DisplayName("should produce different hash for different transactional IDs")
+		void shouldProduceDifferentHashForDifferentTransactionalIds() {
+			final Formula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+			final ReferenceOwnerTranslatingFormula formulaA = createFormula(
+				100L, WORST_CARDINALITY, inner, SIMPLE_EXPANDER
+			);
+			final ReferenceOwnerTranslatingFormula formulaB = createFormula(
+				200L, WORST_CARDINALITY, inner, SIMPLE_EXPANDER
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different inner formulas")
+		void shouldProduceDifferentHashForDifferentInnerFormulas() {
+			final ReferenceOwnerTranslatingFormula formulaA = createFormula(
+				TRANSACTIONAL_ID, WORST_CARDINALITY,
+				new ConstantFormula(new ArrayBitmap(1)),
+				SIMPLE_EXPANDER
+			);
+			final ReferenceOwnerTranslatingFormula formulaB = createFormula(
+				TRANSACTIONAL_ID, WORST_CARDINALITY,
+				new ConstantFormula(new ArrayBitmap(999)),
+				SIMPLE_EXPANDER
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should return worst cardinality passed in constructor")
+		void shouldReturnWorstCardinalityPassedInConstructor() {
+			final ReferenceOwnerTranslatingFormula formula = createFormula(
+				TRANSACTIONAL_ID, 500,
+				new ConstantFormula(new ArrayBitmap(1)),
+				SIMPLE_EXPANDER
+			);
+
+			assertEquals(500, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should return zero worst cardinality when set to zero")
+		void shouldReturnZeroWorstCardinalityWhenSetToZero() {
+			final ReferenceOwnerTranslatingFormula formula = createFormula(
+				TRANSACTIONAL_ID, 0,
+				EmptyFormula.INSTANCE,
+				SIMPLE_EXPANDER
+			);
+
+			assertEquals(0, formula.getEstimatedCardinality());
+		}
+	}
+
+	/**
+	 * Creates a {@link ReferenceOwnerTranslatingFormula} using the package-private constructor,
+	 * which avoids the need for a real {@link io.evitadb.index.GlobalEntityIndex}.
+	 *
+	 * @param transactionalId   transactional ID used in hash computation
+	 * @param worstCardinality  worst-case cardinality estimate
+	 * @param innerFormula      inner formula producing referenced entity PKs
+	 * @param expander          function mapping a referenced PK to owner entity PKs
+	 * @return new formula instance
+	 */
+	@Nonnull
+	private static ReferenceOwnerTranslatingFormula createFormula(
+		long transactionalId,
+		int worstCardinality,
+		@Nonnull Formula innerFormula,
+		@Nonnull IntFunction<Bitmap> expander
+	) {
+		return new ReferenceOwnerTranslatingFormula(
+			transactionalId, worstCardinality, innerFormula, expander
+		);
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormulaTest.java
@@ -1,0 +1,416 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.reference;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.EntityIndexType;
+import io.evitadb.index.ReferencedTypeEntityIndex;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.bitmap.EmptyBitmap;
+import io.evitadb.utils.ArrayUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.function.UnaryOperator;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests for {@link ReferencedEntityIndexPrimaryKeyTranslatingFormula} verifying computation,
+ * memoization, cloning, hashing, cardinality estimation, and cost behaviour.
+ *
+ * @author evitaDB
+ */
+@DisplayName("ReferencedEntityIndexPrimaryKeyTranslatingFormula")
+class ReferencedEntityIndexPrimaryKeyTranslatingFormulaTest {
+
+	private static final long[] TRANSACTIONAL_IDS = {42L};
+	private static final long[] ALT_TRANSACTIONAL_IDS = {99L};
+	private static final int WORST_CARDINALITY = 100;
+
+	@Nested
+	@DisplayName("Computation")
+	class ComputationTest {
+
+		@Test
+		@DisplayName("should translate referenced entity PKs to index PKs without superset")
+		void shouldTranslateReferencedEntityPksToIndexPksWithoutSuperset() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formula = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(),
+				// inner formula returns referenced entity PKs {1, 2}
+				new ConstantFormula(new ArrayBitmap(1, 2))
+			);
+
+			final Bitmap result = formula.compute();
+
+			// referenced entity PK 1 -> index PKs {10, 11}, PK 2 -> index PKs {20, 21}
+			assertArrayEquals(new int[]{10, 11, 20, 21}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should filter by superset when provided")
+		void shouldFilterBySupersetWhenProvided() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			// superset only allows referenced entity PK 1 — PK 2 should be filtered out
+			final Bitmap superSet = new BaseBitmap(1);
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formula = createFormula(
+				superSet, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(),
+				new ConstantFormula(new ArrayBitmap(1, 2))
+			);
+
+			final Bitmap result = formula.compute();
+
+			// only PK 1 passes the superset filter -> index PKs {10, 11}
+			assertArrayEquals(new int[]{10, 11}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should apply expansion function before translation")
+		void shouldApplyExpansionFunctionBeforeTranslation() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			// expansion function doubles each PK (maps 5 -> {1, 2})
+			final UnaryOperator<Bitmap> expansion = bm -> new BaseBitmap(1, 2);
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formula = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				expansion,
+				// inner formula produces PK 5 (not in the index directly),
+				// but expansion replaces it with {1, 2}
+				new ConstantFormula(new ArrayBitmap(5))
+			);
+
+			final Bitmap result = formula.compute();
+
+			// after expansion: {1, 2} -> index PKs {10, 11, 20, 21}
+			assertArrayEquals(new int[]{10, 11, 20, 21}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("should return empty when superset eliminates all PKs")
+		void shouldReturnEmptyWhenSupersetEliminatesAllPks() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			// superset contains PK 999 which doesn't match inner formula result {1, 2}
+			final Bitmap superSet = new BaseBitmap(999);
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formula = createFormula(
+				superSet, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(),
+				new ConstantFormula(new ArrayBitmap(1, 2))
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertEquals(0, result.size());
+		}
+	}
+
+	@Nested
+	@DisplayName("Empty inputs")
+	class EmptyInputsTest {
+
+		@Test
+		@DisplayName("should return EmptyBitmap when inner formula produces empty result")
+		void shouldReturnEmptyBitmapWhenInnerFormulaProducesEmptyResult() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formula = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(),
+				EmptyFormula.INSTANCE
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertSame(EmptyBitmap.INSTANCE, result);
+		}
+
+		@Test
+		@DisplayName("should return EmptyBitmap when expansion function returns empty")
+		void shouldReturnEmptyBitmapWhenExpansionFunctionReturnsEmpty() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final UnaryOperator<Bitmap> emptyExpansion = bm -> EmptyBitmap.INSTANCE;
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formula = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				emptyExpansion,
+				new ConstantFormula(new ArrayBitmap(1))
+			);
+
+			final Bitmap result = formula.compute();
+
+			assertSame(EmptyBitmap.INSTANCE, result);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cloning")
+	class CloningTest {
+
+		@Test
+		@DisplayName("should preserve index and cardinality in clone with new inner formula")
+		void shouldPreserveIndexAndCardinalityInCloneWithNewInnerFormula() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula original = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(),
+				new ConstantFormula(new ArrayBitmap(1))
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas(
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			assertInstanceOf(ReferencedEntityIndexPrimaryKeyTranslatingFormula.class, clone);
+			// clone should use the new inner formula — PK 2 -> index PKs {20, 21}
+			assertArrayEquals(new int[]{20, 21}, clone.compute().getArray());
+			assertEquals(WORST_CARDINALITY, clone.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should preserve superset in clone")
+		void shouldPreserveSupersetInClone() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final Bitmap superSet = new BaseBitmap(2);
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula original = createFormula(
+				superSet, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(),
+				new ConstantFormula(new ArrayBitmap(1, 2))
+			);
+
+			final Formula clone = original.getCloneWithInnerFormulas(
+				new ConstantFormula(new ArrayBitmap(1, 2))
+			);
+
+			// superset {2} should still filter, so only PK 2 -> {20, 21}
+			assertArrayEquals(new int[]{20, 21}, clone.compute().getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash determinism")
+	class HashDeterminismTest {
+
+		@Test
+		@DisplayName("should produce identical hash for identically constructed formulas")
+		void shouldProduceIdenticalHashForIdenticallyConstructedFormulas() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formulaA = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(),
+				new ConstantFormula(new ArrayBitmap(1, 2))
+			);
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formulaB = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(),
+				new ConstantFormula(new ArrayBitmap(1, 2))
+			);
+
+			assertEquals(formulaA.getHash(), formulaB.getHash());
+			assertEquals(
+				formulaA.getTransactionalIdHash(),
+				formulaB.getTransactionalIdHash()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Hash sensitivity")
+	class HashSensitivityTest {
+
+		@Test
+		@DisplayName("should produce different hash for different transactional IDs")
+		void shouldProduceDifferentHashForDifferentTransactionalIds() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final Formula inner = new ConstantFormula(new ArrayBitmap(1));
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formulaA = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(), inner
+			);
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formulaB = createFormula(
+				null, ALT_TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(), inner
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash when empty vs non-empty transactional IDs")
+		void shouldProduceDifferentHashWhenEmptyVsNonEmptyTransactionalIds() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final Formula inner = new ConstantFormula(new ArrayBitmap(1));
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formulaA = createFormula(
+				null, ArrayUtils.EMPTY_LONG_ARRAY, index, WORST_CARDINALITY,
+				UnaryOperator.identity(), inner
+			);
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formulaB = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(), inner
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+
+		@Test
+		@DisplayName("should produce different hash for different inner formulas")
+		void shouldProduceDifferentHashForDifferentInnerFormulas() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formulaA = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(),
+				new ConstantFormula(new ArrayBitmap(1))
+			);
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formulaB = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(),
+				new ConstantFormula(new ArrayBitmap(999))
+			);
+
+			assertNotEquals(formulaA.getHash(), formulaB.getHash());
+		}
+	}
+
+	@Nested
+	@DisplayName("Cardinality estimate")
+	class CardinalityEstimateTest {
+
+		@Test
+		@DisplayName("should return worst cardinality passed in constructor")
+		void shouldReturnWorstCardinalityPassedInConstructor() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formula = createFormula(
+				null, TRANSACTIONAL_IDS, index, 500,
+				UnaryOperator.identity(),
+				new ConstantFormula(new ArrayBitmap(1))
+			);
+
+			assertEquals(500, formula.getEstimatedCardinality());
+		}
+
+		@Test
+		@DisplayName("should return zero worst cardinality when set to zero")
+		void shouldReturnZeroWorstCardinalityWhenSetToZero() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formula = createFormula(
+				null, TRANSACTIONAL_IDS, index, 0,
+				UnaryOperator.identity(),
+				EmptyFormula.INSTANCE
+			);
+
+			assertEquals(0, formula.getEstimatedCardinality());
+		}
+	}
+
+	@Nested
+	@DisplayName("Inner formulas")
+	class InnerFormulasTest {
+
+		@Test
+		@DisplayName("should expose the single inner formula")
+		void shouldExposeSingleInnerFormula() {
+			final ReferencedTypeEntityIndex index = createPopulatedIndex();
+			final Formula inner = new ConstantFormula(new ArrayBitmap(1, 2));
+			final ReferencedEntityIndexPrimaryKeyTranslatingFormula formula = createFormula(
+				null, TRANSACTIONAL_IDS, index, WORST_CARDINALITY,
+				UnaryOperator.identity(), inner
+			);
+
+			final Formula[] innerFormulas = formula.getInnerFormulas();
+
+			assertEquals(1, innerFormulas.length);
+			assertSame(inner, innerFormulas[0]);
+		}
+	}
+
+	/**
+	 * Creates a {@link ReferencedTypeEntityIndex} populated with test data. The index maps:
+	 *
+	 * - referenced entity PK 1 -> index PKs {10, 11}
+	 * - referenced entity PK 2 -> index PKs {20, 21}
+	 * - referenced entity PK 3 -> index PK {30}
+	 *
+	 * @return populated index instance
+	 */
+	@Nonnull
+	private static ReferencedTypeEntityIndex createPopulatedIndex() {
+		final EntityIndexKey indexKey = new EntityIndexKey(
+			EntityIndexType.REFERENCED_ENTITY_TYPE, Scope.DEFAULT_SCOPE, "testReference"
+		);
+		final ReferencedTypeEntityIndex index = new ReferencedTypeEntityIndex(
+			1, "testEntity", indexKey
+		);
+		// insert index PK 10 pointing to referenced entity PK 1
+		index.insertPrimaryKeyIfMissing(10, 1);
+		// insert index PK 11 also pointing to referenced entity PK 1
+		index.insertPrimaryKeyIfMissing(11, 1);
+		// insert index PK 20 pointing to referenced entity PK 2
+		index.insertPrimaryKeyIfMissing(20, 2);
+		// insert index PK 21 also pointing to referenced entity PK 2
+		index.insertPrimaryKeyIfMissing(21, 2);
+		// insert index PK 30 pointing to referenced entity PK 3
+		index.insertPrimaryKeyIfMissing(30, 3);
+		return index;
+	}
+
+	/**
+	 * Creates a {@link ReferencedEntityIndexPrimaryKeyTranslatingFormula} using the package-private
+	 * constructor, which allows direct control over all parameters without requiring complex
+	 * schema and scope setup.
+	 *
+	 * @param referencedEntitySuperSet optional superset bitmap to restrict the translation
+	 * @param transactionalIds         transactional IDs for cache-key hashing
+	 * @param index                    target index for the translation
+	 * @param worstCardinality         worst-case cardinality estimate
+	 * @param expansionFunction        function applied to inner result before translation
+	 * @param innerFormula             inner formula producing referenced entity PKs
+	 * @return new formula instance
+	 */
+	@Nonnull
+	private static ReferencedEntityIndexPrimaryKeyTranslatingFormula createFormula(
+		@Nullable Bitmap referencedEntitySuperSet,
+		@Nonnull long[] transactionalIds,
+		@Nonnull ReferencedTypeEntityIndex index,
+		int worstCardinality,
+		@Nonnull UnaryOperator<Bitmap> expansionFunction,
+		@Nonnull Formula innerFormula
+	) {
+		return new ReferencedEntityIndexPrimaryKeyTranslatingFormula(
+			referencedEntitySuperSet, transactionalIds, index,
+			worstCardinality, expansionFunction, innerFormula
+		);
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/FormulaFactoryTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/FormulaFactoryTest.java
@@ -1,0 +1,174 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.utils;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.AndFormula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.base.NotFormula;
+import io.evitadb.core.query.algebra.base.OrFormula;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link FormulaFactory} verifying static factory methods produce correct formula types
+ * and handle edge cases like empty arrays, single formulas, and nested formula merging.
+ *
+ * @author evitaDB
+ */
+@DisplayName("FormulaFactory")
+class FormulaFactoryTest {
+
+	@Nested
+	@DisplayName("Or factory method")
+	class OrFactoryTest {
+
+		@Test
+		@DisplayName("should return EmptyFormula for empty array")
+		void shouldReturnEmptyFormulaForEmptyArray() {
+			final Formula result = FormulaFactory.or();
+
+			assertSame(EmptyFormula.INSTANCE, result);
+		}
+
+		@Test
+		@DisplayName("should return single formula when only one provided")
+		void shouldReturnSingleFormulaWhenOnlyOneProvided() {
+			final ConstantFormula single = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+
+			final Formula result = FormulaFactory.or(single);
+
+			assertSame(single, result);
+		}
+
+		@Test
+		@DisplayName("should create OrFormula for multiple formulas")
+		void shouldCreateOrFormulaForMultipleFormulas() {
+			final ConstantFormula a = new ConstantFormula(new ArrayBitmap(1, 2));
+			final ConstantFormula b = new ConstantFormula(new ArrayBitmap(3, 4));
+
+			final Formula result = FormulaFactory.or(a, b);
+
+			assertInstanceOf(OrFormula.class, result);
+			assertArrayEquals(new int[]{1, 2, 3, 4}, result.compute().getArray());
+		}
+
+		@Test
+		@DisplayName("should merge nested OrFormulas into flat structure")
+		void shouldMergeNestedOrFormulas() {
+			final ConstantFormula a = new ConstantFormula(new ArrayBitmap(1, 2));
+			final ConstantFormula b = new ConstantFormula(new ArrayBitmap(3, 4));
+			final OrFormula nested = new OrFormula(a, b);
+			final ConstantFormula c = new ConstantFormula(new ArrayBitmap(5, 6));
+
+			final Formula result = FormulaFactory.or(nested, c);
+
+			assertInstanceOf(OrFormula.class, result);
+			// the nested OR should be flattened, so inner formulas should include a, b, and c
+			final Formula[] innerFormulas = result.getInnerFormulas();
+			assertTrue(
+				innerFormulas.length >= 3,
+				"Nested OR should be merged, expected >= 3 inner formulas but got " + innerFormulas.length
+			);
+			assertArrayEquals(new int[]{1, 2, 3, 4, 5, 6}, result.compute().getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("And factory method")
+	class AndFactoryTest {
+
+		@Test
+		@DisplayName("should return EmptyFormula for empty array")
+		void shouldReturnEmptyFormulaForEmptyArray() {
+			final Formula result = FormulaFactory.and();
+
+			assertSame(EmptyFormula.INSTANCE, result);
+		}
+
+		@Test
+		@DisplayName("should return single formula when only one provided")
+		void shouldReturnSingleFormulaWhenOnlyOneProvided() {
+			final ConstantFormula single = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+
+			final Formula result = FormulaFactory.and(single);
+
+			assertSame(single, result);
+		}
+
+		@Test
+		@DisplayName("should create AndFormula for multiple formulas")
+		void shouldCreateAndFormulaForMultipleFormulas() {
+			final ConstantFormula a = new ConstantFormula(new ArrayBitmap(1, 2, 3, 4));
+			final ConstantFormula b = new ConstantFormula(new ArrayBitmap(2, 3, 4, 5));
+
+			final Formula result = FormulaFactory.and(a, b);
+
+			assertInstanceOf(AndFormula.class, result);
+			assertArrayEquals(new int[]{2, 3, 4}, result.compute().getArray());
+		}
+
+		@Test
+		@DisplayName("should merge nested AndFormulas into flat structure")
+		void shouldMergeNestedAndFormulas() {
+			final ConstantFormula a = new ConstantFormula(new ArrayBitmap(1, 2, 3, 4, 5));
+			final ConstantFormula b = new ConstantFormula(new ArrayBitmap(2, 3, 4, 5, 6));
+			final AndFormula nested = new AndFormula(a, b);
+			final ConstantFormula c = new ConstantFormula(new ArrayBitmap(3, 4, 5, 6, 7));
+
+			final Formula result = FormulaFactory.and(nested, c);
+
+			assertInstanceOf(AndFormula.class, result);
+			// the nested AND should be flattened
+			final Formula[] innerFormulas = result.getInnerFormulas();
+			assertTrue(
+				innerFormulas.length >= 3,
+				"Nested AND should be merged, expected >= 3 inner formulas but got " + innerFormulas.length
+			);
+			assertArrayEquals(new int[]{3, 4, 5}, result.compute().getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("Not factory method")
+	class NotFactoryTest {
+
+		@Test
+		@DisplayName("should create NotFormula")
+		void shouldCreateNotFormula() {
+			final ConstantFormula subtracted = new ConstantFormula(new ArrayBitmap(2, 4));
+			final ConstantFormula superset = new ConstantFormula(new ArrayBitmap(1, 2, 3, 4, 5));
+
+			final Formula result = FormulaFactory.not(subtracted, superset);
+
+			assertInstanceOf(NotFormula.class, result);
+			assertArrayEquals(new int[]{1, 3, 5}, result.compute().getArray());
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/FormulaClonerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/FormulaClonerTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2025
+ *   Copyright (c) 2023-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -32,6 +32,8 @@ import io.evitadb.core.query.algebra.base.OrFormula;
 import io.evitadb.core.query.algebra.facet.UserFilterFormula;
 import io.evitadb.index.bitmap.ArrayBitmap;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.UnaryOperator;
@@ -39,10 +41,12 @@ import java.util.function.UnaryOperator;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * This test verifies behaviour of {@link FormulaCloner}.
+ * Tests for {@link FormulaCloner} verifying deep cloning, mutation, and structural
+ * transformations of formula trees.
  *
- * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
+ * @author evitaDB
  */
+@DisplayName("FormulaCloner - formula tree cloning and mutation")
 class FormulaClonerTest {
 	private Formula formula;
 
@@ -64,56 +68,356 @@ class FormulaClonerTest {
 		);
 	}
 
-	@Test
-	void shouldLeaveFormulaUntouched() {
-		final Formula cloneResult = FormulaCloner.clone(this.formula, UnaryOperator.identity());
-		assertSame(this.formula, cloneResult);
+	@Nested
+	@DisplayName("Identity and replacement cloning")
+	class IdentityAndReplacementTest {
+
+		@Test
+		@DisplayName("should return same instance when mutator is identity")
+		void shouldLeaveFormulaUntouched() {
+			final Formula cloneResult = FormulaCloner.clone(formula, UnaryOperator.identity());
+
+			assertSame(formula, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should replace entire tree when mutator returns constant")
+		void shouldReplaceEntireFormula() {
+			final ConstantFormula replacedFormula = new ConstantFormula(new ArrayBitmap(7));
+
+			final Formula cloneResult = FormulaCloner.clone(formula, examinedFormula -> replacedFormula);
+
+			assertSame(replacedFormula, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should clone single leaf formula with identity mutator")
+		void shouldCloneSingleLeafFormulaWithIdentityMutator() {
+			final ConstantFormula leaf = new ConstantFormula(new ArrayBitmap(42));
+
+			final Formula cloneResult = FormulaCloner.clone(leaf, UnaryOperator.identity());
+
+			assertSame(leaf, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should replace single leaf formula")
+		void shouldReplaceSingleLeafFormula() {
+			final ConstantFormula leaf = new ConstantFormula(new ArrayBitmap(42));
+			final ConstantFormula replacement = new ConstantFormula(new ArrayBitmap(99));
+
+			final Formula cloneResult = FormulaCloner.clone(leaf, f -> replacement);
+
+			assertSame(replacement, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should return null when mutator returns null for root")
+		void shouldReturnNullWhenMutatorReturnsNullForRoot() {
+			final ConstantFormula leaf = new ConstantFormula(new ArrayBitmap(42));
+
+			final Formula cloneResult = FormulaCloner.clone(leaf, f -> null);
+
+			assertNull(cloneResult);
+		}
 	}
 
-	@Test
-	void shouldReplaceEntireFormula() {
-		final ConstantFormula replacedFormula = new ConstantFormula(new ArrayBitmap(7));
-		final Formula cloneResult = FormulaCloner.clone(this.formula, examinedFormula -> replacedFormula);
-		assertSame(replacedFormula, cloneResult);
+	@Nested
+	@DisplayName("Child removal and tree reconstruction")
+	class ChildRemovalTest {
+
+		@Test
+		@DisplayName("should remove EmptyFormula and preserve other children")
+		void shouldGetRidOfEmptyFormulas() {
+			final Formula cloneResult = FormulaCloner.clone(
+				formula,
+				examinedFormula -> examinedFormula instanceof EmptyFormula ? null : examinedFormula
+			);
+
+			assertNotSame(formula, cloneResult);
+			assertTrue(FormulaLocator.contains(formula, EmptyFormula.class));
+			assertFalse(FormulaLocator.contains(cloneResult, EmptyFormula.class));
+
+			assertNotSame(formula.getInnerFormulas()[0], cloneResult.getInnerFormulas()[0]);
+			assertSame(
+				formula.getInnerFormulas()[0].getInnerFormulas()[1],
+				cloneResult.getInnerFormulas()[0].getInnerFormulas()[0]
+			);
+			assertSame(
+				formula.getInnerFormulas()[0].getInnerFormulas()[2],
+				cloneResult.getInnerFormulas()[0].getInnerFormulas()[1]
+			);
+			assertSame(formula.getInnerFormulas()[1], cloneResult.getInnerFormulas()[1]);
+		}
+
+		@Test
+		@DisplayName("should collapse parent to single child when sibling removed")
+		void shouldHandleUnnecessaryFormulas() {
+			final Formula cloneResult = FormulaCloner.clone(
+				formula,
+				examinedFormula -> examinedFormula instanceof UserFilterFormula ? null : examinedFormula
+			);
+
+			assertNotSame(formula, cloneResult);
+			// When AndFormula loses one of two children, getCloneWithInnerFormulas returns the surviving child
+			assertSame(formula.getInnerFormulas()[0], cloneResult);
+		}
+
+		@Test
+		@DisplayName("should replace specific inner formula with a different one")
+		void shouldReplaceSpecificInnerFormula() {
+			final ConstantFormula replacement = new ConstantFormula(new ArrayBitmap(77));
+			final Formula cloneResult = FormulaCloner.clone(
+				formula,
+				f -> f instanceof EmptyFormula ? replacement : f
+			);
+
+			assertNotSame(formula, cloneResult);
+			// EmptyFormula should be gone, replaced by ConstantFormula(77)
+			assertFalse(FormulaLocator.contains(cloneResult, EmptyFormula.class));
+			// OrFormula should have replacement as first child now
+			final Formula orClone = cloneResult.getInnerFormulas()[0];
+			assertSame(replacement, orClone.getInnerFormulas()[0]);
+		}
 	}
 
-	@Test
-	void shouldGetRidOfEmptyFormulas() {
-		final Formula cloneResult = FormulaCloner.clone(this.formula, examinedFormula -> examinedFormula instanceof EmptyFormula ? null : examinedFormula);
-		assertNotSame(this.formula, cloneResult);
-		assertTrue(FormulaLocator.contains(this.formula, EmptyFormula.class));
-		assertFalse(FormulaLocator.contains(cloneResult, EmptyFormula.class));
+	@Nested
+	@DisplayName("NotFormula special handling")
+	class NotFormulaHandlingTest {
 
-		assertNotSame(this.formula.getInnerFormulas()[0], cloneResult.getInnerFormulas()[0]);
-		assertSame(this.formula.getInnerFormulas()[0].getInnerFormulas()[1], cloneResult.getInnerFormulas()[0].getInnerFormulas()[0]);
-		assertSame(this.formula.getInnerFormulas()[0].getInnerFormulas()[2], cloneResult.getInnerFormulas()[0].getInnerFormulas()[1]);
-		assertSame(this.formula.getInnerFormulas()[1], cloneResult.getInnerFormulas()[1]);
+		@Test
+		@DisplayName("should return superset when subtracted child is removed from NotFormula")
+		void shouldReturnSupersetWhenSubtractedChildRemoved() {
+			final ConstantFormula subtracted = new ConstantFormula(new ArrayBitmap(5));
+			final ConstantFormula superset = new ConstantFormula(new ArrayBitmap(5, 8, 10));
+			final Formula notFormula = new NotFormula(subtracted, superset);
+
+			// Remove the subtracted formula -> S \ nothing = S
+			final Formula cloneResult = FormulaCloner.clone(
+				notFormula,
+				f -> f == subtracted ? null : f
+			);
+
+			// Result should be the superset
+			assertSame(superset, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should drop NotFormula when superset child is removed")
+		void shouldDropNotFormulaWhenSupersetChildRemoved() {
+			final ConstantFormula subtracted = new ConstantFormula(new ArrayBitmap(5));
+			final ConstantFormula superset = new ConstantFormula(new ArrayBitmap(5, 8, 10));
+			final Formula notFormula = new NotFormula(subtracted, superset);
+
+			// Remove the superset formula -> nothing to subtract from -> drop
+			final Formula cloneResult = FormulaCloner.clone(
+				notFormula,
+				f -> f == superset ? null : f
+			);
+
+			assertNull(cloneResult);
+		}
+
+		@Test
+		@DisplayName("should handle NotFormula in nested tree when subtracted removed")
+		void shouldHandleNotFormulaInNestedTreeWhenSubtractedRemoved() {
+			final ConstantFormula subtracted = new ConstantFormula(new ArrayBitmap(5));
+			final ConstantFormula superset = new ConstantFormula(new ArrayBitmap(5, 8, 10));
+			final Formula tree = new OrFormula(
+				new NotFormula(subtracted, superset),
+				new ConstantFormula(new ArrayBitmap(1))
+			);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				tree,
+				f -> f == subtracted ? null : f
+			);
+
+			// OrFormula should still exist, but NotFormula should be replaced by superset
+			assertNotNull(cloneResult);
+			assertInstanceOf(OrFormula.class, cloneResult);
+			// The NotFormula child should have been replaced with the superset
+			final Formula firstChild = cloneResult.getInnerFormulas()[0];
+			assertSame(superset, firstChild);
+		}
 	}
 
-	@Test
-	void shouldHandleUnnecessaryFormulas() {
-		final Formula cloneResult = FormulaCloner.clone(this.formula, examinedFormula -> examinedFormula instanceof UserFilterFormula ? null : examinedFormula);
-		assertNotSame(this.formula, cloneResult);
-		assertSame(this.formula.getInnerFormulas()[0], cloneResult);
-	}
+	@Nested
+	@DisplayName("BiFunction mutator and parent context")
+	class ParentContextTest {
 
-	@Test
-	void shouldResolveIsWithin() {
-		final Formula cloneResult = FormulaCloner.clone(
-			this.formula, (formulaCloner, currentFormula) -> {
-				if (formulaCloner.isWithin(UserFilterFormula.class)) {
-					return null;
-				} else {
+		@Test
+		@DisplayName("should resolve isWithin with class parameter")
+		void shouldResolveIsWithin() {
+			final Formula cloneResult = FormulaCloner.clone(
+				formula, (formulaCloner, currentFormula) -> {
+					if (formulaCloner.isWithin(UserFilterFormula.class)) {
+						return null;
+					} else {
+						return currentFormula;
+					}
+				}
+			);
+
+			assertNotSame(formula, cloneResult);
+			assertTrue(FormulaLocator.contains(formula, UserFilterFormula.class));
+
+			assertSame(formula.getInnerFormulas()[0], cloneResult.getInnerFormulas()[0]);
+			assertNotSame(formula.getInnerFormulas()[1], cloneResult.getInnerFormulas()[1]);
+			assertEquals(0, cloneResult.getInnerFormulas()[1].getInnerFormulas().length);
+		}
+
+		@Test
+		@DisplayName("should resolve isWithin with predicate parameter")
+		void shouldResolveIsWithinWithPredicate() {
+			final Formula cloneResult = FormulaCloner.clone(
+				formula, (formulaCloner, currentFormula) -> {
+					if (formulaCloner.isWithin(f -> f instanceof OrFormula)) {
+						return null;
+					} else {
+						return currentFormula;
+					}
+				}
+			);
+
+			assertNotNull(cloneResult);
+			// All children of OrFormula should be removed
+			final Formula orClone = cloneResult.getInnerFormulas()[0];
+			assertEquals(0, orClone.getInnerFormulas().length);
+		}
+
+		@Test
+		@DisplayName("should report allParentsMatch correctly")
+		void shouldReportAllParentsMatchCorrectly() {
+			// Track which formulas see all parents matching
+			final Formula cloneResult = FormulaCloner.clone(
+				formula, (formulaCloner, currentFormula) -> {
+					// At root level (no parents), allParentsMatch should be true vacuously
+					if (currentFormula == formula) {
+						assertTrue(
+							formulaCloner.allParentsMatch(f -> f instanceof AndFormula),
+							"allParentsMatch should be vacuously true at root"
+						);
+					}
 					return currentFormula;
 				}
-			}
-		);
+			);
 
-		assertNotSame(this.formula, cloneResult);
-		assertTrue(FormulaLocator.contains(this.formula, UserFilterFormula.class));
+			assertSame(formula, cloneResult);
+		}
 
-		assertSame(this.formula.getInnerFormulas()[0], cloneResult.getInnerFormulas()[0]);
-		assertNotSame(this.formula.getInnerFormulas()[1], cloneResult.getInnerFormulas()[1]);
-		assertEquals(0, cloneResult.getInnerFormulas()[1].getInnerFormulas().length);
+		@Test
+		@DisplayName("should report allParentsMatch false when a parent does not match")
+		void shouldReportAllParentsMatchFalseWhenParentDoesNotMatch() {
+			final ConstantFormula targetLeaf = new ConstantFormula(new ArrayBitmap(1));
+			final Formula tree = new AndFormula(
+				new OrFormula(
+					targetLeaf,
+					new ConstantFormula(new ArrayBitmap(2))
+				),
+				new ConstantFormula(new ArrayBitmap(3, 4))
+			);
+
+			FormulaCloner.clone(
+				tree, (formulaCloner, currentFormula) -> {
+					if (currentFormula == targetLeaf) {
+						// parents are OrFormula + AndFormula, not all are OrFormula
+						assertFalse(formulaCloner.allParentsMatch(f -> f instanceof OrFormula));
+						// but all parents are Formula
+						assertTrue(formulaCloner.allParentsMatch(f -> f instanceof Formula));
+					}
+					return currentFormula;
+				}
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Duplicate instance handling")
+	class DuplicateInstanceTest {
+
+		@Test
+		@DisplayName("should reuse processed result for duplicate formula instance")
+		void shouldReuseProcessedResultForDuplicateFormulaInstance() {
+			final ConstantFormula shared = new ConstantFormula(new ArrayBitmap(42));
+			final Formula tree = new AndFormula(
+				new OrFormula(shared, new ConstantFormula(new ArrayBitmap(1))),
+				new OrFormula(shared, new ConstantFormula(new ArrayBitmap(2)))
+			);
+
+			final ConstantFormula replacement = new ConstantFormula(new ArrayBitmap(99));
+			final Formula cloneResult = FormulaCloner.clone(
+				tree,
+				f -> f == shared ? replacement : f
+			);
+
+			// Both references to 'shared' should be replaced with the same 'replacement'
+			assertNotNull(cloneResult);
+			final Formula firstOr = cloneResult.getInnerFormulas()[0];
+			final Formula secondOr = cloneResult.getInnerFormulas()[1];
+			assertSame(replacement, firstOr.getInnerFormulas()[0]);
+			assertSame(replacement, secondOr.getInnerFormulas()[0]);
+		}
+	}
+
+	@Nested
+	@DisplayName("Deep tree cloning")
+	class DeepTreeTest {
+
+		@Test
+		@DisplayName("should clone four-level deep tree")
+		void shouldCloneFourLevelDeepTree() {
+			final ConstantFormula deepLeaf = new ConstantFormula(new ArrayBitmap(100));
+			final Formula tree = new OrFormula(
+				new AndFormula(
+					new UserFilterFormula(deepLeaf),
+					new ConstantFormula(new ArrayBitmap(2, 3))
+				),
+				new ConstantFormula(new ArrayBitmap(4))
+			);
+
+			// Replace the deep leaf
+			final ConstantFormula replacement = new ConstantFormula(new ArrayBitmap(200));
+			final Formula cloneResult = FormulaCloner.clone(
+				tree,
+				f -> f == deepLeaf ? replacement : f
+			);
+
+			assertNotNull(cloneResult);
+			// Navigate: OrFormula -> AndFormula -> UserFilterFormula -> replacement
+			final Formula andClone = cloneResult.getInnerFormulas()[0];
+			final Formula userFilterClone = andClone.getInnerFormulas()[0];
+			assertSame(replacement, userFilterClone.getInnerFormulas()[0]);
+			// Unchanged branch should be preserved
+			assertSame(tree.getInnerFormulas()[1], cloneResult.getInnerFormulas()[1]);
+		}
+	}
+
+	@Nested
+	@DisplayName("Static clone methods")
+	class StaticMethodTest {
+
+		@Test
+		@DisplayName("should clone with UnaryOperator static method")
+		void shouldCloneWithUnaryOperatorStaticMethod() {
+			final ConstantFormula leaf = new ConstantFormula(new ArrayBitmap(1));
+			final ConstantFormula replacement = new ConstantFormula(new ArrayBitmap(2));
+
+			final Formula result = FormulaCloner.clone(leaf, (UnaryOperator<Formula>) f -> replacement);
+
+			assertSame(replacement, result);
+		}
+
+		@Test
+		@DisplayName("should clone with BiFunction static method")
+		void shouldCloneWithBiFunctionStaticMethod() {
+			final ConstantFormula leaf = new ConstantFormula(new ArrayBitmap(1));
+
+			final Formula result = FormulaCloner.clone(
+				leaf, (cloner, f) -> f
+			);
+
+			assertSame(leaf, result);
+		}
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/FormulaFinderTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/FormulaFinderTest.java
@@ -1,0 +1,365 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.utils.visitor;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.AndFormula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.base.NotFormula;
+import io.evitadb.core.query.algebra.base.OrFormula;
+import io.evitadb.core.query.algebra.facet.UserFilterFormula;
+import io.evitadb.core.query.algebra.utils.visitor.FormulaFinder.LookUp;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link FormulaFinder} verifying formula search in trees with SHALLOW and DEEP modes.
+ *
+ * @author evitaDB
+ */
+@DisplayName("FormulaFinder - formula search in trees")
+class FormulaFinderTest {
+
+	@Nested
+	@DisplayName("Find with class predicate")
+	class FindByClassTest {
+
+		@Test
+		@DisplayName("should find root formula by its type")
+		void shouldFindRootFormulaByItsType() {
+			final ConstantFormula root = new ConstantFormula(new ArrayBitmap(1, 2));
+
+			final Collection<ConstantFormula> result = FormulaFinder.find(root, ConstantFormula.class, LookUp.SHALLOW);
+
+			assertEquals(1, result.size());
+			assertTrue(result.contains(root));
+		}
+
+		@Test
+		@DisplayName("should return empty collection when type not present")
+		void shouldReturnEmptyCollectionWhenTypeNotPresent() {
+			final Formula tree = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			final Collection<NotFormula> result = FormulaFinder.find(tree, NotFormula.class, LookUp.DEEP);
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should find multiple formulas of same type")
+		void shouldFindMultipleFormulasOfSameType() {
+			final ConstantFormula c1 = new ConstantFormula(new ArrayBitmap(1));
+			final ConstantFormula c2 = new ConstantFormula(new ArrayBitmap(2));
+			final ConstantFormula c3 = new ConstantFormula(new ArrayBitmap(3));
+			final Formula tree = new OrFormula(
+				c1,
+				new AndFormula(c2, c3)
+			);
+
+			final Collection<ConstantFormula> result = FormulaFinder.find(tree, ConstantFormula.class, LookUp.DEEP);
+
+			assertEquals(3, result.size());
+			assertTrue(result.contains(c1));
+			assertTrue(result.contains(c2));
+			assertTrue(result.contains(c3));
+		}
+	}
+
+	@Nested
+	@DisplayName("SHALLOW vs DEEP lookup")
+	class LookUpModeTest {
+
+		@Test
+		@DisplayName("should stop at matched node in SHALLOW mode")
+		void shouldStopAtMatchedNodeInShallowMode() {
+			// UserFilterFormula containing another OrFormula with ConstantFormulas inside
+			final ConstantFormula innerConstant = new ConstantFormula(new ArrayBitmap(1));
+			final Formula tree = new OrFormula(
+				new UserFilterFormula(innerConstant),
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			// SHALLOW should find UserFilterFormula but NOT descend into its children
+			final Collection<UserFilterFormula> result = FormulaFinder.find(
+				tree, UserFilterFormula.class, LookUp.SHALLOW
+			);
+
+			assertEquals(1, result.size());
+
+			// Searching for ConstantFormula in SHALLOW should find only the one NOT inside UserFilter
+			// (because tree root is OrFormula, not matching ConstantFormula; it descends into both children)
+			final Collection<ConstantFormula> constants = FormulaFinder.find(
+				tree, ConstantFormula.class, LookUp.SHALLOW
+			);
+			// Should find both: the one inside UserFilter and the sibling
+			// Because SHALLOW stops on the MATCHED node, not on arbitrary nodes
+			assertEquals(2, constants.size());
+		}
+
+		@Test
+		@DisplayName("should descend into matched node in DEEP mode")
+		void shouldDescendIntoMatchedNodeInDeepMode() {
+			// Create a nested structure: OrFormula > OrFormula > ConstantFormula
+			final Formula tree = new OrFormula(
+				new OrFormula(
+					new ConstantFormula(new ArrayBitmap(1)),
+					new ConstantFormula(new ArrayBitmap(2))
+				),
+				new ConstantFormula(new ArrayBitmap(3))
+			);
+
+			// DEEP should find both OrFormulas (root and nested)
+			final Collection<OrFormula> result = FormulaFinder.find(tree, OrFormula.class, LookUp.DEEP);
+
+			assertEquals(2, result.size());
+		}
+
+		@Test
+		@DisplayName("should not descend into matched node in SHALLOW mode")
+		void shouldNotDescendIntoMatchedNodeInShallowMode() {
+			final Formula tree = new OrFormula(
+				new OrFormula(
+					new ConstantFormula(new ArrayBitmap(1)),
+					new ConstantFormula(new ArrayBitmap(2))
+				),
+				new ConstantFormula(new ArrayBitmap(3))
+			);
+
+			// SHALLOW: root OrFormula matches, so it stops - does NOT find the inner OrFormula
+			final Collection<OrFormula> result = FormulaFinder.find(tree, OrFormula.class, LookUp.SHALLOW);
+
+			assertEquals(1, result.size());
+		}
+	}
+
+	@Nested
+	@DisplayName("findAmongChildren - excluding root")
+	class FindAmongChildrenTest {
+
+		@Test
+		@DisplayName("should exclude root when root matches type")
+		void shouldExcludeRootWhenRootMatchesType() {
+			final ConstantFormula c1 = new ConstantFormula(new ArrayBitmap(1));
+			final ConstantFormula c2 = new ConstantFormula(new ArrayBitmap(2));
+			final OrFormula root = new OrFormula(c1, c2);
+
+			// OrFormula is the root, findAmongChildren should skip it
+			final Collection<OrFormula> result = FormulaFinder.findAmongChildren(root, OrFormula.class, LookUp.DEEP);
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should find matching children but not root")
+		void shouldFindMatchingChildrenButNotRoot() {
+			final ConstantFormula c1 = new ConstantFormula(new ArrayBitmap(1));
+			final ConstantFormula c2 = new ConstantFormula(new ArrayBitmap(2));
+			final OrFormula root = new OrFormula(c1, c2);
+
+			final Collection<ConstantFormula> result = FormulaFinder.findAmongChildren(
+				root, ConstantFormula.class, LookUp.SHALLOW
+			);
+
+			assertEquals(2, result.size());
+			assertTrue(result.contains(c1));
+			assertTrue(result.contains(c2));
+		}
+
+		@Test
+		@DisplayName("should work with predicate variant")
+		void shouldWorkWithPredicateVariant() {
+			final ConstantFormula c1 = new ConstantFormula(new ArrayBitmap(1));
+			final ConstantFormula c2 = new ConstantFormula(new ArrayBitmap(2));
+			final OrFormula root = new OrFormula(c1, c2);
+
+			final Collection<ConstantFormula> result = FormulaFinder.findAmongChildren(
+				root,
+				formula -> formula instanceof ConstantFormula,
+				LookUp.SHALLOW
+			);
+
+			assertEquals(2, result.size());
+		}
+	}
+
+	@Nested
+	@DisplayName("Find with custom predicate")
+	class FindByPredicateTest {
+
+		@Test
+		@DisplayName("should find formulas matching custom predicate")
+		void shouldFindFormulasMatchingCustomPredicate() {
+			final ConstantFormula c1 = new ConstantFormula(new ArrayBitmap(1));
+			final ConstantFormula c2 = new ConstantFormula(new ArrayBitmap(2, 3, 4));
+			final Formula tree = new OrFormula(c1, c2);
+
+			// predicate: ConstantFormula with delegate size > 1
+			final Collection<ConstantFormula> result = FormulaFinder.find(
+				tree,
+				formula -> formula instanceof ConstantFormula cf && cf.getDelegate().size() > 1,
+				LookUp.DEEP
+			);
+
+			assertEquals(1, result.size());
+			assertTrue(result.contains(c2));
+		}
+
+		@Test
+		@DisplayName("should find formulas matching predicate among children")
+		void shouldFindFormulasMatchingPredicateAmongChildren() {
+			final ConstantFormula c1 = new ConstantFormula(new ArrayBitmap(1));
+			final ConstantFormula c2 = new ConstantFormula(new ArrayBitmap(2));
+			final Formula tree = new OrFormula(c1, c2);
+
+			final Collection<Formula> result = FormulaFinder.findAmongChildren(
+				tree,
+				formula -> formula instanceof ConstantFormula,
+				LookUp.DEEP
+			);
+
+			assertEquals(2, result.size());
+		}
+	}
+
+	@Nested
+	@DisplayName("Skip predicate behavior")
+	class SkipPredicateTest {
+
+		@Test
+		@DisplayName("should skip formula subtree matching skip predicate")
+		void shouldSkipFormulaSubtreeMatchingSkipPredicate() {
+			final ConstantFormula outsideConstant = new ConstantFormula(new ArrayBitmap(1));
+			final ConstantFormula insideConstant = new ConstantFormula(new ArrayBitmap(2));
+			final Formula tree = new AndFormula(
+				outsideConstant,
+				new UserFilterFormula(insideConstant)
+			);
+
+			// Skip UserFilterFormula and everything below it
+			final Collection<ConstantFormula> result = FormulaFinder.find(
+				tree,
+				formula -> formula instanceof ConstantFormula,
+				formula -> formula instanceof UserFilterFormula,
+				LookUp.DEEP
+			);
+
+			assertEquals(1, result.size());
+			assertTrue(result.contains(outsideConstant));
+			assertFalse(result.contains(insideConstant));
+		}
+
+		@Test
+		@DisplayName("should skip root if root matches skip predicate")
+		void shouldSkipRootIfRootMatchesSkipPredicate() {
+			final ConstantFormula c1 = new ConstantFormula(new ArrayBitmap(1));
+			final ConstantFormula c2 = new ConstantFormula(new ArrayBitmap(2));
+			final Formula tree = new OrFormula(c1, c2);
+
+			// Skip OrFormula (root) so nothing should be found
+			final Collection<ConstantFormula> result = FormulaFinder.find(
+				tree,
+				formula -> formula instanceof ConstantFormula,
+				formula -> formula instanceof OrFormula,
+				LookUp.DEEP
+			);
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should work with findAmongChildren and skip predicate")
+		void shouldWorkWithFindAmongChildrenAndSkipPredicate() {
+			final ConstantFormula c1 = new ConstantFormula(new ArrayBitmap(1));
+			final ConstantFormula c2 = new ConstantFormula(new ArrayBitmap(2));
+			final Formula tree = new AndFormula(
+				new UserFilterFormula(c1),
+				new OrFormula(
+					c2,
+					new ConstantFormula(new ArrayBitmap(3))
+				)
+			);
+
+			// Skip UserFilterFormula subtrees, find ConstantFormulas among children
+			final Collection<ConstantFormula> result = FormulaFinder.findAmongChildren(
+				tree,
+				formula -> formula instanceof ConstantFormula,
+				formula -> formula instanceof UserFilterFormula,
+				LookUp.DEEP
+			);
+
+			assertEquals(2, result.size());
+			assertFalse(result.contains(c1));
+		}
+	}
+
+	@Nested
+	@DisplayName("Edge cases")
+	class EdgeCaseTest {
+
+		@Test
+		@DisplayName("should handle leaf formula with no children")
+		void shouldHandleLeafFormulaWithNoChildren() {
+			final Formula leaf = EmptyFormula.INSTANCE;
+
+			final Collection<EmptyFormula> result = FormulaFinder.find(leaf, EmptyFormula.class, LookUp.DEEP);
+
+			assertEquals(1, result.size());
+		}
+
+		@Test
+		@DisplayName("should not produce duplicates for same formula reference")
+		void shouldNotProduceDuplicatesForSameFormulaReference() {
+			final ConstantFormula shared = new ConstantFormula(new ArrayBitmap(1, 2));
+			// same instance used twice as children (this is valid in formula trees)
+			final Formula tree = new OrFormula(shared, new ConstantFormula(new ArrayBitmap(3)));
+
+			final Collection<ConstantFormula> result = FormulaFinder.find(tree, ConstantFormula.class, LookUp.DEEP);
+
+			assertEquals(2, result.size());
+		}
+
+		@Test
+		@DisplayName("should handle tree with EmptyFormula leaves")
+		void shouldHandleTreeWithEmptyFormulaLeaves() {
+			final Formula tree = new OrFormula(
+				EmptyFormula.INSTANCE,
+				new ConstantFormula(new ArrayBitmap(1))
+			);
+
+			final Collection<EmptyFormula> result = FormulaFinder.find(tree, EmptyFormula.class, LookUp.SHALLOW);
+
+			assertEquals(1, result.size());
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/FormulaLocatorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/FormulaLocatorTest.java
@@ -1,0 +1,181 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.utils.visitor;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.AndFormula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.base.NotFormula;
+import io.evitadb.core.query.algebra.base.OrFormula;
+import io.evitadb.core.query.algebra.facet.UserFilterFormula;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link FormulaLocator} verifying formula type detection in formula trees.
+ *
+ * @author evitaDB
+ */
+@DisplayName("FormulaLocator - formula type detection in trees")
+class FormulaLocatorTest {
+
+	@Nested
+	@DisplayName("Locating formulas in flat structures")
+	class FlatStructureTest {
+
+		@Test
+		@DisplayName("should find type when root formula matches")
+		void shouldFindTypeWhenRootFormulaMatches() {
+			final Formula leaf = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+
+			final boolean result = FormulaLocator.contains(leaf, ConstantFormula.class);
+
+			assertTrue(result);
+		}
+
+		@Test
+		@DisplayName("should not find type when root formula does not match")
+		void shouldNotFindTypeWhenRootFormulaDoesNotMatch() {
+			final Formula leaf = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+
+			final boolean result = FormulaLocator.contains(leaf, OrFormula.class);
+
+			assertFalse(result);
+		}
+
+		@Test
+		@DisplayName("should detect EmptyFormula singleton")
+		void shouldDetectEmptyFormulaSingleton() {
+			final Formula tree = new OrFormula(
+				EmptyFormula.INSTANCE,
+				new ConstantFormula(new ArrayBitmap(1))
+			);
+
+			assertTrue(FormulaLocator.contains(tree, EmptyFormula.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("Locating formulas in deep trees")
+	class DeepTreeTest {
+
+		@Test
+		@DisplayName("should find deeply nested formula type")
+		void shouldFindDeeplyNestedFormulaType() {
+			final Formula tree = new AndFormula(
+				new OrFormula(
+					new ConstantFormula(new ArrayBitmap(1)),
+					new ConstantFormula(new ArrayBitmap(2))
+				),
+				new UserFilterFormula(
+					new ConstantFormula(new ArrayBitmap(3))
+				)
+			);
+
+			assertTrue(FormulaLocator.contains(tree, UserFilterFormula.class));
+		}
+
+		@Test
+		@DisplayName("should not find absent type in deep tree")
+		void shouldNotFindAbsentTypeInDeepTree() {
+			final Formula tree = new AndFormula(
+				new OrFormula(
+					new ConstantFormula(new ArrayBitmap(1)),
+					new ConstantFormula(new ArrayBitmap(2))
+				),
+				new ConstantFormula(new ArrayBitmap(3, 4))
+			);
+
+			assertFalse(FormulaLocator.contains(tree, NotFormula.class));
+		}
+
+		@Test
+		@DisplayName("should find type at intermediate level")
+		void shouldFindTypeAtIntermediateLevel() {
+			final Formula tree = new AndFormula(
+				new OrFormula(
+					new ConstantFormula(new ArrayBitmap(1)),
+					new ConstantFormula(new ArrayBitmap(2))
+				),
+				new NotFormula(
+					new ConstantFormula(new ArrayBitmap(3)),
+					new ConstantFormula(new ArrayBitmap(3, 4, 5))
+				)
+			);
+
+			assertTrue(FormulaLocator.contains(tree, OrFormula.class));
+			assertTrue(FormulaLocator.contains(tree, NotFormula.class));
+			assertTrue(FormulaLocator.contains(tree, AndFormula.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("Short-circuit behavior")
+	class ShortCircuitTest {
+
+		@Test
+		@DisplayName("should stop searching after first match found")
+		void shouldStopSearchingAfterFirstMatchFound() {
+			// tree with two ConstantFormulas at different levels
+			final Formula tree = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				new AndFormula(
+					new ConstantFormula(new ArrayBitmap(2)),
+					new ConstantFormula(new ArrayBitmap(3))
+				)
+			);
+
+			// locator returns true - verifying short-circuit is implicit
+			// (the first ConstantFormula match stops traversal)
+			assertTrue(FormulaLocator.contains(tree, ConstantFormula.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("Supertype and interface matching")
+	class TypeHierarchyTest {
+
+		@Test
+		@DisplayName("should match by supertype using Formula interface")
+		void shouldMatchBySupertypeUsingFormulaInterface() {
+			final Formula leaf = new ConstantFormula(new ArrayBitmap(1, 2));
+
+			// Formula.class is supertype of all formulas
+			assertTrue(FormulaLocator.contains(leaf, Formula.class));
+		}
+
+		@Test
+		@DisplayName("should not match unrelated type")
+		void shouldNotMatchUnrelatedType() {
+			final Formula leaf = new ConstantFormula(new ArrayBitmap(1, 2));
+
+			assertFalse(FormulaLocator.contains(leaf, UserFilterFormula.class));
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/PrettyPrintingFormulaVisitorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/PrettyPrintingFormulaVisitorTest.java
@@ -1,0 +1,330 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.algebra.utils.visitor;
+
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.AndFormula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.base.OrFormula;
+import io.evitadb.core.query.algebra.facet.UserFilterFormula;
+import io.evitadb.core.query.algebra.utils.visitor.PrettyPrintingFormulaVisitor.PrettyPrintStyle;
+import io.evitadb.index.bitmap.ArrayBitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link PrettyPrintingFormulaVisitor} verifying formula tree rendering
+ * in both normal and verbose modes.
+ *
+ * @author evitaDB
+ */
+@DisplayName("PrettyPrintingFormulaVisitor - formula tree rendering")
+class PrettyPrintingFormulaVisitorTest {
+
+	@Nested
+	@DisplayName("Static factory methods")
+	class StaticMethodTest {
+
+		@Test
+		@DisplayName("should produce non-empty output via toString()")
+		void shouldProduceNonEmptyOutputViaToString() {
+			final Formula leaf = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+
+			final String result = PrettyPrintingFormulaVisitor.toString(leaf);
+
+			assertNotNull(result);
+			assertFalse(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should produce non-empty output via toStringVerbose()")
+		void shouldProduceNonEmptyOutputViaToStringVerbose() {
+			final Formula leaf = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+
+			final String result = PrettyPrintingFormulaVisitor.toStringVerbose(leaf);
+
+			assertNotNull(result);
+			assertFalse(result.isEmpty());
+		}
+	}
+
+	@Nested
+	@DisplayName("Leaf formula rendering")
+	class LeafFormulaTest {
+
+		@Test
+		@DisplayName("should render leaf without result count suffix")
+		void shouldRenderLeafWithoutResultCountSuffix() {
+			final Formula leaf = new ConstantFormula(new ArrayBitmap(1, 2));
+
+			final String result = PrettyPrintingFormulaVisitor.toString(leaf);
+
+			// leaf has no inner formulas -> no arrow + result count suffix
+			assertFalse(result.contains("\u2192"));
+			// should contain [#0] formula id
+			assertTrue(result.contains("[#0]"));
+		}
+
+		@Test
+		@DisplayName("should render EmptyFormula")
+		void shouldRenderEmptyFormula() {
+			final String result = PrettyPrintingFormulaVisitor.toString(EmptyFormula.INSTANCE);
+
+			assertTrue(result.contains("[#0]"));
+			assertTrue(result.contains("EMPTY"));
+		}
+	}
+
+	@Nested
+	@DisplayName("Tree structure rendering")
+	class TreeRenderingTest {
+
+		@Test
+		@DisplayName("should render parent with result count")
+		void shouldRenderParentWithResultCount() {
+			final Formula tree = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			final String result = PrettyPrintingFormulaVisitor.toString(tree);
+
+			// parent formula with inner formulas should have arrow + result count
+			assertTrue(result.contains("\u2192"));
+			assertTrue(result.contains("result count"));
+		}
+
+		@Test
+		@DisplayName("should indent children deeper than parent")
+		void shouldIndentChildrenDeeperThanParent() {
+			final Formula tree = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			final String result = PrettyPrintingFormulaVisitor.toString(tree);
+			final String[] lines = result.split("\n");
+
+			// root (line 0) should have no leading spaces
+			assertTrue(lines[0].startsWith("[#"));
+			// children (line 1, 2) should have leading spaces (3 spaces default indent)
+			assertTrue(lines[1].startsWith("   "));
+		}
+
+		@Test
+		@DisplayName("should use custom indent value")
+		void shouldUseCustomIndentValue() {
+			final Formula tree = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			final PrettyPrintingFormulaVisitor visitor = new PrettyPrintingFormulaVisitor(5);
+			tree.accept(visitor);
+			final String result = visitor.getResult();
+			final String[] lines = result.split("\n");
+
+			// children should be indented by 5 spaces
+			assertTrue(lines[1].startsWith("     ["));
+		}
+	}
+
+	@Nested
+	@DisplayName("Duplicate formula detection")
+	class DuplicateDetectionTest {
+
+		@Test
+		@DisplayName("should mark duplicate formula instances as references")
+		void shouldMarkDuplicateFormulaInstancesAsReferences() {
+			final ConstantFormula shared = new ConstantFormula(new ArrayBitmap(1, 2));
+			// Use the same instance in two branches
+			final Formula tree = new AndFormula(
+				new OrFormula(shared, new ConstantFormula(new ArrayBitmap(3))),
+				new OrFormula(shared, new ConstantFormula(new ArrayBitmap(4)))
+			);
+
+			final String result = PrettyPrintingFormulaVisitor.toString(tree);
+
+			// the shared formula should appear once as [#N] and once as [Ref to #N]
+			assertTrue(result.contains("[Ref to #"));
+		}
+
+		@Test
+		@DisplayName("should not mark distinct formulas as references")
+		void shouldNotMarkDistinctFormulasAsReferences() {
+			final Formula tree = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			final String result = PrettyPrintingFormulaVisitor.toString(tree);
+
+			assertFalse(result.contains("[Ref to #"));
+		}
+	}
+
+	@Nested
+	@DisplayName("Normal vs Verbose style")
+	class StyleTest {
+
+		@Test
+		@DisplayName("should print formula toString in NORMAL mode")
+		void shouldPrintFormulaToStringInNormalMode() {
+			final Formula leaf = new ConstantFormula(new ArrayBitmap(1, 2, 3));
+
+			final PrettyPrintingFormulaVisitor visitor = new PrettyPrintingFormulaVisitor(3, PrettyPrintStyle.NORMAL);
+			leaf.accept(visitor);
+			final String result = visitor.getResult();
+
+			// ConstantFormula.toString() returns "N primary keys"
+			assertTrue(result.contains("primary keys"));
+		}
+
+		@Test
+		@DisplayName("should print formula toStringVerbose in VERBOSE mode")
+		void shouldPrintFormulaToStringVerboseInVerboseMode() {
+			final Formula leaf = new ConstantFormula(new ArrayBitmap(5, 10, 15));
+
+			final String result = PrettyPrintingFormulaVisitor.toStringVerbose(leaf);
+
+			// ConstantFormula.toStringVerbose() returns the bitmap contents
+			// which should contain the actual values
+			assertNotNull(result);
+			assertFalse(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should include full bitmap in VERBOSE result count for parent formulas")
+		void shouldIncludeFullBitmapInVerboseResultCountForParentFormulas() {
+			final Formula tree = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			final String normalResult = PrettyPrintingFormulaVisitor.toString(tree);
+			final String verboseResult = PrettyPrintingFormulaVisitor.toStringVerbose(tree);
+
+			// normal contains "result count", verbose contains the actual bitmap
+			assertTrue(normalResult.contains("result count"));
+			// verbose should NOT contain "result count" text - it shows the actual bitmap
+			assertFalse(verboseResult.contains("result count"));
+		}
+	}
+
+	@Nested
+	@DisplayName("Formula ID numbering")
+	class IdNumberingTest {
+
+		@Test
+		@DisplayName("should assign sequential IDs starting from zero")
+		void shouldAssignSequentialIdsStartingFromZero() {
+			final Formula tree = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			final String result = PrettyPrintingFormulaVisitor.toString(tree);
+
+			assertTrue(result.contains("[#0]"));
+			assertTrue(result.contains("[#1]"));
+			assertTrue(result.contains("[#2]"));
+		}
+	}
+
+	@Nested
+	@DisplayName("Deep tree rendering")
+	class DeepTreeTest {
+
+		@Test
+		@DisplayName("should correctly render multi-level tree")
+		void shouldCorrectlyRenderMultiLevelTree() {
+			final Formula tree = new AndFormula(
+				new OrFormula(
+					new ConstantFormula(new ArrayBitmap(1)),
+					new ConstantFormula(new ArrayBitmap(2))
+				),
+				new UserFilterFormula(
+					new ConstantFormula(new ArrayBitmap(1, 2))
+				)
+			);
+
+			final String result = PrettyPrintingFormulaVisitor.toString(tree);
+			final String[] lines = result.split("\n");
+
+			// root at level 0, two children at level 1, grandchildren at level 2
+			assertTrue(lines.length >= 5);
+			// root has no indent
+			assertTrue(lines[0].startsWith("[#0]"));
+			// level 1 children have 3 spaces indent
+			assertTrue(lines[1].startsWith("   [#"));
+			// level 2 grandchildren have 6 spaces indent
+			assertTrue(lines[2].startsWith("      [#"));
+		}
+	}
+
+	@Nested
+	@DisplayName("Constructor variations")
+	class ConstructorTest {
+
+		@Test
+		@DisplayName("should use default indent of 3 with no-arg constructor")
+		void shouldUseDefaultIndentOfThreeWithNoArgConstructor() {
+			final Formula tree = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			final PrettyPrintingFormulaVisitor visitor = new PrettyPrintingFormulaVisitor();
+			tree.accept(visitor);
+			final String result = visitor.getResult();
+			final String[] lines = result.split("\n");
+
+			// children at level 1 should be indented by 3 spaces (default)
+			assertTrue(lines[1].startsWith("   [#"));
+		}
+
+		@Test
+		@DisplayName("should accept zero indent")
+		void shouldAcceptZeroIndent() {
+			final Formula tree = new OrFormula(
+				new ConstantFormula(new ArrayBitmap(1)),
+				new ConstantFormula(new ArrayBitmap(2))
+			);
+
+			final PrettyPrintingFormulaVisitor visitor = new PrettyPrintingFormulaVisitor(0);
+			tree.accept(visitor);
+			final String result = visitor.getResult();
+			final String[] lines = result.split("\n");
+
+			// all lines should start with [# because indent is 0
+			for (String line : lines) {
+				assertTrue(line.startsWith("[#") || line.startsWith("[Ref"));
+			}
+		}
+	}
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/FormulaCostMeasurement.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/FormulaCostMeasurement.java
@@ -44,6 +44,7 @@ import io.evitadb.core.query.extraResult.translator.histogram.producer.Attribute
 import io.evitadb.core.query.extraResult.translator.histogram.producer.PriceHistogramComputer;
 import io.evitadb.index.invertedIndex.suppliers.HistogramBitmapSupplier;
 import io.evitadb.index.price.model.PriceIndexKey;
+import io.evitadb.index.price.model.priceRecord.PriceRecordContract;
 import io.evitadb.spike.mock.BucketsRecordState;
 import io.evitadb.spike.mock.EntityIdsWithPriceRecordsRecordState;
 import io.evitadb.spike.mock.InnerRecordIdsWithPriceRecordsRecordState;
@@ -63,10 +64,25 @@ import java.util.Currency;
 import java.util.concurrent.TimeUnit;
 
 /**
- * This spike test tries to test how fast are formulas.
+ * JMH benchmark suite that measures throughput of individual formula implementations used in
+ * the evitaDB query engine. The results are used to derive **operation cost coefficients** for the
+ * formula caching layer — a cost of 1 corresponds to 1 million ops/s.
  *
- * Results:
- * (COST = 1 = 1mil. ops/s)
+ * All benchmarks operate on datasets of comparable cardinality (~100K records) so that throughput
+ * numbers are directly comparable across formula types. Each benchmark creates a fresh formula instance
+ * per invocation (no caching between iterations) and consumes results via {@link Blackhole} to prevent
+ * dead-code elimination.
+ *
+ * **Note on `plainPriceTermination`:** {@link PlainPriceTerminationFormula} is a pure delegation wrapper
+ * — its `computeInternal()` only forwards to the inner formula without price filtering. The extremely
+ * high throughput (~45M ops/s) reflects this delegation overhead and is intentional — the formula
+ * genuinely has near-zero cost in the cost model. Compare with
+ * {@link PlainPriceTerminationFormulaWithPriceFilter} which performs per-entity price predicate
+ * evaluation and shows realistic filtering cost (~312 ops/s).
+ *
+ * ## Results
+ *
+ * (COST = 1 = 1 mil. ops/s)
  *
  * Benchmark                                                       Mode  Cnt        Score   Error  Units
  * FormulaCostMeasurement.andFormulaInteger                       thrpt    2   116094.151          ops/s
@@ -104,6 +120,10 @@ public class FormulaCostMeasurement {
 		org.openjdk.jmh.Main.main(args);
 	}
 
+	/**
+	 * Measures throughput of {@link AndFormula} — set intersection of two 100K-element
+	 * RoaringBitmap-backed bitmaps.
+	 */
 	@Benchmark
 	public void andFormulaInteger(IntegerBitmapState bitmapDataSet, Blackhole blackhole) {
 		blackhole.consume(
@@ -115,6 +135,10 @@ public class FormulaCostMeasurement {
 		);
 	}
 
+	/**
+	 * Measures throughput of {@link OrFormula} — set union of two 100K-element
+	 * RoaringBitmap-backed bitmaps.
+	 */
 	@Benchmark
 	public void orFormulaInteger(IntegerBitmapState bitmapDataSet, Blackhole blackhole) {
 		blackhole.consume(
@@ -126,6 +150,10 @@ public class FormulaCostMeasurement {
 		);
 	}
 
+	/**
+	 * Measures throughput of {@link NotFormula} — set difference (A minus B) of two 100K-element
+	 * RoaringBitmap-backed bitmaps.
+	 */
 	@Benchmark
 	public void notFormulaInteger(IntegerBitmapState bitmapDataSet, Blackhole blackhole) {
 		blackhole.consume(
@@ -136,6 +164,10 @@ public class FormulaCostMeasurement {
 		);
 	}
 
+	/**
+	 * Measures throughput of {@link JoinFormula} — concatenation (multiset union) of two 100K-element
+	 * RoaringBitmap-backed bitmaps.
+	 */
 	@Benchmark
 	public void joinFormula(IntegerBitmapState bitmapDataSet, Blackhole blackhole) {
 		blackhole.consume(
@@ -147,6 +179,10 @@ public class FormulaCostMeasurement {
 		);
 	}
 
+	/**
+	 * Measures throughput of {@link DisentangleFormula} — separates records unique to A from records
+	 * shared with B, operating on two 100K-element RoaringBitmap-backed bitmaps.
+	 */
 	@Benchmark
 	public void disentangleFormula(IntegerBitmapState bitmapDataSet, Blackhole blackhole) {
 		blackhole.consume(
@@ -157,6 +193,11 @@ public class FormulaCostMeasurement {
 		);
 	}
 
+	/**
+	 * Measures throughput of {@link PriceIdContainerFormula} — resolves price IDs from a price index
+	 * and materializes corresponding {@link PriceRecordContract} array via
+	 * {@link PriceIdContainerFormula#getFilteredPriceRecords}. Operates on ~100K price records.
+	 */
 	@Benchmark
 	public void priceIdContainer(PriceIdsWithPriceRecordsRecordState priceDataSet, Blackhole blackhole) {
 		final PriceIdContainerFormula testedFormula = new PriceIdContainerFormula(
@@ -167,6 +208,11 @@ public class FormulaCostMeasurement {
 		blackhole.consume(testedFormula.getFilteredPriceRecords(priceDataSet.getQueryExecutionContext()));
 	}
 
+	/**
+	 * Measures throughput of {@link PriceIdToEntityIdTranslateFormula} — translates ~100K price IDs
+	 * to entity IDs by looking up each price record in the underlying price index, and collects
+	 * the corresponding filtered price records.
+	 */
 	@Benchmark
 	public void priceIdToEntityIdTranslate(PriceIdsWithPriceRecordsRecordState priceDataSet, Blackhole blackhole) {
 		final PriceIdToEntityIdTranslateFormula testedFormula = new PriceIdToEntityIdTranslateFormula(priceDataSet.getPriceIdsFormula());
@@ -174,6 +220,12 @@ public class FormulaCostMeasurement {
 		blackhole.consume(testedFormula.getFilteredPriceRecords(priceDataSet.getQueryExecutionContext()));
 	}
 
+	/**
+	 * Measures throughput of {@link PlainPriceTerminationFormula} — a pure delegation wrapper that
+	 * returns entity IDs from the inner formula without applying any price predicate filtering.
+	 * The extremely high throughput (~45M ops/s) reflects the near-zero cost of delegation only.
+	 * Operates on an OR-combined formula tree of 3 × 100K price records over ~10K entities.
+	 */
 	@Benchmark
 	public void plainPriceTermination(EntityIdsWithPriceRecordsRecordState priceDataSet, Blackhole blackhole) {
 		final PlainPriceTerminationFormula testedFormula = new PlainPriceTerminationFormula(
@@ -188,6 +240,12 @@ public class FormulaCostMeasurement {
 		blackhole.consume(testedFormula.compute());
 	}
 
+	/**
+	 * Measures throughput of {@link PlainPriceTerminationFormulaWithPriceFilter} — iterates through
+	 * all entity IDs, looks up their associated price records, and evaluates each price against
+	 * a {@link PricePredicate}. Operates on the same dataset as {@link #plainPriceTermination} but
+	 * performs actual per-entity price filtering work (~312 ops/s vs ~45M ops/s for pure delegation).
+	 */
 	@Benchmark
 	public void plainPriceTerminationWithPriceFilter(EntityIdsWithPriceRecordsRecordState priceDataSet, Blackhole blackhole) {
 		final PlainPriceTerminationFormulaWithPriceFilter testedFormula = new PlainPriceTerminationFormulaWithPriceFilter(
@@ -203,6 +261,11 @@ public class FormulaCostMeasurement {
 		blackhole.consume(testedFormula.compute());
 	}
 
+	/**
+	 * Measures throughput of {@link LowestPriceTerminationFormula} — selects the lowest-priced
+	 * variant for each entity from inner-record-specific price records, applying a price predicate.
+	 * Operates on an OR-combined formula tree of 3 × 100K price records with inner record grouping.
+	 */
 	@Benchmark
 	public void firstVariantPriceTermination(InnerRecordIdsWithPriceRecordsRecordState priceDataSet, Blackhole blackhole) {
 		final LowestPriceTerminationFormula testedFormula = new LowestPriceTerminationFormula(
@@ -219,6 +282,11 @@ public class FormulaCostMeasurement {
 		blackhole.consume(testedFormula.compute());
 	}
 
+	/**
+	 * Measures throughput of {@link SumPriceTerminationFormula} — sums prices across all inner
+	 * records for each entity and applies a price predicate to the aggregate. Operates on the same
+	 * dataset as {@link #firstVariantPriceTermination} (3 × 100K inner-record-specific price records).
+	 */
 	@Benchmark
 	public void sumPriceTermination(InnerRecordIdsWithPriceRecordsRecordState priceDataSet, Blackhole blackhole) {
 		final SumPriceTerminationFormula testedFormula = new SumPriceTerminationFormula(
@@ -235,6 +303,10 @@ public class FormulaCostMeasurement {
 		blackhole.consume(testedFormula.compute());
 	}
 
+	/**
+	 * Measures throughput of {@link HistogramBitmapSupplier} — merges bitmaps from 2000 histogram
+	 * buckets (~50 records each, ~100K total) into a single bitmap.
+	 */
 	@Benchmark
 	public void histogramBitmapSupplier(BucketsRecordState bucketDataSet, Blackhole blackhole) {
 		final HistogramBitmapSupplier testedFormula = new HistogramBitmapSupplier(
@@ -243,6 +315,11 @@ public class FormulaCostMeasurement {
 		blackhole.consume(testedFormula.get());
 	}
 
+	/**
+	 * Measures throughput of {@link AttributeHistogramComputer} — computes a 40-bucket attribute
+	 * histogram by intersecting 5 filter indices (each with 2000 value buckets) against ~100K
+	 * entity IDs.
+	 */
 	@Benchmark
 	public void attributeHistogramComputer(BucketsRecordState bucketDataSet, Blackhole blackhole) {
 		final AttributeHistogramComputer testedFormula = new AttributeHistogramComputer(
@@ -254,6 +331,11 @@ public class FormulaCostMeasurement {
 		blackhole.consume(testedFormula.compute());
 	}
 
+	/**
+	 * Measures throughput of {@link PriceHistogramComputer} — computes a 40-bucket price histogram
+	 * from two price record accessors (70K + 30K = 100K prices) over ~10K entities, using
+	 * WITH_TAX price mode with 2 decimal places.
+	 */
 	@Benchmark
 	public void priceHistogramComputer(PriceBucketRecordState bucketDataSet, Blackhole blackhole) {
 		final PriceHistogramComputer testedFormula = new PriceHistogramComputer(

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/BucketsRecordState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/BucketsRecordState.java
@@ -46,14 +46,23 @@ import java.util.Comparator;
 import java.util.Random;
 
 /**
- * No extra information provided - see (selfexplanatory) method signatures.
- * I have the best intention to write more detailed documentation but if you see this, there was not enough time or will to do so.
+ * JMH benchmark state providing histogram bucket data and attribute filter indices for histogram
+ * benchmarks ({@link io.evitadb.spike.FormulaCostMeasurement#histogramBitmapSupplier},
+ * {@link io.evitadb.spike.FormulaCostMeasurement#attributeHistogramComputer}).
+ *
+ * Generates {@link #BUCKET_COUNT} value-to-record buckets with ~{@link #VALUE_COUNT}/{@link #BUCKET_COUNT}
+ * records each (monotonically increasing record IDs with small random gaps). For the attribute
+ * histogram benchmark, 5 {@link FilterIndex} instances are created with the same bucket structure
+ * but 1/5th of the value count each. A separate entity ID bitmap of {@link #VALUE_COUNT} entries
+ * serves as the filtering baseline.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 @State(Scope.Benchmark)
 public class BucketsRecordState {
+	/** Number of histogram buckets (value-to-record mappings). */
 	private static final int BUCKET_COUNT = 2000;
+	/** Total number of records across all buckets. */
 	private static final int VALUE_COUNT = 100_000;
 	private static final Random random = new Random(42);
 	@Getter private ValueToRecordBitmap[] buckets;
@@ -62,7 +71,8 @@ public class BucketsRecordState {
 	@Getter private Formula formula;
 
 	/**
-	 * This setup is called once for each `valueCount`.
+	 * Generates histogram buckets, filter indices, entity ID bitmap, and wraps IDs in
+	 * a {@link ConstantFormula}.
 	 */
 	@Setup(Level.Trial)
 	public void setUp() {

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/EntityIdsWithPriceRecordsRecordState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/EntityIdsWithPriceRecordsRecordState.java
@@ -41,16 +41,28 @@ import org.openjdk.jmh.annotations.State;
 import java.util.Random;
 
 /**
- * No extra information provided - see (selfexplanatory) method signatures.
- * I have the best intention to write more detailed documentation but if you see this, there was not enough time or will to do so.
+ * JMH benchmark state providing three entity ID bitmaps with associated price records, combined
+ * into an {@link OrFormula} tree via {@link MockEntityIdsFormula} leaves. Used by
+ * price termination benchmarks that operate on entity-level IDs
+ * ({@link io.evitadb.spike.FormulaCostMeasurement#plainPriceTermination},
+ * {@link io.evitadb.spike.FormulaCostMeasurement#plainPriceTerminationWithPriceFilter}).
+ *
+ * Each of the three datasets generates {@link #PRICE_COUNT} price records distributed randomly
+ * across {@link #ENTITY_COUNT} entities. Price records use {@link PriceRecordInnerRecordSpecific}
+ * with inner record IDs offset beyond the entity ID range. The {@link OrFormula} is pre-computed
+ * during setup so that benchmark iterations measure only the termination formula cost, not the
+ * underlying bitmap union.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 @State(Scope.Benchmark)
 public class EntityIdsWithPriceRecordsRecordState {
+	/** Number of distinct entities to distribute prices across. */
 	private static final int ENTITY_COUNT = 10_000;
+	/** Number of price records per dataset (3 datasets total = 300K records). */
 	private static final int PRICE_COUNT = 100_000;
 	private static final Random random = new Random(42);
+	/** Monotonic price ID generator — shared across all instances within the same JVM fork. */
 	private static int PRICE_ID_SEQ;
 
 	@Getter private PriceRecordContract[] entitiesPriceRecordsA;
@@ -62,7 +74,8 @@ public class EntityIdsWithPriceRecordsRecordState {
 	@Getter private Formula formula;
 
 	/**
-	 * This setup is called once for each `valueCount`.
+	 * Generates three entity-price datasets, wraps each in a {@link MockEntityIdsFormula},
+	 * combines them via {@link OrFormula}, and pre-computes the union bitmap.
 	 */
 	@Setup(Level.Trial)
 	public void setUp() {
@@ -81,7 +94,7 @@ public class EntityIdsWithPriceRecordsRecordState {
 		this.formula = new OrFormula(
 			new MockEntityIdsFormula(this.entitiesA, new ResolvedFilteredPriceRecords(this.entitiesPriceRecordsA, SortingForm.NOT_SORTED)),
 			new MockEntityIdsFormula(this.entitiesB, new ResolvedFilteredPriceRecords(this.entitiesPriceRecordsB, SortingForm.NOT_SORTED)),
-			new MockEntityIdsFormula(this.entitiesB, new ResolvedFilteredPriceRecords(this.entitiesPriceRecordsC, SortingForm.NOT_SORTED))
+			new MockEntityIdsFormula(this.entitiesC, new ResolvedFilteredPriceRecords(this.entitiesPriceRecordsC, SortingForm.NOT_SORTED))
 		);
 		this.formula.compute();
 	}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/InnerRecordIdsWithPriceRecordsRecordState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/InnerRecordIdsWithPriceRecordsRecordState.java
@@ -42,15 +42,25 @@ import java.util.Comparator;
 import java.util.Random;
 
 /**
- * No extra information provided - see (selfexplanatory) method signatures.
- * I have the best intention to write more detailed documentation but if you see this, there was not enough time or will to do so.
+ * JMH benchmark state providing three entity ID bitmaps with inner-record-specific price records,
+ * combined into an {@link OrFormula} tree via {@link MockInnerRecordIdsFormula} leaves. Used by
+ * inner-record price termination benchmarks
+ * ({@link io.evitadb.spike.FormulaCostMeasurement#firstVariantPriceTermination},
+ * {@link io.evitadb.spike.FormulaCostMeasurement#sumPriceTermination}).
+ *
+ * Each dataset generates {@link #PRICE_COUNT} price records with entity IDs spaced by random gaps
+ * (up to 512) and inner record IDs incrementing within each entity. Price records are sorted by
+ * entity primary key for efficient lookup during termination. The {@link OrFormula} is pre-computed
+ * during setup so that benchmark iterations measure only the termination formula cost.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 @State(Scope.Benchmark)
 public class InnerRecordIdsWithPriceRecordsRecordState {
+	/** Number of price records per dataset (3 datasets total = 300K records). */
 	private static final int PRICE_COUNT = 100_000;
 	private static final Random random = new Random(42);
+	/** Monotonic price ID generator — shared across all instances within the same JVM fork. */
 	private static int PRICE_ID_SEQ;
 
 	@Getter private PriceRecordInnerRecordSpecific[] entitiesPriceRecordsA;
@@ -62,7 +72,8 @@ public class InnerRecordIdsWithPriceRecordsRecordState {
 	@Getter private Formula formula;
 
 	/**
-	 * This setup is called once for each `valueCount`.
+	 * Generates three inner-record price datasets, wraps each in a {@link MockInnerRecordIdsFormula},
+	 * combines them via {@link OrFormula}, and pre-computes the union bitmap.
 	 */
 	@Setup(Level.Trial)
 	public void setUp() {
@@ -84,7 +95,7 @@ public class InnerRecordIdsWithPriceRecordsRecordState {
 		this.formula = new OrFormula(
 			new MockInnerRecordIdsFormula(this.entitiesA, new ResolvedFilteredPriceRecords(this.entitiesPriceRecordsA, SortingForm.ENTITY_PK)),
 			new MockInnerRecordIdsFormula(this.entitiesB, new ResolvedFilteredPriceRecords(this.entitiesPriceRecordsB, SortingForm.ENTITY_PK)),
-			new MockInnerRecordIdsFormula(this.entitiesB, new ResolvedFilteredPriceRecords(this.entitiesPriceRecordsC, SortingForm.ENTITY_PK))
+			new MockInnerRecordIdsFormula(this.entitiesC, new ResolvedFilteredPriceRecords(this.entitiesPriceRecordsC, SortingForm.ENTITY_PK))
 		);
 		this.formula.compute();
 	}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/IntegerBitmapState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/IntegerBitmapState.java
@@ -36,13 +36,19 @@ import org.roaringbitmap.RoaringBitmapWriter;
 import java.util.Random;
 
 /**
- * No extra information provided - see (selfexplanatory) method signatures.
- * I have the best intention to write more detailed documentation but if you see this, there was not enough time or will to do so.
+ * JMH benchmark state providing two pre-generated {@link RoaringBitmapBackedBitmap} instances
+ * for bitmap set-operation benchmarks ({@link io.evitadb.spike.FormulaCostMeasurement}).
+ *
+ * Each bitmap contains {@link #VALUE_COUNT} random integers drawn from [0, 2×VALUE_COUNT),
+ * yielding ~50% overlap between the two bitmaps on average. Both bitmaps are run-optimized
+ * for realistic RoaringBitmap performance characteristics. A fixed seed (42) ensures
+ * deterministic, reproducible datasets across runs.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 @State(Scope.Benchmark)
 public class IntegerBitmapState {
+	/** Number of random values inserted into each bitmap. */
 	private static final int VALUE_COUNT = 100_000;
 	private static final Random random = new Random(42);
 
@@ -50,7 +56,7 @@ public class IntegerBitmapState {
 	@Getter private RoaringBitmapBackedBitmap bitmapB;
 
 	/**
-	 * This setup is called once for each `valueCount`.
+	 * Generates two independent bitmaps with {@link #VALUE_COUNT} random entries each.
 	 */
 	@Setup(Level.Trial)
 	public void setUp() {

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockEntityIdsFormula.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockEntityIdsFormula.java
@@ -42,8 +42,17 @@ import javax.annotation.Nonnull;
  */
 @RequiredArgsConstructor
 public class MockEntityIdsFormula extends AbstractFormula implements FilteredPriceRecordAccessor {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -8786720221479629134L;
+	/**
+	 * Pre-built bitmap of entity primary keys returned directly by {@link #computeInternal()}.
+	 */
 	private final Bitmap entityIds;
+	/**
+	 * Pre-built filtered price records returned by {@link #getFilteredPriceRecords(QueryExecutionContext)}.
+	 */
 	private final FilteredPriceRecords priceRecords;
 
 	@Nonnull

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockInnerRecordIdsFormula.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockInnerRecordIdsFormula.java
@@ -44,8 +44,17 @@ import javax.annotation.Nonnull;
  */
 @RequiredArgsConstructor
 public class MockInnerRecordIdsFormula extends AbstractFormula implements PriceIndexProvidingFormula, FilteredPriceRecordAccessor {
+	/**
+	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
+	 */
 	private static final long CLASS_ID = -8740309489269214775L;
+	/**
+	 * Pre-built bitmap of inner record IDs returned directly by {@link #computeInternal()}.
+	 */
 	private final Bitmap innerRecordIds;
+	/**
+	 * Pre-built filtered price records returned by {@link #getFilteredPriceRecords(QueryExecutionContext)}.
+	 */
 	private final FilteredPriceRecords allPriceRecords;
 
 	@Nonnull

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockPriceIdsFormula.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockPriceIdsFormula.java
@@ -39,7 +39,13 @@ import javax.annotation.Nonnull;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class MockPriceIdsFormula extends PriceIdContainerFormula {
+	/**
+	 * Pre-built bitmap of price record IDs returned directly by {@link #computeInternal()}.
+	 */
 	private final Bitmap priceIds;
+	/**
+	 * Mock price index wrapping pre-generated price records, returned by {@link #getPriceIndex()}.
+	 */
 	private final PriceListAndCurrencyPriceIndex priceList;
 
 	public MockPriceIdsFormula(PriceListAndCurrencyPriceIndex priceIndex, Bitmap priceIds, PriceRecordContract[] priceRecords) {

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockPriceListAndCurrencyPriceIndex.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockPriceListAndCurrencyPriceIndex.java
@@ -41,7 +41,16 @@ import java.io.Serial;
 import java.time.OffsetDateTime;
 
 /**
- * Mock PriceListAndCurrencyPriceIndex implementation to be used in perf. tests.
+ * Mock implementation of {@link PriceListAndCurrencyPriceIndex} that supports incremental price
+ * recording via {@link #recordPrice(PriceRecordContract)}. Maintains an entity-to-price-IDs
+ * lookup map ({@link IntObjectHashMap}) and ordered arrays of price records and inner record IDs.
+ *
+ * Only {@link #getInternalPriceIdsForEntity(int)}, {@link #getPriceRecords()}, and
+ * {@link #getIndexedPriceIds()} are implemented — all other methods throw
+ * {@link UnsupportedOperationException}.
+ *
+ * **Note:** This class is only used by {@link EntityIdsState}, which itself is not referenced
+ * by any benchmark in {@link io.evitadb.spike.FormulaCostMeasurement}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockPriceListAndCurrencyPriceSuperIndex.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockPriceListAndCurrencyPriceSuperIndex.java
@@ -34,8 +34,13 @@ import java.io.Serial;
 import java.util.Currency;
 
 /**
- * No extra information provided - see (selfexplanatory) method signatures.
- * I have the best intention to write more detailed documentation but if you see this, there was not enough time or will to do so.
+ * Mock extension of {@link PriceListAndCurrencyPriceSuperIndex} that stores a pre-built array
+ * of {@link PriceRecordContract} and their extracted price IDs. Overrides
+ * {@link #getPriceRecords()} and {@link #getIndexedPriceIds()} to return the pre-built arrays
+ * directly, bypassing the real index's transactional storage layer.
+ *
+ * Used by {@link PriceIdsWithPriceRecordsRecordState} to back the {@link PriceIdContainerFormula}
+ * with realistic price data for benchmark price-ID-to-entity-ID translation.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/PriceBucketRecordState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/PriceBucketRecordState.java
@@ -43,16 +43,25 @@ import java.util.List;
 import java.util.Random;
 
 /**
- * No extra information provided - see (selfexplanatory) method signatures.
- * I have the best intention to write more detailed documentation but if you see this, there was not enough time or will to do so.
+ * JMH benchmark state providing two disjoint entity-price datasets for the price histogram
+ * benchmark ({@link io.evitadb.spike.FormulaCostMeasurement#priceHistogramComputer}).
+ *
+ * Dataset A contains 70% of the total ({@link #PRICE_COUNT} × 0.7 = 70K prices over ~7K entities)
+ * and dataset B contains the remaining 30% (30K prices over ~3K entities), with non-overlapping
+ * entity ID ranges. Each dataset provides both a {@link ConstantFormula} wrapping the entity ID
+ * bitmap and a {@link FilteredPriceRecordAccessor} backed by {@link MockEntityIdsFormula} for
+ * price record access.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 @State(Scope.Benchmark)
 public class PriceBucketRecordState {
+	/** Total number of distinct entities across both datasets. */
 	private static final int ENTITY_COUNT = 10_000;
+	/** Total number of price records across both datasets. */
 	private static final int PRICE_COUNT = 100_000;
 	private static final Random random = new Random(42);
+	/** Monotonic price ID generator — shared across all instances within the same JVM fork. */
 	private static int PRICE_ID_SEQ;
 	@Getter private Bitmap entityIdsA;
 	@Getter private Bitmap entityIdsB;
@@ -61,7 +70,8 @@ public class PriceBucketRecordState {
 	@Getter private Formula formulaB;
 
 	/**
-	 * This setup is called once for each `valueCount`.
+	 * Generates two non-overlapping entity-price datasets (70/30 split), creates filtered
+	 * price record accessors, and wraps entity IDs in {@link ConstantFormula} instances.
 	 */
 	@Setup(Level.Trial)
 	public void setUp() {

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/PriceIdsWithPriceRecordsRecordState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/PriceIdsWithPriceRecordsRecordState.java
@@ -45,15 +45,24 @@ import java.util.Comparator;
 import java.util.Random;
 
 /**
- * No extra information provided - see (selfexplanatory) method signatures.
- * I have the best intention to write more detailed documentation but if you see this, there was not enough time or will to do so.
+ * JMH benchmark state providing a price ID bitmap, corresponding price records, a mock price
+ * index, and a pre-built {@link PriceIdContainerFormula} for price-related formula benchmarks
+ * ({@link io.evitadb.spike.FormulaCostMeasurement#priceIdContainer},
+ * {@link io.evitadb.spike.FormulaCostMeasurement#priceIdToEntityIdTranslate}).
+ *
+ * Generates {@link #PRICE_COUNT} inner-record-specific price records distributed across entities
+ * with random gaps (up to 512 between entity IDs) and random inner record grouping (up to 10
+ * prices per entity). The price index is backed by
+ * {@link MockPriceListAndCurrencyPriceSuperIndex} for O(1) price record lookups.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 @State(Scope.Benchmark)
 public class PriceIdsWithPriceRecordsRecordState {
+	/** Total number of price records to generate. */
 	private static final int PRICE_COUNT = 100_000;
 	private static final Random random = new Random(42);
+	/** Monotonic price ID generator — shared across all instances within the same JVM fork. */
 	private static int PRICE_ID_SEQ;
 
 	@Getter private PriceRecordContract[] entitiesPriceRecords;
@@ -63,7 +72,8 @@ public class PriceIdsWithPriceRecordsRecordState {
 	@Getter private QueryExecutionContext queryExecutionContext = Mockito.mock(QueryExecutionContext.class);
 
 	/**
-	 * This setup is called once for each `valueCount`.
+	 * Generates price records, builds the price index, and wraps the price ID bitmap in
+	 * a {@link PriceIdContainerFormula} for benchmark consumption.
 	 */
 	@Setup(Level.Trial)
 	public void setUp() {
@@ -100,10 +110,6 @@ public class PriceIdsWithPriceRecordsRecordState {
 		}
 
 		return priceIds;
-	}
-
-	private int getRandomNumber(int entityCount) {
-		return random.nextInt(entityCount);
 	}
 
 }


### PR DESCRIPTION
## Summary

- **Fix**: Correct no-op `Assert.notNull()` to `Assert.isTrue()` in `SelectionFormula` constructor — the boolean expression was autoboxed to `Boolean` (never null), so `SkipFormula` delegates were silently accepted
- **Refactor**: Replace Java stream operations with allocation-free index loops throughout the formula hierarchy (`AbstractFormula`, `AndFormula`, `NotFormula`, facet formulas, `FormulaCloner`, etc.) for better performance on hot paths
- **Refactor**: Extract reusable conjunction helpers into `AbstractFormula` (`sortAndDeduplicateLongArray`, `sortFormulasByComplexity`, `computeSortedConjunctionBitmaps`, etc.) and introduce `AbstractBitmapCacheableFormula` base class to reduce duplication
- **Docs**: Add JavaDoc to all undocumented fields across attribute, deferred, hierarchy, infra, locale, prefetch, reference, and price/termination formula classes
- **Docs**: Add comprehensive developer guide for the formula framework (`documentation/developer/formula/formula_framework.md`)
- **Tests**: Add and expand unit tests for formula framework classes (facet formulas, price formulas, translation formulas, `FormulaFactory`, `FormulaCloner`, `FormulaFinder`, `FormulaLocator`, `PrettyPrintingFormulaVisitor`)