### PR TITLE
fix: derive ReferenceSchemaBuilder base from persisted reference (#1129)

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/ReferenceSchemaBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/ReferenceSchemaBuilder.java
@@ -150,6 +150,12 @@ public final class ReferenceSchemaBuilder
 					"Reference `" + name + "` is expected to exist in the persisted entity schema" +
 						" when the builder is constructed with createNew=false, but was not found."
 				));
+			// Intentional asymmetry: `baseSchema` is the raw persisted reference (see comment above),
+			// but the comparisons below deliberately read `existingSchema` (the post-mutation view).
+			// Any prior entity-type / cardinality change is already present in the `mutations` list
+			// copied a few lines further down, and therefore already reflected in `existingSchema`.
+			// Comparing against the post-mutation view prevents re-emitting a Modify*Mutation that
+			// is already queued.
 			if (referencedEntityTypeManaged != existingSchema.isReferencedEntityTypeManaged() || !entityType.equals(existingSchema.getReferencedEntityType())) {
 				this.mutations.add(
 					new ModifyReferenceSchemaRelatedEntityMutation(

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/ReferenceSchemaBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/ReferenceSchemaBuilder.java
@@ -23,7 +23,6 @@
 
 package io.evitadb.api.requestResponse.schema.builder;
 
-import io.evitadb.api.exception.AttributeAlreadyPresentInEntitySchemaException;
 import io.evitadb.api.exception.InvalidSchemaMutationException;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
@@ -32,7 +31,6 @@ import io.evitadb.api.requestResponse.schema.CatalogSchemaContract;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaEditor;
-import io.evitadb.api.requestResponse.schema.SortableAttributeCompoundSchemaContract;
 import io.evitadb.api.requestResponse.schema.SortableAttributeCompoundSchemaContract.AttributeElement;
 import io.evitadb.api.requestResponse.schema.dto.ReferenceIndexType;
 import io.evitadb.api.requestResponse.schema.dto.ReferenceSchema;
@@ -104,14 +102,18 @@ public final class ReferenceSchemaBuilder
 	) {
 		this.catalogSchema = catalogSchema;
 		this.entitySchema = entitySchema;
-		this.baseSchema = existingSchema == null ?
-			ReferenceSchema._internalBuild(
-				name, entityType, referencedEntityTypeManaged, cardinality,
-				null, false,
-				ScopedReferenceIndexType.EMPTY, Scope.NO_SCOPE
-			) :
-			existingSchema;
 		if (createNew) {
+			// caller promises there is no standard reference persisted under `name` yet, so the
+			// base is either the caller-supplied hint (e.g. a reflected reference being replaced)
+			// or a freshly built placeholder that the CreateReferenceSchemaMutation below will
+			// hydrate during replay.
+			this.baseSchema = existingSchema == null ?
+				ReferenceSchema._internalBuild(
+					name, entityType, referencedEntityTypeManaged, cardinality,
+					null, false,
+					ScopedReferenceIndexType.EMPTY, Scope.NO_SCOPE
+				) :
+				existingSchema;
 			this.mutations.add(
 				new CreateReferenceSchemaMutation(
 					this.baseSchema.getName(),
@@ -135,6 +137,19 @@ public final class ReferenceSchemaBuilder
 				existingSchema != null,
 				"When not creating new reference schema, the existing schema must be provided!"
 			);
+			// baseSchema MUST be the raw persisted reference, never the caller-supplied
+			// `existingSchema`. The caller builds `existingSchema` from `toInstance()`, so it
+			// already reflects every pending entity-level mutation targeting this reference —
+			// the very same mutations that are copied into `this.mutations` below. Starting the
+			// replay from an already-mutated base would re-apply those mutations on top of
+			// themselves (e.g. a bare CreateAttributeSchemaMutation clashing with the same
+			// attribute already enriched by a follow-up ModifyAttributeSchemaDescriptionMutation).
+			// The caller's `createNew == false` guarantees the persisted lookup is present.
+			this.baseSchema = entitySchema.getReference(name)
+				.orElseThrow(() -> new GenericEvitaInternalError(
+					"Reference `" + name + "` is expected to exist in the persisted entity schema" +
+						" when the builder is constructed with createNew=false, but was not found."
+				));
 			if (referencedEntityTypeManaged != existingSchema.isReferencedEntityTypeManaged() || !entityType.equals(existingSchema.getReferencedEntityType())) {
 				this.mutations.add(
 					new ModifyReferenceSchemaRelatedEntityMutation(

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/ReferenceSchemaBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/ReferenceSchemaBuilder.java
@@ -178,16 +178,6 @@ public final class ReferenceSchemaBuilder
 			.forEach(this.mutations::add);
 	}
 
-	public ReferenceSchemaBuilder(
-		@Nonnull CatalogSchemaContract catalogSchema,
-		@Nonnull EntitySchemaContract entitySchema,
-		@Nonnull ReferenceSchemaContract existingSchema
-	) {
-		this.catalogSchema = catalogSchema;
-		this.entitySchema = entitySchema;
-		this.baseSchema = existingSchema;
-	}
-
 	@Override
 	@Nonnull
 	public ReferenceSchemaBuilder withDescription(@Nullable String description) {

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/ReflectedReferenceSchemaBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/ReflectedReferenceSchemaBuilder.java
@@ -93,10 +93,14 @@ public final class ReflectedReferenceSchemaBuilder
 	) {
 		this.catalogSchema = catalogSchema;
 		this.entitySchema = entitySchema;
-		this.baseSchema = existingSchema == null ?
-			ReflectedReferenceSchema._internalBuild(name, entityType, reflectedReferenceName) :
-			(ReflectedReferenceSchema) existingSchema;
 		if (createNew) {
+			// caller promises there is no reflected reference persisted under `name` yet, so the
+			// base is either the caller-supplied hint (e.g. a standard reference being replaced)
+			// or a freshly built placeholder that the CreateReflectedReferenceSchemaMutation below
+			// will hydrate during replay.
+			this.baseSchema = existingSchema == null ?
+				ReflectedReferenceSchema._internalBuild(name, entityType, reflectedReferenceName) :
+				(ReflectedReferenceSchema) existingSchema;
 			this.mutations.add(
 				new CreateReflectedReferenceSchemaMutation(
 					this.baseSchema.getName(),
@@ -118,6 +122,21 @@ public final class ReflectedReferenceSchemaBuilder
 					this.baseSchema.getAttributeInheritanceFilter()
 				)
 			);
+		} else {
+			// baseSchema MUST be the raw persisted reflected reference, never the caller-supplied
+			// `existingSchema`. The caller builds `existingSchema` from `toInstance()`, so it
+			// already reflects every pending entity-level mutation targeting this reference —
+			// the very same mutations that are copied into `this.mutations` below. Starting the
+			// replay from an already-mutated base would re-apply those mutations on top of
+			// themselves (e.g. a bare CreateAttributeSchemaMutation clashing with the same
+			// attribute already enriched by a follow-up ModifyAttributeSchemaDescriptionMutation).
+			// The caller's `createNew == false` guarantees the persisted lookup is present and
+			// is a reflected reference (the caller computes `createNew` from that very check).
+			this.baseSchema = (ReflectedReferenceSchema) entitySchema.getReference(name)
+				.orElseThrow(() -> new GenericEvitaInternalError(
+					"Reflected reference `" + name + "` is expected to exist in the persisted entity" +
+						" schema when the builder is constructed with createNew=false, but was not found."
+				));
 		}
 		mutations.stream()
 			.filter(

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/ReflectedReferenceSchemaBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/builder/ReflectedReferenceSchemaBuilder.java
@@ -123,6 +123,10 @@ public final class ReflectedReferenceSchemaBuilder
 				)
 			);
 		} else {
+			Assert.isPremiseValid(
+				existingSchema != null,
+				"When not creating new reflected reference schema, the existing schema must be provided!"
+			);
 			// baseSchema MUST be the raw persisted reflected reference, never the caller-supplied
 			// `existingSchema`. The caller builds `existingSchema` from `toInstance()`, so it
 			// already reflects every pending entity-level mutation targeting this reference —
@@ -132,11 +136,18 @@ public final class ReflectedReferenceSchemaBuilder
 			// attribute already enriched by a follow-up ModifyAttributeSchemaDescriptionMutation).
 			// The caller's `createNew == false` guarantees the persisted lookup is present and
 			// is a reflected reference (the caller computes `createNew` from that very check).
-			this.baseSchema = (ReflectedReferenceSchema) entitySchema.getReference(name)
+			final ReferenceSchemaContract persistedReference = entitySchema.getReference(name)
 				.orElseThrow(() -> new GenericEvitaInternalError(
 					"Reflected reference `" + name + "` is expected to exist in the persisted entity" +
 						" schema when the builder is constructed with createNew=false, but was not found."
 				));
+			Assert.isPremiseValid(
+				persistedReference instanceof ReflectedReferenceSchema,
+				() -> "Persisted reference `" + name + "` is expected to be a reflected reference" +
+					" when the builder is constructed with createNew=false, but found `" +
+					persistedReference.getClass().getSimpleName() + "`."
+			);
+			this.baseSchema = (ReflectedReferenceSchema) persistedReference;
 		}
 		mutations.stream()
 			.filter(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
@@ -120,7 +120,7 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 		} else {
 			assertEquals(deprecation, attributeSchema.getDeprecationNotice());
 		}
-		assertEquals(expectedType, attributeSchema.getType());
+		assertSame(expectedType, attributeSchema.getType());
 		if (global) {
 			assertTrue(attributeSchema instanceof GlobalAttributeSchema);
 		}
@@ -188,7 +188,7 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 		} else {
 			assertEquals(deprecation, associatedData.getDeprecationNotice());
 		}
-		assertEquals(
+		assertSame(
 			expectedType, associatedData.getType(),
 			"Associated data `" + associatedDataName + "` is expected to be `" + expectedType + "`, but is `" + associatedData.getType() + "`."
 		);
@@ -537,7 +537,7 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 		} else {
 			assertEquals(deprecation, attributeSchema.getDeprecationNotice());
 		}
-		assertEquals(expectedType, attributeSchema.getType());
+		assertSame(expectedType, attributeSchema.getType());
 		if (global) {
 			assertTrue(attributeSchema instanceof GlobalAttributeSchema);
 		}
@@ -3274,10 +3274,7 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 				).orElseThrow();
 
 				final AttributeSchemaContract priorityAttr = schema.getAttribute("priority").orElseThrow();
-				assertEquals(
-					String.class, priorityAttr.getType(),
-					"Enum attribute should be converted to String type"
-				);
+				assertSame(String.class, priorityAttr.getType(), "Enum attribute should be converted to String type");
 			}
 		);
 	}
@@ -3311,6 +3308,61 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 					"Expected CreateAttributeSchemaMutation for brandNote attribute"
 				);
 				assertEquals("brandNote", mutation.get().getName());
+			}
+		);
+	}
+
+	@DisplayName("@Reference + @ReferenceRef on the same reference must not corrupt attribute schema")
+	@Test
+	void shouldDefineReferenceWithDescriptionWhenAlsoMappedViaReferenceRef() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				// V1 persists the entity with the reference but no attributes on the reference DTO
+				// so that the "update round" (V2) is the one that actually creates the attribute.
+				session.defineEntitySchemaFromModelClass(
+					GetterBasedEntityWithReferenceAndReferenceRef.MarketingBrand.class
+				);
+				session.defineEntitySchemaFromModelClass(
+					GetterBasedEntityWithReferenceAndReferenceRefV1.class
+				);
+
+				// V2 adds the `market` attribute via two getters pointing at the same reference:
+				// - mandatory `getMarketingBrand()`           with `@Reference` (carries description)
+				// - optional  `getMarketingBrandIfExists()`   with `@ReferenceRef("marketingBrand")`
+				// The first analyzer pass (`@Reference`) creates the attribute with a follow-up
+				// `ModifyAttributeSchemaDescriptionMutation`; the second pass (`@ReferenceRef`)
+				// re-scans the reference DTO and must reuse the already-created attribute schema
+				// instead of re-creating it with a conflicting `CreateAttributeSchemaMutation`.
+				analyzeAndCaptureMutations(session, GetterBasedEntityWithReferenceAndReferenceRef.class);
+
+				final SealedEntitySchema entitySchema = session.getEntitySchema(
+					GetterBasedEntityWithReferenceAndReferenceRef.ENTITY_NAME
+				).orElseThrow();
+
+				final ReferenceSchemaContract reference = entitySchema
+					.getReference(GetterBasedEntityWithReferenceAndReferenceRef.REFERENCE_NAME)
+					.orElseThrow();
+
+				assertEquals(
+					GetterBasedEntityWithReferenceAndReferenceRef.REFERENCE_DESCRIPTION,
+					reference.getDescription(),
+					"Reference description from @Reference annotation must be preserved."
+				);
+
+				final AttributeSchemaContract attribute = reference
+					.getAttribute(GetterBasedEntityWithReferenceAndReferenceRef.ATTRIBUTE_NAME)
+					.orElseThrow();
+
+				assertEquals(
+					GetterBasedEntityWithReferenceAndReferenceRef.ATTRIBUTE_DESCRIPTION,
+					attribute.getDescription(),
+					"Attribute description from the reference DTO must be preserved."
+				);
+				assertSame(
+					String.class, attribute.getType(),
+					"Attribute type must remain String after the second analyzer pass."
+				);
 			}
 		);
 	}
@@ -3441,10 +3493,8 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 				final AttributeSchemaContract tagsAttribute = entitySchema
 					.getAttribute("tags")
 					.orElseThrow();
-				assertEquals(
-					String[].class, tagsAttribute.getType(),
-					"List<String> field should be resolved to String[]"
-				);
+				assertSame(
+					String[].class, tagsAttribute.getType(), "List<String> field should be resolved to String[]");
 			}
 		);
 	}
@@ -3475,9 +3525,8 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 				final AttributeSchemaContract tagsAttribute = entitySchema
 					.getAttribute("tags")
 					.orElseThrow();
-				assertEquals(
-					String[].class, tagsAttribute.getType(),
-					"List<String> record component should be " +
+				assertSame(
+					String[].class, tagsAttribute.getType(), "List<String> record component should be " +
 						"resolved to String[]"
 				);
 			}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
@@ -43,6 +43,7 @@ import io.evitadb.api.requestResponse.schema.mutation.EntitySchemaMutation;
 import io.evitadb.api.requestResponse.schema.mutation.LocalCatalogSchemaMutation;
 import io.evitadb.api.requestResponse.schema.mutation.associatedData.CreateAssociatedDataSchemaMutation;
 import io.evitadb.api.requestResponse.schema.mutation.attribute.CreateAttributeSchemaMutation;
+import io.evitadb.api.requestResponse.schema.mutation.attribute.RemoveAttributeSchemaMutation;
 import io.evitadb.api.requestResponse.schema.mutation.attribute.SetAttributeSchemaFilterableMutation;
 import io.evitadb.api.requestResponse.schema.mutation.catalog.ModifyEntitySchemaMutation;
 import io.evitadb.api.requestResponse.schema.mutation.reference.CreateReferenceSchemaMutation;
@@ -641,15 +642,18 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 	}
 
 	/**
-	 * Finds a specific mutation type within entity schema mutations.
+	 * Streams every mutation of the requested type found at any nesting level inside the captured
+	 * catalog mutation array. Walks top-level mutations, the entity-level children of
+	 * `ModifyEntitySchemaMutation`, and the attribute-level mutations wrapped inside
+	 * `ModifyReferenceAttributeSchemaMutation`.
 	 *
 	 * @param mutations    the array of catalog mutations to search
 	 * @param mutationType the expected mutation class
 	 * @param <T>          the mutation type
-	 * @return optional containing the found mutation, or empty if not found
+	 * @return stream of all matching mutations in iteration order
 	 */
 	@Nonnull
-	private static <T extends EntitySchemaMutation> Optional<T> findEntitySchemaMutation(
+	private static <T extends EntitySchemaMutation> Stream<T> streamEntitySchemaMutations(
 		@Nonnull LocalCatalogSchemaMutation[] mutations,
 		@Nonnull Class<T> mutationType
 	) {
@@ -666,11 +670,27 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 					.filter(ModifyReferenceAttributeSchemaMutation.class::isInstance)
 					.map(ModifyReferenceAttributeSchemaMutation.class::cast)
 					.map(ModifyReferenceAttributeSchemaMutation::getAttributeSchemaMutation)
-				)
+			)
 			.flatMap(Function.identity())
 			.filter(mutationType::isInstance)
-			.map(mutationType::cast)
-			.findFirst();
+			.map(mutationType::cast);
+	}
+
+	/**
+	 * Finds the first mutation of the requested type at any nesting level inside the captured
+	 * catalog mutation array.
+	 *
+	 * @param mutations    the array of catalog mutations to search
+	 * @param mutationType the expected mutation class
+	 * @param <T>          the mutation type
+	 * @return optional containing the first found mutation, or empty if not found
+	 */
+	@Nonnull
+	private static <T extends EntitySchemaMutation> Optional<T> findEntitySchemaMutation(
+		@Nonnull LocalCatalogSchemaMutation[] mutations,
+		@Nonnull Class<T> mutationType
+	) {
+		return streamEntitySchemaMutations(mutations, mutationType).findFirst();
 	}
 
 	@BeforeEach
@@ -3334,7 +3354,39 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 				// `ModifyAttributeSchemaDescriptionMutation`; the second pass (`@ReferenceRef`)
 				// re-scans the reference DTO and must reuse the already-created attribute schema
 				// instead of re-creating it with a conflicting `CreateAttributeSchemaMutation`.
-				analyzeAndCaptureMutations(session, GetterBasedEntityWithReferenceAndReferenceRef.class);
+				final LocalCatalogSchemaMutation[] mutations =
+					analyzeAndCaptureMutations(session, GetterBasedEntityWithReferenceAndReferenceRef.class);
+
+				// Exactly one CreateAttributeSchemaMutation for `market` — guards against the
+				// duplicate-create regression that originally surfaced this bug.
+				final long createMarketCount = streamEntitySchemaMutations(mutations, CreateAttributeSchemaMutation.class)
+					.filter(it -> GetterBasedEntityWithReferenceAndReferenceRef.ATTRIBUTE_NAME.equals(it.getName()))
+					.count();
+				assertEquals(
+					1L, createMarketCount,
+					"Expected exactly one CreateAttributeSchemaMutation for `market`, found " + createMarketCount
+				);
+
+				// No RemoveAttributeSchemaMutation should be emitted — the second analyzer pass must
+				// not scrub-and-recreate the attribute the first pass already created.
+				final long removeMarketCount = streamEntitySchemaMutations(mutations, RemoveAttributeSchemaMutation.class)
+					.filter(it -> GetterBasedEntityWithReferenceAndReferenceRef.ATTRIBUTE_NAME.equals(it.getName()))
+					.count();
+				assertEquals(
+					0L, removeMarketCount,
+					"No RemoveAttributeSchemaMutation for `market` expected, found " + removeMarketCount
+				);
+
+				// V1 already created `marketingBrand`, so the V2 analyzer round must not emit any
+				// further CreateReferenceSchemaMutation for it.
+				final long createReferenceCount = streamEntitySchemaMutations(mutations, CreateReferenceSchemaMutation.class)
+					.filter(it -> GetterBasedEntityWithReferenceAndReferenceRef.REFERENCE_NAME.equals(it.getName()))
+					.count();
+				assertEquals(
+					0L, createReferenceCount,
+					"No CreateReferenceSchemaMutation for `marketingBrand` expected (V1 already created it)," +
+						" found " + createReferenceCount
+				);
 
 				final SealedEntitySchema entitySchema = session.getEntitySchema(
 					GetterBasedEntityWithReferenceAndReferenceRef.ENTITY_NAME
@@ -3358,6 +3410,79 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 					GetterBasedEntityWithReferenceAndReferenceRef.ATTRIBUTE_DESCRIPTION,
 					attribute.getDescription(),
 					"Attribute description from the reference DTO must be preserved."
+				);
+				assertSame(
+					String.class, attribute.getType(),
+					"Attribute type must remain String after the second analyzer pass."
+				);
+			}
+		);
+	}
+
+	@DisplayName("@ReflectedReference + @ReferenceRef on the same reference must not corrupt attribute schema")
+	@Test
+	void shouldDefineReflectedReferenceWithDescriptionWhenAlsoMappedViaReferenceRef() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				// Persist Brand (the source entity holding the standard `products` reference) and the
+				// V1 entity with the reflected `marketingBrand` mirror, which carries no attributes
+				// yet. The "update round" (V2) is the one that actually creates the `market` attribute
+				// on the reflected reference.
+				session.defineEntitySchemaFromModelClass(
+					GetterBasedEntityWithReflectedReferenceAndReferenceRef.Brand.class
+				);
+				session.defineEntitySchemaFromModelClass(
+					GetterBasedEntityWithReflectedReferenceAndReferenceRefV1.class
+				);
+
+				// V2 adds the `market` attribute via two getters pointing at the same reflected
+				// reference:
+				// - mandatory `getMarketingBrand()`           with `@ReflectedReference("products")`
+				// - optional  `getMarketingBrandIfExists()`   with `@ReferenceRef("marketingBrand")`
+				// The first analyzer pass (`@ReflectedReference`) calls `withReflectedReferenceToEntity`
+				// once, the second pass (`@ReferenceRef`) calls it a second time. The second call must
+				// not re-emit the inherited attribute create on top of an already-mutated base — the
+				// reflected counterpart of the original ReferenceSchemaBuilder bug.
+				final LocalCatalogSchemaMutation[] mutations =
+					analyzeAndCaptureMutations(session, GetterBasedEntityWithReflectedReferenceAndReferenceRef.class);
+
+				// Exactly one CreateAttributeSchemaMutation for `market` — guards against the
+				// duplicate-create regression on the reflected sibling builder.
+				final long createMarketCount = streamEntitySchemaMutations(mutations, CreateAttributeSchemaMutation.class)
+					.filter(it -> GetterBasedEntityWithReflectedReferenceAndReferenceRef.ATTRIBUTE_NAME.equals(it.getName()))
+					.count();
+				assertEquals(
+					1L, createMarketCount,
+					"Expected exactly one CreateAttributeSchemaMutation for `market` on the reflected reference," +
+						" found " + createMarketCount
+				);
+
+				// No RemoveAttributeSchemaMutation should be emitted on the reflected reference either.
+				final long removeMarketCount = streamEntitySchemaMutations(mutations, RemoveAttributeSchemaMutation.class)
+					.filter(it -> GetterBasedEntityWithReflectedReferenceAndReferenceRef.ATTRIBUTE_NAME.equals(it.getName()))
+					.count();
+				assertEquals(
+					0L, removeMarketCount,
+					"No RemoveAttributeSchemaMutation for `market` expected, found " + removeMarketCount
+				);
+
+				final SealedEntitySchema entitySchema = session.getEntitySchema(
+					GetterBasedEntityWithReflectedReferenceAndReferenceRef.ENTITY_NAME
+				).orElseThrow();
+
+				final ReferenceSchemaContract reference = entitySchema
+					.getReference(GetterBasedEntityWithReflectedReferenceAndReferenceRef.REFERENCE_NAME)
+					.orElseThrow();
+
+				final AttributeSchemaContract attribute = reference
+					.getAttribute(GetterBasedEntityWithReflectedReferenceAndReferenceRef.ATTRIBUTE_NAME)
+					.orElseThrow();
+
+				assertEquals(
+					GetterBasedEntityWithReflectedReferenceAndReferenceRef.ATTRIBUTE_DESCRIPTION,
+					attribute.getDescription(),
+					"Attribute description from the reflected DTO must be preserved."
 				);
 				assertSame(
 					String.class, attribute.getType(),

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithReferenceAndReferenceRef.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithReferenceAndReferenceRef.java
@@ -1,0 +1,135 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model;
+
+import io.evitadb.api.requestResponse.data.annotation.Attribute;
+import io.evitadb.api.requestResponse.data.annotation.Entity;
+import io.evitadb.api.requestResponse.data.annotation.PrimaryKey;
+import io.evitadb.api.requestResponse.data.annotation.Reference;
+import io.evitadb.api.requestResponse.data.annotation.ReferenceRef;
+import io.evitadb.api.requestResponse.data.annotation.ReferencedEntity;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+/**
+ * Example interface for ClassSchemaAnalyzerTest.
+ *
+ * Reproduces the scenario where the same logical reference is mapped via two getters on the
+ * entity:
+ *
+ * - the mandatory getter `getMarketingBrand()` carries `@Reference` with a description and
+ *   returns the reference DTO directly,
+ * - the secondary `getMarketingBrandIfExists()` getter returns `Optional` and carries
+ *   `@ReferenceRef("marketingBrand")` to point at the same reference name.
+ *
+ * The reference DTO additionally declares an `@Attribute` with description, so that during the
+ * second analyzer pass (the `@ReferenceRef` path) the attribute schema is re-analyzed and the
+ * attribute create mutation must reconcile with the description previously emitted by the first
+ * pass via a follow-up `ModifyAttributeSchemaDescriptionMutation`.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Entity(name = GetterBasedEntityWithReferenceAndReferenceRef.ENTITY_NAME)
+public interface GetterBasedEntityWithReferenceAndReferenceRef {
+
+	String ENTITY_NAME = "EntityWithReferenceAndReferenceRef";
+	String REFERENCE_NAME = "marketingBrand";
+	String REFERENCE_DESCRIPTION = "Mandatory marketing brand reference of the entity.";
+	String ATTRIBUTE_NAME = "market";
+	String ATTRIBUTE_DESCRIPTION = "Market identifier this brand operates in.";
+
+	/**
+	 * Returns the primary key of the entity.
+	 *
+	 * @return primary key
+	 */
+	@PrimaryKey
+	int getId();
+
+	/**
+	 * Mandatory accessor for the marketing brand reference. Carries the `@Reference` annotation
+	 * with a description, which together with the description on the inner attribute makes the
+	 * generated mutation chain include both `CreateAttributeSchemaMutation` and a follow-up
+	 * `ModifyAttributeSchemaDescriptionMutation`.
+	 *
+	 * @return marketing brand reference (never `null`)
+	 */
+	@Reference(description = REFERENCE_DESCRIPTION)
+	@Nonnull
+	MarketingBrandRef getMarketingBrand();
+
+	/**
+	 * Secondary, optional accessor pointing at the same reference name through `@ReferenceRef`.
+	 * Triggers the second analyzer pass over the same reference, which re-runs the attribute
+	 * analysis and is the path that surfaces the bug under investigation.
+	 *
+	 * @return optional marketing brand reference
+	 */
+	@ReferenceRef(REFERENCE_NAME)
+	@Nonnull
+	Optional<MarketingBrandRef> getMarketingBrandIfExists();
+
+	/**
+	 * Reference DTO that targets the `MarketingBrand` entity and exposes a single attribute with
+	 * a description.
+	 */
+	interface MarketingBrandRef {
+
+		/**
+		 * Returns the referenced marketing brand entity.
+		 *
+		 * @return referenced brand entity
+		 */
+		@ReferencedEntity
+		MarketingBrand getBrand();
+
+		/**
+		 * Returns the market attribute with description. The description is the part that the
+		 * second analyzer pass conflicts on.
+		 *
+		 * @return market identifier
+		 */
+		@Attribute(name = ATTRIBUTE_NAME, description = ATTRIBUTE_DESCRIPTION)
+		String getMarket();
+
+	}
+
+	/**
+	 * Target entity for the marketing brand reference.
+	 */
+	@Entity
+	interface MarketingBrand {
+
+		/**
+		 * Returns the primary key of the brand.
+		 *
+		 * @return primary key
+		 */
+		@PrimaryKey
+		int getId();
+
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithReferenceAndReferenceRefV1.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithReferenceAndReferenceRefV1.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model;
+
+import io.evitadb.api.requestResponse.data.annotation.Entity;
+import io.evitadb.api.requestResponse.data.annotation.PrimaryKey;
+import io.evitadb.api.requestResponse.data.annotation.Reference;
+import io.evitadb.api.requestResponse.data.annotation.ReferencedEntity;
+
+import javax.annotation.Nonnull;
+
+/**
+ * V1 of `GetterBasedEntityWithReferenceAndReferenceRef`. Declares only the mandatory
+ * `@Reference` getter, returning a reference DTO that contains **no** attributes. Used to bring
+ * the entity schema into a known persisted state with the reference present but no attribute on
+ * it before the dual-mapped V2 (which adds the attribute via both `@Reference` and
+ * `@ReferenceRef`) is analyzed against it.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Entity(name = GetterBasedEntityWithReferenceAndReferenceRef.ENTITY_NAME)
+public interface GetterBasedEntityWithReferenceAndReferenceRefV1 {
+
+	/**
+	 * Returns the primary key of the entity.
+	 *
+	 * @return primary key
+	 */
+	@PrimaryKey
+	int getId();
+
+	/**
+	 * Mandatory accessor for the marketing brand reference. The reference DTO is empty (no
+	 * attributes) so that V1 persists only the reference itself.
+	 *
+	 * @return marketing brand reference (never `null`)
+	 */
+	@Reference(description = GetterBasedEntityWithReferenceAndReferenceRef.REFERENCE_DESCRIPTION)
+	@Nonnull
+	BareMarketingBrandRef getMarketingBrand();
+
+	/**
+	 * Bare reference DTO with no attributes - only the target entity link.
+	 */
+	interface BareMarketingBrandRef {
+
+		/**
+		 * Returns the referenced marketing brand entity.
+		 *
+		 * @return referenced brand entity
+		 */
+		@ReferencedEntity
+		GetterBasedEntityWithReferenceAndReferenceRef.MarketingBrand getBrand();
+
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithReflectedReferenceAndReferenceRef.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithReflectedReferenceAndReferenceRef.java
@@ -1,0 +1,162 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model;
+
+import io.evitadb.api.requestResponse.data.annotation.Attribute;
+import io.evitadb.api.requestResponse.data.annotation.Entity;
+import io.evitadb.api.requestResponse.data.annotation.PrimaryKey;
+import io.evitadb.api.requestResponse.data.annotation.Reference;
+import io.evitadb.api.requestResponse.data.annotation.ReferenceRef;
+import io.evitadb.api.requestResponse.data.annotation.ReferencedEntity;
+import io.evitadb.api.requestResponse.data.annotation.ReflectedReference;
+import io.evitadb.api.requestResponse.schema.dto.ReferenceIndexType;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+/**
+ * Example interface for ClassSchemaAnalyzerTest.
+ *
+ * Reflected counterpart of `GetterBasedEntityWithReferenceAndReferenceRef`. The same logical
+ * reference is exposed via two getters on the entity:
+ *
+ * - the mandatory getter `getMarketingBrand()` carries `@ReflectedReference("products")` and
+ *   returns the reflected DTO directly,
+ * - the secondary `getMarketingBrandIfExists()` getter returns `Optional` and carries
+ *   `@ReferenceRef("marketingBrand")` to point at the same reference name.
+ *
+ * The reflected DTO additionally declares an `@Attribute` with description, so that during the
+ * second analyzer pass (the `@ReferenceRef` path) the reflected reference is re-opened and
+ * `withReflectedReferenceToEntity` is called a second time on the same builder. This is the
+ * reflected counterpart of the dual-mapping scenario that originally surfaced the
+ * `ReferenceSchemaBuilder` bug.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Entity(name = GetterBasedEntityWithReflectedReferenceAndReferenceRef.ENTITY_NAME)
+public interface GetterBasedEntityWithReflectedReferenceAndReferenceRef {
+
+	String ENTITY_NAME = "EntityWithReflectedAndReferenceRef";
+	String REFERENCE_NAME = "marketingBrand";
+	String SOURCE_REFERENCE_NAME = "products";
+	String ATTRIBUTE_NAME = "market";
+	String ATTRIBUTE_DESCRIPTION = "Market identifier this brand operates in.";
+
+	/**
+	 * Returns the primary key of the entity.
+	 *
+	 * @return primary key
+	 */
+	@PrimaryKey
+	int getId();
+
+	/**
+	 * Mandatory accessor for the marketing brand reflected reference. Carries the
+	 * `@ReflectedReference` annotation that mirrors the `products` reference declared on
+	 * the `Brand` entity.
+	 *
+	 * @return marketing brand reflected reference (never `null`)
+	 */
+	@ReflectedReference(ofName = SOURCE_REFERENCE_NAME)
+	@Nonnull
+	MarketingBrandRef getMarketingBrand();
+
+	/**
+	 * Secondary, optional accessor pointing at the same reflected reference name through
+	 * `@ReferenceRef`. Triggers the second analyzer pass over the same reference, which re-runs
+	 * the attribute analysis and is the path that surfaces the bug under investigation in the
+	 * reflected sibling builder.
+	 *
+	 * @return optional marketing brand reflected reference
+	 */
+	@ReferenceRef(REFERENCE_NAME)
+	@Nonnull
+	Optional<MarketingBrandRef> getMarketingBrandIfExists();
+
+	/**
+	 * Reflected DTO that targets the `Brand` entity and exposes a single attribute with a
+	 * description that does not exist on the source `products` reference.
+	 */
+	interface MarketingBrandRef {
+
+		/**
+		 * Returns the referenced brand entity.
+		 *
+		 * @return referenced brand entity
+		 */
+		@ReferencedEntity
+		Brand getBrand();
+
+		/**
+		 * Returns the market attribute with description. The description is the part that the
+		 * second analyzer pass conflicts on in the bug under investigation.
+		 *
+		 * @return market identifier
+		 */
+		@Attribute(name = ATTRIBUTE_NAME, description = ATTRIBUTE_DESCRIPTION)
+		String getMarket();
+
+	}
+
+	/**
+	 * Brand entity that holds the source `products` reference reflected from this entity.
+	 */
+	@Entity
+	interface Brand {
+
+		/**
+		 * Returns the primary key of the brand.
+		 *
+		 * @return primary key
+		 */
+		@PrimaryKey
+		int getId();
+
+		/**
+		 * Returns the products linked to this brand. This is the source reference that the
+		 * main entity reflects from.
+		 *
+		 * @return product references
+		 */
+		@Reference(indexed = ReferenceIndexType.FOR_FILTERING)
+		ProductRef[] getProducts();
+
+	}
+
+	/**
+	 * Source-side DTO declaring the standard reference from `Brand` to the main entity.
+	 */
+	interface ProductRef {
+
+		/**
+		 * Returns the referenced entity.
+		 *
+		 * @return product entity
+		 */
+		@ReferencedEntity
+		GetterBasedEntityWithReflectedReferenceAndReferenceRef getProduct();
+
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithReflectedReferenceAndReferenceRefV1.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithReflectedReferenceAndReferenceRefV1.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model;
+
+import io.evitadb.api.requestResponse.data.annotation.Entity;
+import io.evitadb.api.requestResponse.data.annotation.PrimaryKey;
+import io.evitadb.api.requestResponse.data.annotation.ReferencedEntity;
+import io.evitadb.api.requestResponse.data.annotation.ReflectedReference;
+
+import javax.annotation.Nonnull;
+
+/**
+ * V1 of `GetterBasedEntityWithReflectedReferenceAndReferenceRef`. Declares only the mandatory
+ * `@ReflectedReference` getter, returning a reflected DTO that contains **no** attributes. Used
+ * to bring the entity schema into a known persisted state with the reflected reference present
+ * but no attribute on it before the dual-mapped V2 (which adds the attribute via both
+ * `@ReflectedReference` and `@ReferenceRef`) is analyzed against it.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Entity(name = GetterBasedEntityWithReflectedReferenceAndReferenceRef.ENTITY_NAME)
+public interface GetterBasedEntityWithReflectedReferenceAndReferenceRefV1 {
+
+	/**
+	 * Returns the primary key of the entity.
+	 *
+	 * @return primary key
+	 */
+	@PrimaryKey
+	int getId();
+
+	/**
+	 * Mandatory accessor for the marketing brand reflected reference. The DTO is empty (no
+	 * attributes) so that V1 persists only the reflected reference itself.
+	 *
+	 * @return marketing brand reflected reference (never `null`)
+	 */
+	@ReflectedReference(ofName = GetterBasedEntityWithReflectedReferenceAndReferenceRef.SOURCE_REFERENCE_NAME)
+	@Nonnull
+	BareMarketingBrandRef getMarketingBrand();
+
+	/**
+	 * Bare reflected DTO with no attributes — only the target entity link.
+	 */
+	interface BareMarketingBrandRef {
+
+		/**
+		 * Returns the referenced brand entity.
+		 *
+		 * @return referenced brand entity
+		 */
+		@ReferencedEntity
+		GetterBasedEntityWithReflectedReferenceAndReferenceRef.Brand getBrand();
+
+	}
+
+}


### PR DESCRIPTION
## Summary

- Fix `InvalidSchemaMutationException` thrown by `ClassSchemaAnalyzer` when an entity model exposes the same (standard or reflected) reference through two getters — e.g. a mandatory `@Reference` getter and a secondary `@ReferenceRef` getter — and the reference carries attributes enriched by follow-up `Modify*` mutations.
- Derive `baseSchema` in both `ReferenceSchemaBuilder` and `ReflectedReferenceSchemaBuilder` from the **raw persisted** reference (`entitySchema.getReference(name)`) when `createNew == false`, instead of trusting the caller-supplied (already post-mutation) view. This prevents queued mutations from being replayed on top of a base that already reflects them.
- Add `ClassSchemaAnalyzerTest#shouldDefineReferenceWithDescriptionWhenAlsoMappedViaReferenceRef` and its reflected counterpart with V1/V2 model fixtures; strengthen assertions to lock in the exact mutation list (single `CreateAttributeSchemaMutation`, no stray `Remove*`, no second `CreateReferenceSchemaMutation`).
- Delete the dead 3-arg public `ReferenceSchemaBuilder` constructor (no callers, only initialised half its fields).

## Root cause

In `InternalEntitySchemaBuilder.withReferenceToEntity`, `toInstance()` materialises the entity schema by replaying every queued entity-level mutation, so the `existingReference` handed to the builder already reflects the cumulative post-mutation state. The old constructor stored that mutated view as `baseSchema` **and** copied the same entity-level mutations into its local list. On the second analyzer pass, `withAttribute("market", …)` triggered `toInstanceInternal()`, which replayed the inherited `CreateAttributeSchemaMutation` on top of a base where the attribute was already enriched by a follow-up `ModifyAttributeSchemaDescriptionMutation` — collision, throw.

The `createNew == false` contract already guarantees the persisted reference exists, so `entitySchema.getReference(name).orElseThrow(...)` is a safe source of a clean base. The `createNew == true` branch is unchanged.

Closes #1129