### PR TITLE
Replace release-drafter with Claude-generated enriched release notes

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: release-notes
+description: Generate enriched release notes for a major or patch release of evitaDB. Runs the deterministic skeleton generator and adds short user-facing prose to all breaking changes and to the features deemed "interesting", then writes the result to release-notes.md. Invokable locally as /release-notes and headlessly from the CI release workflow.
+allowed-tools: Read, Write, Bash(./tools/generate-release-notes.sh:*), Bash(./tools/list-issues.sh:*), Bash(./tools/list-commits.sh:*), Bash(git tag:*), Bash(git log:*), Bash(git describe:*), Bash(git rev-parse:*), Bash(git show:*), Bash(gh issue view:*), Bash(gh api:*)
+---
+
+# Release Notes
+
+## Overview
+
+Produces the final release notes body for an evitaDB release. Combines a deterministic markdown skeleton (built by `tools/generate-release-notes.sh`) with short, user-facing prose summaries that the model writes for the bullets that warrant explanation. The result is written to `release-notes.md` in the working tree so the calling workflow can `PATCH` it onto the GitHub draft release.
+
+The deterministic skeleton already contains the four canonical sections in the correct order — the skill never fabricates new sections or new bullets. It only **rewrites existing bullets** to bold their title and append a prose continuation line where appropriate.
+
+## When to Use
+
+- Invoked locally as `/release-notes` to preview the notes for the next release
+- Invoked headlessly from `.github/workflows/ci-release.yml` after the draft release is created
+- Useful for both MAJOR releases (e.g. `v2026.1.0`) and PATCH releases (e.g. `v2026.1.3`)
+
+## Inputs
+
+The skill resolves its inputs in this order:
+
+1. **Explicit arguments** passed in the prompt: `version=v2026.1.3 base=v2026.1.2 milestone=2026.1`
+2. **Environment variables** (set by the CI workflow): `RELEASE_VERSION`, `BASE_VERSION`, `MILESTONE`
+3. **Auto-detection**:
+   - `version` — read the first `<version>` tag from the root `pom.xml`, strip `-SNAPSHOT`, prepend `v`, append `.0` if no patch component is present (so `2026.1-SNAPSHOT` becomes `v2026.1.0`)
+   - `base` — let `generate-release-notes.sh` resolve it (highest `v*` tag strictly less than `version`)
+   - `milestone` — strip the leading `v` and trailing `.0` from `version`; if the resulting string identifies an existing GitHub milestone, use it, otherwise leave empty
+
+If both `RELEASE_VERSION` ends with `.0` **and** the matching `MILESTONE` exists on GitHub, treat the run as **MAJOR mode**. Otherwise treat it as **PATCH mode**.
+
+## Workflow
+
+Execute these steps **in order**. Stop and report to the user if any step fails. **Do not** modify any file other than `release-notes.md`. **Do not** stage, commit, push, or create branches.
+
+### Step 1: Resolve inputs
+
+Determine `VERSION`, `BASE`, and `MILESTONE` per the rules above. Echo them to the run output for traceability.
+
+### Step 2: Build the deterministic skeleton
+
+Run the orchestrator and capture stdout. Use `--milestone` only when in MAJOR mode.
+
+```shell
+./tools/generate-release-notes.sh --version "<VERSION>" --base "<BASE>" [--milestone "<MILESTONE>"]
+```
+
+If the orchestrator exits non-zero, abort the skill and report the error. The CI workflow will treat this as a soft failure and keep the release-drafter body untouched.
+
+The skeleton always begins with `## What's Changed` and ends with a `**Full Changelog**: ...` line. Between them are zero or more of these sections, in this fixed order:
+
+1. `### ☢️ Breaking changes`
+2. `### 🚀 Features`
+3. `### 🐛 Bug Fixes`
+4. `### ⛓ Dependencies upgrades`
+
+### Step 3: Identify enrichment candidates
+
+Parse the skeleton and collect the list of bullets that need a prose continuation:
+
+- **Every bullet** in `### ☢️ Breaking changes` — breaking changes always get prose, with no exceptions.
+- **Every "interesting" bullet** in `### 🚀 Features`. A feature is interesting when it changes what the user can do, query, store, observe, or operate. Use this checklist:
+  - ✅ adds or removes a query constraint or query operator
+  - ✅ adds or removes a public API endpoint, gRPC method, REST route, GraphQL field, or evitaQL token
+  - ✅ adds or changes a public Java API on a published interface
+  - ✅ introduces a new storage feature (export, backup, replication, transaction handling)
+  - ✅ introduces a new observability surface (metric, trace, log field, dashboard)
+  - ✅ changes a default that users can perceive (limits, timeouts, sort order, response shape)
+  - ✅ changes performance class significantly (e.g. order-of-magnitude improvement on a documented benchmark)
+  - ❌ pure internal refactor with no user-visible effect
+  - ❌ developer-experience-only improvements (build, test infra, code quality)
+  - ❌ small ergonomic tweaks to internal helpers
+  - ❌ minor wording or formatting changes
+
+  When unsure, **include** the bullet — over-enrichment is cheaper than under-enrichment for the maintainer to clean up.
+
+- **Never** enrich bullets in `### 🐛 Bug Fixes` or `### ⛓ Dependencies upgrades`.
+
+### Step 4: Look up source material for each candidate
+
+For each candidate bullet:
+
+1. Extract the issue number from the trailing `(#NNN)` if present.
+2. If an issue number was found, fetch the issue:
+   ```shell
+   gh issue view <NNN> --repo FgForrest/evitaDB --json title,body,labels,url
+   ```
+   Read the issue body — it is the primary source of user-facing context.
+3. If no issue number is present (typical for PATCH-mode commits without `Ref: #NNN`), look up the commit body instead. Use `git log --grep="<bullet description>" -1 --format=%B` to find the matching commit. The commit body is a weaker source than an issue body — keep the prose conservative.
+4. If neither lookup yields meaningful prose-worthy content, **skip** the bullet (do not invent text). For breaking-change bullets that have no source material, fall back to a one-sentence factual paraphrase of the bullet itself.
+
+### Step 5: Generate prose continuation lines
+
+For each candidate, write a 1-2 sentence prose continuation that meets all of these rules:
+
+1. **Voice**: user-facing. Explain what the user can now do, what changed for them, or what they need to migrate. Never describe internal implementation.
+2. **Vocabulary**: never mention internal Java class names, package paths, gRPC stub names, internal method names, or `BASH_REMATCH`-style implementation jargon. Public API names (e.g. `entityFetch`, `referenceContent`, `evitaQL`, `EntityContract`) are fine when they correspond to documented API surface.
+3. **Length**: maximum 2 sentences. Aim for one when possible. No bullet lists, no headings, no code fences inside the prose.
+4. **Tone**: neutral and factual, matching the voice of the v2025.1.0 release notes. Avoid marketing words ("powerful", "blazing", "exciting", "robust").
+5. **Completeness**: prose must stand alone — a reader should not need to click the issue link to understand what the change is.
+
+### Step 6: Rewrite the bullets in place
+
+For each enriched bullet, replace the original line:
+
+```
+* Added X for Y (#123)
+```
+
+with the bolded-title two-line continuation form:
+
+```
+* **Added X for Y** (#123)<br/>
+  Short user-facing explanation of what this unlocks for the user.
+```
+
+Format rules — follow exactly:
+- Wrap **only the title text** in `**...**`. The title is everything between the leading `* ` and the trailing ` (#NNN)` reference (or end-of-line if there is no issue ref). Do **not** bold the `(#NNN)` part.
+- End the bullet line with `<br/>` so GitHub renders the prose as a continuation of the same list item.
+- Indent the prose line with two spaces so GitHub keeps it inside the same list item.
+- No blank line between the bullet and the prose.
+
+Bullets that were not selected for enrichment are left **byte-for-byte unchanged** — they remain plain (no bolding, no `<br/>`, no prose continuation). The order of bullets within each section is preserved.
+
+### Step 7: Apply light dedupe (best-effort)
+
+Within each section, if the same change appears as both an issue-derived bullet (with `(#NNN)`) and a commit-derived bullet (without an issue number, lower in the section), drop the commit-derived duplicate. Match conservatively — only drop when the descriptions are clearly the same change written two ways. Never delete a bullet that has a unique issue number you have not seen before.
+
+This step is **purely subtractive** and runs only on sections that contain bullets from both sources (i.e. MAJOR mode). PATCH-mode runs skip this step.
+
+### Step 8: Write `release-notes.md`
+
+Write the final body to `release-notes.md` in the current working directory using the Write tool. Overwrite any existing file. Do not append a trailing newline beyond what is already present in the body. Do not modify any other file.
+
+### Step 9: Report
+
+Print a one-paragraph summary to the run output:
+
+- mode (MAJOR or PATCH)
+- version, base, milestone (if any)
+- number of bullets enriched, broken down by section
+- number of bullets dropped by dedupe
+- absolute path of `release-notes.md`
+
+The CI workflow uses this summary only as human-readable log output — no machine parsing.
+
+## Important Notes
+
+- **Soft-failure contract**: this skill runs in CI under `continue-on-error: true`. A failure here must never block the release pipeline. If you cannot complete a step, abort with a clear error message and do not write a partial `release-notes.md`.
+- **No commits, no pushes, no branches**: the skill only writes a single file. The workflow handles publishing.
+- **Idempotent**: running the skill twice with the same inputs must produce byte-identical output. Do not rely on randomness, time-of-day, or any other non-deterministic input.
+- **Token discipline**: limit `gh issue view` calls to candidate bullets only. Never crawl unrelated issues. Never read source code from the repository — the goal is to summarize what was already written in the issue, not to reverse-engineer it.
+- **No guesswork on breaking changes**: if a breaking-change bullet has no usable source material, write a single factual sentence paraphrasing the bullet itself rather than inventing migration guidance.
+- **Patch release without features**: if both the breaking and features sections are empty after Step 3, skip Steps 4–7 entirely and write the unchanged skeleton to `release-notes.md`. This is the normal happy path for a small bugfix patch.

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -177,6 +177,103 @@ jobs:
         latest: ${{ github.ref_name == 'master' && 'true' || 'legacy' }}
         commitish: ${{ github.event.workflow_run.conclusion == 'success' && steps.read_branch.outputs.branch || github.ref }}
 
+    # Resolve previous release tag and milestone for the release-notes skill.
+    # This is best-effort: failures must not block the release pipeline.
+    - name: Resolve release notes inputs
+      id: notes_inputs
+      if: success()
+      env:
+        VERSION: ${{ steps.release_version.outputs.version }}
+        IS_MAJOR: ${{ github.event.workflow_run.conclusion == 'success' }}
+      run: |
+        # Highest v* tag strictly less than VERSION, by semantic version sort.
+        PREV=$( (git tag -l 'v*'; printf "%s\n" "$VERSION") \
+          | sort -V -u \
+          | awk -v v="$VERSION" 'BEGIN { prev = "" }
+                                  $0 == v { print prev; exit }
+                                  { prev = $0 }' )
+        echo "prev_tag=$PREV" >> $GITHUB_OUTPUT
+        echo "Resolved previous tag: ${PREV:-<none>}"
+
+        # Milestone is only set for MAJOR releases (triggered by workflow_run
+        # from CI Master); patch releases use commit-only mode in the skill.
+        if [ "$IS_MAJOR" = "true" ]; then
+          MILESTONE="${VERSION#v}"
+          MILESTONE="${MILESTONE%.0}"
+        else
+          MILESTONE=""
+        fi
+        echo "milestone=$MILESTONE" >> $GITHUB_OUTPUT
+        echo "Resolved milestone: ${MILESTONE:-<none>}"
+
+    # Generate enriched release notes via the .claude/skills/release-notes
+    # skill. The release-drafter draft from the previous step is the safety
+    # net — this step is allowed to fail without affecting the release build.
+    - name: Generate enriched release notes with Claude
+      id: claude_notes
+      if: success()
+      continue-on-error: true
+      uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1.0.55
+      with:
+        claude_code_oauth_token: ${{ secrets.ANTHROPIC_API_KEY }}
+        show_full_output: true
+        prompt: |
+          You are generating release notes for evitaDB ${{ steps.release_version.outputs.version }}.
+
+          RELEASE_VERSION=${{ steps.release_version.outputs.version }}
+          BASE_VERSION=${{ steps.notes_inputs.outputs.prev_tag }}
+          MILESTONE=${{ steps.notes_inputs.outputs.milestone }}
+
+          Read `.claude/skills/release-notes/SKILL.md` and follow its workflow
+          exactly. Pass the values above as inputs (Step 1 of the skill).
+          Write the final notes to `release-notes.md` in the working directory.
+          Do not modify any other file. Do not commit, push, or create branches.
+        claude_args: |
+          --max-turns 30 --allowedTools "Read,Write,Bash(./tools/generate-release-notes.sh:*),Bash(./tools/list-issues.sh:*),Bash(./tools/list-commits.sh:*),Bash(git tag:*),Bash(git log:*),Bash(git describe:*),Bash(git rev-parse:*),Bash(git show:*),Bash(gh issue view:*),Bash(gh api:*)"
+
+    # Always-print diagnostic — surfaces the generated body and Claude outcome
+    # in the build log even when the PATCH step is skipped, so failures are
+    # easy to inspect without re-running the workflow.
+    - name: Show generated release notes
+      if: always() && steps.claude_notes.outcome != 'skipped'
+      run: |
+        echo "claude_notes outcome: ${{ steps.claude_notes.outcome }}"
+        if [ -s release-notes.md ]; then
+          echo "--- release-notes.md ---"
+          cat release-notes.md
+          echo "--- end ---"
+        else
+          echo "(release-notes.md missing or empty)"
+        fi
+
+    # Upload the generated body as a workflow artifact so it can be downloaded
+    # offline for inspection — even if the PATCH step skipped or failed.
+    - name: Upload release-notes.md artifact
+      if: always() && hashFiles('release-notes.md') != ''
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: release-notes-${{ steps.release_version.outputs.version }}
+        path: release-notes.md
+
+    # Patch the drafted release body with the enriched notes if Claude
+    # produced them. Soft failure: missing file or API error is logged and
+    # ignored — the release-drafter draft remains in place as a fallback.
+    - name: Update draft release body with enriched notes
+      if: steps.claude_notes.outcome == 'success'
+      continue-on-error: true
+      env:
+        RELEASE_ID: ${{ steps.create_release.outputs.id }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if [ ! -s release-notes.md ]; then
+          echo "release-notes.md missing or empty — keeping release-drafter body."
+          exit 0
+        fi
+        echo "Patching release $RELEASE_ID with enriched notes from release-notes.md"
+        gh api --method PATCH "/repos/FgForrest/evitaDB/releases/$RELEASE_ID" \
+          --field body=@release-notes.md
+        echo "Release body updated."
+
     - name: Upload dist.zip to release
       uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
       if: success()

--- a/tools/generate-release-notes.sh
+++ b/tools/generate-release-notes.sh
@@ -40,8 +40,8 @@
 #
 # --version    Required. The release being prepared (e.g. v2026.1.3 or v2026.1.0).
 # --base       Optional. Previous release tag to compare against. If omitted,
-#              the script picks the chronologically previous v* tag using
-#              `git tag --sort=-version:refname`.
+#              the script picks the highest v* tag strictly less than --version
+#              by listing matching tags and version-sorting them with `sort -V`.
 # --milestone  Optional. GitHub milestone title (e.g. "2026.1"). When provided
 #              and the milestone exists, the script runs in MAJOR mode and pulls
 #              issues from list-issues.sh + supplements with commits. When
@@ -49,6 +49,7 @@
 #              PATCH mode and uses commits only.
 
 set -e
+set -o pipefail
 
 REPO="FgForrest/evitaDB"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -119,18 +120,23 @@ BASE_BARE="${BASE#v}"
 VERSION_BARE="${VERSION#v}"
 
 # Decide MAJOR vs PATCH mode. If a milestone is supplied, verify it exists in
-# the repository before trusting it; an invalid milestone falls back to PATCH
+# the repository before trusting it. An invalid milestone falls back to PATCH
 # mode rather than aborting (the workflow always treats the prose pipeline as
-# best-effort).
+# best-effort), but we distinguish a real "not found" answer from a gh API
+# failure (auth, rate-limit, network) so CI diagnostics show the actual cause.
 mode="patch"
 if [ -n "$MILESTONE" ]; then
   if command -v gh >/dev/null 2>&1; then
-    if gh api --paginate -H "Accept: application/vnd.github+json" \
-        "/repos/$REPO/milestones?state=all&per_page=100" 2>/dev/null \
-        | jq -e ".[] | select(.title == \"$MILESTONE\")" >/dev/null 2>&1; then
-      mode="major"
+    if milestones_json=$(gh api --paginate -H "Accept: application/vnd.github+json" \
+        "/repos/$REPO/milestones?state=all&per_page=100"); then
+      if printf '%s\n' "$milestones_json" | jq -e --arg milestone "$MILESTONE" \
+          '.[] | select(.title == $milestone)' >/dev/null 2>&1; then
+        mode="major"
+      else
+        echo "Warning: milestone '$MILESTONE' not found — falling back to patch mode." >&2
+      fi
     else
-      echo "Warning: milestone '$MILESTONE' not found — falling back to patch mode." >&2
+      echo "Warning: failed to query milestones for '$REPO' via gh CLI — falling back to patch mode." >&2
     fi
   else
     echo "Warning: gh CLI unavailable — falling back to patch mode." >&2
@@ -139,14 +145,17 @@ fi
 
 # Run the underlying generators and capture their output. Both scripts print
 # their own '## What's Changed' header and section blocks; we strip those and
-# re-emit a single header so we can merge them.
+# re-emit a single header so we can merge them. Failures from either helper
+# must propagate (they return 0 on legitimately empty output, so a non-zero
+# exit always indicates a real error worth surfacing) and stderr is left
+# untouched so the build log shows the actual cause.
 issues_output=""
 commits_output=""
 
 if [ "$mode" = "major" ]; then
-  issues_output=$("$SCRIPT_DIR/list-issues.sh" "$MILESTONE" "$BASE_BARE" 2>/dev/null || true)
+  issues_output=$("$SCRIPT_DIR/list-issues.sh" "$MILESTONE" "$BASE_BARE")
 fi
-commits_output=$("$SCRIPT_DIR/list-commits.sh" "$BASE_BARE" "$VERSION_BARE" 2>/dev/null || true)
+commits_output=$("$SCRIPT_DIR/list-commits.sh" "$BASE_BARE" "$VERSION_BARE")
 
 # Helper: extract a section from a script's output. Sections are introduced by
 # `### <emoji> <name>` and terminated by the next `### ` line or EOF. Trims
@@ -199,21 +208,23 @@ _dedupe_bullets() {
 
 # Helper: filter commit-derived bullets to drop non-user-facing items
 # (CI/CD, build infrastructure, internal refactors, compilation fixes, etc.).
-# This is a conservative pass — uncertain items are kept.
+# This is a conservative pass — uncertain items are kept. The patterns are
+# unique enough that POSIX-style substring matching works (no gawk-specific
+# word boundaries) and the script remains portable to BSD/macOS awk.
 _filter_user_facing() {
   printf "%s\n" "$1" | awk '
     /^\* / {
       lc = tolower($0)
-      if (lc ~ /\<ci\/cd\>/) next
-      if (lc ~ /\<github actions?\>/) next
-      if (lc ~ /\<workflow file/) next
-      if (lc ~ /\<workflow yaml/) next
-      if (lc ~ /\<docker( |-)?(file|workflow|build)/) next
-      if (lc ~ /\<compilation fix\>/) next
-      if (lc ~ /\<tostring\>/) next
-      if (lc ~ /\<code style\>/) next
-      if (lc ~ /\<dependabot\>/) next
-      if (lc ~ /\<bump .* version\>/ && lc !~ /\<dependency\>/) next
+      if (lc ~ /ci\/cd/) next
+      if (lc ~ /github actions?/) next
+      if (lc ~ /workflow file/) next
+      if (lc ~ /workflow yaml/) next
+      if (lc ~ /docker( |-)?(file|workflow|build)/) next
+      if (lc ~ /compilation fix/) next
+      if (lc ~ /tostring/) next
+      if (lc ~ /code style/) next
+      if (lc ~ /dependabot/) next
+      if (lc ~ /bump .* version/ && lc !~ /dependency/) next
       print
       next
     }

--- a/tools/generate-release-notes.sh
+++ b/tools/generate-release-notes.sh
@@ -1,0 +1,288 @@
+#!/bin/bash
+
+#
+#
+#                         _ _        ____  ____
+#               _____   _(_) |_ __ _|  _ \| __ )
+#              / _ \ \ / / | __/ _` | | | |  _ \
+#             |  __/\ V /| | || (_| | |_| | |_) |
+#              \___| \_/ |_|\__\__,_|____/|____/
+#
+#   Copyright (c) 2025
+#
+#   Licensed under the Business Source License, Version 1.1 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Generate the deterministic skeleton of release notes for an evitaDB release.
+#
+# Combines tools/list-issues.sh (milestone/issue based, used for MAJOR releases)
+# and tools/list-commits.sh (conventional-commit based, used for PATCH releases
+# and to supplement the issue list for MAJORs) into a single markdown body
+# matching the established release-notes format. Always appends the GitHub
+# "Full Changelog" compare trailer.
+#
+# This script is intentionally LLM-free; it produces the structural skeleton
+# that the .claude/skills/release-notes skill then enriches with prose
+# descriptions for the user-facing items.
+#
+# Usage:
+#   ./generate-release-notes.sh --version vX.Y.Z [--base vA.B.C] [--milestone X.Y]
+#
+# --version    Required. The release being prepared (e.g. v2026.1.3 or v2026.1.0).
+# --base       Optional. Previous release tag to compare against. If omitted,
+#              the script picks the chronologically previous v* tag using
+#              `git tag --sort=-version:refname`.
+# --milestone  Optional. GitHub milestone title (e.g. "2026.1"). When provided
+#              and the milestone exists, the script runs in MAJOR mode and pulls
+#              issues from list-issues.sh + supplements with commits. When
+#              omitted (or the milestone does not exist), the script runs in
+#              PATCH mode and uses commits only.
+
+set -e
+
+REPO="FgForrest/evitaDB"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+VERSION=""
+BASE=""
+MILESTONE=""
+
+# Parse named arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --base)
+      BASE="$2"
+      shift 2
+      ;;
+    --milestone)
+      MILESTONE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '/^# Usage:/,/^# omitted/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$VERSION" ]; then
+  echo "Error: --version is required (e.g. --version v2026.1.3)" >&2
+  exit 1
+fi
+
+# Normalize VERSION to start with 'v'
+case "$VERSION" in
+  v*) ;;
+  *) VERSION="v$VERSION" ;;
+esac
+
+# Auto-resolve --base if not provided: pick the highest v* tag that is
+# strictly less than the version being released, using semantic version sort.
+# We append the target version into the candidate list and read the line
+# immediately before it after `sort -V`, so this works whether or not the
+# target version has already been tagged in the repository.
+if [ -z "$BASE" ]; then
+  BASE=$( (git tag -l 'v*'; printf "%s\n" "$VERSION") \
+    | sort -V -u \
+    | awk -v v="$VERSION" 'BEGIN { prev = "" }
+                            $0 == v { print prev; exit }
+                            { prev = $0 }' )
+  if [ -z "$BASE" ]; then
+    echo "Error: could not auto-detect previous release tag (no v* tag earlier than $VERSION)." >&2
+    echo "       Provide --base explicitly." >&2
+    exit 1
+  fi
+  echo "Resolved --base to $BASE" >&2
+fi
+
+# Strip the leading 'v' from versions for the helper scripts (they expect
+# bare semver). Keep the v-prefixed values for the compare URL trailer.
+BASE_BARE="${BASE#v}"
+VERSION_BARE="${VERSION#v}"
+
+# Decide MAJOR vs PATCH mode. If a milestone is supplied, verify it exists in
+# the repository before trusting it; an invalid milestone falls back to PATCH
+# mode rather than aborting (the workflow always treats the prose pipeline as
+# best-effort).
+mode="patch"
+if [ -n "$MILESTONE" ]; then
+  if command -v gh >/dev/null 2>&1; then
+    if gh api --paginate -H "Accept: application/vnd.github+json" \
+        "/repos/$REPO/milestones?state=all&per_page=100" 2>/dev/null \
+        | jq -e ".[] | select(.title == \"$MILESTONE\")" >/dev/null 2>&1; then
+      mode="major"
+    else
+      echo "Warning: milestone '$MILESTONE' not found — falling back to patch mode." >&2
+    fi
+  else
+    echo "Warning: gh CLI unavailable — falling back to patch mode." >&2
+  fi
+fi
+
+# Run the underlying generators and capture their output. Both scripts print
+# their own '## What's Changed' header and section blocks; we strip those and
+# re-emit a single header so we can merge them.
+issues_output=""
+commits_output=""
+
+if [ "$mode" = "major" ]; then
+  issues_output=$("$SCRIPT_DIR/list-issues.sh" "$MILESTONE" "$BASE_BARE" 2>/dev/null || true)
+fi
+commits_output=$("$SCRIPT_DIR/list-commits.sh" "$BASE_BARE" "$VERSION_BARE" 2>/dev/null || true)
+
+# Helper: extract a section from a script's output. Sections are introduced by
+# `### <emoji> <name>` and terminated by the next `### ` line or EOF. Trims
+# trailing blank lines.
+_extract_section() {
+  local input="$1"
+  local heading_pattern="$2"
+  printf "%s\n" "$input" \
+    | awk -v pat="$heading_pattern" '
+        BEGIN { capturing = 0 }
+        /^### / {
+          if (capturing) { exit }
+          if (index($0, pat) > 0) { capturing = 1; next }
+        }
+        capturing { print }
+      ' \
+    | sed -e '/./,$!d' -e :a -e '/^$/{$d;N;ba' -e '}'
+}
+
+# Helper: dedupe bullet lines that already appear in `existing` from `incoming`,
+# keyed by lower-cased description (the part after the leading `* `, with any
+# trailing `(#NNN)` issue ref stripped). The dedupe is intentionally fuzzy
+# so commits with the same wording as an issue title are dropped.
+_dedupe_bullets() {
+  local existing="$1"
+  local incoming="$2"
+  local existing_keys
+  existing_keys=$(printf "%s\n" "$existing" \
+    | sed -n 's/^\* \(.*\)$/\1/p' \
+    | sed -E 's/[[:space:]]*\(#[0-9]+\)[[:space:]]*$//' \
+    | tr '[:upper:]' '[:lower:]')
+
+  printf "%s\n" "$incoming" | while IFS= read -r line; do
+    case "$line" in
+      \*\ *)
+        key=$(printf "%s" "${line#\* }" \
+          | sed -E 's/[[:space:]]*\(#[0-9]+\)[[:space:]]*$//' \
+          | tr '[:upper:]' '[:lower:]')
+        if printf "%s\n" "$existing_keys" | grep -Fxq "$key"; then
+          continue
+        fi
+        printf "%s\n" "$line"
+        ;;
+      *)
+        printf "%s\n" "$line"
+        ;;
+    esac
+  done
+}
+
+# Helper: filter commit-derived bullets to drop non-user-facing items
+# (CI/CD, build infrastructure, internal refactors, compilation fixes, etc.).
+# This is a conservative pass — uncertain items are kept.
+_filter_user_facing() {
+  printf "%s\n" "$1" | awk '
+    /^\* / {
+      lc = tolower($0)
+      if (lc ~ /\<ci\/cd\>/) next
+      if (lc ~ /\<github actions?\>/) next
+      if (lc ~ /\<workflow file/) next
+      if (lc ~ /\<workflow yaml/) next
+      if (lc ~ /\<docker( |-)?(file|workflow|build)/) next
+      if (lc ~ /\<compilation fix\>/) next
+      if (lc ~ /\<tostring\>/) next
+      if (lc ~ /\<code style\>/) next
+      if (lc ~ /\<dependabot\>/) next
+      if (lc ~ /\<bump .* version\>/ && lc !~ /\<dependency\>/) next
+      print
+      next
+    }
+    { print }
+  '
+}
+
+# Build merged sections.
+# Order: Breaking → Features → Bug Fixes → Dependencies upgrades.
+# In MAJOR mode the issues output is authoritative; commits supplement.
+# In PATCH mode there is no issues output, so commits are the only source.
+
+issues_breaking=$(_extract_section "$issues_output" "☢️ Breaking changes")
+issues_features=$(_extract_section "$issues_output" "🚀 Features")
+issues_bugfixes=$(_extract_section "$issues_output" "🐛 Bug Fixes")
+issues_deps=$(_extract_section "$issues_output" "⛓ Dependencies upgrades")
+
+commits_breaking=$(_extract_section "$commits_output" "☢️ Breaking changes")
+commits_features=$(_extract_section "$commits_output" "🚀 Features")
+commits_bugfixes=$(_extract_section "$commits_output" "🐛 Bug Fixes")
+
+commits_breaking=$(_filter_user_facing "$commits_breaking")
+commits_features=$(_filter_user_facing "$commits_features")
+commits_bugfixes=$(_filter_user_facing "$commits_bugfixes")
+
+# Merge issues (authoritative) with commits (supplemental, deduped).
+merged_breaking="$issues_breaking"
+extra=$(_dedupe_bullets "$issues_breaking" "$commits_breaking")
+if [ -n "$extra" ] && [ -n "$merged_breaking" ]; then
+  merged_breaking=$(printf "%s\n%s" "$merged_breaking" "$extra")
+elif [ -n "$extra" ]; then
+  merged_breaking="$extra"
+fi
+
+merged_features="$issues_features"
+extra=$(_dedupe_bullets "$issues_features" "$commits_features")
+if [ -n "$extra" ] && [ -n "$merged_features" ]; then
+  merged_features=$(printf "%s\n%s" "$merged_features" "$extra")
+elif [ -n "$extra" ]; then
+  merged_features="$extra"
+fi
+
+merged_bugfixes="$issues_bugfixes"
+extra=$(_dedupe_bullets "$issues_bugfixes" "$commits_bugfixes")
+if [ -n "$extra" ] && [ -n "$merged_bugfixes" ]; then
+  merged_bugfixes=$(printf "%s\n%s" "$merged_bugfixes" "$extra")
+elif [ -n "$extra" ]; then
+  merged_bugfixes="$extra"
+fi
+
+# Print final body.
+printf "## What's Changed\n"
+
+if [ -n "$merged_breaking" ]; then
+  printf "\n### ☢️ Breaking changes\n\n%s\n" "$merged_breaking"
+fi
+
+if [ -n "$merged_features" ]; then
+  printf "\n### 🚀 Features\n\n%s\n" "$merged_features"
+fi
+
+if [ -n "$merged_bugfixes" ]; then
+  printf "\n### 🐛 Bug Fixes\n\n%s\n" "$merged_bugfixes"
+fi
+
+if [ -n "$issues_deps" ]; then
+  printf "\n### ⛓ Dependencies upgrades\n\n%s\n" "$issues_deps"
+fi
+
+# Compare URL trailer — always last, always present.
+printf "\n**Full Changelog**: https://github.com/%s/compare/%s...%s\n" \
+  "$REPO" "$BASE" "$VERSION"

--- a/tools/list-commits.sh
+++ b/tools/list-commits.sh
@@ -58,6 +58,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Associative arrays to store deduplicated commits by type
+declare -A breaking_commits
 declare -A feat_commits
 declare -A fix_commits
 declare -A doc_commits
@@ -66,13 +67,23 @@ declare -A test_commits
 # Process each commit
 while IFS='|||' read -r subject body; do
   # Check if commit follows conventional commit format
-  if [[ "$subject" =~ ^(feat|fix|doc|test|docs|refactor|perf|style|chore|build|ci|revert)(\(.+\))?:\ (.+)$ ]]; then
+  # Group 1: type, Group 2: optional scope, Group 3: optional ! breaking marker, Group 4: description
+  if [[ "$subject" =~ ^(feat|fix|doc|test|docs|refactor|perf|style|chore|build|ci|revert)(\(.+\))?(!)?:\ (.+)$ ]]; then
     commit_type="${BASH_REMATCH[1]}"
-    commit_desc="${BASH_REMATCH[3]}"
+    breaking_marker="${BASH_REMATCH[3]}"
+    commit_desc="${BASH_REMATCH[4]}"
 
     # Normalize commit type (docs -> doc)
     if [ "$commit_type" = "docs" ]; then
       commit_type="doc"
+    fi
+
+    # Detect breaking change: ! marker on subject, or BREAKING CHANGE: / BREAKING-CHANGE: in body
+    is_breaking=false
+    if [ "$breaking_marker" = "!" ]; then
+      is_breaking=true
+    elif [[ "$body" =~ BREAKING[\ -]CHANGE: ]]; then
+      is_breaking=true
     fi
 
     # Extract issue number from subject or body
@@ -88,6 +99,12 @@ while IFS='|||' read -r subject body; do
       entry="$commit_desc (#$issue_number)"
     else
       entry="$commit_desc"
+    fi
+
+    # Breaking changes take precedence over the original type bucket
+    if [ "$is_breaking" = true ]; then
+      breaking_commits["$commit_desc"]="$entry"
+      continue
     fi
 
     # Store in appropriate array (using description as key for deduplication)
@@ -110,6 +127,17 @@ done <<< "$git_log"
 
 # Print sections
 printed_header=false
+
+if [ "${#breaking_commits[@]}" -gt 0 ]; then
+  if [ "$printed_header" = false ]; then
+    echo "## What's Changed"
+    printed_header=true
+  fi
+  echo -e "\n### ☢️ Breaking changes\n"
+  for key in "${!breaking_commits[@]}"; do
+    echo "* ${breaking_commits[$key]}"
+  done | sort -f
+fi
 
 if [ "${#feat_commits[@]}" -gt 0 ]; then
   if [ "$printed_header" = false ]; then


### PR DESCRIPTION
Closes #1131

## Phase 1 — Claude-enriched release notes alongside release-drafter

Adds a Claude Code step at the tail of `ci-release.yml` that generates richer release notes than release-drafter and `PATCH`es them onto the drafted release. release-drafter stays in place as a safety net for this phase; it will be removed in a follow-up once the enriched output is validated on a few real patch releases.

### What lands

- **`tools/generate-release-notes.sh`** (new) — deterministic orchestrator that auto-resolves the previous tag, picks MAJOR vs PATCH mode (milestone-aware), merges `list-issues.sh` + `list-commits.sh` per the existing `release-pr` skill rules, and appends a `**Full Changelog**: .../compare/vA...vB` trailer.
- **`tools/list-commits.sh`** (modified) — now detects the conventional-commits `!` breaking marker (`feat!:`, `refactor!:`, …) and the `BREAKING CHANGE:` body marker, routes them to a new breaking bucket, and emits `### ☢️ Breaking changes` before `### 🚀 Features`.
- **`.claude/skills/release-notes/SKILL.md`** (new) — invokable as `/release-notes` locally and headlessly from CI. Calls the orchestrator, then enriches every breaking-change bullet and every "interesting" feature bullet with a 1–2 sentence user-facing prose continuation and bolds the bullet title. Conservative checklist for "interesting", strict no-internal-class-names rule, idempotent.
- **`.github/workflows/ci-release.yml`** (modified) — five new steps after `Create release`:
  1. resolve previous release tag and milestone (MAJOR vs PATCH detection),
  2. run `anthropics/claude-code-action@88c168b3…` (same pin as `pr-review.yml`) with the prompt pointing at the new skill — `continue-on-error: true`, `--max-turns 30`,
  3. always-print diagnostic step that dumps `release-notes.md` and Claude's outcome to the build log,
  4. upload `release-notes.md` as a workflow artifact (even on failure),
  5. PATCH the drafted release body from `release-notes.md` — `continue-on-error: true`, only if Claude succeeded.

### Safety properties

- Both Claude-related steps are `continue-on-error: true`. A Claude failure, API outage, missing secret, denied tool, or runaway session never fails the release pipeline.
- release-drafter runs first and always produces a usable draft body. If anything in the new pipeline goes wrong, the release-drafter body is left untouched.
- Release stays `publish: false`. Manual publishing is unchanged.
- Works for MAJOR releases (triggered by `workflow_run` from CI Master) and PATCH releases (push to `release_*`) — milestone is only injected in the MAJOR path.

### Operational notes

- Iterating on `--allowedTools` follows the same loop as `pr-review.yml`: read the action's full output (or the auto-uploaded turn-by-turn artifact), find the denied tool, add it to the allowlist, push, re-run.
- The diagnostic + artifact steps make it possible to inspect the generated body without re-running the workflow.

### Out of scope

- Removing release-drafter and `.github/release-drafter.yml` — deferred to Phase 2.

Ref: #1131