### PR TITLE
fix: JoinFormula hash must always include bitmap identities

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/JoinFormula.java
@@ -235,24 +235,20 @@ public class JoinFormula extends AbstractFormula {
 
 	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
-		if (this.bitmaps.length > EXCESSIVE_HIGH_CARDINALITY) {
-			return hashFunction.hashLongs(this.indexTransactionId);
-		} else {
-			return hashFunction.hashLongs(
-				Stream.of(this.bitmaps)
-					.filter(Objects::nonNull)
-					.mapToLong(it -> {
-						if (it instanceof TransactionalLayerProducer) {
-							return ((TransactionalLayerProducer<?, ?>) it).getId();
-						} else {
-							// this shouldn't happen for long arrays - these are expected to be always linked to transactional
-							// bitmaps located in indexes and represented by "transactional id"
-							return hashFunction.hashInts(it.getArray());
-						}
-					})
-					.toArray()
-			);
-		}
+		return hashFunction.hashLongs(
+			Stream.of(this.bitmaps)
+				.filter(Objects::nonNull)
+				.mapToLong(it -> {
+					if (it instanceof TransactionalLayerProducer) {
+						return ((TransactionalLayerProducer<?, ?>) it).getId();
+					} else {
+						// this shouldn't happen for long arrays - these are expected to be always linked to transactional
+						// bitmaps located in indexes and represented by "transactional id"
+						return hashFunction.hashInts(it.getArray());
+					}
+				})
+				.toArray()
+		);
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

- Removes the `EXCESSIVE_HIGH_CARDINALITY` short-circuit from `JoinFormula.includeAdditionalHash()` so that all bitmap identities always participate in the formula hash.
- Fixes `FormulaDeduplicator` silently merging two structurally different `JoinFormula` instances (same index, different bitmaps or different ordering) once each had more than 100 bitmaps, which produced wrong query results.

## Background

`FormulaDeduplicator` uses `Formula.getHash()` as the identity key. `JoinFormula.includeAdditionalHash()` previously collapsed its contribution to just `indexTransactionId` once the bitmap count exceeded `EXCESSIVE_HIGH_CARDINALITY` (100). Because `JoinFormula.isFormulaOrderSignificant()` is `true`, even same-bitmap different-order instances must hash differently — they did not. The shortcut belongs in `gatherBitmapIdsInternal()` (cache-invalidation heuristic, already in place), not in equality/deduplication logic. `AndFormula` and `OrFormula` correctly limit the shortcut to `gatherBitmapIdsInternal()`; this change brings `JoinFormula` in line.

See issue #1134 for full analysis.

Ref: #1134