### PR TITLE
fix: enforce WAL-first discipline — stop unbacked engine-state version bumps (Part B)

### DIFF
--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/engine/DefaultEnginePersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/engine/DefaultEnginePersistenceService.java
@@ -213,17 +213,19 @@ public class DefaultEnginePersistenceService implements EnginePersistenceService
 					this.engineState.walReference(),
 					this.storageSettings
 				);
-				// Update engine state with new storage protocol version and corrected WAL reference
+				// Update engine state with new storage protocol version and corrected WAL reference.
+				// Storage protocol version is orthogonal to the logical version counter — a migration
+				// is not a WAL-backed mutation, so the version counter must not advance here (#1137).
 				final EngineState<LogFileRecordReference> newEngineState = new EngineState<>(
 					STORAGE_PROTOCOL_VERSION,
-					this.engineState.version() + 1,
+					this.engineState.version(),
 					this.engineState.introducedAt(),
 					correctedWalRef != null ? correctedWalRef : this.engineState.walReference(),
 					this.engineState.activeCatalogs(),
 					this.engineState.inactiveCatalogs(),
 					this.engineState.readOnlyCatalogs()
 				);
-				storeEngineState(newEngineState);
+				rewriteEngineStateInPlace(newEngineState);
 			}
 			this.engineState = syncEngineStateByFolderContents(this.storageSettings, this.engineState);
 		} else {
@@ -292,7 +294,9 @@ public class DefaultEnginePersistenceService implements EnginePersistenceService
 	@Override
 	public void storeEngineState(@Nonnull EngineState<LogFileRecordReference> engineState) {
 		this.created = false;
-		// Validate that the version is incremented by exactly one
+		// Validate that the version is incremented by exactly one — this is the
+		// public entry point for WAL-backed state transitions, so the new version
+		// must correspond to exactly one appended mutation.
 		Assert.isPremiseValid(
 			(this.engineState == null && engineState.version() == 1) ||
 				(this.engineState != null && this.engineState.version() + 1 == engineState.version()),
@@ -301,7 +305,38 @@ public class DefaultEnginePersistenceService implements EnginePersistenceService
 				"Engine state version must be incremented by one when storing new engine state! " +
 					"Current version: " + this.engineState.version() + ", new version: " + engineState.version()
 		);
+		writeBootstrapFile(engineState);
+	}
 
+	/**
+	 * Rewrites the bootstrap file in place without advancing the engine version counter.
+	 *
+	 * This is used for non-mutation reconciliation paths where only storage-layer
+	 * metadata changes (e.g. storage protocol upgrade, catalog list reconciliation
+	 * against on-disk contents). Such changes are **not** backed by WAL entries,
+	 * so bumping the version counter here would drift the engine state version
+	 * ahead of the WAL and permanently wedge the engine — the production bug
+	 * addressed by issue #1137.
+	 *
+	 * @param engineState the reconciled engine state to persist; must have the
+	 *                    same version as the current in-memory state
+	 */
+	private void rewriteEngineStateInPlace(@Nonnull EngineState<LogFileRecordReference> engineState) {
+		Assert.isPremiseValid(
+			this.engineState != null && this.engineState.version() == engineState.version(),
+			() -> "In-place engine state rewrite must preserve the version counter! " +
+				"Current version: " + (this.engineState == null ? "<none>" : this.engineState.version()) +
+				", new version: " + engineState.version()
+		);
+		writeBootstrapFile(engineState);
+	}
+
+	/**
+	 * Serializes the given engine state into the bootstrap file via a tmp-rename
+	 * swap and updates the in-memory reference. The caller is responsible for
+	 * enforcing the version-counter invariant appropriate for the call site.
+	 */
+	private void writeBootstrapFile(@Nonnull EngineState<LogFileRecordReference> engineState) {
 		// Initialize handle for writing engine state data to file
 		final Path tmpFile = this.bootstrapFilePath.getParent().resolve(
 			this.bootstrapFilePath.getName(this.bootstrapFilePath.getNameCount() - 1) + ".tmp");
@@ -346,7 +381,6 @@ public class DefaultEnginePersistenceService implements EnginePersistenceService
 
 		// Update the current engine state
 		this.engineState = engineState;
-
 	}
 
 	@Nonnull
@@ -622,15 +656,17 @@ public class DefaultEnginePersistenceService implements EnginePersistenceService
 			return engineState;
 		}
 
-		// Create new engine state with updated catalogs
+		// Create new engine state with updated catalogs — folder-sync reconciliation
+		// reflects on-disk reality, but is not a WAL-backed mutation, so the version
+		// counter must not advance here (#1137). Part C will replace this in-place
+		// rewrite with proper MarkCatalogMissingMutation / auto-discovery mutations.
 		final EngineState<LogFileRecordReference> newEngineState = EngineState.builder(engineState)
-			.version(this.engineState.version() + 1)
 			.activeCatalogs(newActive.toArray(ArrayUtils.EMPTY_STRING_ARRAY))
 			.inactiveCatalogs(newInactive.toArray(ArrayUtils.EMPTY_STRING_ARRAY))
 			.build();
 
-		// Store the newly created engine state
-		storeEngineState(newEngineState);
+		// Rewrite bootstrap in place without bumping the engine version
+		rewriteEngineStateInPlace(newEngineState);
 
 		return newEngineState;
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/engine/DefaultEnginePersistenceServiceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/engine/DefaultEnginePersistenceServiceTest.java
@@ -35,6 +35,7 @@ import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.spi.store.engine.model.EngineState;
 import io.evitadb.store.model.reference.LogFileRecordReference;
 import io.evitadb.test.EvitaTestSupport;
+import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -216,9 +217,11 @@ class DefaultEnginePersistenceServiceTest implements EvitaTestSupport {
 			this.scheduler
 		);
 
-		// Verify the engine state is still persisted after restart
+		// Verify the engine state is still persisted after restart.
+		// Folder-sync reconciliation strips the active catalogs (none exist on disk)
+		// but must NOT advance the engine version — reconciliation is not a WAL mutation (#1137).
 		EngineState restartedState = this.service.getEngineState();
-		assertEquals(3L, restartedState.version());
+		assertEquals(2L, restartedState.version());
 		assertEquals(0, restartedState.activeCatalogs().length);
 		assertEquals(0, restartedState.inactiveCatalogs().length);
 	}
@@ -380,5 +383,77 @@ class DefaultEnginePersistenceServiceTest implements EvitaTestSupport {
 		// Verify bootstrap file was created
 		Path bootstrapFile = getPathInTargetDirectory(this.getClass().getSimpleName()).resolve("evitaDB.boot");
 		assertTrue(Files.exists(bootstrapFile));
+	}
+
+	@Test
+	@DisplayName("should not bump engine version during folder-sync reconciliation")
+	void shouldNotBumpEngineVersionDuringFolderSyncReconciliation() {
+		// Persist a state that claims catalogs on disk that do not actually exist —
+		// this forces syncEngineStateByFolderContents to reconcile the active list.
+		final EngineState<LogFileRecordReference> stateClaimingMissingCatalogs = new EngineState<>(
+			STORAGE_PROTOCOL_VERSION,
+			2L,
+			OffsetDateTime.now(),
+			null,
+			new String[]{"ghost-a", "ghost-b"},
+			ArrayUtils.EMPTY_STRING_ARRAY,
+			ArrayUtils.EMPTY_STRING_ARRAY
+		);
+		this.service.storeEngineState(stateClaimingMissingCatalogs);
+		this.service.close();
+
+		// Reboot — with no directories on disk, sync will strip the ghost catalogs
+		// from the active list. Reconciliation must NOT advance the engine version,
+		// because version advancement requires a corresponding WAL mutation.
+		this.service = new DefaultEnginePersistenceService(
+			this.storageOptions,
+			this.transactionOptions,
+			this.scheduler
+		);
+
+		final EngineState<LogFileRecordReference> reloaded = this.service.getEngineState();
+		assertEquals(
+			2L, reloaded.version(),
+			"Folder sync reconciliation must not bump engine version (would drift WAL ↔ state)."
+		);
+		assertEquals(0, reloaded.activeCatalogs().length);
+		assertEquals(0, reloaded.inactiveCatalogs().length);
+	}
+
+	@Test
+	@DisplayName("should not bump engine version during storage-protocol migration")
+	void shouldNotBumpEngineVersionDuringStorageProtocolMigration() {
+		// Persist a state that reports an older storage protocol version — this
+		// forces the migration branch to run on next boot.
+		final EngineState<LogFileRecordReference> oldProtocolState = new EngineState<>(
+			STORAGE_PROTOCOL_VERSION - 1,
+			2L,
+			OffsetDateTime.now(),
+			null,
+			ArrayUtils.EMPTY_STRING_ARRAY,
+			ArrayUtils.EMPTY_STRING_ARRAY,
+			ArrayUtils.EMPTY_STRING_ARRAY
+		);
+		this.service.storeEngineState(oldProtocolState);
+		this.service.close();
+
+		// Reboot — migration path should rewrite the bootstrap with the current
+		// protocol version but MUST NOT advance the engine version counter
+		// (protocol migration is storage-layer metadata, not a logical mutation).
+		this.service = new DefaultEnginePersistenceService(
+			this.storageOptions,
+			this.transactionOptions,
+			this.scheduler
+		);
+
+		final EngineState<LogFileRecordReference> reloaded = this.service.getEngineState();
+		assertEquals(
+			STORAGE_PROTOCOL_VERSION, reloaded.storageProtocolVersion(),
+			"Storage protocol version must be upgraded on boot."
+		);
+		assertEquals(
+			2L, reloaded.version(),
+			"Storage protocol migration must not bump engine version (would drift WAL ↔ state)."
+		);
 	}
 }


### PR DESCRIPTION
## Summary

Part B of #1137 (hotfix). Closes the production bug where the engine-state
version counter could advance without a corresponding WAL entry, wedging
the engine at startup with "WAL behind state" errors.

Two constructor paths in `DefaultEnginePersistenceService` were bumping the
version without appending WAL:

- **Storage-protocol migration** (~line 219): `Migration_2026_1` upgrade
  rewrote the bootstrap with `version + 1`. Storage protocol version is
  orthogonal to the logical version counter — migrations are not WAL-backed
  mutations, so the counter must not advance.
- **Folder-sync reconciliation** (~line 627): `syncEngineStateByFolderContents`
  rewrote the bootstrap with `version + 1` when on-disk catalogs diverged
  from the active/inactive lists. Reconciliation reflects on-disk reality;
  it is not a mutation.

Both firing simultaneously produced the observed +2 drift in production.

## Implementation

- Extracted the bootstrap serialization into `writeBootstrapFile(EngineState)`.
- Added `rewriteEngineStateInPlace(EngineState)` with a defensive assertion
  that the new version equals the current version — non-mutation call sites
  cannot accidentally advance the counter.
- Public `storeEngineState(EngineState)` keeps its strict `version + 1`
  invariant unchanged; it now delegates the actual write to
  `writeBootstrapFile`.
- Both offending call sites now use `rewriteEngineStateInPlace`.

Parts A, C, D, E (new `CatalogState` values, `MarkCatalogMissingMutation`,
`UpgradeCatalogFormatMutation`, startup invariant check + forward replay,
and internal persistence lock) are out of scope for this PR and will land
in a follow-up that closes #1137.

## Test plan

- [x] New test `shouldNotBumpEngineVersionDuringFolderSyncReconciliation`
- [x] New test `shouldNotBumpEngineVersionDuringStorageProtocolMigration`
- [x] Updated pre-existing `shouldStoreEngineState` assertion that was
      asserting the buggy `v3` outcome (now `v2`, the correct value).
- [x] Full `DefaultEnginePersistenceServiceTest` (17 tests) passes locally.
- [x] `EvitaBasicFunctionalTest` + `EvitaTransactionalFunctionalTest`
      (33 tests) pass locally.

Ref: #1137