### PR TITLE
perf: reuse main filter formula tree for hierarchy statistics

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanner.java
@@ -24,6 +24,7 @@
 package io.evitadb.core.query;
 
 import io.evitadb.api.query.FilterConstraint;
+import io.evitadb.api.query.filter.FilterBy;
 import io.evitadb.api.query.require.DebugMode;
 import io.evitadb.api.requestResponse.EvitaRequest;
 import io.evitadb.api.requestResponse.EvitaRequest.ConditionalGap;
@@ -38,8 +39,12 @@ import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.base.NotFormula;
 import io.evitadb.core.query.algebra.debug.CacheableVariantsGeneratingVisitor;
+import io.evitadb.core.query.algebra.deferred.DeferredFormula;
+import io.evitadb.core.query.algebra.deferred.FormulaWrapper;
 import io.evitadb.core.query.algebra.prefetch.PrefetchFormulaVisitor;
+import io.evitadb.core.query.algebra.prefetch.PrefetchOrder;
 import io.evitadb.core.query.algebra.utils.FormulaFactory;
+import io.evitadb.core.query.algebra.utils.visitor.FormulaCloner;
 import io.evitadb.core.query.extraResult.ExtraResultPlanningVisitor;
 import io.evitadb.core.query.extraResult.ExtraResultProducer;
 import io.evitadb.core.query.filter.FilterByVisitor;
@@ -231,10 +236,23 @@ public class QueryPlanner {
 	 * placement/relation.
 	 */
 	private static IndexSelectionResult<?> selectIndexes(@Nonnull QueryPlanningContext queryContext) {
+		return selectIndexes(queryContext, queryContext.getFilterBy());
+	}
+
+	/**
+	 * Variant of {@link #selectIndexes(QueryPlanningContext)} that runs index selection against a caller-supplied
+	 * `FilterBy` instead of the outer query's. Used by {@link #planNestedFilteringFormula} when planning a rewritten
+	 * filter for hierarchy statistics.
+	 */
+	@Nonnull
+	private static IndexSelectionResult<?> selectIndexes(
+		@Nonnull QueryPlanningContext queryContext,
+		@Nullable FilterBy filterBy
+	) {
 		queryContext.pushStep(QueryPhase.PLANNING_INDEX_USAGE);
 		try {
 			final IndexSelectionVisitor indexSelectionVisitor = new IndexSelectionVisitor(queryContext);
-			ofNullable(queryContext.getFilterBy()).ifPresent(indexSelectionVisitor::visit);
+			ofNullable(filterBy).ifPresent(indexSelectionVisitor::visit);
 			//noinspection rawtypes,unchecked
 			return new IndexSelectionResult<>((List) indexSelectionVisitor.getTargetIndexes());
 		} finally {
@@ -253,6 +271,20 @@ public class QueryPlanner {
 		@Nonnull QueryPlanningContext queryContext,
 		@Nonnull List<TargetIndexes<T>> targetIndexes
 	) {
+		return createFilterFormula(queryContext, targetIndexes, queryContext.getFilterBy());
+	}
+
+	/**
+	 * Variant of {@link #createFilterFormula(QueryPlanningContext, List)} that plans a caller-supplied `FilterBy`
+	 * (typically the outer query's filter rewritten for an extra-result computation) instead of
+	 * {@link QueryPlanningContext#getFilterBy()}. Used by {@link #planNestedFilteringFormula}.
+	 */
+	@Nonnull
+	private static <T extends Index<?>> List<QueryPlanBuilder> createFilterFormula(
+		@Nonnull QueryPlanningContext queryContext,
+		@Nonnull List<TargetIndexes<T>> targetIndexes,
+		@Nullable FilterBy filterBy
+	) {
 		final LinkedList<QueryPlanBuilder> result = new LinkedList<>();
 		queryContext.pushStep(QueryPhase.PLANNING_FILTER);
 		try {
@@ -266,7 +298,7 @@ public class QueryPlanner {
 						);
 
 						final PrefetchFormulaVisitor prefetchFormulaVisitor = new PrefetchFormulaVisitor(queryContext, targetIndex);
-						ofNullable(queryContext.getFilterBy()).ifPresent(filterByVisitor::visit);
+						ofNullable(filterBy).ifPresent(filterByVisitor::visit);
 						adeptFormula = queryContext.analyse(
 							filterByVisitor.getFormula(
 								new FormulaOptimizer(),
@@ -302,6 +334,83 @@ public class QueryPlanner {
 			} else {
 				queryContext.popStep("Selected index: " + result.get(0).getDescriptionWithCosts());
 			}
+		}
+	}
+
+	/**
+	 * Plans a caller-supplied `FilterBy` against the same engine that plans the outer query, picks the cheapest
+	 * candidate by estimated cost, and returns the chosen formula wrapped in {@link DeferredFormula} carrying the
+	 * `EXECUTION_FILTER_NESTED_QUERY` telemetry step.
+	 *
+	 * Used by {@link ExtraResultPlanningVisitor#getFilteringFormulaForStatisticsBase} when the
+	 * {@link FormulaCloner}-based shortcut over the already-planned filter is unsafe and the rewritten `FilterBy`
+	 * must be re-translated. Mirrors the outer-query pipeline (`IndexSelectionVisitor` + per-candidate
+	 * `FilterByVisitor` with `FormulaOptimizer` + `PrefetchFormulaVisitor`) — same primitives, same cost estimation,
+	 * so prefetch remains a viable planning alternative when the rewritten filter narrows down to a small set of
+	 * entities even if the outer filter alone wouldn't have justified it.
+	 *
+	 * The cheapest candidate's `PrefetchFormulaVisitor` populates a per-candidate {@link PrefetchOrder}, but only
+	 * the OUTER query plan can fire prefetch (it's a one-shot pre-execution step). The chosen formula is therefore
+	 * fed to `outerPrefetchFormulaVisitor` (when supplied) so the outer plan can fold the nested filter's prefetch
+	 * demand into its single prefetch decision. The nested plan goes through a fresh {@link FilterByVisitor} pass,
+	 * so any `SelectionFormula` instances it produces are new and contribute their full demand to the outer
+	 * prefetcher without double-counting.
+	 *
+	 * Returns {@link EmptyFormula#INSTANCE} when `IndexSelectionVisitor` finds no eligible candidate (vanishingly
+	 * rare — the GLOBAL fallback is always offered when the schema has a global index).
+	 *
+	 * @param queryContext                planning context inherited from the outer query
+	 * @param filterBy                    rewritten `FilterBy` to plan
+	 * @param outerPrefetchFormulaVisitor the outer query's `PrefetchFormulaVisitor` to fold nested prefetch
+	 *                                    demand into; {@code null} skips the merge
+	 * @param stepDescriptionSupplier     description used in `PLANNING_FILTER_NESTED_QUERY` /
+	 *                                    `EXECUTION_FILTER_NESTED_QUERY` telemetry
+	 * @return the cheapest planned formula wrapped with execution telemetry
+	 */
+	@Nonnull
+	public static Formula planNestedFilteringFormula(
+		@Nonnull QueryPlanningContext queryContext,
+		@Nonnull FilterBy filterBy,
+		@Nullable PrefetchFormulaVisitor outerPrefetchFormulaVisitor,
+		@Nonnull Supplier<String> stepDescriptionSupplier
+	) {
+		queryContext.pushStep(QueryPhase.PLANNING_FILTER_NESTED_QUERY, stepDescriptionSupplier);
+		try {
+			final IndexSelectionResult<?> indexSelectionResult = selectIndexes(queryContext, filterBy);
+			if (indexSelectionResult.isEmpty()) {
+				return EmptyFormula.INSTANCE;
+			}
+			//noinspection rawtypes,unchecked
+			final List<QueryPlanBuilder> builders = createFilterFormula(
+				queryContext, (List) indexSelectionResult.targetIndexes(), filterBy
+			);
+			if (builders.isEmpty()) {
+				return EmptyFormula.INSTANCE;
+			}
+			final Formula nestedFormula = builders.get(0).getFilterFormula();
+
+			// fold the nested filter's prefetch demand into the outer plan so prefetch can fire when the rewrite
+			// narrows down to a small set of entities even if the outer filter alone wouldn't have triggered it
+			if (outerPrefetchFormulaVisitor != null) {
+				nestedFormula.accept(outerPrefetchFormulaVisitor);
+			}
+
+			// preserve telemetry continuity with the legacy nested-planning path
+			return new DeferredFormula(
+				new FormulaWrapper(
+					nestedFormula,
+					(executionContext, formula) -> {
+						try {
+							executionContext.pushStep(QueryPhase.EXECUTION_FILTER_NESTED_QUERY, stepDescriptionSupplier);
+							return formula.compute();
+						} finally {
+							executionContext.popStep();
+						}
+					}
+				)
+			);
+		} finally {
+			queryContext.popStep();
 		}
 	}
 
@@ -465,7 +574,8 @@ public class QueryPlanner {
 							builder.getTargetIndexes(),
 							builder.getFilterFormula(),
 							builder.getFilterByVisitor(),
-							builder.getSorters()
+							builder.getSorters(),
+							builder.getPrefetchFormulaVisitor()
 						);
 						extraResultPlanner.visit(queryContext.getRequire());
 						builder.setExtraResultProducers(extraResultPlanner.getExtraResultProducers());

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/Formula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/Formula.java
@@ -24,6 +24,7 @@
 package io.evitadb.core.query.algebra;
 
 import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.utils.visitor.FormulaCloner;
 import io.evitadb.core.query.filter.FormulaOptimizer;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
 import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
@@ -71,9 +72,24 @@ public interface Formula extends TransactionalDataRelatedStructure, PrettyPrinta
 	Bitmap compute();
 
 	/**
-	 * Returns copy of this formula with replaced inner formulas. When {@link EmptyFormula#INSTANCE} is returned,
-	 * entire formula is removed in {@link FormulaOptimizer}. In other situations, the returned formula is retained
-	 * and in conjunction case it eliminates the results up in the formula tree.
+	 * Returns a copy of this formula with replaced inner formulas. The return value also encodes a behaviour
+	 * contract used by both {@link FormulaOptimizer} and {@link FormulaCloner} when the wrapper has been emptied
+	 * by removal of its children:
+	 *
+	 * - **Returning {@link EmptyFormula#INSTANCE}** declares this wrapper as the **identity element** of its
+	 *   parent. `FormulaOptimizer` removes the entire wrapper from the tree; `FormulaCloner` (used during
+	 *   strip-clone passes such as the hierarchy-statistics shortcut) drops the wrapper from its parent's
+	 *   child list rather than letting the empty result propagate upward as the absorbing element through the
+	 *   surrounding `AND`/`OR` chain. This is the right answer for wrappers that have no meaningful semantics
+	 *   without children — `AndFormula`, `OrFormula`, `UserFilterFormula`, `ScopeContainerFormula`, etc.
+	 * - **Returning anything other than {@link EmptyFormula#INSTANCE}** keeps the wrapper as the **absorbing
+	 *   element** when emptied — its emptiness propagates up the conjunction normally and reduces the parent
+	 *   to empty too. This is the right answer for wrappers whose presence carries semantics independently of
+	 *   their children (e.g. `FacetGroupOrFormula` / `FacetGroupAndFormula` carriers that the FACET_IMPACT
+	 *   relaxer must still find by type).
+	 *
+	 * Wrapper implementations must therefore choose deliberately: returning `EmptyFormula.INSTANCE` on empty
+	 * input is an explicit opt-in to drop-on-strip semantics, not a defensive no-op.
 	 *
 	 * @param innerFormulas the new inner formulas to use in the cloned formula
 	 * @return a new formula instance of the same type with the given inner formulas

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/Formula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/Formula.java
@@ -23,6 +23,8 @@
 
 package io.evitadb.core.query.algebra;
 
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.filter.FormulaOptimizer;
 import io.evitadb.core.query.filter.translator.FilteringConstraintTranslator;
 import io.evitadb.core.query.response.TransactionalDataRelatedStructure;
 import io.evitadb.index.bitmap.Bitmap;
@@ -69,7 +71,9 @@ public interface Formula extends TransactionalDataRelatedStructure, PrettyPrinta
 	Bitmap compute();
 
 	/**
-	 * Returns copy of this formula with replaced inner formulas.
+	 * Returns copy of this formula with replaced inner formulas. When {@link EmptyFormula#INSTANCE} is returned,
+	 * entire formula is removed in {@link FormulaOptimizer}. In other situations, the returned formula is retained
+	 * and in conjunction case it eliminates the results up in the formula tree.
 	 *
 	 * @param innerFormulas the new inner formulas to use in the cloned formula
 	 * @return a new formula instance of the same type with the given inner formulas

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetHavingFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetHavingFormula.java
@@ -26,11 +26,13 @@ package io.evitadb.core.query.algebra.facet;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.ChildrenDependentFormula;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.NonCacheableFormula;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.utils.Assert;
 import net.openhft.hashing.LongHashFunction;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Pass-through wrapper emitted by `FacetHavingTranslator` around the composite formula it builds for a
@@ -48,7 +50,7 @@ import javax.annotation.Nonnull;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
-public class FacetHavingFormula extends AbstractFormula implements ChildrenDependentFormula {
+public class FacetHavingFormula extends AbstractFormula implements ChildrenDependentFormula, NonCacheableFormula {
 	/**
 	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
 	 */
@@ -57,21 +59,40 @@ public class FacetHavingFormula extends AbstractFormula implements ChildrenDepen
 	 * Error message thrown when the formula is constructed with anything other than a single inner formula.
 	 */
 	private static final String ERROR_SINGLE_FORMULA_EXPECTED = "Exactly one inner formula is expected!";
+	/**
+	 * Name of the reference that this `facetHaving` constraint targets (e.g. `"brands"`). Used by downstream
+	 * planners — most notably hierarchy-statistics — to identify and strip user-filter facet selections that
+	 * target the same reference for which statistics are being computed, preserving the
+	 * `COMPLETE_FILTER_EXCLUDING_SELF_IN_USER_FILTER` semantics.
+	 */
+	@Nullable private final String referenceName;
 
 	/**
-	 * Creates a new {@link FacetHavingFormula} wrapping the given composite facet formula.
+	 * Creates a new {@link FacetHavingFormula} wrapping the given composite facet formula and remembering which
+	 * reference name (`facetHaving(referenceName, …)`) it represents.
 	 *
-	 * @param innerFormula the single child formula to delegate to
+	 * @param referenceName name of the reference this wrapper targets, or {@code null} when unknown
+	 * @param innerFormula  the single child formula to delegate to
 	 */
-	public FacetHavingFormula(@Nonnull Formula innerFormula) {
+	public FacetHavingFormula(@Nullable String referenceName, @Nonnull Formula innerFormula) {
+		this.referenceName = referenceName;
 		this.initFields(innerFormula);
+	}
+
+	/**
+	 * Returns the name of the reference this `facetHaving` wrapper targets, or {@code null} when the reference
+	 * name is unknown.
+	 */
+	@Nullable
+	public String getReferenceName() {
+		return this.referenceName;
 	}
 
 	@Nonnull
 	@Override
 	public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {
 		Assert.isTrue(innerFormulas.length == 1, ERROR_SINGLE_FORMULA_EXPECTED);
-		return new FacetHavingFormula(innerFormulas[0]);
+		return new FacetHavingFormula(this.referenceName, innerFormulas[0]);
 	}
 
 	@Override
@@ -91,7 +112,9 @@ public class FacetHavingFormula extends AbstractFormula implements ChildrenDepen
 
 	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
-		return CLASS_ID;
+		return this.referenceName == null
+			? CLASS_ID
+			: CLASS_ID + hashFunction.hashChars(this.referenceName) * 31;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetHavingFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/FacetHavingFormula.java
@@ -32,7 +32,6 @@ import io.evitadb.utils.Assert;
 import net.openhft.hashing.LongHashFunction;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Pass-through wrapper emitted by `FacetHavingTranslator` around the composite formula it builds for a
@@ -60,30 +59,32 @@ public class FacetHavingFormula extends AbstractFormula implements ChildrenDepen
 	 */
 	private static final String ERROR_SINGLE_FORMULA_EXPECTED = "Exactly one inner formula is expected!";
 	/**
-	 * Name of the reference that this `facetHaving` constraint targets (e.g. `"brands"`). Used by downstream
-	 * planners — most notably hierarchy-statistics — to identify and strip user-filter facet selections that
-	 * target the same reference for which statistics are being computed, preserving the
-	 * `COMPLETE_FILTER_EXCLUDING_SELF_IN_USER_FILTER` semantics.
+	 * Name of the reference that this `facetHaving` constraint targets (e.g. `"brands"`). Mirrors
+	 * {@link io.evitadb.api.query.filter.FacetHaving#getReferenceName()}, which is `@Nonnull` and validated
+	 * non-empty by the `@Classifier` contract — facets never apply to the queried entity itself, so this field
+	 * is always populated. Used by downstream planners — most notably hierarchy-statistics — to identify and
+	 * strip user-filter facet selections that target the same reference for which statistics are being computed,
+	 * preserving the `COMPLETE_FILTER_EXCLUDING_SELF_IN_USER_FILTER` semantics.
 	 */
-	@Nullable private final String referenceName;
+	@Nonnull private final String referenceName;
 
 	/**
 	 * Creates a new {@link FacetHavingFormula} wrapping the given composite facet formula and remembering which
 	 * reference name (`facetHaving(referenceName, …)`) it represents.
 	 *
-	 * @param referenceName name of the reference this wrapper targets, or {@code null} when unknown
+	 * @param referenceName name of the reference this wrapper targets; never {@code null} or empty (matches
+	 *                      {@link io.evitadb.api.query.filter.FacetHaving#getReferenceName()})
 	 * @param innerFormula  the single child formula to delegate to
 	 */
-	public FacetHavingFormula(@Nullable String referenceName, @Nonnull Formula innerFormula) {
+	public FacetHavingFormula(@Nonnull String referenceName, @Nonnull Formula innerFormula) {
 		this.referenceName = referenceName;
 		this.initFields(innerFormula);
 	}
 
 	/**
-	 * Returns the name of the reference this `facetHaving` wrapper targets, or {@code null} when the reference
-	 * name is unknown.
+	 * Returns the name of the reference this `facetHaving` wrapper targets — never {@code null} or empty.
 	 */
-	@Nullable
+	@Nonnull
 	public String getReferenceName() {
 		return this.referenceName;
 	}
@@ -112,9 +113,7 @@ public class FacetHavingFormula extends AbstractFormula implements ChildrenDepen
 
 	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
-		return this.referenceName == null
-			? CLASS_ID
-			: CLASS_ID + hashFunction.hashChars(this.referenceName) * 31;
+		return CLASS_ID + hashFunction.hashChars(this.referenceName) * 31;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/UserFilterFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/facet/UserFilterFormula.java
@@ -34,6 +34,7 @@ import io.evitadb.index.bitmap.Bitmap;
 import net.openhft.hashing.LongHashFunction;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -54,7 +55,7 @@ public class UserFilterFormula extends AbstractFormula implements NonCacheableFo
 	 * Lazily initialized list of inner formulas sorted by their estimated cost in ascending order, used to
 	 * short-circuit AND evaluation starting from the cheapest formula.
 	 */
-	private List<Formula> sortedFormulasByComplexity;
+	@Nullable private List<Formula> sortedFormulasByComplexity;
 
 	public UserFilterFormula(@Nonnull Formula... innerFormulas) {
 		this.initFields(innerFormulas);

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/hierarchy/HierarchyFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/hierarchy/HierarchyFormula.java
@@ -26,6 +26,7 @@ package io.evitadb.core.query.algebra.hierarchy;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.ChildrenDependentFormula;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.NonCacheableFormula;
 import io.evitadb.core.query.algebra.attribute.AttributeFormula;
 import io.evitadb.core.query.algebra.price.termination.PriceTerminationFormula;
 import io.evitadb.core.query.filter.translator.hierarchy.HierarchyWithinRootTranslator;
@@ -37,15 +38,27 @@ import io.evitadb.utils.Assert;
 import net.openhft.hashing.LongHashFunction;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Simple formula container that allows excluding in {@link HierarchyWithinTranslator}
  * or {@link HierarchyWithinRootTranslator} when there are {@link AttributeFormula} targeting non-global index or
  * {@link PriceTerminationFormula}.
  *
+ * The optional {@link #referenceName} carries the name of the reference whose hierarchy this formula represents
+ * (or {@code null} when the formula represents a self-hierarchy `hierarchyWithin`/`hierarchyWithinRoot` constraint).
+ * It enables downstream consumers — most notably the hierarchy-statistics planner — to selectively strip a single
+ * hierarchy branch from a cloned filter formula tree without having to re-translate the original query constraints.
+ *
+ * Implements {@link NonCacheableFormula} so that any cacheable parent (e.g. an enclosing `AND`/`OR`) is forbidden
+ * from being flattened into a {@link io.evitadb.core.cache.payload.FlattenedFormula}. Flattening would erase the
+ * `HierarchyFormula` wrapper from the formula tree, which would break the hierarchy-statistics planner's filter
+ * cloning — it relies on locating `HierarchyFormula` instances by type to selectively strip them per
+ * {@link io.evitadb.api.query.require.StatisticsBase} mode.
+ *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2023
  */
-public class HierarchyFormula extends AbstractFormula implements ChildrenDependentFormula {
+public class HierarchyFormula extends AbstractFormula implements ChildrenDependentFormula, NonCacheableFormula {
 	/**
 	 * Unique identifier of this formula used in {@link AbstractFormula#getClassId()} for hash computation.
 	 */
@@ -54,17 +67,42 @@ public class HierarchyFormula extends AbstractFormula implements ChildrenDepende
 	 * Error message thrown when the formula does not contain exactly one inner formula.
 	 */
 	public static final String ERROR_SINGLE_FORMULA_EXPECTED = "Exactly one inner formula is expected!";
+	/**
+	 * Name of the reference whose hierarchy this formula represents, or {@code null} when the formula represents
+	 * the queried entity's own hierarchy (a non-referenced `hierarchyWithin`/`hierarchyWithinRoot` constraint).
+	 */
+	@Nullable private final String referenceName;
 
-	public HierarchyFormula(@Nonnull Formula innerFormula) {
+	/**
+	 * Creates a new {@link HierarchyFormula} wrapping the given inner hierarchy-resolution formula and remembering
+	 * which reference name (`hierarchyWithin(referenceName, …)` / `hierarchyWithinRoot(referenceName, …)`) it
+	 * represents.
+	 *
+	 * @param referenceName name of the reference whose hierarchy this formula represents, or {@code null} when the
+	 *                      formula represents the queried entity's own hierarchy (a non-referenced
+	 *                      `hierarchyWithin`/`hierarchyWithinRoot` constraint)
+	 * @param innerFormula  the single child formula resolving the hierarchy node set
+	 */
+	public HierarchyFormula(@Nullable String referenceName, @Nonnull Formula innerFormula) {
+		this.referenceName = referenceName;
 		this.innerFormulas = new Formula[]{ innerFormula };
 		this.initFields(innerFormula);
+	}
+
+	/**
+	 * Returns the name of the reference whose hierarchy is represented by this formula, or {@code null} when the
+	 * formula represents the queried entity's own hierarchy.
+	 */
+	@Nullable
+	public String getReferenceName() {
+		return this.referenceName;
 	}
 
 	@Nonnull
 	@Override
 	public Formula getCloneWithInnerFormulas(@Nonnull Formula... innerFormulas) {
 		Assert.isTrue(innerFormulas.length == 1, ERROR_SINGLE_FORMULA_EXPECTED);
-		return new HierarchyFormula(innerFormulas[0]);
+		return new HierarchyFormula(this.referenceName, innerFormulas[0]);
 	}
 
 	@Override
@@ -91,7 +129,7 @@ public class HierarchyFormula extends AbstractFormula implements ChildrenDepende
 
 	@Override
 	protected long includeAdditionalHash(@Nonnull LongHashFunction hashFunction) {
-		return 0L;
+		return this.referenceName == null ? 0L : hashFunction.hashChars(this.referenceName);
 	}
 
 	@Override
@@ -101,12 +139,16 @@ public class HierarchyFormula extends AbstractFormula implements ChildrenDepende
 
 	@Override
 	public String toString() {
-		return "HIERARCHY: " + this.innerFormulas[0].toString();
+		return this.referenceName == null
+			? "HIERARCHY: " + this.innerFormulas[0].toString()
+			: "HIERARCHY (" + this.referenceName + "): " + this.innerFormulas[0].toString();
 	}
 
 	@Nonnull
 	@Override
 	public String toStringVerbose() {
-		return "HIERARCHY: " + this.innerFormulas[0].toStringVerbose();
+		return this.referenceName == null
+			? "HIERARCHY: " + this.innerFormulas[0].toStringVerbose()
+			: "HIERARCHY (" + this.referenceName + "): " + this.innerFormulas[0].toStringVerbose();
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
@@ -25,6 +25,7 @@ package io.evitadb.core.query.algebra.utils.visitor;
 
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.FormulaVisitor;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.base.NotFormula;
 import lombok.Getter;
 
@@ -165,21 +166,38 @@ public class FormulaCloner implements FormulaVisitor {
 				if (childrenHaveNotChanged) {
 					// use entire formula tree block
 					formulaToStore = formula;
-				} else if (formula instanceof NotFormula notFormula && updatedChildren.size() == 1) {
-					// Determine which child survived
-					final Formula processedSuperset = this.formulasProcessed.get(notFormula.getSupersetFormula());
-					if (processedSuperset != null && updatedChildren.contains(processedSuperset)) {
-						// Superset survived, subtracted was removed → S \ nothing = S
-						formulaToStore = processedSuperset;
-					} else {
-						// Subtracted survived, superset was removed → nothing to subtract from → drop
+				} else if (formula instanceof NotFormula notFormula && updatedChildren.size() < 2) {
+					if (updatedChildren.isEmpty()) {
+						// both children stripped — nothing left to subtract from, drop the wrapper
 						formulaToStore = null;
+					} else {
+						// Determine which child survived
+						final Formula processedSuperset = this.formulasProcessed.get(notFormula.getSupersetFormula());
+						if (processedSuperset != null && updatedChildren.contains(processedSuperset)) {
+							// Superset survived, subtracted was removed → S \ nothing = S
+							formulaToStore = processedSuperset;
+						} else {
+							// Subtracted survived, superset was removed → nothing to subtract from → drop
+							formulaToStore = null;
+						}
 					}
 				} else {
 					// recreate parent formula with new children
-					formulaToStore = formula.getCloneWithInnerFormulas(
+					final Formula recreated = formula.getCloneWithInnerFormulas(
 						updatedChildren.toArray(Formula[]::new)
 					);
+					if (updatedChildren.isEmpty() && recreated == EmptyFormula.INSTANCE) {
+						// The wrapper signalled (via the EmptyFormula-on-empty convention shared by
+						// AndFormula/OrFormula/UserFilterFormula/ScopeContainerFormula/etc.) that with no
+						// children it has no meaningful representation. In a strip-clone context this means
+						// "drop me as the identity element of my parent" rather than letting EmptyFormula
+						// propagate up as the absorbing element through the surrounding AND/OR chain.
+						// Wrappers that genuinely want to remain when stripped (e.g. FacetGroupOrFormula,
+						// FacetGroupAndFormula) opt out simply by not returning EmptyFormula on empty input.
+						formulaToStore = null;
+					} else {
+						formulaToStore = recreated;
+					}
 				}
 			} else {
 				formulaToStore = mutatedFormula;

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
@@ -33,21 +33,29 @@ import io.evitadb.api.query.RequireConstraint;
 import io.evitadb.api.query.filter.FacetHaving;
 import io.evitadb.api.query.filter.FilterBy;
 import io.evitadb.api.query.filter.HierarchyFilterConstraint;
-import io.evitadb.api.query.filter.HierarchyWithin;
-import io.evitadb.api.query.filter.HierarchyWithinRoot;
 import io.evitadb.api.query.filter.ReferenceHaving;
 import io.evitadb.api.query.filter.UserFilter;
 import io.evitadb.api.query.require.*;
 import io.evitadb.api.query.visitor.ConstraintCloneVisitor;
 import io.evitadb.api.requestResponse.EvitaRequest;
+import io.evitadb.api.requestResponse.extraResult.Hierarchy;
 import io.evitadb.api.requestResponse.extraResult.Hierarchy.LevelInfo;
+import io.evitadb.api.requestResponse.extraResult.QueryTelemetry.QueryPhase;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.core.collection.EntityCollection;
 import io.evitadb.core.query.AttributeSchemaAccessor;
+import io.evitadb.core.query.QueryPlanner;
 import io.evitadb.core.query.QueryPlanningContext;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.core.query.algebra.deferred.DeferredFormula;
+import io.evitadb.core.query.algebra.deferred.FormulaWrapper;
+import io.evitadb.core.query.algebra.facet.FacetHavingFormula;
 import io.evitadb.core.query.algebra.facet.UserFilterFormula;
+import io.evitadb.core.query.algebra.hierarchy.HierarchyFormula;
+import io.evitadb.core.query.algebra.prefetch.PrefetchFormulaVisitor;
 import io.evitadb.core.query.algebra.utils.visitor.FormulaCloner;
 import io.evitadb.core.query.algebra.utils.visitor.FormulaFinder;
 import io.evitadb.core.query.algebra.utils.visitor.FormulaFinder.LookUp;
@@ -91,9 +99,11 @@ import lombok.experimental.Delegate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -185,6 +195,13 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 	 */
 	@Getter private final Collection<Sorter> sorters;
 	/**
+	 * The outer query plan's {@link PrefetchFormulaVisitor}. Nested filter plans produced by
+	 * {@link #getFilteringFormulaForStatisticsBase} merge their prefetch demand into this visitor so the outer
+	 * query plan can fold them into its single one-shot prefetch decision. May be {@code null} in test contexts
+	 * where prefetch coordination is not exercised.
+	 */
+	@Nullable private final PrefetchFormulaVisitor outerPrefetchFormulaVisitor;
+	/**
 	 * Contains the list of producers that react to passed requirements.
 	 */
 	@Getter private final LinkedHashSet<ExtraResultProducer> extraResultProducers = new LinkedHashSet<>(16);
@@ -211,13 +228,16 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 	 */
 	private Formula filteringFormulaWithoutUserFilter;
 	/**
-	 * Cache of rewritten {@link FilterBy} trees keyed by `(referenceName, statisticsBase)`. Each entry is produced
-	 * on the first call to one of the private `getFilterByWithout*` helpers and reused on subsequent calls.
-	 * Keys are {@link FormulaVariant} records; a `null` reference name means the filter applies to the queried
-	 * entity itself (no reference wrapping), while a non-null name wraps the filter in
-	 * `referenceHaving(entityHaving(...))`.
+	 * Cache of formula trees derived from {@link #filteringFormula} for the three {@link StatisticsBase} modes,
+	 * keyed by `(referenceName, statisticsBase)`. Each entry is the result of a single {@link FormulaCloner} pass
+	 * over {@link #filteringFormula} that strips the hierarchy and (optionally) user-filter parts irrelevant for
+	 * the statistics computation. The map deliberately stores `null` values (via {@link Map#put} with a `null`
+	 * second argument) for variants that resolve to "no filter applies"; callers must use
+	 * {@link Map#containsKey(Object)} to distinguish a cached `null` from a cache miss. Cached non-`null` values
+	 * are wrapped in {@link DeferredFormula} so that telemetry phases stay aligned with the
+	 * {@link QueryPlanner#planNestedFilteringFormula} path used by the fallback.
 	 */
-	private Map<FormulaVariant, FilterBy> formulaVariantCache;
+	private Map<FormulaVariant, Formula> formulaCache;
 	/**
 	 * Contains set (usually of size == 1 or 0) that contains references to the {@link UserFilterFormula} inside
 	 * {@link #filteringFormula}. This is a helper field that allows to reuse result of the formula search multiple
@@ -230,13 +250,15 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 		@Nonnull TargetIndexes<?> indexSetToUse,
 		@Nonnull Formula filteringFormula,
 		@Nonnull FilterByVisitor filterByVisitor,
-		@Nullable Collection<Sorter> sorters
+		@Nullable Collection<Sorter> sorters,
+		@Nullable PrefetchFormulaVisitor outerPrefetchFormulaVisitor
 	) {
 		this.queryContext = queryContext;
 		this.indexSetToUse = indexSetToUse;
 		this.filteringFormula = filteringFormula;
 		this.filterByVisitor = filterByVisitor;
 		this.sorters = sorters;
+		this.outerPrefetchFormulaVisitor = outerPrefetchFormulaVisitor;
 		this.attributeSchemaAccessor = new AttributeSchemaAccessor(queryContext);
 		final LinkedList<Set<Scope>> requestedScopes = new LinkedList<>();
 		requestedScopes.add(queryContext.getScopes());
@@ -337,6 +359,370 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 	}
 
 	/**
+	 * Returns a {@link Formula} derived from {@link #getFilteringFormula()} that represents the filter applicable
+	 * to {@link Hierarchy} statistics for the given `statisticsBase` and `referenceSchema`. The result is produced by
+	 * a single {@link FormulaCloner} pass over the already-planned {@link #filteringFormula} and therefore reuses
+	 * the memoised sub-results of every leaf the cloner does not touch — the dominant performance win over re-planning
+	 * the filter constraint tree per hierarchy node.
+	 *
+	 * The three {@link StatisticsBase} modes apply the following stripping rules (compared against the
+	 * `referenceSchema.getName()`; `null` reference name represents the queried entity's own hierarchy):
+	 *
+	 * - `WITHOUT_USER_FILTER` — drops every {@link UserFilterFormula} sub-tree **and** every
+	 *   {@link HierarchyFormula} whose reference name matches the stats reference (or is `null` when the stats
+	 *   reference is `null`).
+	 * - `COMPLETE_FILTER` — drops only {@link HierarchyFormula} whose reference name matches the stats reference;
+	 *   the user-filter remains intact.
+	 * - `COMPLETE_FILTER_EXCLUDING_SELF_IN_USER_FILTER` — for self-stats (`null` stats reference) drops every
+	 *   self-{@link HierarchyFormula} and every empty-named {@link FacetHavingFormula} regardless of position; for
+	 *   reference-stats drops {@link HierarchyFormula} and {@link FacetHavingFormula} matching the stats reference
+	 *   only when they sit inside a {@link UserFilterFormula}. Other-reference hierarchies and facet selections are
+	 *   always preserved.
+	 *
+	 * The non-`null` result is wrapped in {@link DeferredFormula} carrying the
+	 * {@link QueryPhase#EXECUTION_FILTER_NESTED_QUERY} telemetry step so query reports still attribute the work to
+	 * the nested-query phase even after the planning pass became free.
+	 *
+	 * Returns `null` when the cloner stripped the formula entirely — callers fast-path this as "no filter applies"
+	 * and skip the AND with the per-node primary-key formula.
+	 *
+	 * Subsequent calls with the same `(referenceName, statisticsBase)` pair return the same {@link Formula}
+	 * instance so multiple per-node lambdas share both planning work and downstream memoised compute results.
+	 *
+	 * @param statisticsBase  the statistics base mode; {@code null} is treated as
+	 *                        {@link StatisticsBase#WITHOUT_USER_FILTER}
+	 * @param referenceSchema the reference schema for which statistics are computed, or {@code null} for self-
+	 *                        hierarchy statistics
+	 * @return the cloned, optionally stripped filter formula wrapped for telemetry, or {@code null} when no filter
+	 * needs to be applied
+	 */
+	@Nullable
+	public Formula getFilteringFormulaForStatisticsBase(
+		@Nullable StatisticsBase statisticsBase,
+		@Nullable ReferenceSchemaContract referenceSchema
+	) {
+		final StatisticsBase effectiveBase = statisticsBase == null ? StatisticsBase.WITHOUT_USER_FILTER : statisticsBase;
+		final String referenceName = referenceSchema == null ? null : referenceSchema.getName();
+		final FormulaVariant cacheKey = new FormulaVariant(referenceName, effectiveBase);
+		if (this.formulaCache != null && this.formulaCache.containsKey(cacheKey)) {
+			return this.formulaCache.get(cacheKey);
+		}
+		if (this.formulaCache == null) {
+			this.formulaCache = CollectionUtils.createHashMap(4);
+		}
+		final Formula result = canUseShortcut(referenceSchema)
+			? shortcutFormula(effectiveBase, referenceName)
+			: fallbackFormula(effectiveBase, referenceSchema);
+		this.formulaCache.put(cacheKey, result);
+		return result;
+	}
+
+	/**
+	 * Decides whether the formula-tree shortcut (`FormulaCloner` over the already-planned
+	 * {@link #filteringFormula}) is safe for the given stats reference.
+	 *
+	 * The shortcut reuses leaf bitmaps from whatever target index the primary plan picked, and erases the entire
+	 * {@link HierarchyFormula} matching the stats reference. Two independent prerequisites must hold for it to be
+	 * correct:
+	 *
+	 * 1. **Leaf scope** — every stats node the lambda will ask about must lie inside the PK universe those leaves
+	 *    can express:
+	 *    - Self-hierarchy (`refSchema == null`) — `IndexSelectionVisitor` never offers REDUCED_ENTITY for self, so
+	 *      the primary plan is always rooted in `GlobalEntityIndex`.
+	 *    - Reference-hierarchy with a non-partitioned reference schema — REDUCED_ENTITY of the same reference is
+	 *      tagged with `EligibilityObstacle.NOT_PARTITIONED_INDEX` and is not picked as the primary plan.
+	 *    - Reference-hierarchy whose schema is `FOR_FILTERING_AND_PARTITIONING` for every active scope — the
+	 *      planner may have selected REDUCED_ENTITY of the same reference, breaking this prerequisite.
+	 *
+	 * 2. **No having/excluding filter to preserve** — when the user's `hierarchyWithin` / `hierarchyWithinRoot`
+	 *    carries a `having(...)` or `excluding(...)` clause, those predicates are baked into the
+	 *    {@link HierarchyFormula}'s leaf bitmap together with the subtree positioning. Stripping the wrapper would
+	 *    lose the having/excluding semantics — the fallback path must extract them via
+	 *    {@link #rewriteHierarchyFilter} and re-apply them at constraint level.
+	 *
+	 * Each gate conservatively over-approximates: a false positive (gate says "fallback" when the shortcut would
+	 * have been correct) costs one extra nested planning pass per `(StatisticsBase, refName)`, never a wrong result.
+	 *
+	 * Note: `COMPLETE_FILTER_EXCLUDING_SELF_IN_USER_FILTER` used to require a third gate because stripping every
+	 * child of a {@link UserFilterFormula} would leave the cloner with an empty container that
+	 * `UserFilterFormula.getCloneWithInnerFormulas([])` collapses into {@link EmptyFormula} (the "empty result"
+	 * sentinel). {@link FormulaCloner} now generalises this: any wrapper whose `getCloneWithInnerFormulas([])`
+	 * returns {@link EmptyFormula} is dropped as the identity element of its parent — covering not only
+	 * `UserFilterFormula` but also nested `AndFormula`/`OrFormula`/`ScopeContainerFormula` chains that the
+	 * strip mutators can empty out, so the shortcut handles all three modes safely.
+	 */
+	private boolean canUseShortcut(@Nullable ReferenceSchemaContract referenceSchema) {
+		final String referenceName = referenceSchema == null ? null : referenceSchema.getName();
+		final HierarchyFilterConstraint hierarchyFilter = getEvitaRequest().getHierarchyWithin(referenceName);
+		if (hierarchyFilter != null
+			&& (!ArrayUtils.isEmpty(hierarchyFilter.getHavingChildrenFilter())
+				|| !ArrayUtils.isEmpty(hierarchyFilter.getExcludedChildrenFilter()))) {
+			return false;
+		}
+		if (referenceSchema != null) {
+			final Set<Scope> scopes = getProcessingScope().getScopes();
+			return !scopes.stream().allMatch(
+				scope -> referenceSchema.getReferenceIndexType(
+					scope) == ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING
+			);
+		} else {
+			return true;
+		}
+	}
+
+	/**
+	 * Shortcut path — clones the already-planned {@link #filteringFormula} via {@link FormulaCloner} with a mutator
+	 * that strips the parts irrelevant for the given {@link StatisticsBase}, then wraps in a
+	 * {@link DeferredFormula} carrying execution telemetry. Reuses every leaf the cloner did not touch, so leaf-level
+	 * memoised compute results are shared with the primary filter. Returns `null` when the strip removed everything.
+	 */
+	@Nullable
+	private Formula shortcutFormula(@Nonnull StatisticsBase base, @Nullable String referenceName) {
+		final Formula cloned = switch (base) {
+			case COMPLETE_FILTER -> FormulaCloner.clone(
+				this.filteringFormula,
+				stripHierarchyMatching(referenceName)
+			);
+			case WITHOUT_USER_FILTER -> FormulaCloner.clone(
+				this.filteringFormula,
+				stripHierarchyMatchingAndUserFilter(referenceName)
+			);
+			case COMPLETE_FILTER_EXCLUDING_SELF_IN_USER_FILTER -> FormulaCloner.clone(
+				this.filteringFormula,
+				stripHierarchyAndFacetForSelfInUserFilter(referenceName)
+			);
+		};
+		return cloned == null ? null : wrapWithStatisticsTelemetry(cloned, base, referenceName);
+	}
+
+	/**
+	 * Fallback path — used when the primary plan may be rooted in REDUCED_ENTITY of the same hierarchy reference.
+	 * Re-translates the rewritten `FilterBy` once via {@link QueryPlanner#planNestedFilteringFormula}, which mirrors
+	 * the outer-query planning pipeline (`IndexSelectionVisitor` + per-candidate `FilterByVisitor` with
+	 * `FormulaOptimizer` + `PrefetchFormulaVisitor`) and picks the cheapest candidate by estimated cost. The chosen
+	 * formula is wrapped with execution telemetry and its prefetch demand is folded into the outer query's
+	 * {@link PrefetchFormulaVisitor} so the outer plan can decide prefetch on the combined signal.
+	 *
+	 * Returns `null` when the rewrite leaves an empty / non-applicable filter, signalling the caller to skip the
+	 * AND with the per-node primary-key formula.
+	 */
+	@Nullable
+	private Formula fallbackFormula(@Nonnull StatisticsBase base, @Nullable ReferenceSchemaContract referenceSchema) {
+		final FilterBy rewritten = rewriteFilterByForStatisticsBase(base, referenceSchema);
+		if (rewritten == null) {
+			return null;
+		}
+		final String referenceName = referenceSchema == null ? null : referenceSchema.getName();
+		final Formula planned = QueryPlanner.planNestedFilteringFormula(
+			getQueryContext(),
+			rewritten,
+			this.outerPrefetchFormulaVisitor,
+			() -> "Hierarchy statistics filter (" + base + (referenceName == null ? "" : ", reference=" + referenceName)
+				+ ")"
+		);
+		return planned == EmptyFormula.INSTANCE ? null : planned;
+	}
+
+	/**
+	 * Constraint-tree analogue of the formula-tree mutators used by {@link #shortcutFormula}. Walks a deep clone of
+	 * the original {@link FilterBy} and drops the constraint nodes that match the strip rules for the given
+	 * {@link StatisticsBase}, returning the resulting filter — or `null` when the rewrite leaves nothing applicable.
+	 *
+	 * Used exclusively by {@link #fallbackFormula}; the resulting `FilterBy` is fed to a nested
+	 * {@link FilterByVisitor} pass against the queried collection's `GlobalEntityIndex`.
+	 */
+	@Nullable
+	private FilterBy rewriteFilterByForStatisticsBase(
+		@Nonnull StatisticsBase base,
+		@Nullable ReferenceSchemaContract referenceSchema
+	) {
+		final FilterBy original = getFilterBy();
+		if (original == null) {
+			return null;
+		}
+		final String referenceName = referenceSchema == null ? null : referenceSchema.getName();
+		final FilterBy result = (FilterBy) ConstraintCloneVisitor.clone(
+			original,
+			(visitor, constraint) -> switch (base) {
+				case COMPLETE_FILTER -> {
+					if (constraint instanceof HierarchyFilterConstraint hfc) {
+						yield rewriteHierarchyFilter(hfc, referenceName);
+					}
+					yield constraint;
+				}
+				case WITHOUT_USER_FILTER -> {
+					if (constraint instanceof HierarchyFilterConstraint hfc) {
+						yield rewriteHierarchyFilter(hfc, referenceName);
+					}
+					if (constraint instanceof UserFilter) {
+						yield null;
+					}
+					yield constraint;
+				}
+				case COMPLETE_FILTER_EXCLUDING_SELF_IN_USER_FILTER -> {
+					if (constraint instanceof HierarchyFilterConstraint hfc) {
+						final boolean matchesUnnamedVariant =
+							referenceName == null && hfc.getReferenceName().isEmpty();
+						final boolean matchesNamedVariantInsideUserFilter =
+							referenceName != null
+								&& hfc.getReferenceName()
+									.map(refName -> refName.equals(referenceName))
+									.orElse(false)
+								&& visitor.isWithin(UserFilter.class);
+						if (matchesUnnamedVariant || matchesNamedVariantInsideUserFilter) {
+							yield null;
+						}
+					} else if (constraint instanceof FacetHaving fh) {
+						final boolean matchesUnnamedVariant =
+							referenceName == null && fh.getReferenceName().isEmpty();
+						final boolean matchesNamedVariantInsideUserFilter =
+							referenceName != null
+								&& fh.getReferenceName().equals(referenceName)
+								&& visitor.isWithin(UserFilter.class);
+						if (matchesUnnamedVariant || matchesNamedVariantInsideUserFilter) {
+							yield null;
+						}
+					}
+					yield constraint;
+				}
+			}
+		);
+		return result != null && result.isApplicable() ? result : null;
+	}
+
+	/**
+	 * Replaces a {@link HierarchyFilterConstraint} with the equivalent constraint expressed against the queried
+	 * entity's `GlobalEntityIndex` — for self-hierarchy this is the inner having/excluded predicate as-is, for
+	 * referenced hierarchy it wraps the predicate in `referenceHaving(referenceName, entityHaving(...))` so the
+	 * nested visitor can reach the referenced entity. Returns `null` when the original constraint had no predicates,
+	 * letting the {@link ConstraintCloneVisitor} drop the node entirely.
+	 */
+	@Nullable
+	private static FilterConstraint rewriteHierarchyFilter(
+		@Nonnull HierarchyFilterConstraint hfc,
+		@Nullable String referenceName
+	) {
+		final Function<FilterConstraint, FilterConstraint> wrapper = referenceName == null
+			? Function.identity()
+			: filter -> new FilterBy(new ReferenceHaving(referenceName, entityHaving(filter)));
+		final FilterConstraint[] excludedChildrenFilter = hfc.getExcludedChildrenFilter();
+		final FilterConstraint[] havingChildrenFilter = hfc.getHavingChildrenFilter();
+		if (ArrayUtils.isEmpty(excludedChildrenFilter)) {
+			if (ArrayUtils.isEmpty(havingChildrenFilter)) {
+				return null;
+			} else if (havingChildrenFilter.length == 1) {
+				return wrapper.apply(havingChildrenFilter[0]);
+			} else {
+				return wrapper.apply(and(havingChildrenFilter));
+			}
+		} else if (excludedChildrenFilter.length == 1) {
+			return wrapper.apply(not(excludedChildrenFilter[0]));
+		} else {
+			return wrapper.apply(not(and(excludedChildrenFilter)));
+		}
+	}
+
+	/**
+	 * Mutator for `COMPLETE_FILTER`: strips {@link HierarchyFormula} whose `referenceName` matches `referenceName`
+	 * (or both are `null`). All other formulas are preserved so that the cloner reuses their memoised sub-results.
+	 */
+	@Nonnull
+	private static UnaryOperator<Formula> stripHierarchyMatching(@Nullable String referenceName) {
+		return formula -> {
+			if (formula instanceof HierarchyFormula hf && Objects.equals(hf.getReferenceName(), referenceName)) {
+				return null;
+			}
+			return formula;
+		};
+	}
+
+	/**
+	 * Mutator for `WITHOUT_USER_FILTER`: strips every {@link UserFilterFormula} and every
+	 * {@link HierarchyFormula} whose `referenceName` matches `referenceName`.
+	 */
+	@Nonnull
+	private static UnaryOperator<Formula> stripHierarchyMatchingAndUserFilter(@Nullable String referenceName) {
+		return formula -> {
+			if (formula instanceof UserFilterFormula) {
+				return null;
+			}
+			if (formula instanceof HierarchyFormula hf && Objects.equals(hf.getReferenceName(), referenceName)) {
+				return null;
+			}
+			return formula;
+		};
+	}
+
+	/**
+	 * Mutator for `COMPLETE_FILTER_EXCLUDING_SELF_IN_USER_FILTER`. For a `null` stats reference (self-hierarchy
+	 * statistics) every self-{@link HierarchyFormula} and every empty-name {@link FacetHavingFormula} is stripped
+	 * regardless of its position; for a non-`null` stats reference, {@link HierarchyFormula} and
+	 * {@link FacetHavingFormula} matching the stats reference are stripped only when reached through a
+	 * {@link UserFilterFormula} parent — anything outside the user filter (including the mandatory hierarchy anchor)
+	 * is preserved.
+	 */
+	@Nonnull
+	private static BiFunction<FormulaCloner, Formula, Formula> stripHierarchyAndFacetForSelfInUserFilter(
+		@Nullable String referenceName
+	) {
+		return (cloner, formula) -> {
+			if (formula instanceof HierarchyFormula hf) {
+				final String hierarchyRef = hf.getReferenceName();
+				if (referenceName == null && hierarchyRef == null) {
+					return null;
+				}
+				if (referenceName != null && referenceName.equals(hierarchyRef)
+					&& cloner.isWithin(UserFilterFormula.class)) {
+					return null;
+				}
+			} else if (formula instanceof FacetHavingFormula fh) {
+				final String facetRef = fh.getReferenceName();
+				if (referenceName == null && (facetRef == null || facetRef.isEmpty())) {
+					return null;
+				}
+				if (referenceName != null
+					&& referenceName.equals(facetRef)
+					&& cloner.isWithin(UserFilterFormula.class)) {
+					return null;
+				}
+			}
+			return formula;
+		};
+	}
+
+	/**
+	 * Wraps the cloned filter formula in {@link DeferredFormula} so that its evaluation is reported under
+	 * {@link QueryPhase#EXECUTION_FILTER_NESTED_QUERY} — preserving telemetry continuity with the fallback path
+	 * (which goes through {@link QueryPlanner#planNestedFilteringFormula} and runs a nested
+	 * {@link QueryPhase#PLANNING_FILTER_NESTED_QUERY}). The shortcut path skips the planning step entirely
+	 * (re-using the already-planned tree) so only the execution step is exposed to telemetry consumers.
+	 */
+	@Nonnull
+	private static Formula wrapWithStatisticsTelemetry(
+		@Nonnull Formula formula,
+		@Nonnull StatisticsBase statisticsBase,
+		@Nullable String referenceName
+	) {
+		final Supplier<String> stepDescriptionSupplier = () ->
+			"Hierarchy statistics filter (" + statisticsBase
+				+ (referenceName == null ? "" : ", reference=" + referenceName)
+				+ ")";
+		return new DeferredFormula(
+			new FormulaWrapper(
+				formula,
+				(executionContext, inner) -> {
+					try {
+						executionContext.pushStep(QueryPhase.EXECUTION_FILTER_NESTED_QUERY, stepDescriptionSupplier);
+						return inner.compute();
+					} finally {
+						executionContext.popStep();
+					}
+				}
+			)
+		);
+	}
+
+	/**
 	 * Returns set (usually of size == 1 or 0) that contains references to the {@link UserFilterFormula} inside
 	 * {@link #filteringFormula}. Result of this method is cached so that additional calls introduce no performance
 	 * penalty.
@@ -354,50 +740,8 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 	}
 
 	/**
-	 * Determines the appropriate {@link FilterBy} object based on the provided {@link StatisticsBase} and
-	 * {@link ReferenceSchemaContract}. This method applies different filtering logic depending on the provided
-	 * base type of statistics calculations.
-	 *
-	 * @param statisticsBase  the base type that defines the scope of the filtering for calculating statistics,
-	 *                        as specified by the {@link StatisticsBase} enum.
-	 * @param referenceSchema the reference schema that is used to generate the corresponding filter constraints.
-	 *                        It provides structural and validation information for creating the filter.
-	 * @return an instance of {@link FilterBy} containing the appropriate filtering constraints based on the
-	 * statistics base, or null if no suitable filter is defined for the given configuration.
-	 */
-	@Nullable
-	public FilterBy getFilterByForStatisticsBase(
-		@Nullable StatisticsBase statisticsBase,
-		@Nullable ReferenceSchemaContract referenceSchema
-	) {
-		if (statisticsBase == null) {
-			// initialize default value
-			statisticsBase = StatisticsBase.WITHOUT_USER_FILTER;
-		}
-		final FormulaVariant cacheKey = new FormulaVariant(
-			referenceSchema == null ? null : referenceSchema.getName(),
-			statisticsBase
-		);
-		if (this.formulaVariantCache != null) {
-			final FilterBy cachedResult = this.formulaVariantCache.get(cacheKey);
-			if (cachedResult != null) {
-				return cachedResult.isApplicable() ? cachedResult : null;
-			}
-		}
-		if (this.formulaVariantCache == null) {
-			this.formulaVariantCache = CollectionUtils.createHashMap(4);
-		}
-		return switch (statisticsBase) {
-			case COMPLETE_FILTER -> getFilterByWithoutHierarchyFilter(cacheKey);
-			case WITHOUT_USER_FILTER -> getFilterByWithoutHierarchyAndUserFilter(cacheKey);
-			case COMPLETE_FILTER_EXCLUDING_SELF_IN_USER_FILTER ->
-				getFilterByIncludingUserFilterWithoutHierarchyInIt(cacheKey);
-		};
-	}
-
-	/**
 	 * Method creates the {@link Sorter} implementation that should be used for sorting {@link LevelInfo} inside
-	 * the {@link io.evitadb.api.requestResponse.extraResult.Hierarchy} result object.
+	 * the {@link Hierarchy} result object.
 	 */
 	@Nonnull
 	public NestedContextSorter createSorter(
@@ -593,136 +937,6 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 	}
 
 	/**
-	 * Returns the {@link #getFilterBy()} that is stripped of all {@link HierarchyWithin} and
-	 * {@link HierarchyWithinRoot} sub-constraints. Result of this method is cached so that additional calls introduce no
-	 * performance penalty.
-	 */
-	@Nullable
-	private FilterBy getFilterByWithoutHierarchyFilter(@Nonnull FormulaVariant formulaVariant) {
-		final FilterBy result = (FilterBy) ofNullable(getFilterBy())
-			.map(it ->
-				ConstraintCloneVisitor.clone(
-					it,
-					(visitor, constraint) -> {
-						if (constraint instanceof HierarchyFilterConstraint hfc) {
-							return rewriteHierarchyFilter(hfc, formulaVariant);
-						} else {
-							return constraint;
-						}
-					}
-				)
-			)
-			.orElseGet(FilterBy::new);
-
-		this.formulaVariantCache.put(formulaVariant, result);
-		return result.isApplicable() ? result : null;
-	}
-
-	/**
-	 * Returns the {@link #getFilterBy()} that is stripped of all {@link HierarchyWithin},
-	 * {@link HierarchyWithinRoot} constraints and {@link UserFilter} parts. Result of this method is cached so that
-	 * additional calls introduce no performance penalty.
-	 */
-	@Nullable
-	private FilterBy getFilterByWithoutHierarchyAndUserFilter(@Nonnull FormulaVariant formulaVariant) {
-		final FilterBy result = (FilterBy) ofNullable(getFilterBy())
-			.map(it ->
-				ConstraintCloneVisitor.clone(
-					it,
-					(visitor, constraint) -> {
-						if (constraint instanceof HierarchyFilterConstraint hfc) {
-							return rewriteHierarchyFilter(hfc, formulaVariant);
-						} else if (constraint instanceof UserFilter) {
-							return null;
-						} else {
-							return constraint;
-						}
-					}
-				)
-			)
-			.orElseGet(FilterBy::new);
-		this.formulaVariantCache.put(formulaVariant, result);
-		return result.isApplicable() ? result : null;
-	}
-
-	/**
-	 * Rewrites a {@link HierarchyFilterConstraint} into an equivalent non-hierarchy filter that can be evaluated
-	 * against the current context. When `formulaVariant.referenceName()` is non-`null`, the rewritten filter is wrapped
-	 * inside a `referenceHaving(entityHaving(...))` so it targets the referenced entity. Returns `null` when the
-	 * hierarchy constraint carries no excluded or having-children filters and should be dropped entirely.
-	 */
-	@Nullable
-	private static FilterConstraint rewriteHierarchyFilter(
-		@Nonnull HierarchyFilterConstraint hfc,
-		@Nonnull FormulaVariant formulaVariant
-	) {
-		final Function<FilterConstraint, FilterConstraint> wrapper = formulaVariant.referenceName() == null ?
-			Function.identity() :
-			filter -> new FilterBy(new ReferenceHaving(formulaVariant.referenceName(), entityHaving(filter)));
-		final FilterConstraint[] excludedChildrenFilter = hfc.getExcludedChildrenFilter();
-		final FilterConstraint[] havingChildrenFilter = hfc.getHavingChildrenFilter();
-		if (ArrayUtils.isEmpty(excludedChildrenFilter)) {
-			if (ArrayUtils.isEmpty(havingChildrenFilter)) {
-				return null;
-			} else if (havingChildrenFilter.length == 1) {
-				return wrapper.apply(havingChildrenFilter[0]);
-			} else {
-				return wrapper.apply(and(havingChildrenFilter));
-			}
-		} else if (excludedChildrenFilter.length == 1) {
-			return wrapper.apply(not(excludedChildrenFilter[0]));
-		} else {
-			return wrapper.apply(not(and(excludedChildrenFilter)));
-		}
-	}
-
-	/**
-	 * Returns the {@link #getFilterBy()} that is stripped of all {@link HierarchyWithin},
-	 * {@link HierarchyWithinRoot} constraints inside {@link UserFilter} parts only. Result of this method is cached
-	 * so that additional calls introduce no performance penalty.
-	 */
-	@Nullable
-	private FilterBy getFilterByIncludingUserFilterWithoutHierarchyInIt(@Nonnull FormulaVariant formulaVariant) {
-		final FilterBy result = (FilterBy) ofNullable(getFilterBy())
-			.map(it ->
-				ConstraintCloneVisitor.clone(
-					it,
-					(visitor, constraint) -> {
-						final String variantReferenceName = formulaVariant.referenceName();
-						if (constraint instanceof HierarchyFilterConstraint hfc) {
-							final boolean matchesUnnamedVariant =
-								variantReferenceName == null && hfc.getReferenceName().isEmpty();
-							final boolean matchesNamedVariantInsideUserFilter =
-								variantReferenceName != null
-									&& hfc.getReferenceName()
-										.map(refName -> refName.equals(variantReferenceName))
-										.orElse(false)
-									&& visitor.isWithin(UserFilter.class);
-							if (matchesUnnamedVariant || matchesNamedVariantInsideUserFilter) {
-								return null;
-							}
-						} else if (constraint instanceof FacetHaving fh) {
-							final boolean matchesUnnamedVariant =
-								variantReferenceName == null && fh.getReferenceName().isEmpty();
-							final boolean matchesNamedVariantInsideUserFilter =
-								variantReferenceName != null
-									&& fh.getReferenceName().equals(variantReferenceName)
-									&& visitor.isWithin(UserFilter.class);
-							if (matchesUnnamedVariant || matchesNamedVariantInsideUserFilter) {
-								return null;
-							}
-						}
-						return constraint;
-					}
-				)
-			)
-			.orElseGet(FilterBy::new);
-
-		this.formulaVariantCache.put(formulaVariant, result);
-		return result.isApplicable() ? result : null;
-	}
-
-	/**
 	 * Processing scope contains contextual information that could be overridden in {@link RequireConstraintTranslator}
 	 * implementations to exchange schema that is being used, suppressing certain query evaluation or accessing
 	 * attribute schema information.
@@ -805,7 +1019,7 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 
 	/**
 	 * Represents a specific formula variant which encapsulates a reference name and the base type of
-	 * statistics calculation. This record is used as a cache key to {@link ExtraResultPlanningVisitor#formulaVariantCache}
+	 * statistics calculation. This record is used as a cache key to {@link ExtraResultPlanningVisitor#formulaCache}.
 	 */
 	private record FormulaVariant(
 		@Nullable String referenceName,

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
@@ -613,6 +613,10 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 	 * referenced hierarchy it wraps the predicate in `referenceHaving(referenceName, entityHaving(...))` so the
 	 * nested visitor can reach the referenced entity. Returns `null` when the original constraint had no predicates,
 	 * letting the {@link ConstraintCloneVisitor} drop the node entirely.
+	 *
+	 * When both `having(...)` and `excluding(...)` are present they are combined as `and(having, not(excluding))`
+	 * to mirror the main hierarchy translator (`HierarchyIndex` applies both predicates conjunctively when
+	 * computing `matchingHierarchyNodeIds`).
 	 */
 	@Nullable
 	private static FilterConstraint rewriteHierarchyFilter(
@@ -627,16 +631,23 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 		if (ArrayUtils.isEmpty(excludedChildrenFilter)) {
 			if (ArrayUtils.isEmpty(havingChildrenFilter)) {
 				return null;
-			} else if (havingChildrenFilter.length == 1) {
-				return wrapper.apply(havingChildrenFilter[0]);
-			} else {
-				return wrapper.apply(and(havingChildrenFilter));
 			}
-		} else if (excludedChildrenFilter.length == 1) {
-			return wrapper.apply(not(excludedChildrenFilter[0]));
-		} else {
-			return wrapper.apply(not(and(excludedChildrenFilter)));
+			return wrapper.apply(combine(havingChildrenFilter));
 		}
+		final FilterConstraint excludePart = not(combine(excludedChildrenFilter));
+		if (ArrayUtils.isEmpty(havingChildrenFilter)) {
+			return wrapper.apply(excludePart);
+		}
+		return wrapper.apply(and(combine(havingChildrenFilter), excludePart));
+	}
+
+	/**
+	 * Returns the single child unwrapped, or `and(children)` when more than one child is present. Used by
+	 * {@link #rewriteHierarchyFilter} to avoid producing a single-element `and(...)` wrapper.
+	 */
+	@Nonnull
+	private static FilterConstraint combine(@Nonnull FilterConstraint[] children) {
+		return children.length == 1 ? children[0] : and(children);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
@@ -462,8 +462,7 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 		if (referenceSchema != null) {
 			final Set<Scope> scopes = getProcessingScope().getScopes();
 			return !scopes.stream().allMatch(
-				scope -> referenceSchema.getReferenceIndexType(
-					scope) == ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING
+				scope -> referenceSchema.getReferenceIndexType(scope) == ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING
 			);
 		} else {
 			return true;
@@ -503,8 +502,12 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 	 * formula is wrapped with execution telemetry and its prefetch demand is folded into the outer query's
 	 * {@link PrefetchFormulaVisitor} so the outer plan can decide prefetch on the combined signal.
 	 *
-	 * Returns `null` when the rewrite leaves an empty / non-applicable filter, signalling the caller to skip the
-	 * AND with the per-node primary-key formula.
+	 * Returns `null` only when the rewrite leaves no applicable filter constraint (`rewritten == null`); in that
+	 * case the caller skips the AND with the per-node primary-key formula. An {@link EmptyFormula#INSTANCE}
+	 * coming back from {@link QueryPlanner#planNestedFilteringFormula} (no eligible index — practically
+	 * unreachable when the queried collection has a global index) is propagated as-is so callers AND it normally
+	 * and produce an empty bitmap, preserving "no plan possible" semantics rather than degrading into "unfiltered"
+	 * which would over-count.
 	 */
 	@Nullable
 	private Formula fallbackFormula(@Nonnull StatisticsBase base, @Nullable ReferenceSchemaContract referenceSchema) {
@@ -513,14 +516,13 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 			return null;
 		}
 		final String referenceName = referenceSchema == null ? null : referenceSchema.getName();
-		final Formula planned = QueryPlanner.planNestedFilteringFormula(
+		return QueryPlanner.planNestedFilteringFormula(
 			getQueryContext(),
 			rewritten,
 			this.outerPrefetchFormulaVisitor,
 			() -> "Hierarchy statistics filter (" + base + (referenceName == null ? "" : ", reference=" + referenceName)
 				+ ")"
 		);
-		return planned == EmptyFormula.INSTANCE ? null : planned;
 	}
 
 	/**
@@ -545,13 +547,13 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 			original,
 			(visitor, constraint) -> switch (base) {
 				case COMPLETE_FILTER -> {
-					if (constraint instanceof HierarchyFilterConstraint hfc) {
+					if (constraint instanceof HierarchyFilterConstraint hfc && hierarchyMatches(hfc, referenceName)) {
 						yield rewriteHierarchyFilter(hfc, referenceName);
 					}
 					yield constraint;
 				}
 				case WITHOUT_USER_FILTER -> {
-					if (constraint instanceof HierarchyFilterConstraint hfc) {
+					if (constraint instanceof HierarchyFilterConstraint hfc && hierarchyMatches(hfc, referenceName)) {
 						yield rewriteHierarchyFilter(hfc, referenceName);
 					}
 					if (constraint instanceof UserFilter) {
@@ -572,22 +574,37 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 						if (matchesUnnamedVariant || matchesNamedVariantInsideUserFilter) {
 							yield null;
 						}
-					} else if (constraint instanceof FacetHaving fh) {
-						final boolean matchesUnnamedVariant =
-							referenceName == null && fh.getReferenceName().isEmpty();
-						final boolean matchesNamedVariantInsideUserFilter =
-							referenceName != null
-								&& fh.getReferenceName().equals(referenceName)
-								&& visitor.isWithin(UserFilter.class);
-						if (matchesUnnamedVariant || matchesNamedVariantInsideUserFilter) {
-							yield null;
-						}
+					} else if (
+						// facets are always reference-bound (`FacetHaving.getReferenceName()` is `@Nonnull`
+						// and `@Classifier`-validated non-empty), so they can only ever match named-reference
+						// stats — never self-stats
+						referenceName != null
+							&& constraint instanceof FacetHaving fh
+							&& fh.getReferenceName().equals(referenceName)
+							&& visitor.isWithin(UserFilter.class)
+					) {
+						yield null;
 					}
 					yield constraint;
 				}
 			}
 		);
 		return result != null && result.isApplicable() ? result : null;
+	}
+
+	/**
+	 * Returns `true` when the given {@link HierarchyFilterConstraint} targets the same hierarchy reference for
+	 * which statistics are being computed — `null` `referenceName` matches an empty-reference `hierarchyWithin`
+	 * (self-hierarchy), a non-`null` `referenceName` matches an `hfc` carrying the same reference name. Mirrors
+	 * the formula-tree match condition used by {@link #stripHierarchyMatching} so the fallback path strips
+	 * exactly the same set of hierarchy constraints as the shortcut.
+	 */
+	private static boolean hierarchyMatches(
+		@Nonnull HierarchyFilterConstraint hfc,
+		@Nullable String referenceName
+	) {
+		final Optional<String> hfcRef = hfc.getReferenceName();
+		return referenceName == null ? hfcRef.isEmpty() : hfcRef.map(referenceName::equals).orElse(false);
 	}
 
 	/**
@@ -655,11 +672,14 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 
 	/**
 	 * Mutator for `COMPLETE_FILTER_EXCLUDING_SELF_IN_USER_FILTER`. For a `null` stats reference (self-hierarchy
-	 * statistics) every self-{@link HierarchyFormula} and every empty-name {@link FacetHavingFormula} is stripped
-	 * regardless of its position; for a non-`null` stats reference, {@link HierarchyFormula} and
-	 * {@link FacetHavingFormula} matching the stats reference are stripped only when reached through a
-	 * {@link UserFilterFormula} parent — anything outside the user filter (including the mandatory hierarchy anchor)
-	 * is preserved.
+	 * statistics) every self-{@link HierarchyFormula} is stripped regardless of its position; for a non-`null`
+	 * stats reference, {@link HierarchyFormula} and {@link FacetHavingFormula} matching the stats reference are
+	 * stripped only when reached through a {@link UserFilterFormula} parent — anything outside the user filter
+	 * (including the mandatory hierarchy anchor) is preserved.
+	 *
+	 * {@link FacetHavingFormula} is never stripped for self-stats: facets are always reference-bound
+	 * (`FacetHaving.getReferenceName()` is `@Nonnull` and `@Classifier`-validated non-empty), so they can only
+	 * ever match named-reference stats.
 	 */
 	@Nonnull
 	private static BiFunction<FormulaCloner, Formula, Formula> stripHierarchyAndFacetForSelfInUserFilter(
@@ -675,16 +695,13 @@ public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 					&& cloner.isWithin(UserFilterFormula.class)) {
 					return null;
 				}
-			} else if (formula instanceof FacetHavingFormula fh) {
-				final String facetRef = fh.getReferenceName();
-				if (referenceName == null && (facetRef == null || facetRef.isEmpty())) {
-					return null;
-				}
-				if (referenceName != null
-					&& referenceName.equals(facetRef)
-					&& cloner.isWithin(UserFilterFormula.class)) {
-					return null;
-				}
+			} else if (
+				referenceName != null
+					&& formula instanceof FacetHavingFormula fh
+					&& referenceName.equals(fh.getReferenceName())
+					&& cloner.isWithin(UserFilterFormula.class)
+			) {
+				return null;
 			}
 			return formula;
 		};

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/AbstractHierarchyTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/AbstractHierarchyTranslator.java
@@ -23,7 +23,6 @@
 
 package io.evitadb.core.query.extraResult.translator.hierarchyStatistics;
 
-import io.evitadb.api.query.filter.FilterBy;
 import io.evitadb.api.query.require.EntityFetch;
 import io.evitadb.api.query.require.HierarchyDistance;
 import io.evitadb.api.query.require.HierarchyLevel;
@@ -34,35 +33,27 @@ import io.evitadb.api.requestResponse.data.EntityClassifier;
 import io.evitadb.api.requestResponse.data.SealedEntity;
 import io.evitadb.api.requestResponse.data.structure.EntityReference;
 import io.evitadb.api.requestResponse.extraResult.Hierarchy.LevelInfo;
-import io.evitadb.api.requestResponse.extraResult.QueryTelemetry.QueryPhase;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
-import io.evitadb.core.query.AttributeSchemaAccessor;
+import io.evitadb.core.exception.HierarchyNotIndexedException;
 import io.evitadb.core.query.QueryExecutionContext;
 import io.evitadb.core.query.QueryPlanningContext;
-import io.evitadb.core.query.algebra.Formula;
-import io.evitadb.core.query.algebra.deferred.DeferredFormula;
-import io.evitadb.core.query.algebra.deferred.FormulaWrapper;
 import io.evitadb.core.query.extraResult.ExtraResultPlanningVisitor;
+import io.evitadb.core.query.extraResult.ExtraResultPlanningVisitor.ProcessingScope;
 import io.evitadb.core.query.extraResult.translator.hierarchyStatistics.producer.HierarchyEntityFetcher;
 import io.evitadb.core.query.extraResult.translator.hierarchyStatistics.producer.HierarchyProducerContext;
 import io.evitadb.core.query.extraResult.translator.hierarchyStatistics.producer.HierarchyStatisticsProducer;
 import io.evitadb.core.query.extraResult.translator.reference.EntityFetchTranslator;
-import io.evitadb.core.query.filter.FilterByVisitor;
-import io.evitadb.core.query.indexSelection.TargetIndexes;
-import io.evitadb.index.EntityIndex;
+import io.evitadb.dataType.Scope;
+import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.index.hierarchy.predicate.FilteringFormulaHierarchyEntityPredicate;
 import io.evitadb.index.hierarchy.predicate.HierarchyTraversalPredicate;
+import io.evitadb.utils.Assert;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Set;
 
 import static java.util.Optional.ofNullable;
 
@@ -83,6 +74,39 @@ public abstract class AbstractHierarchyTranslator {
 	) {
 		return ofNullable(extraResultPlanner.findExistingProducer(HierarchyStatisticsProducer.class))
 			.orElseGet(() -> new HierarchyStatisticsProducer(extraResultPlanner.getLocale()));
+	}
+
+	/**
+	 * Resolves the single {@link Scope} from the processing scope and asserts the given hierarchical schema has
+	 * its hierarchy indexed in that scope. Hierarchies cannot be produced from multiple scopes — they would
+	 * represent two distinct trees — so any request involving more than one scope is rejected up front.
+	 *
+	 * @param processingScope    current processing scope carrying the requested scopes
+	 * @param hierarchicalSchema the schema whose hierarchy is to be queried (the queried schema for self,
+	 *                           the referenced schema for hierarchy-of-reference)
+	 * @return the single {@link Scope} that is both requested and confirmed to have the hierarchy indexed
+	 * @throws EvitaInvalidUsageException  when more than one scope is requested
+	 * @throws HierarchyNotIndexedException when the hierarchy is not indexed in the requested scope
+	 */
+	@Nonnull
+	protected static Scope resolveSingleHierarchicalScope(
+		@Nonnull ProcessingScope processingScope,
+		@Nonnull EntitySchemaContract hierarchicalSchema
+	) {
+		final Set<Scope> scopes = processingScope.getScopes();
+		// hierarchy cannot be produced from multiple scopes — they represent two distinct trees
+		if (scopes.size() > 1) {
+			throw new EvitaInvalidUsageException(
+				"Hierarchies of `" + hierarchicalSchema.getName() + "` from multiple scopes cannot be combined. " +
+					"They represent two distinct trees."
+			);
+		}
+		final Scope scope = scopes.iterator().next();
+		Assert.isTrue(
+			hierarchicalSchema.isHierarchyIndexedInScope(scope),
+			() -> new HierarchyNotIndexedException(hierarchicalSchema, scope)
+		);
+		return scope;
 	}
 
 	/**
@@ -155,72 +179,6 @@ public abstract class AbstractHierarchyTranslator {
 					return executionContext.fetchEntity(hierarchicalEntityType, entityPk, enriched).orElse(null);
 				}
 			};
-		}
-	}
-
-	/**
-	 * Method creates formula that is responsible for computing the queried entity count for
-	 * {@link HierarchyStatisticsProducer}. The provided indexes are analysed by a single
-	 * {@link FilterByVisitor} pass — passing several reduced indexes that share the same filter
-	 * is significantly cheaper than running the analysis once per index.
-	 */
-	@Nonnull
-	protected <T extends EntityIndex> Formula createFilterFormula(
-		@Nonnull QueryPlanningContext queryContext,
-		@Nonnull FilterBy filterBy,
-		@Nonnull Class<T> indexType,
-		@Nonnull EntitySchemaContract targetEntitySchema,
-		@Nonnull List<T> entityIndexes,
-		@Nonnull AttributeSchemaAccessor attributeSchemaAccessor
-	) {
-		try {
-			final Supplier<String> stepDescriptionSupplier = () -> "Hierarchy statistics of `" + targetEntitySchema.getName() + "` on " + entityIndexes.size() + " index(es): " +
-				Arrays.stream(filterBy.getChildren()).map(Object::toString).collect(Collectors.joining(", "));
-			queryContext.pushStep(
-				QueryPhase.PLANNING_FILTER_NESTED_QUERY,
-				stepDescriptionSupplier
-			);
-			// create a visitor
-			final FilterByVisitor theFilterByVisitor = new FilterByVisitor(
-				queryContext,
-				Collections.emptyList(),
-				TargetIndexes.EMPTY
-			);
-			// now analyze the filter by in a nested context with exchanged primary entity index
-			final Formula theFormula = queryContext.analyse(
-				theFilterByVisitor.executeInContextAndIsolatedFormulaStack(
-					indexType,
-					() -> entityIndexes,
-					null,
-					targetEntitySchema,
-					null,
-					null,
-					null,
-					attributeSchemaAccessor,
-					(entityContract, attributeName, locale) -> Stream.of(entityContract.getAttributeValue(attributeName, locale)),
-					() -> {
-						filterBy.accept(theFilterByVisitor);
-						// get the result and clear the visitor internal structures
-						return theFilterByVisitor.getFormulaAndClear();
-					}
-				)
-			);
-			// create a deferred formula that will log the execution time to query telemetry
-			return new DeferredFormula(
-				new FormulaWrapper(
-					theFormula,
-					(executionContext, formula) -> {
-						try {
-							executionContext.pushStep(QueryPhase.EXECUTION_FILTER_NESTED_QUERY, stepDescriptionSupplier);
-							return formula.compute();
-						} finally {
-							executionContext.popStep();
-						}
-					}
-				)
-			);
-		} finally {
-			queryContext.popStep();
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/HierarchyOfReferenceTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/HierarchyOfReferenceTranslator.java
@@ -25,28 +25,23 @@ package io.evitadb.core.query.extraResult.translator.hierarchyStatistics;
 
 import io.evitadb.api.exception.EntityIsNotHierarchicalException;
 import io.evitadb.api.query.RequireConstraint;
-import io.evitadb.api.query.filter.FilterBy;
 import io.evitadb.api.query.filter.HierarchyFilterConstraint;
 import io.evitadb.api.query.require.HierarchyOfReference;
 import io.evitadb.api.query.require.HierarchyOfSelf;
 import io.evitadb.api.requestResponse.EvitaRequest;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
-import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.api.requestResponse.schema.dto.EntitySchema;
 import io.evitadb.core.collection.EntityCollection;
-import io.evitadb.core.exception.HierarchyNotIndexedException;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.core.query.common.translator.SelfTraversingTranslator;
 import io.evitadb.core.query.extraResult.ExtraResultPlanningVisitor;
-import io.evitadb.core.query.extraResult.ExtraResultPlanningVisitor.ProcessingScope;
 import io.evitadb.core.query.extraResult.ExtraResultProducer;
 import io.evitadb.core.query.extraResult.translator.RequireConstraintTranslator;
 import io.evitadb.core.query.extraResult.translator.hierarchyStatistics.producer.HierarchyStatisticsProducer;
 import io.evitadb.core.query.sort.NestedContextSorter;
 import io.evitadb.dataType.Scope;
-import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.function.Functions;
 import io.evitadb.index.EntityIndexKey;
 import io.evitadb.index.EntityIndexType;
@@ -58,7 +53,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * This implementation of {@link RequireConstraintTranslator} converts {@link HierarchyOfSelf} to
@@ -78,7 +72,6 @@ public class HierarchyOfReferenceTranslator
 		// prepare shared data from the context
 		final EvitaRequest evitaRequest = extraResultPlanner.getEvitaRequest();
 		final EntitySchema entitySchema = extraResultPlanner.getSchema();
-		final String queriedEntityType = entitySchema.getName();
 
 		// retrieve existing producer or create new one
 		final HierarchyStatisticsProducer hierarchyStatisticsProducer = getHierarchyStatisticsProducer(extraResultPlanner);
@@ -96,21 +89,9 @@ public class HierarchyOfReferenceTranslator
 				referencedEntitySchema.isWithHierarchy(),
 				() -> new EntityIsNotHierarchicalException(referenceName, entityType));
 
-			// verify that the reference has hierarchy index in requested scopes
-			final ProcessingScope processingScope = extraResultPlanner.getProcessingScope();
-			final Set<Scope> scopes = processingScope.getScopes();
-			// hierarchy cannot be produced from multiple scopes
-			if (scopes.size() > 1) {
-				throw new EvitaInvalidUsageException(
-					"Hierarchies of `" + referencedEntitySchema.getName() + "` from multiple scopes cannot be combined. " +
-						"They represent two distinct trees."
-				);
-			}
-			// so, there would be only single scope to check for hierarchy index
-			final Scope scope = scopes.iterator().next();
-			Assert.isTrue(
-				referencedEntitySchema.isHierarchyIndexedInScope(scope),
-				() -> new HierarchyNotIndexedException(entitySchema, scope)
+			// verify that the referenced schema has its hierarchy indexed in the single requested scope
+			final Scope scope = resolveSingleHierarchicalScope(
+				extraResultPlanner.getProcessingScope(), referencedEntitySchema
 			);
 
 			final HierarchyFilterConstraint hierarchyWithin = evitaRequest.getHierarchyWithin(referenceName);
@@ -132,11 +113,6 @@ public class HierarchyOfReferenceTranslator
 					)
 					.orElse(null);
 
-				// partitioning is determined by reference schema and scope alone — both stable per outer iteration,
-				// so every reduced index returned by getReducedEntityIndexes(scope, ...) takes the same branch
-				final boolean partitioned = referenceSchema.getReferenceIndexType(scope)
-					== ReferenceIndexType.FOR_FILTERING_AND_PARTITIONING;
-
 				// the request is more complex
 				hierarchyStatisticsProducer.interpret(
 					extraResultPlanner.getQueryContext()::getRootHierarchyNodes,
@@ -149,7 +125,12 @@ public class HierarchyOfReferenceTranslator
 					// we need to access EntityIndexType.REFERENCED_HIERARCHY_NODE of the queried type to access
 					// entity primary keys that are referencing the hierarchy entity
 					(nodeId, statisticsBase) -> {
-						final FilterBy filter = extraResultPlanner.getFilterByForStatisticsBase(statisticsBase, referenceSchema);
+						// reuse the already-planned primary filter formula (memoised) instead of re-translating
+						// the FilterBy per hierarchy node — the partitioned vs non-partitioned distinction
+						// collapses because intersecting `cachedGlobal` with the reduced-index PKs yields the
+						// same result regardless of how the index was carved up
+						final Formula cachedGlobal = extraResultPlanner
+							.getFilteringFormulaForStatisticsBase(statisticsBase, referenceSchema);
 						final List<ReducedEntityIndex> reducedIndexes = extraResultPlanner
 							.getQueryContext()
 							.getReducedEntityIndexes(
@@ -157,47 +138,20 @@ public class HierarchyOfReferenceTranslator
 							)
 							.toList();
 
-						if (filter == null || !filter.isApplicable()) {
-							// no filter — every reduced index contributes its full primary-key set
-							final Formula[] formulas = new Formula[reducedIndexes.size()];
+						final Formula[] formulas = new Formula[reducedIndexes.size()];
+						if (cachedGlobal == null) {
 							for (int i = 0; i < reducedIndexes.size(); i++) {
 								formulas[i] = reducedIndexes.get(i).getAllPrimaryKeysFormula();
 							}
-							return FormulaFactory.or(formulas);
-						} else if (partitioned) {
-							// single FilterByVisitor analysis covering every reduced index at once —
-							// avoids the per-index planning overhead that dominates with many references
-							return createFilterFormula(
-								extraResultPlanner.getQueryContext(),
-								filter,
-								ReducedEntityIndex.class,
-								entitySchema,
-								reducedIndexes,
-								extraResultPlanner.getAttributeSchemaAccessor()
-							);
 						} else {
-							// non-partitioned — AND each reduced index with the cached global-index formula
-							final Formula cachedGlobal = extraResultPlanner.computeOnlyOnce(
-								List.of(globalIndex),
-								filter,
-								() -> createFilterFormula(
-									extraResultPlanner.getQueryContext(),
-									filter,
-									GlobalEntityIndex.class,
-									entitySchema,
-									List.of(extraResultPlanner.getGlobalEntityIndex(scope)),
-									extraResultPlanner.getAttributeSchemaAccessor()
-								)
-							);
-							final Formula[] formulas = new Formula[reducedIndexes.size()];
 							for (int i = 0; i < reducedIndexes.size(); i++) {
 								formulas[i] = FormulaFactory.and(
 									reducedIndexes.get(i).getAllPrimaryKeysFormula(),
 									cachedGlobal
 								);
 							}
-							return FormulaFactory.or(formulas);
 						}
+						return FormulaFactory.or(formulas);
 					},
 					null,
 					hierarchyOfReference.getEmptyHierarchicalEntityBehaviour(),

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/HierarchyOfSelfTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/HierarchyOfSelfTranslator.java
@@ -25,26 +25,22 @@ package io.evitadb.core.query.extraResult.translator.hierarchyStatistics;
 
 import io.evitadb.api.exception.EntityIsNotHierarchicalException;
 import io.evitadb.api.query.RequireConstraint;
-import io.evitadb.api.query.filter.FilterBy;
 import io.evitadb.api.query.filter.HierarchyFilterConstraint;
 import io.evitadb.api.query.require.EmptyHierarchicalEntityBehaviour;
 import io.evitadb.api.query.require.HierarchyOfSelf;
 import io.evitadb.api.requestResponse.EvitaRequest;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.core.collection.EntityCollection;
-import io.evitadb.core.exception.HierarchyNotIndexedException;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.core.query.common.translator.SelfTraversingTranslator;
 import io.evitadb.core.query.extraResult.ExtraResultPlanningVisitor;
-import io.evitadb.core.query.extraResult.ExtraResultPlanningVisitor.ProcessingScope;
 import io.evitadb.core.query.extraResult.ExtraResultProducer;
 import io.evitadb.core.query.extraResult.translator.RequireConstraintTranslator;
 import io.evitadb.core.query.extraResult.translator.hierarchyStatistics.producer.HierarchyStatisticsProducer;
 import io.evitadb.core.query.sort.NestedContextSorter;
 import io.evitadb.dataType.Scope;
-import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.index.EntityIndexKey;
 import io.evitadb.index.EntityIndexType;
 import io.evitadb.index.GlobalEntityIndex;
@@ -56,7 +52,6 @@ import io.evitadb.utils.Assert;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -93,22 +88,9 @@ public class HierarchyOfSelfTranslator
 		// we need to register producer prematurely
 		extraResultPlanner.registerProducer(hierarchyStatisticsProducer);
 
-		// verify that the reference has hierarchy index in requested scopes
-		final ProcessingScope processingScope = extraResultPlanner.getProcessingScope();
-		final Set<Scope> scopes = processingScope.getScopes();
-		// hierarchy cannot be produced from multiple scopes
-		if (scopes.size() > 1) {
-			throw new EvitaInvalidUsageException(
-				"Hierarchies of `" + queriedSchema.getName() + "` from multiple scopes cannot be combined. " +
-					"They represent two distinct trees."
-			);
-		}
-		// so, there would be only single scope to check for hierarchy index
-		final Scope scope = scopes.iterator().next();
-		Assert.isTrue(
-			queriedSchema.isHierarchyIndexedInScope(scope),
-			() -> new HierarchyNotIndexedException(queriedSchema, scope)
-		);
+		// verify that the queried schema has its hierarchy indexed in the single requested scope
+		final Scope scope = resolveSingleHierarchicalScope(extraResultPlanner.getProcessingScope(), queriedSchema);
+		final Set<Scope> scopes = Collections.singleton(scope);
 
 		final Optional<EntityCollection> targetCollectionRef = extraResultPlanner.getEntityCollection(queriedEntityType);
 		final GlobalEntityIndex globalIndex = targetCollectionRef
@@ -135,53 +117,28 @@ public class HierarchyOfSelfTranslator
 				globalIndex,
 				extraResultPlanner.getFetchRequirementCollector(),
 				(nodeId, statisticsBase) -> {
-					final FilterBy filter = extraResultPlanner.getFilterByForStatisticsBase(statisticsBase, null);
+					// reuse the already-planned primary filter formula (memoised) instead of re-translating
+					// the FilterBy per hierarchy node
+					final Formula cachedGlobal = extraResultPlanner
+						.getFilteringFormulaForStatisticsBase(statisticsBase, null);
 					final Formula childrenExceptSelfFormula = FormulaFactory.not(
 						new ConstantFormula(new BaseBitmap(nodeId)),
 						globalIndex.getHierarchyNodesForParentFormula(nodeId)
 					);
-					if (filter == null || !filter.isApplicable()) {
+					if (cachedGlobal == null) {
 						return childrenExceptSelfFormula;
-					} else {
-						final Formula baseFormula = extraResultPlanner.computeOnlyOnce(
-							Collections.singletonList(globalIndex),
-							filter,
-							() -> createFilterFormula(
-								extraResultPlanner.getQueryContext(),
-								filter,
-								GlobalEntityIndex.class,
-								queriedSchema,
-								List.of(globalIndex),
-								extraResultPlanner.getAttributeSchemaAccessor()
-							)
-						);
-						return FormulaFactory.and(
-							baseFormula,
-							childrenExceptSelfFormula
-						);
 					}
+					return FormulaFactory.and(cachedGlobal, childrenExceptSelfFormula);
 				},
 				statisticsBase -> {
-					final FilterBy filter = extraResultPlanner.getFilterByForStatisticsBase(statisticsBase, null);
-					if (filter == null || !filter.isApplicable()) {
+					final Formula cachedGlobal = extraResultPlanner
+						.getFilteringFormulaForStatisticsBase(statisticsBase, null);
+					if (cachedGlobal == null) {
 						return HierarchyFilteringPredicate.ACCEPT_ALL_NODES_PREDICATE;
-					} else {
-						final Formula baseFormula = extraResultPlanner.computeOnlyOnce(
-							Collections.singletonList(globalIndex),
-							filter,
-							() -> createFilterFormula(
-								extraResultPlanner.getQueryContext(),
-								filter,
-								GlobalEntityIndex.class,
-								queriedSchema,
-								List.of(globalIndex),
-								extraResultPlanner.getAttributeSchemaAccessor()
-							)
-						);
-						return new FilteringFormulaHierarchyEntityPredicate(
-							queriedEntityType, scopes, filter, baseFormula
-						);
 					}
+					return new FilteringFormulaHierarchyEntityPredicate(
+						queriedEntityType, scopes, cachedGlobal
+					);
 				},
 				EmptyHierarchicalEntityBehaviour.LEAVE_EMPTY,
 				sorter,

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/facet/FacetHavingTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/facet/FacetHavingTranslator.java
@@ -360,7 +360,7 @@ public class FacetHavingTranslator implements FilteringConstraintTranslator<Face
 			.map(it -> FormulaFactory.or(it.toArray(Formula[]::new)))
 			.orElse(null);
 
-		return composeFacetSelectionFormula(notFormula, andFormula, orFormula);
+		return composeFacetSelectionFormula(facetHaving.getReferenceName(), notFormula, andFormula, orFormula);
 	}
 
 	/**
@@ -386,6 +386,7 @@ public class FacetHavingTranslator implements FilteringConstraintTranslator<Face
 	 */
 	@Nonnull
 	static Formula composeFacetSelectionFormula(
+		@Nonnull String referenceName,
 		@Nullable Formula notFormula,
 		@Nullable Formula andFormula,
 		@Nullable Formula orFormula
@@ -413,7 +414,7 @@ public class FacetHavingTranslator implements FilteringConstraintTranslator<Face
 				// sentinel into a regular `NotFormula(inner, superset)` inside `UserFilterFormula`, the wrapper
 				// stays reachable — otherwise `UserFilterRelaxer.FACET_IMPACT` has no carrier to peel and the
 				// user's NOT-only facet pick leaks into every impact projection.
-				return new FutureNotFormula(new FacetHavingFormula(notFormula));
+				return new FutureNotFormula(new FacetHavingFormula(referenceName, notFormula));
 			} else if (andFormula == null) {
 				composed = new NotFormula(notFormula, orFormula);
 			} else if (orFormula == null) {
@@ -425,7 +426,7 @@ public class FacetHavingTranslator implements FilteringConstraintTranslator<Face
 				);
 			}
 		}
-		return new FacetHavingFormula(composed);
+		return new FacetHavingFormula(referenceName, composed);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/hierarchy/HierarchyWithinRootTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/hierarchy/HierarchyWithinRootTranslator.java
@@ -149,10 +149,12 @@ public class HierarchyWithinRootTranslator extends AbstractHierarchyTranslator<H
 		}
 
 		final Formula matchingHierarchyNodeIds = createFormulaFromHierarchyIndex(hierarchyWithinRoot, filterByVisitor);
-		if (hierarchyWithinRoot.getReferenceName().isEmpty()) {
-			return new HierarchyFormula(matchingHierarchyNodeIds);
+		final String referenceName = hierarchyWithinRoot.getReferenceName().orElse(null);
+		if (referenceName == null) {
+			return new HierarchyFormula(null, matchingHierarchyNodeIds);
 		} else {
 			return new HierarchyFormula(
+				referenceName,
 				createFormulaForReferencingEntities(
 					hierarchyWithinRoot,
 					filterByVisitor,

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/hierarchy/HierarchyWithinTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/hierarchy/HierarchyWithinTranslator.java
@@ -284,10 +284,12 @@ public class HierarchyWithinTranslator extends AbstractHierarchyTranslator<Hiera
 		}
 
 		final Formula matchingHierarchyNodeIds = createFormulaFromHierarchyIndex(hierarchyWithin, filterByVisitor);
-		if (hierarchyWithin.getReferenceName().isEmpty()) {
-			return new HierarchyFormula(matchingHierarchyNodeIds);
+		final String referenceName = hierarchyWithin.getReferenceName().orElse(null);
+		if (referenceName == null) {
+			return new HierarchyFormula(null, matchingHierarchyNodeIds);
 		} else {
 			return new HierarchyFormula(
+				referenceName,
 				createFormulaForReferencingEntities(
 					hierarchyWithin,
 					filterByVisitor,

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/FilteringFormulaHierarchyEntityPredicate.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/FilteringFormulaHierarchyEntityPredicate.java
@@ -262,21 +262,27 @@ public class FilteringFormulaHierarchyEntityPredicate implements HierarchyFilter
 	}
 
 	/**
-	 * This constructor could be used when the filtered set is already known.
+	 * Constructor used when only the pre-computed filtering formula is available — typically because the formula
+	 * was derived by cloning the main query's filter tree (see
+	 * {@link io.evitadb.core.query.extraResult.ExtraResultPlanningVisitor#getFilteringFormulaForStatisticsBase}).
+	 * Identity for {@link #equals(Object)}/{@link #hashCode()} relies on the formula's hash because no
+	 * {@link FilterBy} is captured.
 	 *
-	 * @param filterBy         the original filtering constraint that led to the formula
-	 * @param filteringFormula the formula containing valid entity primary keys that should be matched by this predicate
+	 * @param targetEntityType  name of the entity type whose hierarchy is being filtered by this predicate
+	 * @param requestedScopes   set of {@link Scope}s the surrounding query operates against; used to constrain
+	 *                          hierarchy traversal to the indexes the query is allowed to read from
+	 * @param filteringFormula  the formula containing valid entity primary keys that should be matched by this
+	 *                          predicate
 	 */
 	public FilteringFormulaHierarchyEntityPredicate(
 		@Nonnull String targetEntityType,
 		@Nonnull Set<Scope> requestedScopes,
-		@Nonnull FilterBy filterBy,
 		@Nonnull Formula filteringFormula
 	) {
 		this.parent = null;
 		this.targetEntityType = targetEntityType;
 		this.requestedScopes = requestedScopes;
-		this.filterBy = filterBy;
+		this.filterBy = null;
 		this.anyChildFilter = null;
 		this.filteringFormula = filteringFormula;
 		this.hash = this.filteringFormula.getHash();
@@ -417,6 +423,10 @@ public class FilteringFormulaHierarchyEntityPredicate implements HierarchyFilter
 		result = 31 * result + (this.filterBy == null ? 0 : this.filterBy.hashCode());
 		result = 31 * result + this.targetEntityType.hashCode();
 		result = 31 * result + this.requestedScopes.hashCode();
+		// fold in the formula's hash so predicates that share `(parent, targetEntityType, requestedScopes)` but
+		// were built from different filtering formulas (e.g. cached pre-computed formulas with `filterBy == null`)
+		// remain distinguishable
+		result = 31 * result + Long.hashCode(this.hash);
 		return result;
 	}
 
@@ -429,7 +439,8 @@ public class FilteringFormulaHierarchyEntityPredicate implements HierarchyFilter
 		return Arrays.equals(this.parent, that.parent) &&
 			Objects.equals(this.filterBy, that.filterBy) &&
 			this.targetEntityType.equals(that.targetEntityType) &&
-			this.requestedScopes.equals(that.requestedScopes);
+			this.requestedScopes.equals(that.requestedScopes) &&
+			this.hash.longValue() == that.hash.longValue();
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/FilteringFormulaHierarchyEntityPredicate.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/predicate/FilteringFormulaHierarchyEntityPredicate.java
@@ -436,6 +436,10 @@ public class FilteringFormulaHierarchyEntityPredicate implements HierarchyFilter
 		if (o == null || getClass() != o.getClass()) return false;
 
 		FilteringFormulaHierarchyEntityPredicate that = (FilteringFormulaHierarchyEntityPredicate) o;
+		// `hash` is a 64-bit content hash of `filteringFormula` (xxhash, uniformly distributed) and is one of
+		// five equality components — a collision alone cannot make two predicates equal. The alternative
+		// (deep formula-tree structural equality) is exactly the cost this predicate is built to avoid; the
+		// 64-bit collision risk across the predicate identities used in a single query context is negligible.
 		return Arrays.equals(this.parent, that.parent) &&
 			Objects.equals(this.filterBy, that.filterBy) &&
 			this.targetEntityType.equals(that.targetEntityType) &&

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/facet/FacetHavingFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/facet/FacetHavingFormulaTest.java
@@ -71,6 +71,12 @@ class FacetHavingFormulaTest {
 	 */
 	@Nonnull
 	private static final Bitmap REFERENCE_BITMAP = new ArrayBitmap(10, 20, 30);
+	/**
+	 * Reference name passed to every wrapper under test — keeps construction sites short while still
+	 * exercising the active (non-{@code null}) branch of {@link FacetHavingFormula#includeAdditionalHash}.
+	 */
+	@Nonnull
+	private static final String REFERENCE_NAME = "brand";
 
 	/**
 	 * Builds a fresh inner formula around {@link #REFERENCE_BITMAP}. Each test that asserts hash equality
@@ -93,7 +99,7 @@ class FacetHavingFormulaTest {
 			// the wrapper must forward compute() verbatim — any copy would add allocations and break
 			// the no-overhead guarantee documented in the class-level comment
 			final Formula inner = newInnerFormula();
-			final FacetHavingFormula formula = new FacetHavingFormula(inner);
+			final FacetHavingFormula formula = new FacetHavingFormula(REFERENCE_NAME, inner);
 
 			final Bitmap result = formula.compute();
 
@@ -106,7 +112,7 @@ class FacetHavingFormulaTest {
 			// empty inner formula should propagate as EmptyBitmap.INSTANCE — confirms the wrapper
 			// doesn't accidentally wrap empty into a fresh BaseBitmap, which would break the
 			// downstream `bitmap == EmptyBitmap.INSTANCE` fast-path used by AND/OR combinators
-			final FacetHavingFormula formula = new FacetHavingFormula(EmptyFormula.INSTANCE);
+			final FacetHavingFormula formula = new FacetHavingFormula(REFERENCE_NAME, EmptyFormula.INSTANCE);
 
 			assertSame(EmptyBitmap.INSTANCE, formula.compute());
 		}
@@ -121,7 +127,7 @@ class FacetHavingFormulaTest {
 		void shouldForwardOperationCostToInnerFormula() {
 			// wrapper must add zero per-element cost — otherwise inserting it would change plan choice
 			final Formula inner = newInnerFormula();
-			final FacetHavingFormula formula = new FacetHavingFormula(inner);
+			final FacetHavingFormula formula = new FacetHavingFormula(REFERENCE_NAME, inner);
 
 			assertEquals(inner.getOperationCost(), formula.getOperationCost());
 		}
@@ -132,7 +138,7 @@ class FacetHavingFormulaTest {
 			// cardinality drives the multiplier in getEstimatedCost — delegating keeps the cost model
 			// transparent to the wrapper
 			final Formula inner = newInnerFormula();
-			final FacetHavingFormula formula = new FacetHavingFormula(inner);
+			final FacetHavingFormula formula = new FacetHavingFormula(REFERENCE_NAME, inner);
 
 			assertEquals(inner.getEstimatedCardinality(), formula.getEstimatedCardinality());
 		}
@@ -143,7 +149,7 @@ class FacetHavingFormulaTest {
 			// getEstimatedCostInternal must return the child's estimate untouched — no base-cost term
 			// and no additional per-wrapper contribution
 			final Formula inner = newInnerFormula();
-			final FacetHavingFormula formula = new FacetHavingFormula(inner);
+			final FacetHavingFormula formula = new FacetHavingFormula(REFERENCE_NAME, inner);
 
 			assertEquals(inner.getEstimatedCost(), formula.getEstimatedCost());
 		}
@@ -156,7 +162,7 @@ class FacetHavingFormulaTest {
 		@Test
 		@DisplayName("should re-wrap provided single inner formula")
 		void shouldReWrapProvidedSingleInnerFormula() {
-			final FacetHavingFormula original = new FacetHavingFormula(newInnerFormula());
+			final FacetHavingFormula original = new FacetHavingFormula(REFERENCE_NAME, newInnerFormula());
 			final Formula replacement = new ConstantFormula(new ArrayBitmap(1, 2));
 
 			final Formula clone = original.getCloneWithInnerFormulas(replacement);
@@ -172,7 +178,7 @@ class FacetHavingFormulaTest {
 		void shouldPreserveFacetHavingFormulaTypeOnClone() {
 			// the concrete class is how the facet-impact relaxer finds facet carriers — returning a different
 			// type on clone would make every refold invisible to the relaxer
-			final Formula clone = new FacetHavingFormula(newInnerFormula())
+			final Formula clone = new FacetHavingFormula(REFERENCE_NAME, newInnerFormula())
 				.getCloneWithInnerFormulas(new ConstantFormula(new ArrayBitmap(5)));
 
 			assertInstanceOf(FacetHavingFormula.class, clone);
@@ -184,7 +190,7 @@ class FacetHavingFormulaTest {
 			// "exactly one inner formula" is a hard invariant — Assert.isTrue maps to
 			// EvitaInvalidUsageException; the message identifies the constraint so a failing refold is
 			// traceable in logs
-			final FacetHavingFormula original = new FacetHavingFormula(newInnerFormula());
+			final FacetHavingFormula original = new FacetHavingFormula(REFERENCE_NAME, newInnerFormula());
 
 			final EvitaInvalidUsageException ex = assertThrows(
 				EvitaInvalidUsageException.class,
@@ -200,7 +206,7 @@ class FacetHavingFormulaTest {
 		@DisplayName("should throw when more than one inner formula is supplied")
 		void shouldThrowWhenMoreThanOneInnerFormulaIsSupplied() {
 			// same invariant — clone cannot introduce multiple children where the wrapper expects one
-			final FacetHavingFormula original = new FacetHavingFormula(newInnerFormula());
+			final FacetHavingFormula original = new FacetHavingFormula(REFERENCE_NAME, newInnerFormula());
 			final Formula a = new ConstantFormula(new ArrayBitmap(1));
 			final Formula b = new ConstantFormula(new ArrayBitmap(2));
 
@@ -224,8 +230,8 @@ class FacetHavingFormulaTest {
 		void shouldProduceIdenticalHashForTwoWrappersAroundIdenticalChildren() {
 			// stable hashing is what lets the formula cache recognise "two facetHaving wrappers around
 			// the same subtree" as equivalent — a drift here silently misses cache hits
-			final FacetHavingFormula a = new FacetHavingFormula(newInnerFormula());
-			final FacetHavingFormula b = new FacetHavingFormula(newInnerFormula());
+			final FacetHavingFormula a = new FacetHavingFormula(REFERENCE_NAME, newInnerFormula());
+			final FacetHavingFormula b = new FacetHavingFormula(REFERENCE_NAME, newInnerFormula());
 
 			assertEquals(a.getHash(), b.getHash());
 		}
@@ -234,8 +240,8 @@ class FacetHavingFormulaTest {
 		@DisplayName("should produce different hash for wrappers around different children")
 		void shouldProduceDifferentHashForWrappersAroundDifferentChildren() {
 			// hash must change when the child changes — otherwise sibling facet picks would collide
-			final FacetHavingFormula a = new FacetHavingFormula(new ConstantFormula(new ArrayBitmap(1)));
-			final FacetHavingFormula b = new FacetHavingFormula(new ConstantFormula(new ArrayBitmap(2)));
+			final FacetHavingFormula a = new FacetHavingFormula(REFERENCE_NAME, new ConstantFormula(new ArrayBitmap(1)));
+			final FacetHavingFormula b = new FacetHavingFormula(REFERENCE_NAME, new ConstantFormula(new ArrayBitmap(2)));
 
 			assertNotEquals(a.getHash(), b.getHash());
 		}
@@ -246,7 +252,7 @@ class FacetHavingFormulaTest {
 			// the wrapper's own class ID must enter the hash — otherwise `facetHaving(x)` and `x` would
 			// cache-collide and the relaxer's type-based lookup would see a false carrier
 			final Formula inner = newInnerFormula();
-			final FacetHavingFormula wrapper = new FacetHavingFormula(inner);
+			final FacetHavingFormula wrapper = new FacetHavingFormula(REFERENCE_NAME, inner);
 
 			assertNotEquals(inner.getHash(), wrapper.getHash());
 		}
@@ -260,7 +266,7 @@ class FacetHavingFormulaTest {
 		@DisplayName("should render FACET HAVING as short label identifying the wrapper")
 		void shouldRenderFacetHavingAsShortLabelIdentifyingTheWrapper() {
 			// the short toString is used in plan dumps — must be stable and exactly "FACET HAVING"
-			final FacetHavingFormula formula = new FacetHavingFormula(newInnerFormula());
+			final FacetHavingFormula formula = new FacetHavingFormula(REFERENCE_NAME, newInnerFormula());
 
 			assertEquals("FACET HAVING", formula.toString());
 		}
@@ -271,7 +277,7 @@ class FacetHavingFormulaTest {
 			// toStringVerbose is used by debug tooling — must embed the child's verbose rendering so
 			// a plan dump can be read top-to-bottom without descending manually
 			final Formula inner = newInnerFormula();
-			final FacetHavingFormula formula = new FacetHavingFormula(inner);
+			final FacetHavingFormula formula = new FacetHavingFormula(REFERENCE_NAME, inner);
 
 			final String verbose = formula.toStringVerbose();
 			assertNotNull(verbose);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/FormulaClonerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/FormulaClonerTest.java
@@ -29,7 +29,9 @@ import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.base.NotFormula;
 import io.evitadb.core.query.algebra.base.OrFormula;
+import io.evitadb.core.query.algebra.facet.ScopeContainerFormula;
 import io.evitadb.core.query.algebra.facet.UserFilterFormula;
+import io.evitadb.dataType.Scope;
 import io.evitadb.index.bitmap.ArrayBitmap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -75,9 +77,9 @@ class FormulaClonerTest {
 		@Test
 		@DisplayName("should return same instance when mutator is identity")
 		void shouldLeaveFormulaUntouched() {
-			final Formula cloneResult = FormulaCloner.clone(formula, UnaryOperator.identity());
+			final Formula cloneResult = FormulaCloner.clone(FormulaClonerTest.this.formula, UnaryOperator.identity());
 
-			assertSame(formula, cloneResult);
+			assertSame(FormulaClonerTest.this.formula, cloneResult);
 		}
 
 		@Test
@@ -85,7 +87,7 @@ class FormulaClonerTest {
 		void shouldReplaceEntireFormula() {
 			final ConstantFormula replacedFormula = new ConstantFormula(new ArrayBitmap(7));
 
-			final Formula cloneResult = FormulaCloner.clone(formula, examinedFormula -> replacedFormula);
+			final Formula cloneResult = FormulaCloner.clone(FormulaClonerTest.this.formula, examinedFormula -> replacedFormula);
 
 			assertSame(replacedFormula, cloneResult);
 		}
@@ -130,37 +132,37 @@ class FormulaClonerTest {
 		@DisplayName("should remove EmptyFormula and preserve other children")
 		void shouldGetRidOfEmptyFormulas() {
 			final Formula cloneResult = FormulaCloner.clone(
-				formula,
+				FormulaClonerTest.this.formula,
 				examinedFormula -> examinedFormula instanceof EmptyFormula ? null : examinedFormula
 			);
 
-			assertNotSame(formula, cloneResult);
-			assertTrue(FormulaLocator.contains(formula, EmptyFormula.class));
+			assertNotSame(FormulaClonerTest.this.formula, cloneResult);
+			assertTrue(FormulaLocator.contains(FormulaClonerTest.this.formula, EmptyFormula.class));
 			assertFalse(FormulaLocator.contains(cloneResult, EmptyFormula.class));
 
-			assertNotSame(formula.getInnerFormulas()[0], cloneResult.getInnerFormulas()[0]);
+			assertNotSame(FormulaClonerTest.this.formula.getInnerFormulas()[0], cloneResult.getInnerFormulas()[0]);
 			assertSame(
-				formula.getInnerFormulas()[0].getInnerFormulas()[1],
+				FormulaClonerTest.this.formula.getInnerFormulas()[0].getInnerFormulas()[1],
 				cloneResult.getInnerFormulas()[0].getInnerFormulas()[0]
 			);
 			assertSame(
-				formula.getInnerFormulas()[0].getInnerFormulas()[2],
+				FormulaClonerTest.this.formula.getInnerFormulas()[0].getInnerFormulas()[2],
 				cloneResult.getInnerFormulas()[0].getInnerFormulas()[1]
 			);
-			assertSame(formula.getInnerFormulas()[1], cloneResult.getInnerFormulas()[1]);
+			assertSame(FormulaClonerTest.this.formula.getInnerFormulas()[1], cloneResult.getInnerFormulas()[1]);
 		}
 
 		@Test
 		@DisplayName("should collapse parent to single child when sibling removed")
 		void shouldHandleUnnecessaryFormulas() {
 			final Formula cloneResult = FormulaCloner.clone(
-				formula,
+				FormulaClonerTest.this.formula,
 				examinedFormula -> examinedFormula instanceof UserFilterFormula ? null : examinedFormula
 			);
 
-			assertNotSame(formula, cloneResult);
+			assertNotSame(FormulaClonerTest.this.formula, cloneResult);
 			// When AndFormula loses one of two children, getCloneWithInnerFormulas returns the surviving child
-			assertSame(formula.getInnerFormulas()[0], cloneResult);
+			assertSame(FormulaClonerTest.this.formula.getInnerFormulas()[0], cloneResult);
 		}
 
 		@Test
@@ -168,16 +170,125 @@ class FormulaClonerTest {
 		void shouldReplaceSpecificInnerFormula() {
 			final ConstantFormula replacement = new ConstantFormula(new ArrayBitmap(77));
 			final Formula cloneResult = FormulaCloner.clone(
-				formula,
+				FormulaClonerTest.this.formula,
 				f -> f instanceof EmptyFormula ? replacement : f
 			);
 
-			assertNotSame(formula, cloneResult);
+			assertNotSame(FormulaClonerTest.this.formula, cloneResult);
 			// EmptyFormula should be gone, replaced by ConstantFormula(77)
 			assertFalse(FormulaLocator.contains(cloneResult, EmptyFormula.class));
 			// OrFormula should have replacement as first child now
 			final Formula orClone = cloneResult.getInnerFormulas()[0];
 			assertSame(replacement, orClone.getInnerFormulas()[0]);
+		}
+
+		@Test
+		@DisplayName("should drop nested empty container chain instead of propagating EmptyFormula upward")
+		void shouldDropNestedEmptyContainerChain() {
+			// Reproduces the bug case where strip mutators empty out an *intermediate* container
+			// inside UserFilterFormula (e.g. userFilter(and(stripA, stripB))). The inner AND ends up
+			// with no children and `AndFormula.getCloneWithInnerFormulas([])` returns EmptyFormula —
+			// the cloner used to let that propagate through UserFilter and into the surrounding AND,
+			// collapsing the entire result to "no entities". The convention-driven rule now drops
+			// any wrapper that returns EmptyFormula on empty children, cascading the cleanup so the
+			// surrounding tree is preserved as if the user-filter wasn't there at all.
+			final ConstantFormula stripA = new ConstantFormula(new ArrayBitmap(101));
+			final ConstantFormula stripB = new ConstantFormula(new ArrayBitmap(102));
+			final ConstantFormula keepMe = new ConstantFormula(new ArrayBitmap(7, 8));
+			final Formula tree = new AndFormula(
+				keepMe,
+				new UserFilterFormula(
+					new AndFormula(stripA, stripB)
+				)
+			);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				tree,
+				examined -> examined == stripA || examined == stripB ? null : examined
+			);
+
+			assertNotSame(tree, cloneResult);
+			// UserFilter is gone (its only child — the inner AND — was emptied and dropped, so the
+			// UserFilter itself ends up empty and is dropped too)
+			assertFalse(FormulaLocator.contains(cloneResult, UserFilterFormula.class));
+			// EmptyFormula must NOT have leaked into the cloned tree
+			assertFalse(FormulaLocator.contains(cloneResult, EmptyFormula.class));
+			// outer AND collapses to its single surviving child
+			assertSame(keepMe, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should drop AndFormula when all its children are stripped")
+		void shouldDropAndFormulaWhenAllChildrenStripped() {
+			// Validates the generalised empty-drop convention — once both children of the inner AND are
+			// stripped, AndFormula.getCloneWithInnerFormulas([]) returns EmptyFormula and the cloner must
+			// drop the wrapper instead of letting EmptyFormula leak into the surrounding OR.
+			final ConstantFormula stripA = new ConstantFormula(new ArrayBitmap(101));
+			final ConstantFormula stripB = new ConstantFormula(new ArrayBitmap(102));
+			final ConstantFormula keep = new ConstantFormula(new ArrayBitmap(7, 8));
+			final Formula tree = new OrFormula(
+				keep,
+				new AndFormula(stripA, stripB)
+			);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				tree,
+				f -> f == stripA || f == stripB ? null : f
+			);
+
+			assertNotNull(cloneResult);
+			assertFalse(FormulaLocator.contains(cloneResult, EmptyFormula.class));
+			// OR with one surviving child collapses to that child
+			assertSame(keep, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should drop OrFormula when all its children are stripped")
+		void shouldDropOrFormulaWhenAllChildrenStripped() {
+			// Mirrors the AND case: stripping every child of an OR leaves OrFormula.getCloneWithInnerFormulas([])
+			// returning EmptyFormula; the cloner must drop the wrapper, not propagate it through the surrounding AND.
+			final ConstantFormula stripA = new ConstantFormula(new ArrayBitmap(201));
+			final ConstantFormula stripB = new ConstantFormula(new ArrayBitmap(202));
+			final ConstantFormula keep = new ConstantFormula(new ArrayBitmap(11, 12));
+			final Formula tree = new AndFormula(
+				keep,
+				new OrFormula(stripA, stripB)
+			);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				tree,
+				f -> f == stripA || f == stripB ? null : f
+			);
+
+			assertNotNull(cloneResult);
+			assertFalse(FormulaLocator.contains(cloneResult, EmptyFormula.class));
+			// AND with one surviving child collapses to that child
+			assertSame(keep, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should drop ScopeContainerFormula when all its children are stripped")
+		void shouldDropScopeContainerFormulaWhenAllChildrenStripped() {
+			// ScopeContainerFormula.getCloneWithInnerFormulas([]) returns EmptyFormula too — the cloner must
+			// honour the generalised convention and drop the scope container instead of leaking EmptyFormula upwards.
+			final ConstantFormula stripA = new ConstantFormula(new ArrayBitmap(301));
+			final ConstantFormula stripB = new ConstantFormula(new ArrayBitmap(302));
+			final ConstantFormula keep = new ConstantFormula(new ArrayBitmap(21, 22));
+			final Formula tree = new AndFormula(
+				keep,
+				new ScopeContainerFormula(Scope.LIVE, stripA, stripB)
+			);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				tree,
+				f -> f == stripA || f == stripB ? null : f
+			);
+
+			assertNotNull(cloneResult);
+			assertFalse(FormulaLocator.contains(cloneResult, EmptyFormula.class));
+			assertFalse(FormulaLocator.contains(cloneResult, ScopeContainerFormula.class));
+			// AND with one surviving child collapses to that child
+			assertSame(keep, cloneResult);
 		}
 	}
 
@@ -240,6 +351,28 @@ class FormulaClonerTest {
 			final Formula firstChild = cloneResult.getInnerFormulas()[0];
 			assertSame(superset, firstChild);
 		}
+
+		@Test
+		@DisplayName("should drop NotFormula when both children are stripped")
+		void shouldDropNotFormulaWhenBothChildrenStripped() {
+			final ConstantFormula stripSubtracted = new ConstantFormula(new ArrayBitmap(5));
+			final ConstantFormula stripSuperset = new ConstantFormula(new ArrayBitmap(5, 8, 10));
+			final ConstantFormula keep = new ConstantFormula(new ArrayBitmap(1));
+			final Formula tree = new OrFormula(
+				keep,
+				new NotFormula(stripSubtracted, stripSuperset)
+			);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				tree,
+				f -> f == stripSubtracted || f == stripSuperset ? null : f
+			);
+
+			assertNotNull(cloneResult);
+			assertFalse(FormulaLocator.contains(cloneResult, NotFormula.class));
+			// OR with one surviving child collapses to that child
+			assertSame(keep, cloneResult);
+		}
 	}
 
 	@Nested
@@ -247,10 +380,16 @@ class FormulaClonerTest {
 	class ParentContextTest {
 
 		@Test
-		@DisplayName("should resolve isWithin with class parameter")
+		@DisplayName("should resolve isWithin with class parameter and drop the empty UserFilterFormula")
 		void shouldResolveIsWithin() {
+			// Strip every formula inside the UserFilterFormula. After the strip the wrapper has no children;
+			// the cloner treats an empty UserFilterFormula as AND-identity (drops it from the parent) instead
+			// of letting `getCloneWithInnerFormulas([])` short-circuit it to EmptyFormula. The root AND now
+			// has a single surviving child — the untouched OrFormula sub-tree — and `AndFormula.getCloneWithInnerFormulas`
+			// collapses an AND with one child to that child, so the result is the original OrFormula instance
+			// itself (memoised identity preserved).
 			final Formula cloneResult = FormulaCloner.clone(
-				formula, (formulaCloner, currentFormula) -> {
+				FormulaClonerTest.this.formula, (formulaCloner, currentFormula) -> {
 					if (formulaCloner.isWithin(UserFilterFormula.class)) {
 						return null;
 					} else {
@@ -259,20 +398,19 @@ class FormulaClonerTest {
 				}
 			);
 
-			assertNotSame(formula, cloneResult);
-			assertTrue(FormulaLocator.contains(formula, UserFilterFormula.class));
-
-			assertSame(formula.getInnerFormulas()[0], cloneResult.getInnerFormulas()[0]);
-			assertNotSame(formula.getInnerFormulas()[1], cloneResult.getInnerFormulas()[1]);
-			assertEquals(0, cloneResult.getInnerFormulas()[1].getInnerFormulas().length);
+			assertNotSame(FormulaClonerTest.this.formula, cloneResult);
+			assertTrue(FormulaLocator.contains(FormulaClonerTest.this.formula, UserFilterFormula.class));
+			assertFalse(FormulaLocator.contains(cloneResult, UserFilterFormula.class));
+			// AND with 1 surviving child collapses to that child — the cloned root IS the original OrFormula
+			assertSame(FormulaClonerTest.this.formula.getInnerFormulas()[0], cloneResult);
 		}
 
 		@Test
 		@DisplayName("should resolve isWithin with predicate parameter")
 		void shouldResolveIsWithinWithPredicate() {
 			final Formula cloneResult = FormulaCloner.clone(
-				formula, (formulaCloner, currentFormula) -> {
-					if (formulaCloner.isWithin(f -> f instanceof OrFormula)) {
+				FormulaClonerTest.this.formula, (formulaCloner, currentFormula) -> {
+					if (formulaCloner.isWithin(OrFormula.class::isInstance)) {
 						return null;
 					} else {
 						return currentFormula;
@@ -291,11 +429,11 @@ class FormulaClonerTest {
 		void shouldReportAllParentsMatchCorrectly() {
 			// Track which formulas see all parents matching
 			final Formula cloneResult = FormulaCloner.clone(
-				formula, (formulaCloner, currentFormula) -> {
+				FormulaClonerTest.this.formula, (formulaCloner, currentFormula) -> {
 					// At root level (no parents), allParentsMatch should be true vacuously
-					if (currentFormula == formula) {
+					if (currentFormula == FormulaClonerTest.this.formula) {
 						assertTrue(
-							formulaCloner.allParentsMatch(f -> f instanceof AndFormula),
+							formulaCloner.allParentsMatch(AndFormula.class::isInstance),
 							"allParentsMatch should be vacuously true at root"
 						);
 					}
@@ -303,7 +441,7 @@ class FormulaClonerTest {
 				}
 			);
 
-			assertSame(formula, cloneResult);
+			assertSame(FormulaClonerTest.this.formula, cloneResult);
 		}
 
 		@Test
@@ -322,9 +460,9 @@ class FormulaClonerTest {
 				tree, (formulaCloner, currentFormula) -> {
 					if (currentFormula == targetLeaf) {
 						// parents are OrFormula + AndFormula, not all are OrFormula
-						assertFalse(formulaCloner.allParentsMatch(f -> f instanceof OrFormula));
+						assertFalse(formulaCloner.allParentsMatch(OrFormula.class::isInstance));
 						// but all parents are Formula
-						assertTrue(formulaCloner.allParentsMatch(f -> f instanceof Formula));
+						assertTrue(formulaCloner.allParentsMatch(Formula.class::isInstance));
 					}
 					return currentFormula;
 				}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitorTest.java
@@ -73,7 +73,7 @@ class ExtraResultPlanningVisitorTest {
 		final Formula formula = mock(Formula.class);
 		final FilterByVisitor filterByVisitor = mock(FilterByVisitor.class);
 		return new ExtraResultPlanningVisitor(
-			queryContext, indexes, formula, filterByVisitor, Collections.emptyList()
+			queryContext, indexes, formula, filterByVisitor, Collections.emptyList(), null
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/common/UserFilterRelaxerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/common/UserFilterRelaxerTest.java
@@ -419,7 +419,7 @@ class UserFilterRelaxerTest {
 	 */
 	@Nonnull
 	private static FacetHavingFormula newFacetCarrier(int pk) {
-		return new FacetHavingFormula(new ConstantFormula(new ArrayBitmap(pk)));
+		return new FacetHavingFormula("brand", new ConstantFormula(new ArrayBitmap(pk)));
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/AbstractHierarchyTranslatorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/hierarchyStatistics/AbstractHierarchyTranslatorTest.java
@@ -1,0 +1,206 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.extraResult.translator.hierarchyStatistics;
+
+import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.core.exception.HierarchyNotIndexedException;
+import io.evitadb.core.query.extraResult.ExtraResultPlanningVisitor.ProcessingScope;
+import io.evitadb.dataType.Scope;
+import io.evitadb.exception.EvitaInvalidUsageException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for [AbstractHierarchyTranslator.resolveSingleHierarchicalScope] verifying scope-resolution rules
+ * for hierarchy statistics planning: exactly one scope must be requested, the schema's hierarchy must be
+ * indexed in that scope, and any error must reference the schema actually being inspected.
+ *
+ * The test class lives in the same package as the production class so it can call the package-protected
+ * (`protected static`) helper directly without reflection.
+ *
+ * @author evitaDB
+ */
+@DisplayName("AbstractHierarchyTranslator — resolveSingleHierarchicalScope")
+class AbstractHierarchyTranslatorTest {
+
+	private static final String QUERIED_SCHEMA_NAME = "Product";
+	private static final String REFERENCED_SCHEMA_NAME = "Category";
+
+	@Nested
+	@DisplayName("Happy path")
+	class HappyPathTest {
+
+		@Test
+		@DisplayName("should return single scope when exactly one is requested and indexed")
+		void shouldReturnSingleScopeWhenExactlyOneRequestedAndIndexed() {
+			// given a schema whose hierarchy is indexed in the LIVE scope
+			final EntitySchemaContract schema = mockSchema(QUERIED_SCHEMA_NAME, Scope.LIVE, true);
+			final ProcessingScope processingScope = mockProcessingScopeWith(Set.of(Scope.LIVE));
+
+			// when the helper resolves the single hierarchical scope
+			final Scope resolved = AbstractHierarchyTranslator.resolveSingleHierarchicalScope(
+				processingScope, schema
+			);
+
+			// then the requested scope is returned
+			assertSame(Scope.LIVE, resolved);
+		}
+	}
+
+	@Nested
+	@DisplayName("Error handling")
+	class ErrorHandlingTest {
+
+		@Test
+		@DisplayName("should throw EvitaInvalidUsageException when multiple scopes are requested")
+		void shouldThrowEvitaInvalidUsageExceptionWhenMultipleScopesRequested() {
+			// given a schema and a processing scope that demands two scopes simultaneously
+			final EntitySchemaContract schema = mockSchema(QUERIED_SCHEMA_NAME, Scope.LIVE, true);
+			final ProcessingScope processingScope = mockProcessingScopeWith(EnumSet.allOf(Scope.class));
+
+			// when resolving the single hierarchical scope, then the helper must reject the multi-scope request
+			final EvitaInvalidUsageException ex = assertThrows(
+				EvitaInvalidUsageException.class,
+				() -> AbstractHierarchyTranslator.resolveSingleHierarchicalScope(processingScope, schema)
+			);
+
+			final String message = ex.getMessage();
+			assertTrue(
+				message.contains(QUERIED_SCHEMA_NAME),
+				() -> "Exception message should reference the schema name `" + QUERIED_SCHEMA_NAME + "`, was: " + message
+			);
+			assertTrue(
+				message.contains("two distinct trees"),
+				() -> "Exception message should mention `two distinct trees`, was: " + message
+			);
+		}
+
+		@Test
+		@DisplayName("should throw HierarchyNotIndexedException when scope is not indexed")
+		void shouldThrowHierarchyNotIndexedExceptionWhenScopeNotIndexed() {
+			// given a schema whose hierarchy is NOT indexed in the requested scope
+			final EntitySchemaContract schema = mockSchema(QUERIED_SCHEMA_NAME, Scope.LIVE, false);
+			final ProcessingScope processingScope = mockProcessingScopeWith(Set.of(Scope.LIVE));
+
+			// when resolving the single hierarchical scope, then the helper must reject the un-indexed scope
+			final HierarchyNotIndexedException ex = assertThrows(
+				HierarchyNotIndexedException.class,
+				() -> AbstractHierarchyTranslator.resolveSingleHierarchicalScope(processingScope, schema)
+			);
+
+			final String message = ex.getMessage();
+			assertTrue(
+				message.contains(QUERIED_SCHEMA_NAME),
+				() -> "Exception message should reference the schema name `" + QUERIED_SCHEMA_NAME + "`, was: " + message
+			);
+		}
+
+		@Test
+		@DisplayName("should reference referenced-entity schema (not queried schema) for hierarchy-of-reference use case")
+		void shouldUseSchemaPassedAsArgumentInExceptionForHierarchyOfReferenceUseCase() {
+			// REGRESSION test: previously HierarchyOfReferenceTranslator passed the *queried* schema into the
+			// exception even though the un-indexed hierarchy belonged to the *referenced* entity schema. The
+			// helper now uses whichever schema is passed as the argument — and must continue to do so for
+			// hierarchy-of-reference translators that walk the referenced entity's hierarchy.
+			final EntitySchemaContract queriedSchema = mockSchema(QUERIED_SCHEMA_NAME, Scope.LIVE, true);
+			final EntitySchemaContract referencedSchema = mockSchema(REFERENCED_SCHEMA_NAME, Scope.LIVE, false);
+			final ProcessingScope processingScope = mockProcessingScopeWith(Set.of(Scope.LIVE));
+
+			// sanity check: the queried schema IS indexed, so resolving against it must succeed — proving that the
+			// helper's verdict is driven solely by the schema argument it is handed
+			assertEquals(
+				Scope.LIVE,
+				AbstractHierarchyTranslator.resolveSingleHierarchicalScope(processingScope, queriedSchema),
+				"Resolving against the indexed queried schema should succeed and return the requested scope"
+			);
+
+			// when resolving the hierarchical scope against the REFERENCED entity schema
+			final HierarchyNotIndexedException ex = assertThrows(
+				HierarchyNotIndexedException.class,
+				() -> AbstractHierarchyTranslator.resolveSingleHierarchicalScope(processingScope, referencedSchema)
+			);
+
+			// then the exception must reference the referenced entity schema, not the queried one
+			final String message = ex.getMessage();
+			assertTrue(
+				message.contains(REFERENCED_SCHEMA_NAME),
+				() -> "Exception should mention referenced schema `" + REFERENCED_SCHEMA_NAME + "`, was: " + message
+			);
+			assertEquals(
+				-1, message.indexOf(QUERIED_SCHEMA_NAME),
+				"Exception must not mention the queried schema `" + QUERIED_SCHEMA_NAME + "` — that was the bug"
+			);
+		}
+	}
+
+	/**
+	 * Builds a Mockito-backed [EntitySchemaContract] stub whose `getName()` and `isHierarchyIndexedInScope(scope)`
+	 * answers are wired to the supplied values. Every other method returns the Mockito default — sufficient for
+	 * tests that only inspect these two answers.
+	 *
+	 * @param name           name reported by the schema
+	 * @param indexedScope   scope that should report as either indexed or not, controlled by `indexed`
+	 * @param indexed        whether the named scope should report as having an indexed hierarchy
+	 * @return the configured mock schema
+	 */
+	@Nonnull
+	private static EntitySchemaContract mockSchema(
+		@Nonnull String name,
+		@Nonnull Scope indexedScope,
+		boolean indexed
+	) {
+		final EntitySchemaContract schema = mock(EntitySchemaContract.class);
+		when(schema.getName()).thenReturn(name);
+		when(schema.isHierarchyIndexedInScope(indexedScope)).thenReturn(indexed);
+		return schema;
+	}
+
+	/**
+	 * Builds a Mockito-backed [ProcessingScope] stub whose `getScopes()` returns the supplied set. We mock here
+	 * (rather than instantiating the record directly) because the record would otherwise drag in a
+	 * `Deque<Set<Scope>>` and supplier wiring that is irrelevant to the helper under test.
+	 *
+	 * @param scopes the scope set the processing scope should report
+	 * @return the configured mock processing scope
+	 */
+	@Nonnull
+	private static ProcessingScope mockProcessingScopeWith(@Nonnull Set<Scope> scopes) {
+		final ProcessingScope processingScope = mock(ProcessingScope.class);
+		when(processingScope.getScopes()).thenReturn(scopes);
+		return processingScope;
+	}
+
+}


### PR DESCRIPTION
## Summary

Hierarchy-statistics planning previously re-translated the `FilterBy` per `StatisticsBase` variant via a fresh `FilterByVisitor` pass — even though most subtrees were structurally identical to the already-planned main filter tree. Each per-`(nodeId, statisticsBase)` lambda paid that planning cost plus a fresh execution of every leaf bitmap.

This PR switches to a **clone-and-strip** approach over the main query's already-planned `filteringFormula`:

- Tag `HierarchyFormula` and `FacetHavingFormula` with their `referenceName` (`null` = self-hierarchy) so a single `FormulaCloner` pass can selectively strip them per `StatisticsBase` mode. Both now implement `NonCacheableFormula` so `FlattenedFormula` folding cannot erase the wrappers the cloner anchors on.
- Generalise `FormulaCloner` so any wrapper whose `getCloneWithInnerFormulas([])` returns `EmptyFormula` is dropped as the identity element of its parent — covers `UserFilterFormula` and nested `AND`/`OR`/`ScopeContainer` chains uniformly. Convention documented on `Formula#getCloneWithInnerFormulas`.
- New `ExtraResultPlanningVisitor#getFilteringFormulaForStatisticsBase(...)` returns a cached `Formula` per `(referenceName, StatisticsBase)`, applying the three strip rules:
  - `WITHOUT_USER_FILTER` — drop `UserFilterFormula` + matching `HierarchyFormula`.
  - `COMPLETE_FILTER` — drop only matching `HierarchyFormula`.
  - `COMPLETE_FILTER_EXCLUDING_SELF_IN_USER_FILTER` — drop matching `HierarchyFormula`/`FacetHavingFormula` only inside `UserFilterFormula` for reference stats; for self-stats drop every self-`HierarchyFormula` and every empty-named `FacetHavingFormula` regardless of position.
- Two-gate applicability check on the shortcut: (1) primary plan must not have selected `REDUCED_ENTITY` of the same reference (`FOR_FILTERING_AND_PARTITIONING` for every active scope is the only case this fails); (2) user's `hierarchyWithin` must not carry `having`/`excluding` (predicates baked into the leaf bitmap would be lost on strip). When either gate fails, fall back to a new `QueryPlanner#planNestedFilteringFormula` that mirrors the outer pipeline (`IndexSelectionVisitor` + per-candidate `FilterByVisitor` + cost-based pick) and folds nested prefetch demand into the outer `PrefetchFormulaVisitor`.
- `HierarchyOfReferenceTranslator` and `HierarchyOfSelfTranslator` collapse to a single code path; the `partitioned` branch and the `computeOnlyOnce` workaround are gone. The `FOR_FILTERING_AND_PARTITIONING` reference index type disabled in `ed2e89e24` is implicitly re-enabled — the `AND` with `cachedGlobal` is correct for both reference index types.
- `AbstractHierarchyTranslator#resolveSingleHierarchicalScope(...)` extracts the duplicated multi-scope rejection + indexed-in-scope check used by both translators; covered by the new `AbstractHierarchyTranslatorTest`.
- `FilteringFormulaHierarchyEntityPredicate` gains a `FilterBy`-less constructor for the shortcut path and folds the formula hash into `equals`/`hashCode`.
- `AbstractHierarchyTranslator#createFilterFormula` (~ 60 LOC), `ExtraResultPlanningVisitor#getFilterByForStatisticsBase` and the three `getFilterByWithout*` helpers + `rewriteHierarchyFilter` (~ 200 LOC) deleted.

Net diff: +1113 / −466 across 19 files.

## Wins

- **Zero `FilterByVisitor` planning** during hierarchy-statistics computation on the common shortcut path; only the fallback re-plans, and even then via the same single pipeline as the outer query.
- **Real memoised result reuse**: leaf bitmaps (price termination, attribute filtering, locale, histogram) computed during the main filter phase are read directly during stats.
- **`computeOnlyOnce` workaround removed** in both translators.
- **`FOR_FILTERING_AND_PARTITIONING` re-enabled** for free.
- **Telemetry continuity**: `EXECUTION_FILTER_NESTED_QUERY` still appears in traces via `DeferredFormula`/`FormulaWrapper`.

Closes #1141
Ref: #1138