### PR TITLE
fix: collapse NotFormula(X, X) and DisentangleFormula(X, X) to empty

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/DisentangleFormula.java
@@ -30,6 +30,7 @@ import io.evitadb.core.query.algebra.price.CacheablePriceFormula;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.bitmap.EmptyBitmap;
 import io.evitadb.index.bitmap.RoaringBitmapBackedBitmap;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
@@ -132,8 +133,8 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 			bitmapIdCount++;
 		}
 		int innerIdCount = 0;
-		for (int i = 0; i < this.innerFormulas.length; i++) {
-			innerIdCount += this.innerFormulas[i].gatherTransactionalIds().length;
+		for (final Formula formula : this.innerFormulas) {
+			innerIdCount += formula.gatherTransactionalIds().length;
 		}
 		final long[] result = new long[bitmapIdCount + innerIdCount];
 		int pos = 0;
@@ -143,8 +144,8 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 		if (this.controlBitmap instanceof TransactionalLayerProducer) {
 			result[pos++] = ((TransactionalLayerProducer<?, ?>) this.controlBitmap).getId();
 		}
-		for (int i = 0; i < this.innerFormulas.length; i++) {
-			final long[] ids = this.innerFormulas[i].gatherTransactionalIds();
+		for (final Formula innerFormula : this.innerFormulas) {
+			final long[] ids = innerFormula.gatherTransactionalIds();
 			System.arraycopy(ids, 0, result, pos, ids.length);
 			pos += ids.length;
 		}
@@ -274,6 +275,14 @@ public class DisentangleFormula extends AbstractCacheableFormula implements Cach
 	@Nonnull
 	@Override
 	protected Bitmap computeInternal() {
+		// disentangle(X, X) = ∅ — every element in main is at the same position in control,
+		// so all entries are swallowed. Guards against direct construction with identical inputs
+		// and against FormulaCloner-induced collapse when FormulaDeduplicator unifies the two
+		// positional siblings (see analogous guard in NotFormula).
+		if ((this.mainBitmap != null && this.mainBitmap == this.controlBitmap) ||
+			(this.mainBitmap == null && this.innerFormulas[0] == this.innerFormulas[1])) {
+			return EmptyBitmap.INSTANCE;
+		}
 		final RoaringBitmapWriter<RoaringBitmap> writer = RoaringBitmapBackedBitmap.buildWriter();
 		final OfInt controlIt = this.controlBitmap != null
 			? this.controlBitmap.iterator()

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/NotFormula.java
@@ -250,7 +250,8 @@ public class NotFormula extends AbstractCacheableFormula {
 	protected Bitmap computeInternal() {
 		final Bitmap theResult;
 		if (this.subtractedBitmap != null && this.supersetBitmap != null) {
-			if (this.supersetBitmap.isEmpty()) {
+			// X \ X = ∅ — guards against direct construction with the same bitmap on both sides
+			if (this.supersetBitmap.isEmpty() || this.subtractedBitmap == this.supersetBitmap) {
 				theResult = EmptyBitmap.INSTANCE;
 			} else {
 				theResult = new BaseBitmap(
@@ -260,6 +261,9 @@ public class NotFormula extends AbstractCacheableFormula {
 					)
 				);
 			}
+		} else if (getSubtractedFormula() == getSupersetFormula()) {
+			// X \ X = ∅ — guards against direct construction with the same formula on both sides
+			theResult = EmptyBitmap.INSTANCE;
 		} else {
 			final Bitmap supersetBitmap = getSupersetFormula().compute();
 			if (supersetBitmap.isEmpty()) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
@@ -193,14 +193,34 @@ public class FormulaCloner implements FormulaVisitor {
 							formulaToStore = null;
 						}
 					}
-				} else if (formula instanceof DisentangleFormula && updatedChildren.size() < 2) {
+				} else if (formula instanceof DisentangleFormula disentangleFormula && updatedChildren.size() < 2) {
 					// DisentangleFormula(main, control) requires two positional siblings — the same
 					// dedup-collapse pattern that hits NotFormula above can drop one of them when
 					// FormulaDeduplicator unifies structurally equivalent inputs. Without this guard
-					// the fall-through would call `getCloneWithInnerFormulas([X])` and NPE on
-					// `innerFormulas[1]`. Mathematically `disentangle(X, X) = ∅`, so collapse to
-					// EmptyFormula instead.
-					formulaToStore = EmptyFormula.INSTANCE;
+					// the fall-through would call `getCloneWithInnerFormulas([X])` and throw
+					// ArrayIndexOutOfBoundsException on `innerFormulas[1]`.
+					if (updatedChildren.isEmpty()) {
+						// both children stripped — no operation possible, drop the wrapper
+						formulaToStore = null;
+					} else {
+						// Determine which child survived
+						final Formula processedMain = this.formulasProcessed.get(disentangleFormula.getInnerFormulas()[0]);
+						final Formula processedControl = this.formulasProcessed.get(disentangleFormula.getInnerFormulas()[1]);
+						if (processedMain != null && processedMain == processedControl
+							&& updatedChildren.contains(processedMain)) {
+							// Both positional siblings post-process to the same formula instance
+							// (FormulaDeduplicator collapsing structurally equivalent inputs).
+							// Mathematically `disentangle(X, X) = ∅`.
+							formulaToStore = EmptyFormula.INSTANCE;
+						} else if (processedMain != null && updatedChildren.contains(processedMain)) {
+							// Main survived, control was removed → `disentangle(main, ∅) = main`
+							// (matches RangeIndex.createDisentangleFormulaIfNecessary semantics).
+							formulaToStore = processedMain;
+						} else {
+							// Control survived, main was removed → nothing to disentangle → drop
+							formulaToStore = null;
+						}
+					}
 				} else {
 					// recreate parent formula with new children
 					final Formula recreated = formula.getCloneWithInnerFormulas(

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/utils/visitor/FormulaCloner.java
@@ -25,6 +25,7 @@ package io.evitadb.core.query.algebra.utils.visitor;
 
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.FormulaVisitor;
+import io.evitadb.core.query.algebra.base.DisentangleFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.base.NotFormula;
 import lombok.Getter;
@@ -172,8 +173,19 @@ public class FormulaCloner implements FormulaVisitor {
 						formulaToStore = null;
 					} else {
 						// Determine which child survived
+						final Formula processedSubtracted = this.formulasProcessed.get(notFormula.getSubtractedFormula());
 						final Formula processedSuperset = this.formulasProcessed.get(notFormula.getSupersetFormula());
-						if (processedSuperset != null && updatedChildren.contains(processedSuperset)) {
+						if (processedSubtracted != null && processedSubtracted == processedSuperset
+							&& updatedChildren.contains(processedSuperset)) {
+							// Both positional siblings post-process to the same formula instance
+							// (typically due to FormulaDeduplicator collapsing two structurally
+							// equivalent ConstantFormula children of `or(P, not(P))`). The single
+							// Set entry hides what used to be two distinct positional siblings.
+							// Mathematically `X \ X = ∅`, so collapse the wrapper to EmptyFormula
+							// rather than mistakenly returning the surviving child as if subtracted
+							// had been dropped.
+							formulaToStore = EmptyFormula.INSTANCE;
+						} else if (processedSuperset != null && updatedChildren.contains(processedSuperset)) {
 							// Superset survived, subtracted was removed → S \ nothing = S
 							formulaToStore = processedSuperset;
 						} else {
@@ -181,6 +193,14 @@ public class FormulaCloner implements FormulaVisitor {
 							formulaToStore = null;
 						}
 					}
+				} else if (formula instanceof DisentangleFormula && updatedChildren.size() < 2) {
+					// DisentangleFormula(main, control) requires two positional siblings — the same
+					// dedup-collapse pattern that hits NotFormula above can drop one of them when
+					// FormulaDeduplicator unifies structurally equivalent inputs. Without this guard
+					// the fall-through would call `getCloneWithInnerFormulas([X])` and NPE on
+					// `innerFormulas[1]`. Mathematically `disentangle(X, X) = ∅`, so collapse to
+					// EmptyFormula instead.
+					formulaToStore = EmptyFormula.INSTANCE;
 				} else {
 					// recreate parent formula with new children
 					final Formula recreated = formula.getCloneWithInnerFormulas(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/reference/OrNotReferenceHavingFilterFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/reference/OrNotReferenceHavingFilterFunctionalTest.java
@@ -58,9 +58,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * `or(referenceX_Having, not(referenceX_Having))` returned only a partial result instead of
  * the entire entity collection.
  *
- * The fix landed via [commit a5ee5a8e22](https://github.com/FgForrest/evitaDB/commit/a5ee5a8e22)
- * which corrected `FutureNotFormula.postProcess` to apply DeMorgan-aware aggregators when a
- * `NOT` term appears within an `OR` container. These tests guard that behaviour against
+ * The fix is in `FormulaCloner` (detecting dedup-collapsed positional siblings of
+ * `NotFormula` / `DisentangleFormula` and collapsing the wrapper to `EmptyFormula`),
+ * with defensive identity guards added in `NotFormula.computeInternal` and
+ * `DisentangleFormula.computeInternal`. These tests guard that behaviour against
  * regressions for reference-based predicates (the original reproduction used
  * `referenceShippingMethodHaving`).
  *
@@ -139,10 +140,11 @@ public class OrNotReferenceHavingFilterFunctionalTest extends AbstractReferenceF
 	 * Same `or(P, not(P))` shape as the universe test, but with an inner reference predicate
 	 * (`entityPrimaryKeyInSet`). The two branches still form an exhaustive partition of the
 	 * collection — every product either has a STORE reference matching `targetStorePk` or it
-	 * does not — so the engine must return every product. Currently fails: 83/100 are returned,
-	 * the 17 missing products are exactly those that have **no** STORE reference at all,
-	 * suggesting that `not(referenceHaving(...))` only complements within products that have at
-	 * least one matching reference type, not within the entire collection.
+	 * does not — so the engine must return every product. Before the fix in this PR, only
+	 * 83/100 were returned — the 17 missing products were exactly those that had **no** STORE
+	 * reference at all, because `FormulaDeduplicator` collapsed the two structurally equivalent
+	 * positional siblings of the inner `NotFormula(P, P)` into a single instance and the
+	 * `FormulaCloner` mistakenly returned the surviving superset rather than `EmptyFormula`.
 	 */
 	@DisplayName("Should return all products for or(referenceHaving(filter), not(referenceHaving(filter)))")
 	@UseDataSet(HUNDRED_PRODUCTS)
@@ -186,8 +188,7 @@ public class OrNotReferenceHavingFilterFunctionalTest extends AbstractReferenceF
 
 	/**
 	 * The empty set — `and(P, not(P))` must return no products. This is the dual of the
-	 * `or(P, not(P))` guarantee and exercises the CONJUNCTION path of
-	 * `FutureNotFormula.postProcess`.
+	 * `or(P, not(P))` guarantee for the conjunction path of `FutureNotFormula.postProcess`.
 	 */
 	@DisplayName("Should return no products for and(referenceHaving, not(referenceHaving))")
 	@UseDataSet(HUNDRED_PRODUCTS)

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/reference/OrNotReferenceHavingFilterFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/reference/OrNotReferenceHavingFilterFunctionalTest.java
@@ -1,0 +1,225 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.reference;
+
+import io.evitadb.api.query.require.DebugMode;
+import io.evitadb.api.requestResponse.EvitaResponse;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.data.structure.EntityReference;
+import io.evitadb.core.Evita;
+import io.evitadb.test.Entities;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.*;
+import static io.evitadb.test.TestConstants.TEST_CATALOG;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.FILTER;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Functional tests for boolean logic involving `not(referenceHaving(...))` combined with its
+ * positive counterpart inside `or` / `and` containers. Reproduces the regression reported in
+ * issue [#1025](https://github.com/FgForrest/evitaDB/issues/1025), where
+ * `or(referenceX_Having, not(referenceX_Having))` returned only a partial result instead of
+ * the entire entity collection.
+ *
+ * The fix landed via [commit a5ee5a8e22](https://github.com/FgForrest/evitaDB/commit/a5ee5a8e22)
+ * which corrected `FutureNotFormula.postProcess` to apply DeMorgan-aware aggregators when a
+ * `NOT` term appears within an `OR` container. These tests guard that behaviour against
+ * regressions for reference-based predicates (the original reproduction used
+ * `referenceShippingMethodHaving`).
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Filtering by or/and combined with not(referenceHaving)")
+@ExtendWith(EvitaParameterResolver.class)
+@Slf4j
+@Tag(CONTRACT)
+@Tag(REFERENCE)
+@Tag(FILTER)
+public class OrNotReferenceHavingFilterFunctionalTest extends AbstractReferenceFilterFunctionalTest {
+
+	/**
+	 * The universe — `or(P, not(P))` must return every product in the collection regardless of
+	 * whether it has the BRAND reference. The BRAND reference has cardinality `ZERO_OR_ONE`, so
+	 * the dataset deliberately contains both branches of the partition.
+	 */
+	@DisplayName("Should return all products for or(referenceHaving, not(referenceHaving))")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnAllProductsForOrOfReferenceHavingAndItsNegation(
+		Evita evita,
+		List<SealedEntity> originalProducts
+	) {
+		final Set<Integer> withBrand = originalProducts.stream()
+			.filter(it -> !it.getReferences(Entities.BRAND).isEmpty())
+			.map(SealedEntity::getPrimaryKey)
+			.collect(Collectors.toSet());
+		final Set<Integer> withoutBrand = originalProducts.stream()
+			.filter(it -> it.getReferences(Entities.BRAND).isEmpty())
+			.map(SealedEntity::getPrimaryKey)
+			.collect(Collectors.toSet());
+		Assumptions.assumeFalse(
+			withBrand.isEmpty() || withoutBrand.isEmpty(),
+			"Test requires the BRAND reference partition to contain both branches"
+		);
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							or(
+								referenceHaving(Entities.BRAND),
+								not(referenceHaving(Entities.BRAND))
+							)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+
+				assertEquals(
+					originalProducts.size(), result.getRecordData().size(),
+					"or(P, NOT(P)) must cover the entire collection"
+				);
+				final Set<Integer> returnedPks = result.getRecordData().stream()
+					.map(EntityReference::getPrimaryKey)
+					.collect(Collectors.toSet());
+				final Set<Integer> expectedPks = originalProducts.stream()
+					.map(SealedEntity::getPrimaryKey)
+					.collect(Collectors.toSet());
+				assertEquals(expectedPks, returnedPks, "Returned primary keys must equal the universe");
+				return null;
+			}
+		);
+	}
+
+	/**
+	 * Same `or(P, not(P))` shape as the universe test, but with an inner reference predicate
+	 * (`entityPrimaryKeyInSet`). The two branches still form an exhaustive partition of the
+	 * collection — every product either has a STORE reference matching `targetStorePk` or it
+	 * does not — so the engine must return every product. Currently fails: 83/100 are returned,
+	 * the 17 missing products are exactly those that have **no** STORE reference at all,
+	 * suggesting that `not(referenceHaving(...))` only complements within products that have at
+	 * least one matching reference type, not within the entire collection.
+	 */
+	@DisplayName("Should return all products for or(referenceHaving(filter), not(referenceHaving(filter)))")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnAllProductsForOrOfReferenceHavingWithInnerFilterAndItsNegation(
+		Evita evita,
+		List<SealedEntity> originalProducts,
+		List<SealedEntity> originalStores
+	) {
+		final SealedEntity targetStore = originalStores.get(0);
+		final int targetStorePk = targetStore.getPrimaryKey();
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							or(
+								referenceHaving(Entities.STORE, entityPrimaryKeyInSet(targetStorePk)),
+								not(referenceHaving(Entities.STORE, entityPrimaryKeyInSet(targetStorePk)))
+							)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+
+				assertEquals(
+					originalProducts.size(), result.getRecordData().size(),
+					"or(referenceHaving(filter), NOT(referenceHaving(filter))) must cover the entire collection"
+				);
+				return null;
+			}
+		);
+	}
+
+	/**
+	 * The empty set — `and(P, not(P))` must return no products. This is the dual of the
+	 * `or(P, not(P))` guarantee and exercises the CONJUNCTION path of
+	 * `FutureNotFormula.postProcess`.
+	 */
+	@DisplayName("Should return no products for and(referenceHaving, not(referenceHaving))")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnNoProductsForAndOfReferenceHavingAndItsNegation(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								referenceHaving(Entities.BRAND),
+								not(referenceHaving(Entities.BRAND))
+							)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+
+				assertTrue(
+					result.getRecordData().isEmpty(),
+					"and(P, NOT(P)) must collapse to the empty set"
+				);
+				return null;
+			}
+		);
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/FormulaClonerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/utils/visitor/FormulaClonerTest.java
@@ -26,6 +26,7 @@ package io.evitadb.core.query.algebra.utils.visitor;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.AndFormula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.DisentangleFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.base.NotFormula;
 import io.evitadb.core.query.algebra.base.OrFormula;
@@ -377,6 +378,131 @@ class FormulaClonerTest {
 			assertFalse(FormulaLocator.contains(cloneResult, NotFormula.class));
 			// OR with one surviving child collapses to that child
 			assertSame(keep, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should collapse NotFormula to EmptyFormula when both siblings dedup to same instance")
+		void shouldCollapseNotFormulaWhenSiblingsDedupToSameInstance() {
+			// Reproduces the dedup-collapse path: two distinct ConstantFormula positional siblings
+			// of NotFormula post-process to the *same* instance (mutator returns the same target
+			// formula for both inputs). The LinkedHashSet of updated children then has size 1, but
+			// this is mathematically X \ X = ∅, NOT "subtracted stripped, return superset".
+			final ConstantFormula original = new ConstantFormula(new ArrayBitmap(5));
+			final ConstantFormula clone = new ConstantFormula(new ArrayBitmap(5));
+			final ConstantFormula shared = new ConstantFormula(new ArrayBitmap(5));
+			final Formula notFormula = new NotFormula(original, clone);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				notFormula,
+				f -> f == original || f == clone ? shared : f
+			);
+
+			assertSame(EmptyFormula.INSTANCE, cloneResult);
+		}
+	}
+
+	@Nested
+	@DisplayName("DisentangleFormula special handling")
+	class DisentangleFormulaHandlingTest {
+
+		@Test
+		@DisplayName("should return main when control child is stripped from DisentangleFormula")
+		void shouldReturnMainWhenControlChildStripped() {
+			// disentangle(main, ∅) = main per RangeIndex.createDisentangleFormulaIfNecessary
+			final ConstantFormula main = new ConstantFormula(new ArrayBitmap(5, 8, 10));
+			final ConstantFormula control = new ConstantFormula(new ArrayBitmap(8));
+			final Formula disentangleFormula = new DisentangleFormula(main, control);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				disentangleFormula,
+				f -> f == control ? null : f
+			);
+
+			assertSame(main, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should drop DisentangleFormula when main child is stripped")
+		void shouldDropDisentangleFormulaWhenMainChildStripped() {
+			// No main → nothing to disentangle → drop the wrapper
+			final ConstantFormula main = new ConstantFormula(new ArrayBitmap(5, 8, 10));
+			final ConstantFormula control = new ConstantFormula(new ArrayBitmap(8));
+			final Formula disentangleFormula = new DisentangleFormula(main, control);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				disentangleFormula,
+				f -> f == main ? null : f
+			);
+
+			assertNull(cloneResult);
+		}
+
+		@Test
+		@DisplayName("should drop DisentangleFormula when both children are stripped")
+		void shouldDropDisentangleFormulaWhenBothChildrenStripped() {
+			final ConstantFormula main = new ConstantFormula(new ArrayBitmap(5, 8, 10));
+			final ConstantFormula control = new ConstantFormula(new ArrayBitmap(8));
+			final ConstantFormula keep = new ConstantFormula(new ArrayBitmap(1));
+			final Formula tree = new OrFormula(
+				keep,
+				new DisentangleFormula(main, control)
+			);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				tree,
+				f -> f == main || f == control ? null : f
+			);
+
+			assertNotNull(cloneResult);
+			assertFalse(FormulaLocator.contains(cloneResult, DisentangleFormula.class));
+			// OR with one surviving child collapses to that child
+			assertSame(keep, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should collapse DisentangleFormula to EmptyFormula when both siblings dedup to same instance")
+		void shouldCollapseDisentangleFormulaWhenSiblingsDedupToSameInstance() {
+			// Mirrors the NotFormula dedup-collapse case for DisentangleFormula:
+			// disentangle(X, X) = ∅, so when both positional siblings post-process to the same
+			// instance the wrapper must collapse to EmptyFormula — *not* return the survivor as
+			// if `disentangle(main, ∅) = main` had triggered.
+			final ConstantFormula original = new ConstantFormula(new ArrayBitmap(5, 8, 10));
+			final ConstantFormula clone = new ConstantFormula(new ArrayBitmap(5, 8, 10));
+			final ConstantFormula shared = new ConstantFormula(new ArrayBitmap(5, 8, 10));
+			final Formula disentangleFormula = new DisentangleFormula(original, clone);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				disentangleFormula,
+				f -> f == original || f == clone ? shared : f
+			);
+
+			assertSame(EmptyFormula.INSTANCE, cloneResult);
+		}
+
+		@Test
+		@DisplayName("should preserve main in nested tree when control is stripped")
+		void shouldPreserveMainInNestedTreeWhenControlStripped() {
+			final ConstantFormula main = new ConstantFormula(new ArrayBitmap(5, 8, 10));
+			final ConstantFormula control = new ConstantFormula(new ArrayBitmap(8));
+			final ConstantFormula keep = new ConstantFormula(new ArrayBitmap(1));
+			final Formula tree = new OrFormula(
+				keep,
+				new DisentangleFormula(main, control)
+			);
+
+			final Formula cloneResult = FormulaCloner.clone(
+				tree,
+				f -> f == control ? null : f
+			);
+
+			assertNotNull(cloneResult);
+			assertInstanceOf(OrFormula.class, cloneResult);
+			assertFalse(FormulaLocator.contains(cloneResult, DisentangleFormula.class));
+			// OrFormula(keep, main) — main replaced the DisentangleFormula
+			final Formula[] children = cloneResult.getInnerFormulas();
+			assertEquals(2, children.length);
+			assertSame(keep, children[0]);
+			assertSame(main, children[1]);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes the documented case in #1025 where `or(referenceX_Having: {}, not(referenceX_Having: {}))` was expected to return *all* records but returned a wrong subset.

The root cause was a deduplication / cloning interaction in the formula tree:

1. `OrTranslator` builds `NotFormula(combinedPositives, combinedNegatives)` where both children are different `ConstantFormula` instances wrapping the **same** transactional bitmap.
2. `FilterByTranslator` wraps it as `NotFormula(NotFormula(P, P), universe)`.
3. `FormulaDeduplicator` unifies the two structurally equivalent `ConstantFormula` children (same hash).
4. `FormulaCloner` collected the survivors into a `LinkedHashSet`, silently collapsing the two positional siblings of the wrapping `NotFormula` into a single entry.
5. The `NotFormula`-special branch in the cloner mistook this for *"subtracted child stripped"* and returned the surviving superset → result `100 \ 17 = 83` instead of the correct `100`.

`DisentangleFormula` shares the same two-positional-children invariant and would have NPE'd on `getCloneWithInnerFormulas([X])`. `JoinFormula` is unaffected — it is uncloneable, uses `Bitmap[]` rather than `Formula[]`, and `JoinFormula(X, X)` has documented "doubled element" semantics.

### Fix

- **`FormulaCloner`** — when a `NotFormula` / `DisentangleFormula` wrapper has fewer than two updated children, detect whether both positional siblings post-process to the same instance and collapse to `EmptyFormula` (`X \ X = ∅`, `disentangle(X, X) = ∅`). Otherwise preserve the previous "drop subtracted, keep superset" semantics for `NotFormula`.
- **`NotFormula` / `DisentangleFormula`** — defensive identity guards in `computeInternal` so direct construction with the same operand on both sides also returns empty rather than producing inconsistent bitmaps.
- **`OrNotReferenceHavingFilterFunctionalTest`** — new functional tests covering the empty-inner OR/NOT case, the AND/NOT contradiction, and the inner-filter variant that previously regressed to 83/100.

## Test plan

- [x] New test `OrNotReferenceHavingFilterFunctionalTest` passes (3 tests).
- [x] Existing engine algebra tests pass (56 algebra tests).
- [x] Reference / attribute / price functional tests pass (54 reference/combined, 308 attribute, 97 price).
- [x] Verified in JDWP that the dedup-collapse path now produces `EmptyFormula` and the wrapping `OrFormula` correctly resolves to the universe in the empty-inner case and to the universe minus the contradictory partition in the inner-filter case.

Closes #1025