### PR TITLE
feat: expose evitadb_build_info Prometheus metric

### DIFF
--- a/documentation/user/en/operate/reference/metrics.md
+++ b/documentation/user/en/operate/reference/metrics.md
@@ -5,14 +5,20 @@
   <dl>
     <dt>api</dt>
     <dd><strong>API type</strong>: The identification of the API being called.</dd>
+    <dt>api_type</dt>
+    <dd><strong>API type</strong>: External API whose readiness is being reported (REST, GraphQL, gRPC, ...).</dd>
     <dt>area</dt>
     <dd><strong>Area</strong>: Area for which events are published.</dd>
     <dt>buildType</dt>
     <dd><strong>Build type</strong>: Type of the instance build: NEW or REFRESH</dd>
     <dt>catalogName</dt>
     <dd><strong>Catalog</strong>: The name of the catalog to which this event/metric is associated.</dd>
+    <dt>commit</dt>
+    <dd><strong>Commit hash</strong>: Abbreviated Git commit hash injected into the manifest at build time.</dd>
     <dt>entityType</dt>
     <dd><strong>Entity type</strong>: The name of the related entity type (collection).</dd>
+    <dt>error_type</dt>
+    <dd><strong>Error type</strong>: Class of the error being counted.</dd>
     <dt>fileType</dt>
     <dd><strong>File type</strong>: The type of the file that was flushed. One of: CATALOG, ENTITY_COLLECTION, WAL, or BOOTSTRAP</dd>
     <dt>graphQLInstanceType</dt>
@@ -29,6 +35,8 @@
     <dd><strong>Initiator of the call</strong>: Initiator of the gRPC call (either client or server).</dd>
     <dt>instanceId</dt>
     <dd><strong>Server instance id</strong>: Unique server name taken from the configuration file.</dd>
+    <dt>java_version</dt>
+    <dd><strong>JVM version</strong>: The <code>java.version</code> system property of the JVM running evitaDB.</dd>
     <dt>methodName</dt>
     <dd><strong>Method name</strong>: The endpoint or method name from RequestLog.</dd>
     <dt>name</dt>
@@ -41,6 +49,8 @@
     <dd><strong>Prefetched vs. non-prefetched query</strong>: Whether or not the query used a prefetch plan. Prefetch plan optimistically fetches queried entities in advance and executes directly on them (without accessing the indexes).</dd>
     <dt>probeResult</dt>
     <dd><strong>Probe result</strong>: The result of the readiness probe (ok, timeout, error).</dd>
+    <dt>problem_type</dt>
+    <dd><strong>Health problem type</strong>: Identifier of the active health problem.</dd>
     <dt>procedureName</dt>
     <dd><strong>Procedure name</strong>: Name of the gRPC procedure that was called (the method name).</dd>
     <dt>prospective</dt>
@@ -69,6 +79,8 @@ duration of the probe.</dd>
     <dd><strong>Transaction stage</strong>: The name of the stage the transaction is waiting for.</dd>
     <dt>taskName</dt>
     <dd><strong>Task name</strong>: Name of the background task.</dd>
+    <dt>version</dt>
+    <dd><strong>evitaDB version</strong>: The Maven version of the running evitaDB build.</dd>
   </dl>
 </UsedTerms>
 
@@ -505,16 +517,16 @@ duration of the probe.</dd>
 
 <dl>
   <dt><code>evitadb_build_info</code> (INFO)</dt>
-  <dd><strong>evitaDB build information</strong>: a constant <code>info</code> metric exposing the running server's version, abbreviated git commit hash and JVM version. Useful for tracking deployments without consulting logs.<br/><br/><strong>Labels:</strong> <code>version</code>, <code>commit</code>, <code>java_version</code><br/></dd>
+  <dd><strong>evitaDB build information</strong>: a constant <code>info</code> metric exposing the running server's version, abbreviated git commit hash and JVM version. Useful for tracking deployments without consulting logs.<br/><br/><strong>Labels:</strong> <Term>version</Term>, <Term>commit</Term>, <Term>java_version</Term><br/></dd>
   <dt><code>io_evitadb_probe_health_problem</code> (GAUGE)</dt>
-  <dd><strong>Health problem indicator</strong>: set to <code>1</code> while the named health problem is active and reset to <code>0</code> once it clears.<br/><br/><strong>Labels:</strong> <code>problem_type</code><br/></dd>
+  <dd><strong>Health problem indicator</strong>: set to <code>1</code> while the named health problem is active and reset to <code>0</code> once it clears.<br/><br/><strong>Labels:</strong> <Term>problem_type</Term><br/></dd>
   <dt><code>io_evitadb_probe_api_readiness</code> (GAUGE)</dt>
-  <dd><strong>API readiness</strong>: <code>1</code> when the named external API is ready to serve traffic (verified via internal HTTP probe), <code>0</code> otherwise.<br/><br/><strong>Labels:</strong> <code>api_type</code><br/></dd>
+  <dd><strong>API readiness</strong>: <code>1</code> when the named external API is ready to serve traffic (verified via internal HTTP probe), <code>0</code> otherwise.<br/><br/><strong>Labels:</strong> <Term>api_type</Term><br/></dd>
   <dt><code>jvm_errors_total</code> (COUNTER)</dt>
-  <dd><strong>JVM errors</strong>: total number of internal JVM errors, partitioned by error type.<br/><br/><strong>Labels:</strong> <code>error_type</code><br/></dd>
+  <dd><strong>JVM errors</strong>: total number of internal JVM errors, partitioned by error type.<br/><br/><strong>Labels:</strong> <Term>error_type</Term><br/></dd>
   <dt><code>io_evitadb_errors_total</code> (COUNTER)</dt>
-  <dd><strong>evitaDB errors</strong>: total number of internal evitaDB errors, partitioned by error type.<br/><br/><strong>Labels:</strong> <code>error_type</code><br/></dd>
+  <dd><strong>evitaDB errors</strong>: total number of internal evitaDB errors, partitioned by error type.<br/><br/><strong>Labels:</strong> <Term>error_type</Term><br/></dd>
   <dt><code>io_evitadb_client_errors_total</code> (COUNTER)</dt>
-  <dd><strong>Client errors</strong>: total number of <code>EvitaInvalidUsageException</code>s raised by client requests, partitioned by error type.<br/><br/><strong>Labels:</strong> <code>error_type</code><br/></dd>
+  <dd><strong>Client errors</strong>: total number of <code>EvitaInvalidUsageException</code>s raised by client requests, partitioned by error type.<br/><br/><strong>Labels:</strong> <Term>error_type</Term><br/></dd>
 </dl>
 

--- a/documentation/user/en/operate/reference/metrics.md
+++ b/documentation/user/en/operate/reference/metrics.md
@@ -501,3 +501,20 @@ duration of the probe.</dd>
   <dd>WAL rotations</dd>
 </dl>
 
+#### Static metrics
+
+<dl>
+  <dt><code>evitadb_build_info</code> (INFO)</dt>
+  <dd><strong>evitaDB build information</strong>: a constant <code>info</code> metric exposing the running server's version, abbreviated git commit hash and JVM version. Useful for tracking deployments without consulting logs.<br/><br/><strong>Labels:</strong> <code>version</code>, <code>commit</code>, <code>java_version</code><br/></dd>
+  <dt><code>io_evitadb_probe_health_problem</code> (GAUGE)</dt>
+  <dd><strong>Health problem indicator</strong>: set to <code>1</code> while the named health problem is active and reset to <code>0</code> once it clears.<br/><br/><strong>Labels:</strong> <code>problem_type</code><br/></dd>
+  <dt><code>io_evitadb_probe_api_readiness</code> (GAUGE)</dt>
+  <dd><strong>API readiness</strong>: <code>1</code> when the named external API is ready to serve traffic (verified via internal HTTP probe), <code>0</code> otherwise.<br/><br/><strong>Labels:</strong> <code>api_type</code><br/></dd>
+  <dt><code>jvm_errors_total</code> (COUNTER)</dt>
+  <dd><strong>JVM errors</strong>: total number of internal JVM errors, partitioned by error type.<br/><br/><strong>Labels:</strong> <code>error_type</code><br/></dd>
+  <dt><code>io_evitadb_errors_total</code> (COUNTER)</dt>
+  <dd><strong>evitaDB errors</strong>: total number of internal evitaDB errors, partitioned by error type.<br/><br/><strong>Labels:</strong> <code>error_type</code><br/></dd>
+  <dt><code>io_evitadb_client_errors_total</code> (COUNTER)</dt>
+  <dd><strong>Client errors</strong>: total number of <code>EvitaInvalidUsageException</code>s raised by client requests, partitioned by error type.<br/><br/><strong>Labels:</strong> <code>error_type</code><br/></dd>
+</dl>
+

--- a/evita_common/src/main/java/io/evitadb/utils/VersionUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/VersionUtils.java
@@ -41,17 +41,42 @@ import static java.util.Optional.ofNullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2023
  */
 public class VersionUtils {
+	public static final String UNKNOWN_VALUE = "?";
 	private static final String DEFAULT_MANIFEST_LOCATION = "META-INF/MANIFEST.MF";
 	private static final String IMPLEMENTATION_VENDOR_TITLE = "Implementation-Title";
 	private static final String IO_EVITADB_SERVER_TITLE = "evitaDB - Standalone server";
 	private static final String IO_EVITADB_CLIENT_TITLE = "evitaDB - Java driver (gRPC client side)";
 	private static final String IMPLEMENTATION_VERSION = "Implementation-Version";
+	private static final String IMPLEMENTATION_BUILD_COMMIT = "Implementation-Build-Commit";
 
 	/**
 	 * Method reads the current evitaDB version from the Manifest file where the version is injected during Maven build.
 	 */
 	@Nonnull
 	public static String readVersion() {
+		return readManifestAttribute(IMPLEMENTATION_VERSION);
+	}
+
+	/**
+	 * Reads the abbreviated git commit hash that was injected into the evitaDB manifest by
+	 * `git-commit-id-maven-plugin` during the build. Returns {@link #UNKNOWN_VALUE} when the
+	 * manifest cannot be located or the attribute is missing — typically inside the IDE, in
+	 * unit tests, or when building from a source tarball without a `.git` directory.
+	 */
+	@Nonnull
+	public static String readCommitHash() {
+		return readManifestAttribute(IMPLEMENTATION_BUILD_COMMIT);
+	}
+
+	/**
+	 * Walks the classpath manifests, picks the one belonging to the evitaDB server or driver
+	 * jar (identified by `Implementation-Title`), and returns the requested attribute.
+	 *
+	 * @param attributeName name of the manifest main-section attribute to read
+	 * @return value of the attribute or {@link #UNKNOWN_VALUE} when not found
+	 */
+	@Nonnull
+	private static String readManifestAttribute(@Nonnull String attributeName) {
 		try {
 			final Enumeration<URL> resources = VersionUtils.class.getClassLoader().getResources(DEFAULT_MANIFEST_LOCATION);
 			while (resources.hasMoreElements()) {
@@ -60,14 +85,14 @@ public class VersionUtils {
 					final Attributes mainAttributes = manifest.getMainAttributes();
 					if (IO_EVITADB_SERVER_TITLE.equals(mainAttributes.getValue(IMPLEMENTATION_VENDOR_TITLE)) ||
 						IO_EVITADB_CLIENT_TITLE.equals(mainAttributes.getValue(IMPLEMENTATION_VENDOR_TITLE))) {
-						return ofNullable(mainAttributes.getValue(IMPLEMENTATION_VERSION)).orElse("?");
+						return ofNullable(mainAttributes.getValue(attributeName)).orElse(UNKNOWN_VALUE);
 					}
 				}
 			}
 		} catch (Exception ignored) {
 			// just return unknown value
 		}
-		return "?";
+		return UNKNOWN_VALUE;
 	}
 
 	/**

--- a/evita_common/src/main/java/io/evitadb/utils/VersionUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/VersionUtils.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2025
+ *   Copyright (c) 2023-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -41,6 +41,13 @@ import static java.util.Optional.ofNullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2023
  */
 public class VersionUtils {
+	/**
+	 * Fallback returned by {@link #readVersion()} and {@link #readCommitHash()} when the
+	 * manifest cannot be located or the requested attribute is missing — typically inside
+	 * the IDE, in unit tests, or when building from a source tarball without a `.git`
+	 * directory. Also used in place of unresolved Maven placeholders that may slip into
+	 * the manifest when the build runs without a Git working copy.
+	 */
 	public static final String UNKNOWN_VALUE = "?";
 	private static final String DEFAULT_MANIFEST_LOCATION = "META-INF/MANIFEST.MF";
 	private static final String IMPLEMENTATION_VENDOR_TITLE = "Implementation-Title";
@@ -85,7 +92,13 @@ public class VersionUtils {
 					final Attributes mainAttributes = manifest.getMainAttributes();
 					if (IO_EVITADB_SERVER_TITLE.equals(mainAttributes.getValue(IMPLEMENTATION_VENDOR_TITLE)) ||
 						IO_EVITADB_CLIENT_TITLE.equals(mainAttributes.getValue(IMPLEMENTATION_VENDOR_TITLE))) {
-						return ofNullable(mainAttributes.getValue(attributeName)).orElse(UNKNOWN_VALUE);
+						final String value = mainAttributes.getValue(attributeName);
+						// guard against unresolved Maven placeholders that survive when a build
+						// runs outside a Git checkout (e.g. `${git.commit.id.abbrev}` literal)
+						if (value == null || value.startsWith("${")) {
+							return UNKNOWN_VALUE;
+						}
+						return value;
 					}
 				}
 			}

--- a/evita_external_api/evita_external_api_grpc/client/pom.xml
+++ b/evita_external_api/evita_external_api_grpc/client/pom.xml
@@ -155,17 +155,22 @@
 	<build>
 		<plugins>
 			<plugin>
+				<!-- Inherits version + execution + configuration from the parent pluginManagement. -->
+				<groupId>io.github.git-commit-id</groupId>
+				<artifactId>git-commit-id-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<!--
+					Implementation-Title / -Version / -Vendor come from the parent's
+					addDefaultImplementationEntries=true; only the build-commit entry is
+					module-specific (paired with the git-commit-id stub above).
+				-->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<configuration>
 					<archive>
-						<manifest>
-							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-						</manifest>
 						<manifestEntries>
-							<Implementation-Title>${project.name}</Implementation-Title>
-							<Implementation-Version>${project.parent.version}</Implementation-Version>
-							<Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
+							<Implementation-Build-Commit>${git.commit.id.abbrev}</Implementation-Build-Commit>
 						</manifestEntries>
 					</archive>
 				</configuration>

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/MetricHandler.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/MetricHandler.java
@@ -40,10 +40,12 @@ import io.evitadb.function.ChainableConsumer;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.ReflectionLookup;
 import io.evitadb.utils.StringUtils;
+import io.evitadb.utils.VersionUtils;
 import io.prometheus.metrics.core.metrics.Counter;
 import io.prometheus.metrics.core.metrics.Gauge;
 import io.prometheus.metrics.core.metrics.Histogram;
 import io.prometheus.metrics.core.metrics.Histogram.Builder;
+import io.prometheus.metrics.core.metrics.Info;
 import io.prometheus.metrics.core.metrics.Metric;
 import io.prometheus.metrics.core.metrics.Summary;
 import io.prometheus.metrics.instrumentation.jvm.*;
@@ -132,9 +134,30 @@ public class MetricHandler {
 			"JvmRuntimeInfoMetric", () -> JvmRuntimeInfoMetric.builder().register(),
 			"ProcessMetrics", () -> ProcessMetrics.builder().register()
 		);
+		registerBuildInfo();
 	}
 
 	private final ObservabilityOptions observabilityConfig;
+
+	/**
+	 * Registers the `evitadb_build_info` Prometheus `info` metric and stamps it with the
+	 * current build's version, commit hash and JVM version. The metric is a constant —
+	 * its labels are resolved once at class-loading time and never mutated again, so the
+	 * `Info` instance is intentionally not retained as a field; the default Prometheus
+	 * registry owns the only live reference and exposes it via the scrape endpoint.
+	 */
+	private static void registerBuildInfo() {
+		final Info info = Info.builder()
+			.name("evitadb_build_info")
+			.labelNames("version", "commit", "java_version")
+			.help("evitaDB build information (version, abbreviated commit hash, JVM version)")
+			.register();
+		info.setLabelValues(
+			VersionUtils.readVersion(),
+			VersionUtils.readCommitHash(),
+			System.getProperty("java.version", VersionUtils.UNKNOWN_VALUE)
+		);
+	}
 
 	/**
 	 * Composes the name of the metric from the event class, export metric and field name.

--- a/evita_server/pom.xml
+++ b/evita_server/pom.xml
@@ -138,19 +138,24 @@
     <build>
         <plugins>
             <plugin>
+                <!-- Inherits version + execution + configuration from the parent pluginManagement. -->
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <!-- Version + addDefaultImplementationEntries inherited from parent pluginManagement. -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.5.0</version>
                 <configuration>
                     <archive>
                         <manifest>
                             <mainClass>io.evitadb.server.EvitaServer</mainClass>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                         <manifestEntries>
                             <Premain-Class>io.evitadb.externalApi.observability.agent.ErrorMonitoringAgent</Premain-Class>
                             <Can-Redefine-Classes>true</Can-Redefine-Classes>
                             <Can-Retransform-Classes>true</Can-Retransform-Classes>
+                            <Implementation-Build-Commit>${git.commit.id.abbrev}</Implementation-Build-Commit>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/jfr/JfrDocumentation.java
+++ b/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/jfr/JfrDocumentation.java
@@ -257,8 +257,84 @@ public class JfrDocumentation implements EvitaTestSupport {
 						}
 					}
 				);
+
+			// statically registered metrics — these are not driven by JFR events but by direct
+			// Prometheus-core registration in MetricHandler (build info, error counters, probes).
+			writeStaticMetricsSection(writer);
 		}
 	}
+
+	/**
+	 * Writes a "Static metrics" section listing metrics that {@link MetricHandler} registers
+	 * directly with the Prometheus registry — i.e. metrics whose values do not flow through
+	 * the JFR pipeline. This includes the build-info metric as well as the long-standing
+	 * error counters and health/readiness probes.
+	 *
+	 * @param writer destination writer for `metrics.md`
+	 * @throws IOException if writing fails
+	 */
+	private static void writeStaticMetricsSection(@Nonnull Writer writer) throws IOException {
+		writer.write("#### Static metrics\n\n");
+		writer.write("<dl>\n");
+		for (Metric metric : STATIC_METRICS) {
+			writer.write("  <dt><code>" + metric.name() + "</code> (" + metric.metricType() + ")</dt>\n");
+			writer.write("  <dd>");
+			writer.write(metric.description());
+			if (metric.labels().length > 0) {
+				writer.write("<br/><br/><strong>Labels:</strong> ");
+				writer.write(Arrays.stream(metric.labels())
+					.map(label -> "<code>" + label + "</code>").collect(Collectors.joining(", ")));
+				writer.write("<br/>");
+			}
+			writer.write("</dd>\n");
+		}
+		writer.write("</dl>\n\n");
+	}
+
+	/**
+	 * Hard-coded descriptors for the metrics statically registered in {@link MetricHandler}.
+	 * The list is small and changes rarely; keeping it here avoids reflective discovery and
+	 * the runtime coupling that would come with it. Update this when a new static metric is
+	 * added to {@link MetricHandler}.
+	 */
+	private static final List<Metric> STATIC_METRICS = List.of(
+		new Metric(
+			"evitadb_build_info",
+			"INFO",
+			"<strong>evitaDB build information</strong>: a constant <code>info</code> metric exposing the running server's version, abbreviated git commit hash and JVM version. Useful for tracking deployments without consulting logs.",
+			new String[]{"version", "commit", "java_version"}
+		),
+		new Metric(
+			"io_evitadb_probe_health_problem",
+			"GAUGE",
+			"<strong>Health problem indicator</strong>: set to <code>1</code> while the named health problem is active and reset to <code>0</code> once it clears.",
+			new String[]{"problem_type"}
+		),
+		new Metric(
+			"io_evitadb_probe_api_readiness",
+			"GAUGE",
+			"<strong>API readiness</strong>: <code>1</code> when the named external API is ready to serve traffic (verified via internal HTTP probe), <code>0</code> otherwise.",
+			new String[]{"api_type"}
+		),
+		new Metric(
+			"jvm_errors_total",
+			"COUNTER",
+			"<strong>JVM errors</strong>: total number of internal JVM errors, partitioned by error type.",
+			new String[]{"error_type"}
+		),
+		new Metric(
+			"io_evitadb_errors_total",
+			"COUNTER",
+			"<strong>evitaDB errors</strong>: total number of internal evitaDB errors, partitioned by error type.",
+			new String[]{"error_type"}
+		),
+		new Metric(
+			"io_evitadb_client_errors_total",
+			"COUNTER",
+			"<strong>Client errors</strong>: total number of <code>EvitaInvalidUsageException</code>s raised by client requests, partitioned by error type.",
+			new String[]{"error_type"}
+		)
+	);
 
 	/**
 	 * Transform {@link ExportInvocationMetric} to metric record.

--- a/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/jfr/JfrDocumentation.java
+++ b/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/jfr/JfrDocumentation.java
@@ -146,24 +146,28 @@ public class JfrDocumentation implements EvitaTestSupport {
 			// write header
 			writer.write("### Metrics\n\n");
 
-			// collect all labels used in metrics
-			final List<MetricLabel> labels = EvitaJfrEventRegistry.getEventClasses()
-				.stream()
-				.flatMap(it -> {
-					final Map<Field, List<ExportMetricLabel>> fields = lookup.getFields(it, ExportMetricLabel.class);
-					return fields.entrySet()
-						.stream()
-						.map(
-							field -> {
-								final ExportMetricLabel annotation = field.getValue().get(0);
-								final String label = ofNullable(field.getKey().getAnnotation(Label.class)).map(Label::value).orElse("N/A");
-								final String description = ofNullable(field.getKey().getAnnotation(Description.class)).map(Description::value).orElse("N/A");
-								return new MetricLabel(
-									ofNullable(annotation.value()).filter(value -> !value.isBlank()).orElse(field.getKey().getName()),
-									"<strong>" + label + "</strong>: " + description
-								);
-							});
-				})
+			// collect all labels used in metrics — JFR-driven labels harvested from event
+			// classes plus the labels of statically registered metrics in MetricHandler
+			final List<MetricLabel> labels = Stream.concat(
+				EvitaJfrEventRegistry.getEventClasses()
+					.stream()
+					.flatMap(it -> {
+						final Map<Field, List<ExportMetricLabel>> fields = lookup.getFields(it, ExportMetricLabel.class);
+						return fields.entrySet()
+							.stream()
+							.map(
+								field -> {
+									final ExportMetricLabel annotation = field.getValue().get(0);
+									final String label = ofNullable(field.getKey().getAnnotation(Label.class)).map(Label::value).orElse("N/A");
+									final String description = ofNullable(field.getKey().getAnnotation(Description.class)).map(Description::value).orElse("N/A");
+									return new MetricLabel(
+										ofNullable(annotation.value()).filter(value -> !value.isBlank()).orElse(field.getKey().getName()),
+										"<strong>" + label + "</strong>: " + description
+									);
+								});
+					}),
+				STATIC_METRIC_LABELS.stream()
+			)
 				// we care only about distinct labels
 				.distinct()
 				// sort labels by name
@@ -283,7 +287,7 @@ public class JfrDocumentation implements EvitaTestSupport {
 			if (metric.labels().length > 0) {
 				writer.write("<br/><br/><strong>Labels:</strong> ");
 				writer.write(Arrays.stream(metric.labels())
-					.map(label -> "<code>" + label + "</code>").collect(Collectors.joining(", ")));
+					.map(label -> "<Term>" + label + "</Term>").collect(Collectors.joining(", ")));
 				writer.write("<br/>");
 			}
 			writer.write("</dd>\n");
@@ -292,12 +296,28 @@ public class JfrDocumentation implements EvitaTestSupport {
 	}
 
 	/**
+	 * Glossary entries for the labels referenced by {@link #STATIC_METRICS}. They are
+	 * merged into the page-wide <code>UsedTerms</code> block so the static-metrics section
+	 * uses the same <code>&lt;Term&gt;</code> rendering as the JFR-driven sections.
+	 */
+	private static final List<MetricLabel> STATIC_METRIC_LABELS = List.of(
+		new MetricLabel("version", "<strong>evitaDB version</strong>: The Maven version of the running evitaDB build."),
+		new MetricLabel("commit", "<strong>Commit hash</strong>: Abbreviated Git commit hash injected into the manifest at build time."),
+		new MetricLabel("java_version", "<strong>JVM version</strong>: The <code>java.version</code> system property of the JVM running evitaDB."),
+		new MetricLabel("problem_type", "<strong>Health problem type</strong>: Identifier of the active health problem."),
+		new MetricLabel("api_type", "<strong>API type</strong>: External API whose readiness is being reported (REST, GraphQL, gRPC, ...)."),
+		new MetricLabel("error_type", "<strong>Error type</strong>: Class of the error being counted.")
+	);
+
+	/**
 	 * Hard-coded descriptors for the metrics statically registered in {@link MetricHandler}.
 	 * The list is small and changes rarely; keeping it here avoids reflective discovery and
-	 * the runtime coupling that would come with it. Update this when a new static metric is
-	 * added to {@link MetricHandler}.
+	 * the runtime coupling that would come with it. The companion
+	 * `JfrDocumentationStaticMetricsParityTest` scrapes the Prometheus default registry
+	 * after `MetricHandler` class-loads and asserts parity, so a forgotten update breaks
+	 * the build rather than producing stale docs.
 	 */
-	private static final List<Metric> STATIC_METRICS = List.of(
+	static final List<Metric> STATIC_METRICS = List.of(
 		new Metric(
 			"evitadb_build_info",
 			"INFO",
@@ -409,7 +429,7 @@ public class JfrDocumentation implements EvitaTestSupport {
 	 * @param description description
 	 * @param labels array of label names used in metrics
 	 */
-	private record Metric(
+	record Metric(
 		@Nonnull String name,
 		@Nonnull String metricType,
 		@Nonnull String description,

--- a/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/jfr/JfrDocumentationStaticMetricsParityTest.java
+++ b/evita_test/evita_documentation_tests/src/test/java/io/evitadb/documentation/jfr/JfrDocumentationStaticMetricsParityTest.java
@@ -1,0 +1,111 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.documentation.jfr;
+
+import io.evitadb.externalApi.observability.metric.MetricHandler;
+import io.prometheus.metrics.core.metrics.Counter;
+import io.prometheus.metrics.core.metrics.Info;
+import io.prometheus.metrics.core.metrics.Metric;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static io.evitadb.test.TestTags.OBSERVABILITY_API;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Guards against silent drift between the Prometheus metrics that
+ * {@link MetricHandler} registers directly (statically, at class load) and the
+ * hand-curated descriptors in {@link JfrDocumentation#STATIC_METRICS} that drive the
+ * generated `metrics.md`. If somebody adds a new static metric to {@link MetricHandler}
+ * but forgets to add a descriptor here, this test fails — keeping the documentation
+ * in lockstep with the runtime.
+ *
+ * Only metrics registered at MetricHandler class-load are compared; JFR-driven and
+ * JVM library metrics are registered lazily and are intentionally out of scope.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("JfrDocumentation STATIC_METRICS list must mirror MetricHandler registrations")
+@Tag(OBSERVABILITY_API)
+@Tag(OBSERVABILITY)
+class JfrDocumentationStaticMetricsParityTest {
+
+	/**
+	 * The build-info metric is registered through {@link MetricHandler}'s static initializer
+	 * but the {@link io.prometheus.metrics.core.metrics.Info} instance is intentionally not
+	 * exposed as a field (Prometheus owns the only live reference). The reflection-based
+	 * scan below cannot see it, so it is added explicitly to the expected set.
+	 */
+	private static final String BUILD_INFO_METRIC_NAME = "evitadb_build_info";
+
+	@Test
+	void shouldDeclareEveryStaticallyRegisteredMetricInStaticMetricsList() throws IllegalAccessException {
+		// trigger MetricHandler's static initializer so the eagerly registered metrics
+		// (counters, probes, build-info) are present in the default registry
+		assertNotNull(MetricHandler.HEALTH_PROBLEMS);
+
+		final Set<String> declaredNames = JfrDocumentation.STATIC_METRICS.stream()
+			.map(JfrDocumentation.Metric::name)
+			.collect(Collectors.toCollection(TreeSet::new));
+
+		// enumerate every public static Prometheus Metric field declared in MetricHandler.
+		// scrape() can't be used here because Counter/Gauge metrics with declared label
+		// dimensions but no observed values yield empty data points and are filtered
+		// out of the snapshot list — we'd see only the build-info Info metric. Both
+		// `getName()` and `getPrometheusName()` return the base name; the Prometheus
+		// exposition format only re-applies the `_total` / `_info` suffix at serialization
+		// time, so we restore the suffix manually here to align with the names used in
+		// {@link JfrDocumentation#STATIC_METRICS}.
+		final Set<String> registeredStaticNames = new TreeSet<>();
+		registeredStaticNames.add(BUILD_INFO_METRIC_NAME);
+		for (final Field field : MetricHandler.class.getDeclaredFields()) {
+			if (Modifier.isStatic(field.getModifiers()) && Metric.class.isAssignableFrom(field.getType())) {
+				field.setAccessible(true);
+				final Metric metric = (Metric) field.get(null);
+				final String baseName = metric.collect().getMetadata().getPrometheusName();
+				final String suffix = metric instanceof Counter ? "_total"
+					: metric instanceof Info ? "_info" : "";
+				registeredStaticNames.add(baseName + suffix);
+			}
+		}
+
+		assertEquals(
+			declaredNames,
+			registeredStaticNames,
+			"STATIC_METRICS in JfrDocumentation must list exactly the metrics that " +
+				"MetricHandler registers eagerly. Update STATIC_METRICS (and the labels in " +
+				"STATIC_METRIC_LABELS) when adding or removing a static metric."
+		);
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/metric/MetricHandlerBuildInfoTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/metric/MetricHandlerBuildInfoTest.java
@@ -1,0 +1,97 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.observability.metric;
+
+import io.evitadb.utils.VersionUtils;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import io.prometheus.metrics.model.snapshots.InfoSnapshot;
+import io.prometheus.metrics.model.snapshots.InfoSnapshot.InfoDataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.Labels;
+import io.prometheus.metrics.model.snapshots.MetricSnapshot;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static io.evitadb.test.TestTags.OBSERVABILITY_API;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link MetricHandler} exposes the static `evitadb_build_info` Prometheus
+ * `info` metric with the expected labels — version, abbreviated commit hash and JVM
+ * version. The labels are populated from {@link VersionUtils} and `java.version`, so the
+ * concrete values depend on the build environment; the test asserts only that the metric
+ * is registered, has all three labels and that none of them is null.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("MetricHandler build-info metric contract")
+@Tag(OBSERVABILITY_API)
+@Tag(OBSERVABILITY)
+class MetricHandlerBuildInfoTest {
+
+	@Test
+	void shouldExposeBuildInfoMetricWithVersionCommitAndJavaVersionLabels() {
+		// Touch any static field on MetricHandler so the class' static initializer runs and
+		// registers `evitadb_build_info` with the default Prometheus registry. We pick
+		// HEALTH_PROBLEMS arbitrarily — the build-info metric is intentionally not exposed as
+		// a field (Prometheus owns the only live reference).
+		assertNotNull(MetricHandler.HEALTH_PROBLEMS);
+
+		final InfoDataPointSnapshot dataPoint = findBuildInfoDataPoint();
+		assertNotNull(dataPoint, "evitadb_build_info metric is not registered with the default Prometheus registry");
+
+		final Labels labels = dataPoint.getLabels();
+		assertEquals(3, labels.size(), "evitadb_build_info should expose exactly three labels");
+		assertTrue(labels.contains("version"), "evitadb_build_info is missing the `version` label");
+		assertTrue(labels.contains("commit"), "evitadb_build_info is missing the `commit` label");
+		assertTrue(labels.contains("java_version"), "evitadb_build_info is missing the `java_version` label");
+
+		// Values are environment-dependent (no shaded jar in tests), so we only check non-null.
+		assertNotNull(labels.get("version"));
+		assertNotNull(labels.get("commit"));
+		assertNotNull(labels.get("java_version"));
+	}
+
+	/**
+	 * Walks the default registry, locates the `evitadb_build_info` snapshot and returns
+	 * its first (and only) data point.
+	 *
+	 * @return the data point or `null` when the metric has not been registered
+	 */
+	private static InfoDataPointSnapshot findBuildInfoDataPoint() {
+		for (MetricSnapshot snapshot : PrometheusRegistry.defaultRegistry.scrape()) {
+			if (snapshot instanceof final InfoSnapshot infoSnapshot
+				&& "evitadb_build".equals(infoSnapshot.getMetadata().getName())) {
+				return infoSnapshot.getDataPoints().isEmpty()
+					? null
+					: infoSnapshot.getDataPoints().get(0);
+			}
+		}
+		return null;
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/metric/MetricHandlerBuildInfoTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/metric/MetricHandlerBuildInfoTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import static io.evitadb.test.TestTags.OBSERVABILITY;
 import static io.evitadb.test.TestTags.OBSERVABILITY_API;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -70,10 +71,12 @@ class MetricHandlerBuildInfoTest {
 		assertTrue(labels.contains("commit"), "evitadb_build_info is missing the `commit` label");
 		assertTrue(labels.contains("java_version"), "evitadb_build_info is missing the `java_version` label");
 
-		// Values are environment-dependent (no shaded jar in tests), so we only check non-null.
-		assertNotNull(labels.get("version"));
-		assertNotNull(labels.get("commit"));
-		assertNotNull(labels.get("java_version"));
+		// Values are environment-dependent (no shaded jar in tests), so we can only check
+		// that none of the labels was registered with an empty value — which would mask a
+		// regression in the manifest-reading or `java.version` system-property logic.
+		assertFalse(labels.get("version").isEmpty(), "evitadb_build_info `version` label is empty");
+		assertFalse(labels.get("commit").isEmpty(), "evitadb_build_info `commit` label is empty");
+		assertFalse(labels.get("java_version").isEmpty(), "evitadb_build_info `java_version` label is empty");
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/VersionUtilsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/VersionUtilsTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.DATA_TYPE;
 
@@ -51,5 +53,15 @@ public class VersionUtilsTest {
 		assertEquals(-1, SemVer.fromString("1.1.0").compareTo(SemVer.fromString("1.2.0")));
 		assertEquals(1, SemVer.fromString("2025.1.0").compareTo(SemVer.fromString("2024.12.0")));
 		assertEquals(-1, SemVer.fromString("2024.12.0").compareTo(SemVer.fromString("2025.1.0")));
+	}
+
+	@Test
+	void shouldReturnNonNullCommitHash() {
+		// Whether or not the evita_server / java_driver jar happens to be on the test classpath
+		// (depends on local maven cache state), the contract is the same: never null, never blank.
+		// When the manifest cannot be resolved the fallback is the literal "?".
+		final String commitHash = VersionUtils.readCommitHash();
+		assertNotNull(commitHash);
+		assertFalse(commitHash.isBlank(), "commit hash must not be blank");
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/VersionUtilsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/VersionUtilsTest.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2025
+ *   Copyright (c) 2025-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import static io.evitadb.test.TestTags.DATA_TYPE;
 /**
  * This test verifies contract of  the {@link VersionUtils} class.
  *
- * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025-2026
  */
 @DisplayName("VersionUtils contract tests")
 @Tag(ENGINE)

--- a/pom.xml
+++ b/pom.xml
@@ -516,6 +516,52 @@
 					<artifactId>maven-shade-plugin</artifactId>
 					<version>3.6.1</version>
 				</plugin>
+				<plugin>
+					<!--
+						Default jar manifest configuration shared by every jar module:
+						addDefaultImplementationEntries pulls Implementation-Title /
+						-Version / -Vendor from the project's <name>, <version> and
+						<organization>. Modules with extra needs (main class, premain,
+						build commit, ...) layer additional configuration on top.
+					-->
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.5.0</version>
+					<configuration>
+						<archive>
+							<manifest>
+								<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+							</manifest>
+						</archive>
+					</configuration>
+				</plugin>
+				<plugin>
+					<!--
+						Captures the short git SHA at build time and exposes it as the
+						${git.commit.id.abbrev} project property, which is then baked into
+						MANIFEST.MF and surfaced by VersionUtils#readCommitHash for the
+						evitadb_build_info metric. Submodules opt in by declaring just
+						<groupId>+<artifactId>; version, execution and configuration are
+						inherited from this management block.
+					-->
+					<groupId>io.github.git-commit-id</groupId>
+					<artifactId>git-commit-id-maven-plugin</artifactId>
+					<version>9.0.2</version>
+					<executions>
+						<execution>
+							<id>get-the-git-infos</id>
+							<phase>initialize</phase>
+							<goals>
+								<goal>revision</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<generateGitPropertiesFile>false</generateGitPropertiesFile>
+						<failOnNoGitDirectory>false</failOnNoGitDirectory>
+						<abbrevLength>7</abbrevLength>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>


### PR DESCRIPTION
## Summary

- Adds a constant Prometheus `info` metric `evitadb_build_info{version, commit, java_version}=1`, registered directly in `MetricHandler` next to the existing static probes (issue #1146).
- Captures the abbreviated git commit SHA at jar-assembly time via `git-commit-id-maven-plugin` and bakes it into a new `Implementation-Build-Commit` MANIFEST.MF entry on both the standalone server and the gRPC Java driver; `VersionUtils#readCommitHash()` reads it at startup.
- Unifies the maven-jar-plugin and git-commit-id-maven-plugin configs in the parent pom's `<pluginManagement>`: `addDefaultImplementationEntries=true` applies to every jar in the reactor; the build-commit pieces are opt-in (server + driver today). Metrics docs are regenerated to include a new "Static metrics" section covering build_info plus the long-standing error counters and probes.

## Test plan

- [x] `mvn clean install` (full reactor) — green, 1:58s.
- [x] `VersionUtilsTest.shouldReturnNonNullCommitHash` — new contract test, passes.
- [x] `MetricHandlerBuildInfoTest.shouldExposeBuildInfoMetricWithVersionCommitAndJavaVersionLabels` — scrapes the default Prometheus registry and asserts the metric is registered with the three expected labels.
- [x] Manifest verified on the shaded `evita-server.jar` and the `evita_java_driver` jar (`Implementation-Build-Commit: 4575aa6`); non-opted modules (`evita_api`, `evita_common`, `evita_external_api_observability`) only get the parent-managed `Implementation-Title/Version/Vendor` triplet, no stray `${git.commit.id.abbrev}` leakage.
- [x] Documentation generator (`JfrDocumentation#updateJfrReferenceDocumentation`) re-run under the `documentation` profile; `metrics.md` updated.

Closes #1146