### PR TITLE
feat: support fetching full price range for master product variants

### DIFF
--- a/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.graphql
+++ b/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.graphql
@@ -1,0 +1,38 @@
+{
+  queryProduct(
+    filterBy: {
+      entityPrimaryKeyInSet: [
+        103911
+      ],
+      priceInCurrency: EUR,
+      priceInPriceLists: [
+        "employee-basic-price",
+        "basic"
+      ]
+    }
+  ) {
+    recordPage {
+      data {
+        primaryKey
+        attributes {
+          code
+        }
+        priceForSale {
+          priceWithoutTax
+          priceWithTax
+          taxRate
+        }
+        priceForSaleMin {
+          priceWithoutTax
+          priceWithTax
+          taxRate
+        }
+        priceForSaleMax {
+          priceWithoutTax
+          priceWithTax
+          taxRate
+        }
+      }
+    }
+  }
+}

--- a/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.graphql.json.md
+++ b/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.graphql.json.md
@@ -1,0 +1,27 @@
+```json
+{
+  "data" : [
+    {
+      "primaryKey" : 103911,
+      "attributes" : {
+        "code" : "apple-ipad-10-2-10th-generation-2022"
+      },
+      "priceForSale" : {
+        "priceWithoutTax" : "395.87",
+        "priceWithTax" : "479.0",
+        "taxRate" : "21.0"
+      },
+      "priceForSaleMin" : {
+        "priceWithoutTax" : "395.87",
+        "priceWithTax" : "479.0",
+        "taxRate" : "21.0"
+      },
+      "priceForSaleMax" : {
+        "priceWithoutTax" : "436.36",
+        "priceWithTax" : "528.0",
+        "taxRate" : "21.0"
+      }
+    }
+  ]
+}
+```

--- a/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.rest
+++ b/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.rest
@@ -1,0 +1,22 @@
+POST /rest/evita/Product/query
+
+{
+  "filterBy" : {
+    "entityPrimaryKeyInSet" : [
+      103911
+    ],
+    "priceInCurrency" : "EUR",
+    "priceInPriceLists" : [
+      "employee-basic-price",
+      "basic"
+    ]
+  },
+  "require" : {
+    "entityFetch" : {
+      "attributeContent" : [
+        "code"
+      ],
+      "priceContentRespectingFilter" : [ ]
+    }
+  }
+}

--- a/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.rest.json.md
+++ b/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.rest.json.md
@@ -1,0 +1,424 @@
+```json
+{
+  "data" : [
+    {
+      "primaryKey" : 103911,
+      "type" : "Product",
+      "version" : 2,
+      "scope" : "LIVE",
+      "allLocales" : [
+        "cs",
+        "de",
+        "en"
+      ],
+      "priceInnerRecordHandling" : "LOWEST_PRICE",
+      "attributes" : {
+        "global" : {
+          "code" : "apple-ipad-10-2-10th-generation-2022"
+        }
+      },
+      "prices" : [
+        {
+          "priceId" : 783,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105697,
+          "indexed" : true,
+          "priceWithoutTax" : "429.75",
+          "priceWithTax" : "520.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 785,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105698,
+          "indexed" : true,
+          "priceWithoutTax" : "454.55",
+          "priceWithTax" : "550.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 787,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105699,
+          "indexed" : true,
+          "priceWithoutTax" : "429.75",
+          "priceWithTax" : "520.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 789,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105700,
+          "indexed" : true,
+          "priceWithoutTax" : "454.55",
+          "priceWithTax" : "550.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 791,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105702,
+          "indexed" : true,
+          "priceWithoutTax" : "429.75",
+          "priceWithTax" : "520.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 793,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105703,
+          "indexed" : true,
+          "priceWithoutTax" : "454.55",
+          "priceWithTax" : "550.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 795,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105705,
+          "indexed" : true,
+          "priceWithoutTax" : "429.75",
+          "priceWithTax" : "520.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 797,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105706,
+          "indexed" : true,
+          "priceWithoutTax" : "454.55",
+          "priceWithTax" : "550.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 799,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105707,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 801,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105708,
+          "indexed" : true,
+          "priceWithoutTax" : "429.75",
+          "priceWithTax" : "520.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 803,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105709,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 805,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105710,
+          "indexed" : true,
+          "priceWithoutTax" : "429.75",
+          "priceWithTax" : "520.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 807,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105711,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 809,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105712,
+          "indexed" : true,
+          "priceWithoutTax" : "429.75",
+          "priceWithTax" : "520.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 811,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105713,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 813,
+          "priceList" : "basic",
+          "currency" : "EUR",
+          "innerRecordId" : 105714,
+          "indexed" : true,
+          "priceWithoutTax" : "429.75",
+          "priceWithTax" : "520.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13492,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105697,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13494,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105698,
+          "indexed" : true,
+          "priceWithoutTax" : "436.36",
+          "priceWithTax" : "528.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13496,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105699,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13498,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105700,
+          "indexed" : true,
+          "priceWithoutTax" : "436.36",
+          "priceWithTax" : "528.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13500,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105702,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13502,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105703,
+          "indexed" : true,
+          "priceWithoutTax" : "436.36",
+          "priceWithTax" : "528.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13504,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105705,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13506,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105706,
+          "indexed" : true,
+          "priceWithoutTax" : "436.36",
+          "priceWithTax" : "528.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13508,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105707,
+          "indexed" : true,
+          "priceWithoutTax" : "395.87",
+          "priceWithTax" : "479.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13510,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105708,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13512,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105709,
+          "indexed" : true,
+          "priceWithoutTax" : "395.87",
+          "priceWithTax" : "479.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13514,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105710,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13516,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105711,
+          "indexed" : true,
+          "priceWithoutTax" : "395.87",
+          "priceWithTax" : "479.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13518,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105712,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13520,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105713,
+          "indexed" : true,
+          "priceWithoutTax" : "395.87",
+          "priceWithTax" : "479.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        },
+        {
+          "priceId" : 13522,
+          "priceList" : "employee-basic-price",
+          "currency" : "EUR",
+          "innerRecordId" : 105714,
+          "indexed" : true,
+          "priceWithoutTax" : "412.4",
+          "priceWithTax" : "499.0",
+          "taxRate" : "21.0",
+          "validity" : null
+        }
+      ],
+      "priceForSale" : {
+        "priceId" : 13508,
+        "priceList" : "employee-basic-price",
+        "currency" : "EUR",
+        "innerRecordId" : 105707,
+        "indexed" : true,
+        "priceWithoutTax" : "395.87",
+        "priceWithTax" : "479.0",
+        "taxRate" : "21.0",
+        "validity" : null
+      },
+      "priceForSaleMin" : {
+        "priceId" : 13508,
+        "priceList" : "employee-basic-price",
+        "currency" : "EUR",
+        "innerRecordId" : 105707,
+        "indexed" : true,
+        "priceWithoutTax" : "395.87",
+        "priceWithTax" : "479.0",
+        "taxRate" : "21.0",
+        "validity" : null
+      },
+      "priceForSaleMax" : {
+        "priceId" : 13494,
+        "priceList" : "employee-basic-price",
+        "currency" : "EUR",
+        "innerRecordId" : 105698,
+        "indexed" : true,
+        "priceWithoutTax" : "436.36",
+        "priceWithTax" : "528.0",
+        "taxRate" : "21.0",
+        "validity" : null
+      },
+      "multiplePricesForSaleAvailable" : true
+    }
+  ],
+  "type" : "PAGE",
+  "totalRecordCount" : 1,
+  "first" : true,
+  "last" : true,
+  "hasPrevious" : false,
+  "hasNext" : false,
+  "singlePage" : true,
+  "empty" : false,
+  "pageSize" : 20,
+  "pageNumber" : 1,
+  "lastPageNumber" : 1,
+  "firstPageItemNumber" : 0,
+  "lastPageItemNumber" : 1
+}
+```

--- a/documentation/user/en/query/requirements/fetching.md
+++ b/documentation/user/en/query/requirements/fetching.md
@@ -5,7 +5,7 @@ perex: |
   reduce the amount of data transferred over the network and to reduce the load on the server. Fetching is similar to
   joins and column selection in SQL, but is inspired by data fetching in the GraphQL protocol by incrementally following
   the relationships in the data.
-date: '23.7.2023'
+date: '5.5.2026'
 author: 'Ing. Jan Novotný'
 proofreading: 'done'
 preferredLang: 'evitaql'
@@ -1195,6 +1195,92 @@ As you can see, the price for sale matching the filter constraints is returned, 
 flag indicating that there are multiple prices for sale available.
 
 </Note>
+
+</LS>
+<LS to="g,r">
+
+### Price for sale range
+
+When rendering category listings or master-product cards, a typical front store wants to show the canonical selling
+price together with a "from / to" span across the variants (e.g. _"iPad 10 — from €479 to €528"_) without paging
+through `allPricesForSale` and folding it client-side. Two sibling fields, `priceForSaleMin` and `priceForSaleMax`,
+return exactly that pair of bounds — both computed from the same currency / valid-in / price-list filters that produce
+`priceForSale`, so all three values are directly comparable.
+
+The semantics depend on the [inner record handling](../filtering/price.md#price-for-sale-selection-in-a-nutshell)
+strategy of the entity:
+
+- **`NONE`** — `priceForSaleMin == priceForSaleMax == priceForSale` (a single selling price candidate).
+- **`LOWEST_PRICE`** — `priceForSaleMin == priceForSale` (the cheapest per-inner-record selling price),
+  `priceForSaleMax` is the most expensive per-inner-record selling price.
+- **`SUM`** — `priceForSaleMin` and `priceForSaleMax` are the cheapest and most expensive per-inner-record components;
+  `priceForSale` is the cumulated (summed) price across all components.
+
+The bounds reuse the same internal computation as `priceForSale`, so asking for all three siblings on the same entity
+costs the same as asking for `priceForSale` alone.
+
+</LS>
+<LS to="g">
+
+Both fields accept the same arguments (`priceLists`, `currency`, `validIn`, `validNow`, `locale`) as `priceForSale`;
+when omitted, they fall back to the surrounding query's price constraints.
+
+<SourceCodeTabs langSpecificTabOnly>
+
+[Getting entity with price for sale and its variant range](/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.graphql)
+
+</SourceCodeTabs>
+
+<Note type="info">
+
+<NoteTitle toggles="true">
+
+##### The result of an entity fetched with its price for sale range
+
+</NoteTitle>
+
+The query returns the canonical selling price together with the lowest and highest variant prices:
+
+<MDInclude sourceVariable="data.queryProduct.recordPage">[The result of an entity fetched with its price for sale range](/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.graphql.json.md)</MDInclude>
+
+The bounds reflect the cheapest and most expensive per-variant prices, while `priceForSale` is the resolved selling
+price for the master entity itself.
+
+</Note>
+
+</LS>
+<LS to="r">
+
+Both fields are emitted alongside `priceForSale` whenever a `priceContent` (e.g. `priceContentRespectingFilter`)
+requirement is present in the entity fetch; the bounds reflect the price constraints in the surrounding `filterBy`
+clause.
+
+<SourceCodeTabs langSpecificTabOnly>
+
+[Getting entity with price for sale and its variant range](/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.rest)
+
+</SourceCodeTabs>
+
+<Note type="info">
+
+<NoteTitle toggles="true">
+
+##### The result of an entity fetched with its price for sale range
+
+</NoteTitle>
+
+The response carries the canonical selling price together with the lowest and highest variant prices as siblings of
+`priceForSale`:
+
+<MDInclude sourceVariable="recordPage">[The result of an entity fetched with its price for sale range](/documentation/user/en/query/requirements/examples/fetching/priceForSaleRangeField.rest.json.md)</MDInclude>
+
+The bounds reflect the cheapest and most expensive per-variant prices, while `priceForSale` is the resolved selling
+price for the master entity itself.
+
+</Note>
+
+</LS>
+<LS to="g">
 
 ### Accompanying prices
 

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResult.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResult.java
@@ -37,7 +37,6 @@ import java.util.Collection;
 import java.util.Currency;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Optional.ofNullable;
 
@@ -68,6 +67,16 @@ import static java.util.Optional.ofNullable;
  */
 public class PriceForSaleContextWithCachedResult implements PriceForSaleContext {
 	/**
+	 * Tiny two-state holder used purely as a nullability sentinel for the cache slots — a `null` field
+	 * reference means "not yet computed", a non-null holder wrapping a (possibly `null`) `value` means
+	 * "computed; value may legitimately be `null` for entities with no sellable price". Replaces a previous
+	 * `AtomicReference` whose CAS capabilities were unused; safe publication is provided by the `volatile`
+	 * declaration on the cache fields, not by this holder.
+	 */
+	private record ComputedHolder<T>(@Nullable T value) {
+	}
+
+	/**
 	 * List of price lists sorted by priority.
 	 */
 	@Nullable private final String[] priceListPriority;
@@ -90,14 +99,14 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 	 * published to concurrent readers — multiple GraphQL / REST data fetchers may evaluate fields on the same
 	 * {@link io.evitadb.api.requestResponse.data.structure.EntityDecorator} in parallel.
 	 */
-	private volatile AtomicReference<PriceForSaleComputationResult> cachedComputation;
+	private volatile ComputedHolder<PriceForSaleComputationResult> cachedComputation;
 	/**
 	 * Cache for the assembled {@link PriceForSaleWithAccompanyingPrices} returned by {@link #compute}. May be
 	 * pre-seeded at construction (gRPC reverse path) or populated on the first {@code compute()} call so the
 	 * accompanying-price selection runs at most once. Declared `volatile` for the same safe-publication reason
 	 * as {@link #cachedComputation}.
 	 */
-	private volatile AtomicReference<PriceForSaleWithAccompanyingPrices> cachedResult;
+	private volatile ComputedHolder<PriceForSaleWithAccompanyingPrices> cachedResult;
 
 	public PriceForSaleContextWithCachedResult(
 		@Nullable String[] priceListPriority,
@@ -119,7 +128,7 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 		@Nonnull PriceForSaleWithAccompanyingPrices priceForSaleWithAccompanyingPrices
 	) {
 		this(priceListPriority, currency, atTheMoment, accompanyingPrices);
-		this.cachedResult = new AtomicReference<>(priceForSaleWithAccompanyingPrices);
+		this.cachedResult = new ComputedHolder<>(priceForSaleWithAccompanyingPrices);
 	}
 
 	@Nonnull
@@ -180,7 +189,7 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 		@Nonnull PriceInnerRecordHandling innerRecordHandling
 	) {
 		if (this.cachedResult != null) {
-			return ofNullable(this.cachedResult.get());
+			return ofNullable(this.cachedResult.value());
 		}
 		final PriceForSaleComputationResult computation = ensureComputation(prices, innerRecordHandling);
 		final PriceForSaleWithAccompanyingPrices result = computation == null
@@ -192,7 +201,7 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 						.orElse(PricesContract.NO_ACCOMPANYING_PRICES)
 				)
 			);
-		this.cachedResult = new AtomicReference<>(result);
+		this.cachedResult = new ComputedHolder<>(result);
 		return ofNullable(result);
 	}
 
@@ -266,7 +275,7 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 		@Nonnull PriceInnerRecordHandling innerRecordHandling
 	) {
 		if (this.cachedResult != null) {
-			return ofNullable(this.cachedResult.get())
+			return ofNullable(this.cachedResult.value())
 				.map(PriceForSaleWithAccompanyingPrices::priceForSale);
 		}
 		final PriceForSaleComputationResult computation = ensureComputation(prices, innerRecordHandling);
@@ -287,7 +296,7 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 		@Nonnull PriceInnerRecordHandling innerRecordHandling
 	) {
 		if (this.cachedComputation != null) {
-			return this.cachedComputation.get();
+			return this.cachedComputation.value();
 		}
 		final PriceForSaleComputationResult computation = PricesContract.computePriceForSaleResult(
 			prices,
@@ -297,7 +306,7 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 			ofNullable(this.priceListPriority).orElseThrow(ContextMissingException::new),
 			Objects::nonNull
 		);
-		this.cachedComputation = new AtomicReference<>(computation);
+		this.cachedComputation = new ComputedHolder<>(computation);
 		return computation;
 	}
 }

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResult.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResult.java
@@ -188,8 +188,9 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 		@Nonnull Collection<PriceContract> prices,
 		@Nonnull PriceInnerRecordHandling innerRecordHandling
 	) {
-		if (this.cachedResult != null) {
-			return ofNullable(this.cachedResult.value());
+		final ComputedHolder<PriceForSaleWithAccompanyingPrices> snapshot = this.cachedResult;
+		if (snapshot != null) {
+			return ofNullable(snapshot.value());
 		}
 		final PriceForSaleComputationResult computation = ensureComputation(prices, innerRecordHandling);
 		final PriceForSaleWithAccompanyingPrices result = computation == null
@@ -274,8 +275,9 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 		@Nonnull Collection<PriceContract> prices,
 		@Nonnull PriceInnerRecordHandling innerRecordHandling
 	) {
-		if (this.cachedResult != null) {
-			return ofNullable(this.cachedResult.value())
+		final ComputedHolder<PriceForSaleWithAccompanyingPrices> snapshot = this.cachedResult;
+		if (snapshot != null) {
+			return ofNullable(snapshot.value())
 				.map(PriceForSaleWithAccompanyingPrices::priceForSale);
 		}
 		final PriceForSaleComputationResult computation = ensureComputation(prices, innerRecordHandling);
@@ -295,8 +297,9 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 		@Nonnull Collection<PriceContract> prices,
 		@Nonnull PriceInnerRecordHandling innerRecordHandling
 	) {
-		if (this.cachedComputation != null) {
-			return this.cachedComputation.value();
+		final ComputedHolder<PriceForSaleComputationResult> snapshot = this.cachedComputation;
+		if (snapshot != null) {
+			return snapshot.value();
 		}
 		final PriceForSaleComputationResult computation = PricesContract.computePriceForSaleResult(
 			prices,

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResult.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResult.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2025
+ *   Copyright (c) 2025-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ package io.evitadb.api.requestResponse.data;
 
 import io.evitadb.api.exception.ContextMissingException;
 import io.evitadb.api.requestResponse.data.PricesContract.AccompanyingPrice;
+import io.evitadb.api.requestResponse.data.PricesContract.PriceForSaleComputationResult;
 import io.evitadb.api.requestResponse.data.PricesContract.PriceForSaleContext;
 import io.evitadb.api.requestResponse.data.PricesContract.PriceForSaleWithAccompanyingPrices;
 
@@ -41,7 +42,29 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.Optional.ofNullable;
 
 /**
- * Describes context for computation of price for sale.
+ * Per-entity cache for the price-for-sale computation. Caches the rich
+ * {@link PriceForSaleComputationResult} once so that follow-up calls — selling price, range, accompanying
+ * prices — can be derived without re-running {@link PricesContract#computePriceForSaleResult} for every view.
+ * REST / gRPC / GraphQL serializers materializing both `priceForSale` and `priceForSaleMin` / `priceForSaleMax` for the same
+ * entity therefore pay only one full pass.
+ *
+ * Two independent cache slots are kept:
+ *
+ * - `cachedComputation` — the full {@link PriceForSaleComputationResult}, populated by the first
+ *   {@code compute*} call that needs the per-bucket detail (range or selling price without seed). Range
+ *   views and {@link #computePriceForSale} both derive from this slot.
+ * - `cachedResult` — the assembled {@link PriceForSaleWithAccompanyingPrices} returned by {@link #compute}.
+ *   May be pre-seeded at construction by callers that already hold the value (e.g. the gRPC reverse path
+ *   that reads selling price and accompanying prices straight off the wire); otherwise it is populated by
+ *   the first {@code compute()} call so that the accompanying-price selection runs only once.
+ *
+ * The cache is per {@link io.evitadb.api.requestResponse.data.structure.EntityDecorator} (request-scoped) and
+ * is intended for short-lived materialization workloads.
+ *
+ * Filter predicate handling: the cache always assumes the no-op {@code Objects::nonNull} predicate that the
+ * default {@code getPriceForSale} / {@code getPriceRangeForSale} overloads use. Callers passing a custom
+ * predicate must bypass the cache entirely (the public defaults already do this — they only consult the
+ * cache through the contextual entry points).
  */
 public class PriceForSaleContextWithCachedResult implements PriceForSaleContext {
 	/**
@@ -61,7 +84,15 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 	 */
 	@Nullable private final AccompanyingPrice[] accompanyingPrices;
 	/**
-	 * Cached result of price for sale calculation.
+	 * Rich computation cache populated lazily by the first {@code compute*} call that needs the per-bucket
+	 * detail. Drives {@link #computePriceForSale}, {@link #computeRange}, and
+	 * {@link #computeRangeWithAccompanyingPrices}.
+	 */
+	private AtomicReference<PriceForSaleComputationResult> cachedComputation;
+	/**
+	 * Cache for the assembled {@link PriceForSaleWithAccompanyingPrices} returned by {@link #compute}. May be
+	 * pre-seeded at construction (gRPC reverse path) or populated on the first {@code compute()} call so the
+	 * accompanying-price selection runs at most once.
 	 */
 	private AtomicReference<PriceForSaleWithAccompanyingPrices> cachedResult;
 
@@ -131,10 +162,12 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 	}
 
 	/**
-	 * Computes price for sale with accompanying prices from the provided collection of prices.
-	 * If the result is already cached, it returns the cached value. Method doesn't check the input price collection
-	 * and inner record handling strategy consistency against cached value. Method is expected to be always called
-	 * with the same parameters as the first call.
+	 * Computes price for sale with accompanying prices from the provided collection of prices. Returns the
+	 * cached result on every subsequent call — whether the cache was pre-seeded at construction (gRPC
+	 * reverse-path) or filled by a prior call to this method. The accompanying-price selection therefore
+	 * runs at most once. Method doesn't check the input price collection and inner record handling strategy
+	 * consistency against cached value — it is expected to be always called with the same parameters as the
+	 * first call.
 	 *
 	 * @return an Optional containing the computed PriceForSaleWithAccompanyingPrices or empty if no valid price is found
 	 */
@@ -143,20 +176,122 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 		@Nonnull Collection<PriceContract> prices,
 		@Nonnull PriceInnerRecordHandling innerRecordHandling
 	) {
-		if (this.cachedResult == null) {
-			this.cachedResult = new AtomicReference<>(
-				PricesContract.computePriceForSale(
-					prices,
-					innerRecordHandling,
-					ofNullable(this.currency).orElseThrow(ContextMissingException::new),
-					this.atTheMoment,
-					ofNullable(this.priceListPriority).orElseThrow(ContextMissingException::new),
-					Objects::nonNull,
+		if (this.cachedResult != null) {
+			return ofNullable(this.cachedResult.get());
+		}
+		final PriceForSaleComputationResult computation = ensureComputation(prices, innerRecordHandling);
+		final PriceForSaleWithAccompanyingPrices result = computation == null
+			? null
+			: new PriceForSaleWithAccompanyingPrices(
+				computation.priceForSale(),
+				computation.calculateAccompanyingPrices(
 					ofNullable(this.accompanyingPrices)
 						.orElse(PricesContract.NO_ACCOMPANYING_PRICES)
-				).orElse(null)
+				)
 			);
+		this.cachedResult = new AtomicReference<>(result);
+		return ofNullable(result);
+	}
+
+	/**
+	 * Returns the cached / freshly-computed price-for-sale range. Range queries read the rich
+	 * {@code cachedComputation} slot, which is independent of the {@code cachedResult} seed used by
+	 * {@link #compute}: a pre-seeded {@code cachedResult} carries no per-bucket data, so the first range
+	 * query always runs a full computation. Subsequent range / selling-price / accompanying-price calls
+	 * reuse the populated {@code cachedComputation}.
+	 *
+	 * @return an Optional containing the computed PriceRangeForSale or empty if no valid selling price exists
+	 */
+	@Nonnull
+	public Optional<PriceRangeForSale> computeRange(
+		@Nonnull Collection<PriceContract> prices,
+		@Nonnull PriceInnerRecordHandling innerRecordHandling
+	) {
+		final PriceForSaleComputationResult computation = ensureComputation(prices, innerRecordHandling);
+		if (computation == null) {
+			return Optional.empty();
 		}
-		return ofNullable(this.cachedResult.get());
+		return Optional.of(
+			new PriceRangeForSale(
+				computation.lowestPrice(),
+				computation.highestPrice(),
+				computation.priceForSale()
+			)
+		);
+	}
+
+	/**
+	 * Returns the cached / freshly-computed price-for-sale range together with the requested accompanying
+	 * prices. Behaves like {@link #computeRange} for the range bounds and like {@link #compute} for the
+	 * accompanying-price selection — both views share the same underlying {@link PriceForSaleComputationResult}.
+	 *
+	 * @param requestedAccompanyingPrices array of accompanying-price requirements; may differ from the
+	 *                                    requirements stored in the context (the rich cache is independent
+	 *                                    of any specific accompanying-price set)
+	 * @return an Optional containing the computed PriceRangeForSaleWithAccompanyingPrices or empty
+	 */
+	@Nonnull
+	public Optional<PriceRangeForSaleWithAccompanyingPrices> computeRangeWithAccompanyingPrices(
+		@Nonnull Collection<PriceContract> prices,
+		@Nonnull PriceInnerRecordHandling innerRecordHandling,
+		@Nonnull AccompanyingPrice[] requestedAccompanyingPrices
+	) {
+		final PriceForSaleComputationResult computation = ensureComputation(prices, innerRecordHandling);
+		if (computation == null) {
+			return Optional.empty();
+		}
+		return Optional.of(
+			new PriceRangeForSaleWithAccompanyingPrices(
+				new PriceRangeForSale(
+					computation.lowestPrice(),
+					computation.highestPrice(),
+					computation.priceForSale()
+				),
+				computation.calculateAccompanyingPrices(requestedAccompanyingPrices)
+			)
+		);
+	}
+
+	/**
+	 * Returns just the selling price. If {@link #compute} has already been called (or the cache was seeded),
+	 * the answer is read from {@code cachedResult}. Otherwise the result is derived from the rich
+	 * computation cache (populated on demand) without paying for the accompanying-price selection.
+	 */
+	@Nonnull
+	public Optional<PriceContract> computePriceForSale(
+		@Nonnull Collection<PriceContract> prices,
+		@Nonnull PriceInnerRecordHandling innerRecordHandling
+	) {
+		if (this.cachedResult != null) {
+			return ofNullable(this.cachedResult.get())
+				.map(PriceForSaleWithAccompanyingPrices::priceForSale);
+		}
+		final PriceForSaleComputationResult computation = ensureComputation(prices, innerRecordHandling);
+		return ofNullable(computation).map(PriceForSaleComputationResult::priceForSale);
+	}
+
+	/**
+	 * Returns the rich computation result, running the full {@link PricesContract#computePriceForSaleResult}
+	 * pass and caching the result on the first call. Concurrent first-callers may both run the computation;
+	 * the last writer wins.
+	 */
+	@Nullable
+	private PriceForSaleComputationResult ensureComputation(
+		@Nonnull Collection<PriceContract> prices,
+		@Nonnull PriceInnerRecordHandling innerRecordHandling
+	) {
+		if (this.cachedComputation != null) {
+			return this.cachedComputation.get();
+		}
+		final PriceForSaleComputationResult computation = PricesContract.computePriceForSaleResult(
+			prices,
+			innerRecordHandling,
+			ofNullable(this.currency).orElseThrow(ContextMissingException::new),
+			this.atTheMoment,
+			ofNullable(this.priceListPriority).orElseThrow(ContextMissingException::new),
+			Objects::nonNull
+		);
+		this.cachedComputation = new AtomicReference<>(computation);
+		return computation;
 	}
 }

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResult.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResult.java
@@ -86,15 +86,18 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 	/**
 	 * Rich computation cache populated lazily by the first {@code compute*} call that needs the per-bucket
 	 * detail. Drives {@link #computePriceForSale}, {@link #computeRange}, and
-	 * {@link #computeRangeWithAccompanyingPrices}.
+	 * {@link #computeRangeWithAccompanyingPrices}. Declared `volatile` so the field reference is safely
+	 * published to concurrent readers — multiple GraphQL / REST data fetchers may evaluate fields on the same
+	 * {@link io.evitadb.api.requestResponse.data.structure.EntityDecorator} in parallel.
 	 */
-	private AtomicReference<PriceForSaleComputationResult> cachedComputation;
+	private volatile AtomicReference<PriceForSaleComputationResult> cachedComputation;
 	/**
 	 * Cache for the assembled {@link PriceForSaleWithAccompanyingPrices} returned by {@link #compute}. May be
 	 * pre-seeded at construction (gRPC reverse path) or populated on the first {@code compute()} call so the
-	 * accompanying-price selection runs at most once.
+	 * accompanying-price selection runs at most once. Declared `volatile` for the same safe-publication reason
+	 * as {@link #cachedComputation}.
 	 */
-	private AtomicReference<PriceForSaleWithAccompanyingPrices> cachedResult;
+	private volatile AtomicReference<PriceForSaleWithAccompanyingPrices> cachedResult;
 
 	public PriceForSaleContextWithCachedResult(
 		@Nullable String[] priceListPriority,
@@ -272,8 +275,11 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 
 	/**
 	 * Returns the rich computation result, running the full {@link PricesContract#computePriceForSaleResult}
-	 * pass and caching the result on the first call. Concurrent first-callers may both run the computation;
-	 * the last writer wins.
+	 * pass and caching the result on the first call. The cache field is `volatile`, so the value written by
+	 * the first completing thread is visible to subsequent readers. Concurrent first-callers may both run
+	 * the computation (no compare-and-set on the field); the last writer wins. The cached
+	 * {@link PriceForSaleComputationResult} is deterministic for a given input set, so duplicate computation
+	 * is wasteful but not incorrect.
 	 */
 	@Nullable
 	private PriceForSaleComputationResult ensureComputation(

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResult.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResult.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.Currency;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -107,6 +108,14 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 	 * as {@link #cachedComputation}.
 	 */
 	private volatile ComputedHolder<PriceForSaleWithAccompanyingPrices> cachedResult;
+	/**
+	 * Lazily computed `priceList -> priority` lookup derived from {@link #priceListPriority}. The map is a pure
+	 * function of the priority array, so building it once per cache instance avoids the otherwise-repeated
+	 * {@link PricesContract#getPriceListPriorityIndex} allocation inside the engine's hot path. Declared
+	 * `volatile` for the same safe-publication reason as the other cache slots — the holder reference is
+	 * published to concurrent readers atomically.
+	 */
+	private volatile ComputedHolder<Map<String, Integer>> cachedPriorityIndex;
 
 	public PriceForSaleContextWithCachedResult(
 		@Nullable String[] priceListPriority,
@@ -306,10 +315,29 @@ public class PriceForSaleContextWithCachedResult implements PriceForSaleContext 
 			innerRecordHandling,
 			ofNullable(this.currency).orElseThrow(ContextMissingException::new),
 			this.atTheMoment,
-			ofNullable(this.priceListPriority).orElseThrow(ContextMissingException::new),
+			ensurePriorityIndex(),
 			Objects::nonNull
 		);
 		this.cachedComputation = new ComputedHolder<>(computation);
 		return computation;
+	}
+
+	/**
+	 * Lazily builds the `priceList -> priority` lookup from {@link #priceListPriority} and caches it for
+	 * future calls. Concurrent first-callers may both run the conversion (no compare-and-set on the field);
+	 * the last writer wins. The result is deterministic for a given input array, so duplicate computation is
+	 * wasteful but not incorrect.
+	 */
+	@Nonnull
+	private Map<String, Integer> ensurePriorityIndex() {
+		final ComputedHolder<Map<String, Integer>> snapshot = this.cachedPriorityIndex;
+		if (snapshot != null && snapshot.value() != null) {
+			return snapshot.value();
+		}
+		final Map<String, Integer> priorityIndex = PricesContract.getPriceListPriorityIndex(
+			ofNullable(this.priceListPriority).orElseThrow(ContextMissingException::new)
+		);
+		this.cachedPriorityIndex = new ComputedHolder<>(priorityIndex);
+		return priorityIndex;
 	}
 }

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceRangeForSale.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceRangeForSale.java
@@ -1,0 +1,57 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.data;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+/**
+ * Holds the full price range for an entity together with the resolved selling price. The range is computed
+ * using the same currency / valid-in / price-list filters as the selling price and is therefore directly
+ * comparable.
+ *
+ * Strategy semantics:
+ *
+ * - `NONE`: `lowestPrice == highestPrice == priceForSale` — there is exactly one selling price candidate.
+ * - `LOWEST_PRICE`: `lowestPrice == priceForSale` (the cheapest per-inner-record selling price),
+ *   `highestPrice` is the most expensive per-inner-record selling price computed with identical filter rules.
+ * - `SUM`: `lowestPrice` is the cheapest per-inner-record component, `highestPrice` is the most expensive
+ *   per-inner-record component, `priceForSale` is the
+ *   {@link io.evitadb.api.requestResponse.data.structure.CumulatedPrice} over all components.
+ *
+ * The bounds are always concrete, indexed inner-record prices that satisfy the same filter as the selling
+ * price.
+ *
+ * @param lowestPrice  the lowest selling price (or component price for `SUM`)
+ * @param highestPrice the highest selling price (or component price for `SUM`)
+ * @param priceForSale the resolved selling price (per-strategy semantics — see above)
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public record PriceRangeForSale(
+	@Nonnull PriceContract lowestPrice,
+	@Nonnull PriceContract highestPrice,
+	@Nonnull PriceContract priceForSale
+) implements Serializable {
+}

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceRangeForSale.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceRangeForSale.java
@@ -43,8 +43,20 @@ import java.io.Serializable;
  * The bounds are always concrete, indexed inner-record prices that satisfy the same filter as the selling
  * price.
  *
- * @param lowestPrice  the lowest selling price (or component price for `SUM`)
- * @param highestPrice the highest selling price (or component price for `SUM`)
+ * Predicate-filter asymmetry under `LOWEST_PRICE`: the `filterPredicate` passed to
+ * {@link PricesContract#computePriceRangeForSale} is a selling-price scoped filter inherited from the legacy
+ * {@code getPriceForSale*} API. It applies to `lowestPrice` (which equals the selling price by construction)
+ * but **not** to `highestPrice` — the upper bound describes the unfiltered indexed catalogue spread for the
+ * resolved currency / valid-in / price-list filters, which is the value e-commerce front-ends typically need
+ * for "price from / to" displays. Symmetric clipping would amount to "the highest price that still passes the
+ * selling-price filter", which is rarely useful and would break the invariant that the bounds describe the
+ * real catalogue spread.
+ *
+ * @param lowestPrice  the lowest selling price (or component price for `SUM`); under `LOWEST_PRICE` this is
+ *                     the cheapest indexed candidate that **passes** the selling-price `filterPredicate`
+ * @param highestPrice the highest selling price (or component price for `SUM`); under `LOWEST_PRICE` this is
+ *                     the most expensive indexed candidate **regardless** of the `filterPredicate` — see the
+ *                     "Predicate-filter asymmetry" note above
  * @param priceForSale the resolved selling price (per-strategy semantics — see above)
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceRangeForSaleWithAccompanyingPrices.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceRangeForSaleWithAccompanyingPrices.java
@@ -35,11 +35,20 @@ import java.util.Optional;
  * are interchangeable in terms of the accompanying-price contents — only the price-range information is
  * added on top.
  *
+ * Bound-vs-accompanying scope: under `LOWEST_PRICE`, `accompanyingPrices` are scoped to the inner record of
+ * the **selling** price (i.e. the cheapest variant), not to the inner record of `priceRange.highestPrice()`.
+ * The same map is returned regardless of which bound the consumer subsequently surfaces (`priceForSaleMin`
+ * vs `priceForSaleMax`). This is intentional — the engine resolves accompanying prices once per request and
+ * the bound fields are presentation-layer views over the same resolved context. Consumers wanting the
+ * accompanying prices of a specific variant should query that variant directly rather than via the bound
+ * field.
+ *
  * @param priceRange         price range for sale (lowest/highest/priceForSale)
  * @param accompanyingPrices map of accompanying prices keyed by their requested
  *                           {@link PricesContract.AccompanyingPrice#priceName()}; values are wrapped in
  *                           {@link Optional} so that absent accompanying prices may be represented
- *                           explicitly
+ *                           explicitly. See the "Bound-vs-accompanying scope" note above for how the map
+ *                           relates to the range bounds under `LOWEST_PRICE`
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceRangeForSaleWithAccompanyingPrices.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PriceRangeForSaleWithAccompanyingPrices.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.data;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Combines a {@link PriceRangeForSale} with the map of accompanying prices that were computed alongside the
+ * price for sale. The accompanying prices follow exactly the same selection rules as
+ * {@link PricesContract.PriceForSaleWithAccompanyingPrices#accompanyingPrices()} returns, so the two methods
+ * are interchangeable in terms of the accompanying-price contents — only the price-range information is
+ * added on top.
+ *
+ * @param priceRange         price range for sale (lowest/highest/priceForSale)
+ * @param accompanyingPrices map of accompanying prices keyed by their requested
+ *                           {@link PricesContract.AccompanyingPrice#priceName()}; values are wrapped in
+ *                           {@link Optional} so that absent accompanying prices may be represented
+ *                           explicitly
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public record PriceRangeForSaleWithAccompanyingPrices(
+	@Nonnull PriceRangeForSale priceRange,
+	@Nonnull Map<String, Optional<PriceContract>> accompanyingPrices
+) implements Serializable {
+}

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
@@ -303,8 +303,11 @@ public interface PricesContract extends Versioned, Serializable {
 			case NONE -> {
 				PriceContract bestForSale = null;
 				int bestPriority = Integer.MAX_VALUE;
-				// candidates collected during the first pass — reused for accompanying-price calc
-				final List<PriceContract> candidates = new ArrayList<>(entityPrices.size());
+				// candidates collected during the first pass — reused for accompanying-price calc.
+				// Mirrors the `distinctInnerEstimate` heuristic used by the inner-record branches: assume that
+				// roughly half of `entityPrices` survives the currency / validity filter (multi-currency
+				// catalogues are common), with a small reserve to absorb noise.
+				final List<PriceContract> candidates = new ArrayList<>(entityPrices.size() / 2 + 2);
 				for (final PriceContract price : entityPrices) {
 					if (isNotCandidate(price, currency, atTheMoment)) {
 						continue;

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
@@ -415,12 +415,16 @@ public interface PricesContract extends Versioned, Serializable {
 				final List<PriceContract> components = new ArrayList<>(bestPerInner.size());
 				PriceContract lowest = null;
 				PriceContract highest = null;
+				// share the deterministic tie-break with LOWEST_PRICE so that ties on `priceWithTax` resolve by
+				// `priceId` (then `innerRecordId`) instead of leaving the running incumbent untouched. Keeps the
+				// SUM range bounds independent of input iteration order — same invariant as the LOWEST_PRICE
+				// branch above.
 				for (final PriceContract candidate : bestPerInner.values()) {
 					components.add(candidate);
-					if (lowest == null || candidate.priceWithTax().compareTo(lowest.priceWithTax()) < 0) {
+					if (isBetterPriceForSaleCandidate(lowest, candidate, true)) {
 						lowest = candidate;
 					}
-					if (highest == null || candidate.priceWithTax().compareTo(highest.priceWithTax()) > 0) {
+					if (isBetterPriceForSaleCandidate(highest, candidate, false)) {
 						highest = candidate;
 					}
 				}

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
@@ -47,7 +47,6 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static io.evitadb.utils.CollectionUtils.createHashMap;
 import static java.util.Optional.empty;
@@ -60,7 +59,7 @@ import static java.util.Optional.ofNullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public interface PricesContract extends Versioned, Serializable {
-	AccompanyingPrice[] NO_ACCOMPANYING_PRICES = new AccompanyingPrice[0];
+	AccompanyingPrice[] NO_ACCOMPANYING_PRICES = AccompanyingPrice.EMPTY_ARRAY;
 
 	/**
 	 * Computes a price for which the entity should be sold. Only indexed prices in requested currency, valid
@@ -86,7 +85,9 @@ public interface PricesContract extends Versioned, Serializable {
 	/**
 	 * Computes a price for which the entity should be sold. Only indexed prices in requested currency, valid
 	 * at the passed moment are taken into an account. Prices are also limited by the passed set of price lists and
-	 * the first price found in the order of the requested price list ids will be returned.
+	 * the first price found in the order of the requested price list ids will be returned. Accompanying prices
+	 * are computed alongside the selling price and follow the same currency / valid-in / inner-record rules as
+	 * the selling price itself.
 	 */
 	@Nonnull
 	static Optional<PriceForSaleWithAccompanyingPrices> computePriceForSale(
@@ -98,89 +99,96 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nonnull Predicate<PriceContract> filterPredicate,
 		@Nonnull AccompanyingPrice[] accompanyingPrices
 	) {
-		if (entityPrices.isEmpty()) {
+		final PriceForSaleComputationResult computation = computeInternal(
+			entityPrices, innerRecordHandling, currency, atTheMoment, priceListPriority, filterPredicate
+		);
+		if (computation == null) {
 			return empty();
 		}
+		return of(
+			new PriceForSaleWithAccompanyingPrices(
+				computation.priceForSale(),
+				computation.calculateAccompanyingPrices(accompanyingPrices)
+			)
+		);
+	}
 
-		final Map<String, Integer> priorityIndex = getPriceListPriorityIndex(priceListPriority);
-		final Stream<PriceContract> pricesStream = entityPrices
-			.stream()
-			.filter(PriceContract::exists)
-			.filter(it -> currency.equals(it.currency()))
-			.filter(it -> isValidAtTheMoment(atTheMoment, it));
+	/**
+	 * Internal entry point that exposes the rich {@link PriceForSaleComputationResult} produced by
+	 * {@link #computeInternal} so that {@link PriceForSaleContextWithCachedResult} can cache it once and
+	 * derive both the selling-price view and the range view from a single computation pass. External
+	 * callers must use the public {@code computePriceForSale} / {@code computePriceRangeForSale} entry
+	 * points instead — this method is part of the cache plumbing.
+	 *
+	 * @apiNote internal — not part of the public API; subject to change without notice.
+	 */
+	@Nullable
+	static PriceForSaleComputationResult computePriceForSaleResult(
+		@Nonnull Collection<PriceContract> entityPrices,
+		@Nonnull PriceInnerRecordHandling innerRecordHandling,
+		@Nonnull Currency currency,
+		@Nullable OffsetDateTime atTheMoment,
+		@Nonnull String[] priceListPriority,
+		@Nonnull Predicate<PriceContract> filterPredicate
+	) {
+		return computeInternal(entityPrices, innerRecordHandling, currency, atTheMoment, priceListPriority, filterPredicate);
+	}
 
-		switch (innerRecordHandling) {
-			case NONE -> {
-				final Optional<PriceContract> priceForSale = pricesStream
-					.filter(PriceContract::indexed)
-					.filter(it -> priorityIndex.containsKey(it.priceList()))
-					.min(Comparator.comparing(o -> priorityIndex.get(o.priceList())))
-					.filter(filterPredicate);
-				return priceForSale
-					.map(
-						priceContract -> new PriceForSaleWithAccompanyingPrices(
-							priceContract,
-							calculateAccompanyingPricesForNoneInnerRecordHandling(
-								entityPrices, currency, atTheMoment, accompanyingPrices
-							)
-						)
-					);
-			}
-			case LOWEST_PRICE -> {
-				final Map<Integer, List<PriceContract>> pricesByInnerId = pricesStream
-					.collect(Collectors.groupingBy(it -> ofNullable(it.innerRecordId()).orElse(0)));
-				final Optional<PriceContract> priceForSale = pricesByInnerId
-					.values()
-					.stream()
-					.map(prices -> prices.stream()
-						.filter(PriceContract::indexed)
-						.filter(it -> priorityIndex.containsKey(it.priceList()))
-						.min(Comparator.comparing(o -> priorityIndex.get(o.priceList())))
-						.orElse(null))
-					.filter(Objects::nonNull)
-					.filter(filterPredicate)
-					.min(Comparator.comparing(PriceContract::priceWithTax));
-				return priceForSale
-					.map(
-						priceContract -> new PriceForSaleWithAccompanyingPrices(
-							priceContract,
-							calculateAccompanyingPricesForLowestPriceInnerRecordHandling(
-								pricesByInnerId.get(priceContract.innerRecordId()), accompanyingPrices
-							)
-						)
-					);
-			}
-			case SUM -> {
-				final Map<Integer, List<PriceContract>> pricesByInnerId = pricesStream
-					.collect(Collectors.groupingBy(it -> ofNullable(it.innerRecordId()).orElse(0)));
-				final List<PriceContract> pricesToSum = pricesByInnerId
-					.values()
-					.stream()
-					.map(prices -> prices.stream()
-						.filter(PriceContract::indexed)
-						.filter(it -> priorityIndex.containsKey(it.priceList()))
-						.min(Comparator.comparing(o -> priorityIndex.get(o.priceList())))
-						.orElse(null))
-					.filter(Objects::nonNull)
-					.toList();
-				if (pricesToSum.isEmpty()) {
-					return empty();
-				} else {
-					final PriceContract priceForSale = calculateSumPrice(pricesToSum);
-					return filterPredicate.test(priceForSale) ?
-						of(
-							new PriceForSaleWithAccompanyingPrices(
-								priceForSale,
-								calculateAccompanyingPricesForSumInnerRecordHandling(
-									priceForSale, entityPrices, currency, atTheMoment, accompanyingPrices
-								)
-							)
-						) : empty();
-				}
-			}
-			default ->
-				throw new GenericEvitaInternalError("Unknown price inner record handling mode: " + innerRecordHandling);
+	/**
+	 * Computes the full price range for the entity together with the resolved selling price. Only indexed prices
+	 * in the requested currency, valid at the passed moment, and contained in the passed price lists are
+	 * considered. Range bounds are real, indexed prices that satisfy the same filter rules as the selling price.
+	 *
+	 * Strategy semantics — see {@link PriceRangeForSale}.
+	 */
+	@Nonnull
+	static Optional<PriceRangeForSale> computePriceRangeForSale(
+		@Nonnull Collection<PriceContract> entityPrices,
+		@Nonnull PriceInnerRecordHandling innerRecordHandling,
+		@Nonnull Currency currency,
+		@Nullable OffsetDateTime atTheMoment,
+		@Nonnull String[] priceListPriority,
+		@Nonnull Predicate<PriceContract> filterPredicate
+	) {
+		return computePriceRangeForSale(
+			entityPrices, innerRecordHandling, currency, atTheMoment, priceListPriority,
+			filterPredicate, NO_ACCOMPANYING_PRICES
+		)
+			.map(PriceRangeForSaleWithAccompanyingPrices::priceRange);
+	}
+
+	/**
+	 * Computes the full price range for the entity together with the resolved selling price and accompanying
+	 * prices.
+	 *
+	 * Strategy semantics — see {@link PriceRangeForSale}.
+	 */
+	@Nonnull
+	static Optional<PriceRangeForSaleWithAccompanyingPrices> computePriceRangeForSale(
+		@Nonnull Collection<PriceContract> entityPrices,
+		@Nonnull PriceInnerRecordHandling innerRecordHandling,
+		@Nonnull Currency currency,
+		@Nullable OffsetDateTime atTheMoment,
+		@Nonnull String[] priceListPriority,
+		@Nonnull Predicate<PriceContract> filterPredicate,
+		@Nonnull AccompanyingPrice[] accompanyingPrices
+	) {
+		final PriceForSaleComputationResult computation = computeInternal(
+			entityPrices, innerRecordHandling, currency, atTheMoment, priceListPriority, filterPredicate
+		);
+		if (computation == null) {
+			return empty();
 		}
+		return of(
+			new PriceRangeForSaleWithAccompanyingPrices(
+				new PriceRangeForSale(
+					computation.lowestPrice(),
+					computation.highestPrice(),
+					computation.priceForSale()
+				),
+				computation.calculateAccompanyingPrices(accompanyingPrices)
+			)
+		);
 	}
 
 	/**
@@ -222,13 +230,13 @@ public interface PricesContract extends Versioned, Serializable {
 	 * Calculates a map of accompanying prices based on the provided price, collection of entity prices,
 	 * inner record handling, currency, moment in time, and accompanying price configuration.
 	 *
-	 * @param priceForSale        The primary price to reference for calculating accompanying prices.
-	 * @param entityPrices        A collection of price contracts related to the entity for which accompanying prices should be calculated.
-	 * @param innerRecordHandling The method of handling inner record prices, which affects the way accompanying prices are aggregated.
-	 * @param currency            The currency in which the accompanying prices are expected to be calculated.
-	 * @param atTheMoment         The specific point in time at which the accompanying prices should be calculated. May be null to ignore time-based context.
-	 * @param accompanyingPrices  An array of accompanying price configurations that determines which prices to calculate.
-	 * @return A map where the keys are the names of the accompanying prices and the values are Optional instances of corresponding price contracts.
+	 * @param priceForSale        the primary price to reference for calculating accompanying prices
+	 * @param entityPrices        a collection of price contracts related to the entity
+	 * @param innerRecordHandling the inner-record handling strategy
+	 * @param currency            currency in which accompanying prices are expected
+	 * @param atTheMoment         moment in time the accompanying prices should be valid for; {@code null} ignores time
+	 * @param accompanyingPrices  array of accompanying-price requirements
+	 * @return a map keyed by accompanying-price name with optional matched prices
 	 */
 	@Nonnull
 	static Map<String, Optional<PriceContract>> calculateAccompanyingPrices(
@@ -239,111 +247,275 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nullable OffsetDateTime atTheMoment,
 		@Nonnull AccompanyingPrice[] accompanyingPrices
 	) {
+		if (accompanyingPrices.length == 0) {
+			return Collections.emptyMap();
+		}
 		return switch (innerRecordHandling) {
-			case NONE -> calculateAccompanyingPricesForNoneInnerRecordHandling(
-				entityPrices, currency, atTheMoment, accompanyingPrices
+			case NONE -> selectAccompanyingPrices(
+				filterCandidatesByCurrencyAndValidity(entityPrices, currency, atTheMoment),
+				accompanyingPrices
 			);
-			case LOWEST_PRICE -> calculateAccompanyingPricesForLowestPriceInnerRecordHandling(
-				entityPrices.stream()
-					.filter(it -> Objects.equals(priceForSale.innerRecordId(), it.innerRecordId()))
-					.collect(Collectors.toList()),
+			case LOWEST_PRICE -> selectAccompanyingPrices(
+				filterCandidatesByInnerRecordRelation(entityPrices, priceForSale),
 				accompanyingPrices
 			);
 			case SUM -> calculateAccompanyingPricesForSumInnerRecordHandling(
 				priceForSale, entityPrices, currency, atTheMoment, accompanyingPrices
 			);
-			default ->
-				throw new GenericEvitaInternalError("Unknown price inner record handling mode: " + innerRecordHandling);
+			case UNKNOWN ->
+				throw new GenericEvitaInternalError("Cannot compute accompanying prices for UNKNOWN inner record handling.");
 		};
 	}
 
 	/**
-	 * Method will calculate all required accompanying prices for the entity. The method is used when the entity
-	 * has no inner record handling.
+	 * Single allocation-light pass over `entityPrices` that produces the per-strategy selling price together
+	 * with the lowest / highest range bounds and the bookkeeping needed to compute accompanying prices later.
+	 * The method is the single source of truth for the price-for-sale logic — the public `computePriceForSale*`
+	 * and `computePriceRangeForSale*` overloads are thin wrappers over its result.
 	 *
-	 * @param entityPrices       source collection of all entity prices
-	 * @param currency           currency used for price for sale calculation
-	 * @param atTheMoment        moment used for price for sale calculation
-	 * @param accompanyingPrices array of requirements for accompanying prices
-	 * @return map of calculated accompanying prices
+	 * Returns `null` when no selling price exists for the given filter (e.g. predicate eliminated everything,
+	 * currency / validity rejected all candidates, or no inner record yielded a valid candidate).
 	 */
-	@Nonnull
-	private static Map<String, Optional<PriceContract>> calculateAccompanyingPricesForNoneInnerRecordHandling(
+	@Nullable
+	private static PriceForSaleComputationResult computeInternal(
 		@Nonnull Collection<PriceContract> entityPrices,
+		@Nonnull PriceInnerRecordHandling innerRecordHandling,
 		@Nonnull Currency currency,
 		@Nullable OffsetDateTime atTheMoment,
-		@Nonnull AccompanyingPrice[] accompanyingPrices
+		@Nonnull String[] priceListPriority,
+		@Nonnull Predicate<PriceContract> filterPredicate
 	) {
-		if (accompanyingPrices.length > 0) {
-			final List<PriceContract> accompanyingPriceBaseCollection = entityPrices
-				.stream()
-				.filter(PriceContract::exists)
-				.filter(it -> currency.equals(it.currency()))
-				.filter(it -> isValidAtTheMoment(atTheMoment, it))
-				.toList();
-			return Arrays.stream(accompanyingPrices)
-				.collect(
-					Collectors.toMap(
-						AccompanyingPrice::priceName,
-						accompanyingPrice -> {
-							final Map<String, Integer> accompanyingPriorityIndex = getPriceListPriorityIndex(
-								accompanyingPrice.priceListPriority()
-							);
-							return accompanyingPriceBaseCollection
-								.stream()
-								.filter(it -> accompanyingPriorityIndex.containsKey(it.priceList()))
-								.min(Comparator.comparing(o -> accompanyingPriorityIndex.get(o.priceList())));
-						}
-					)
-				);
-		} else {
-			return Collections.emptyMap();
+		if (entityPrices.isEmpty()) {
+			return null;
 		}
+
+		// hoisted out of the hot loop
+		final Map<String, Integer> priorityIndex = getPriceListPriorityIndex(priceListPriority);
+		// presize estimates: assume each inner record carries roughly one price per priority list, so the
+		// number of distinct inner records ≈ N/L. A small reserve absorbs noise (entities with extra price
+		// lists outside the priority, or sparse inner records).
+		final int innerBucketEstimate = Math.max(2, priceListPriority.length + 2);
+		final int distinctInnerEstimate = Math.max(
+			2, entityPrices.size() / Math.max(1, priceListPriority.length) + 2
+		);
+
+		return switch (innerRecordHandling) {
+			case NONE -> {
+				PriceContract bestForSale = null;
+				int bestPriority = Integer.MAX_VALUE;
+				// candidates collected during the first pass — reused for accompanying-price calc
+				final List<PriceContract> candidates = new ArrayList<>(entityPrices.size());
+				for (final PriceContract price : entityPrices) {
+					if (isNotCandidate(price, currency, atTheMoment)) {
+						continue;
+					}
+					candidates.add(price);
+					if (!price.indexed()) {
+						continue;
+					}
+					final Integer priorityBoxed = priorityIndex.get(price.priceList());
+					if (priorityBoxed == null) {
+						continue;
+					}
+					final int priority = priorityBoxed;
+					if (priority < bestPriority) {
+						bestPriority = priority;
+						bestForSale = price;
+					}
+				}
+				if (bestForSale == null || !filterPredicate.test(bestForSale)) {
+					yield null;
+				}
+				// NONE collapses the range to a single point
+				yield new PriceForSaleComputationResult(
+					innerRecordHandling, bestForSale, bestForSale, bestForSale,
+					candidates, null
+				);
+			}
+			case LOWEST_PRICE -> {
+				// per-inner-record state — outer maps sized for the estimated number of distinct inner records;
+				// per-inner-record raw price list presized for one price per priority entry plus reserve
+				final Map<Integer, PriceContract> bestPerInner = CollectionUtils.createLinkedHashMap(distinctInnerEstimate);
+				final Map<Integer, Integer> bestPriorityPerInner = CollectionUtils.createHashMap(distinctInnerEstimate);
+				final Map<Integer, List<PriceContract>> rawByInner = CollectionUtils.createLinkedHashMap(distinctInnerEstimate);
+				for (final PriceContract price : entityPrices) {
+					if (isNotCandidate(price, currency, atTheMoment)) {
+						continue;
+					}
+					final int innerKey = innerRecordKey(price);
+					rawByInner.computeIfAbsent(innerKey, k -> new ArrayList<>(innerBucketEstimate)).add(price);
+					updateBestPerInner(price, innerKey, priorityIndex, bestPerInner, bestPriorityPerInner);
+				}
+				if (bestPerInner.isEmpty()) {
+					yield null;
+				}
+				// pick lowest and highest by priceWithTax in a single pass.
+				// `lowest` (== selling price under LOWEST_PRICE) must satisfy `filterPredicate` — the predicate
+				// is a selling-price scoped filter inherited from the legacy `getPriceForSale*` API.
+				// `highest` is the most expensive per-inner-record candidate regardless of `filterPredicate`,
+				// because the range bounds describe the real indexed catalogue spread for the resolved currency
+				// / valid-in / price-list filters and must NOT be clipped by the selling-price predicate.
+				// Tie-break is deterministic: lower priceWithTax wins, then lower priceId, then lower
+				// innerRecordId (null sorts before non-null).
+				PriceContract lowest = null;
+				PriceContract highest = null;
+				for (final PriceContract candidate : bestPerInner.values()) {
+					if (isBetterPriceForSaleCandidate(highest, candidate, false)) {
+						highest = candidate;
+					}
+					if (filterPredicate.test(candidate)
+						&& isBetterPriceForSaleCandidate(lowest, candidate, true)) {
+						lowest = candidate;
+					}
+				}
+				if (lowest == null) {
+					yield null;
+				}
+				// for LOWEST_PRICE, accompanying prices are sourced from raw prices that share innerRecordId
+				// with the selling price
+				final int innerKey = innerRecordKey(lowest);
+				final List<PriceContract> accompanyingCandidates = rawByInner.getOrDefault(innerKey, Collections.emptyList());
+				yield new PriceForSaleComputationResult(
+					innerRecordHandling, lowest, lowest, highest,
+					accompanyingCandidates, null
+				);
+			}
+			case SUM -> {
+				// per-inner-record state — outer maps sized for the estimated number of distinct inner records;
+				// per-inner-record price-list maps presized for one price per priority entry plus reserve.
+				// byInnerByListAll is built for ALL inner records during the first pass; later filtered to only
+				// those that contributed to the cumulated selling price (mirrors the original behaviour: only
+				// inner records that produced a selling-price component participate in SUM accompanying-price).
+				final Map<Integer, PriceContract> bestPerInner = CollectionUtils.createLinkedHashMap(distinctInnerEstimate);
+				final Map<Integer, Integer> bestPriorityPerInner = CollectionUtils.createHashMap(distinctInnerEstimate);
+				final Map<Integer, Map<String, PriceContract>> byInnerByListAll = CollectionUtils
+					.createLinkedHashMap(distinctInnerEstimate);
+				for (final PriceContract price : entityPrices) {
+					if (isNotCandidate(price, currency, atTheMoment)) {
+						continue;
+					}
+					final int innerKey = innerRecordKey(price);
+					byInnerByListAll.computeIfAbsent(innerKey, k -> CollectionUtils.createHashMap(innerBucketEstimate))
+						.put(price.priceList(), price);
+					updateBestPerInner(price, innerKey, priorityIndex, bestPerInner, bestPriorityPerInner);
+				}
+				if (bestPerInner.isEmpty()) {
+					yield null;
+				}
+				// gather components, plus min/max in a single pass
+				final List<PriceContract> components = new ArrayList<>(bestPerInner.size());
+				PriceContract lowest = null;
+				PriceContract highest = null;
+				for (final PriceContract candidate : bestPerInner.values()) {
+					components.add(candidate);
+					if (lowest == null || candidate.priceWithTax().compareTo(lowest.priceWithTax()) < 0) {
+						lowest = candidate;
+					}
+					if (highest == null || candidate.priceWithTax().compareTo(highest.priceWithTax()) > 0) {
+						highest = candidate;
+					}
+				}
+				final PriceContract sumPrice = calculateSumPrice(components);
+				if (!filterPredicate.test(sumPrice)) {
+					yield null;
+				}
+				// trim byInnerByList to only inner records that contributed to the cumulated price (matches the
+				// `priceForSale.relatesTo(it)` semantics in the original SUM accompanying-price path)
+				final Map<Integer, Map<String, PriceContract>> byInnerByList = CollectionUtils
+					.createHashMap(bestPerInner.size());
+				for (final Integer key : bestPerInner.keySet()) {
+					final Map<String, PriceContract> entry = byInnerByListAll.get(key);
+					if (entry != null) {
+						byInnerByList.put(key, entry);
+					}
+				}
+				yield new PriceForSaleComputationResult(
+					innerRecordHandling, sumPrice, lowest, highest,
+					Collections.emptyList(), byInnerByList
+				);
+			}
+			case UNKNOWN ->
+				throw new GenericEvitaInternalError("Cannot compute price for sale for UNKNOWN inner record handling.");
+		};
 	}
 
 	/**
-	 * Method will calculate all required accompanying prices for the entity. The method is used when the entity
-	 * has lowest price record handling.
+	 * Single, shared accompanying-price selection helper. Each accompanying-price request resolves to the price
+	 * with the highest price-list priority among the supplied `candidates` (already filtered to whatever scope the
+	 * caller wants). This collapses the previously divergent NONE / LOWEST_PRICE / SUM accompanying-price code
+	 * paths into one routine — the strategy-specific logic lives only in choosing the candidate collection.
 	 *
-	 * @param entityPrices       source collection of all entity prices
-	 * @param accompanyingPrices array of requirements for accompanying prices
-	 * @return map of calculated accompanying prices
+	 * Absent matches are returned as present `Optional.empty()` keys — every requested accompanying
+	 * price always appears in the resulting map (with an empty optional when no candidate matched).
+	 *
+	 * @param candidates         pre-filtered candidate prices (already constrained by currency / valid-in / inner
+	 *                           record relation, depending on strategy)
+	 * @param accompanyingPrices array of accompanying-price requirements
+	 * @return a map keyed by accompanying-price name with the matched price (or empty optional)
 	 */
 	@Nonnull
-	private static Map<String, Optional<PriceContract>> calculateAccompanyingPricesForLowestPriceInnerRecordHandling(
-		@Nonnull Collection<PriceContract> entityPrices,
+	private static Map<String, Optional<PriceContract>> selectAccompanyingPrices(
+		@Nonnull Collection<PriceContract> candidates,
 		@Nonnull AccompanyingPrice[] accompanyingPrices
 	) {
-		if (accompanyingPrices.length > 0) {
-			return Arrays.stream(accompanyingPrices)
-				.collect(
-					Collectors.toMap(
-						AccompanyingPrice::priceName,
-						accompanyingPrice -> {
-							final Map<String, Integer> accompanyingPriorityIndex = getPriceListPriorityIndex(
-								accompanyingPrice.priceListPriority()
-							);
-							return entityPrices.stream()
-								.filter(it -> accompanyingPriorityIndex.containsKey(it.priceList()))
-								.min(Comparator.comparing(o -> accompanyingPriorityIndex.get(o.priceList())));
-						}
-					)
-				);
-		} else {
+		if (accompanyingPrices.length == 0) {
 			return Collections.emptyMap();
 		}
+		final Map<String, Optional<PriceContract>> result = CollectionUtils.createHashMap(accompanyingPrices.length);
+		for (final AccompanyingPrice accompanyingPrice : accompanyingPrices) {
+			final Map<String, Integer> accompanyingPriorityIndex = getPriceListPriorityIndex(
+				accompanyingPrice.priceListPriority()
+			);
+			final PriceContract best = pickBestByPriority(candidates, accompanyingPriorityIndex, null);
+			result.put(accompanyingPrice.priceName(), ofNullable(best));
+		}
+		return result;
 	}
 
 	/**
-	 * Method will calculate all required accompanying prices for the entity. The method is used when the entity
-	 * has no inner record handling.
-	 *
-	 * @param priceForSale       price for sale
-	 * @param entityPrices       source collection of all entity prices
-	 * @param currency           currency used for price for sale calculation
-	 * @param atTheMoment        moment used for price for sale calculation
-	 * @param accompanyingPrices array of requirements for accompanying prices
-	 * @return map of calculated accompanying prices
+	 * Filters the supplied entity prices by currency / validity (no inner-record / price-list / indexed checks).
+	 * Used as the candidate basis for accompanying-price calculation under the `NONE` strategy.
+	 */
+	@Nonnull
+	private static List<PriceContract> filterCandidatesByCurrencyAndValidity(
+		@Nonnull Collection<PriceContract> entityPrices,
+		@Nonnull Currency currency,
+		@Nullable OffsetDateTime atTheMoment
+	) {
+		final List<PriceContract> result = new ArrayList<>(entityPrices.size());
+		for (final PriceContract price : entityPrices) {
+			if (isNotCandidate(price, currency, atTheMoment)) {
+				continue;
+			}
+			result.add(price);
+		}
+		return result;
+	}
+
+	/**
+	 * Filters the supplied prices to those that share an inner record with the supplied selling price. Used as
+	 * the candidate basis for accompanying-price calculation under `LOWEST_PRICE`.
+	 */
+	@Nonnull
+	private static List<PriceContract> filterCandidatesByInnerRecordRelation(
+		@Nonnull Collection<PriceContract> entityPrices,
+		@Nonnull PriceContract priceForSale
+	) {
+		final List<PriceContract> result = new ArrayList<>(entityPrices.size());
+		for (final PriceContract price : entityPrices) {
+			if (Objects.equals(priceForSale.innerRecordId(), price.innerRecordId())) {
+				result.add(price);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Calculates accompanying prices under `SUM` strategy — for every accompanying-price requirement we sum
+	 * the per-inner-record component prices that match the requirement's price-list priority. When the
+	 * accompanying-price selection misses some inner records (their price list isn't part of the priority), we
+	 * fall back to the components from the cumulated selling price for those records, mirroring the original
+	 * behaviour.
 	 */
 	@Nonnull
 	private static Map<String, Optional<PriceContract>> calculateAccompanyingPricesForSumInnerRecordHandling(
@@ -353,61 +525,78 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nullable OffsetDateTime atTheMoment,
 		@Nonnull AccompanyingPrice[] accompanyingPrices
 	) {
-		if (accompanyingPrices.length > 0) {
-			final Collection<Map<String, PriceContract>> accompanyingPriceBaseCollection = entityPrices
-				.stream()
-				.filter(PriceContract::exists)
-				.filter(it -> currency.equals(it.currency()))
-				.filter(it -> isValidAtTheMoment(atTheMoment, it))
-				.filter(it -> it.innerRecordId() == null || priceForSale.relatesTo(it))
-				.collect(
-					Collectors.groupingBy(
-						it -> ofNullable(it.innerRecordId()).orElse(0),
-						Collectors.toMap(PriceContract::priceList, Function.identity())
-					)
-				)
-				.values();
-			return Arrays.stream(accompanyingPrices)
-				.collect(
-					Collectors.toMap(
-						AccompanyingPrice::priceName,
-						accompanyingPrice -> {
-							final Map<String, Integer> accompanyingPriorityIndex = getPriceListPriorityIndex(
-								accompanyingPrice.priceListPriority()
-							);
-							final List<PriceContract> pricesToSum = accompanyingPriceBaseCollection
-								.stream()
-								.map(
-									it -> it.values().stream().filter(prices -> accompanyingPriorityIndex.containsKey(prices.priceList()))
-										.min(Comparator.comparing(o -> accompanyingPriorityIndex.get(o.priceList())))
-								)
-								.filter(Optional::isPresent)
-								.map(Optional::get)
-								.collect(Collectors.toCollection(ArrayList::new));
-
-							if (pricesToSum.isEmpty()) {
-								return empty();
-							} else {
-								if (priceForSale instanceof CumulatedPrice cumulatedPrice && pricesToSum.size() < cumulatedPrice.innerRecordPrices().size()) {
-									// the reference prices are not complete,
-									// we cannot calculate the sum price without adding prices of missing components
-									final Set<Integer> componentsWithReferencePrice = pricesToSum
-										.stream()
-										.map(PriceContract::innerRecordId)
-										.collect(Collectors.toSet());
-									cumulatedPrice.innerRecordPrices().entrySet().stream()
-										.filter(it -> !componentsWithReferencePrice.contains(it.getKey()))
-										.map(Map.Entry::getValue)
-										.forEach(pricesToSum::add);
-								}
-								return of(calculateSumPrice(pricesToSum));
-							}
-						}
-					)
-				);
-		} else {
+		if (accompanyingPrices.length == 0) {
 			return Collections.emptyMap();
 		}
+		// build per-inner-record price-list -> price map filtered down to records relating to the selling price.
+		// When priceForSale is a CumulatedPrice we know the exact distinct-inner-record count; otherwise a
+		// conservative estimate based on entityPrices.size() applies. Inner maps are sized for the entity's
+		// price-list cardinality (we don't have a single priorityIndex here, so a small constant + reserve).
+		final int distinctInnerEstimate = priceForSale instanceof CumulatedPrice cumulatedPrice
+			? Math.max(2, cumulatedPrice.innerRecordPrices().size())
+			: Math.max(2, entityPrices.size() / 4 + 2);
+		final Map<Integer, Map<String, PriceContract>> byInnerByList = CollectionUtils.createLinkedHashMap(
+			distinctInnerEstimate
+		);
+		for (final PriceContract price : entityPrices) {
+			if (isNotCandidate(price, currency, atTheMoment)) {
+				continue;
+			}
+			if (price.innerRecordId() != null && !priceForSale.relatesTo(price)) {
+				continue;
+			}
+			final int innerKey = innerRecordKey(price);
+			byInnerByList.computeIfAbsent(innerKey, k -> CollectionUtils.createHashMap(4))
+				.put(price.priceList(), price);
+		}
+		return resolveSumAccompanyingPrices(priceForSale, byInnerByList, accompanyingPrices);
+	}
+
+	/**
+	 * Computes a sum-style accompanying-price map from a pre-built per-inner-record / per-price-list lookup
+	 * structure. Shared between the public `calculateAccompanyingPrices` entry point and the cached
+	 * computation result so the candidate map is built only once per selling-price computation.
+	 */
+	@Nonnull
+	private static Map<String, Optional<PriceContract>> resolveSumAccompanyingPrices(
+		@Nonnull PriceContract priceForSale,
+		@Nonnull Map<Integer, Map<String, PriceContract>> byInnerByList,
+		@Nonnull AccompanyingPrice[] accompanyingPrices
+	) {
+		final Map<String, Optional<PriceContract>> result = CollectionUtils.createHashMap(accompanyingPrices.length);
+		for (final AccompanyingPrice accompanyingPrice : accompanyingPrices) {
+			final Map<String, Integer> accompanyingPriorityIndex = getPriceListPriorityIndex(
+				accompanyingPrice.priceListPriority()
+			);
+			final List<PriceContract> pricesToSum = new ArrayList<>(byInnerByList.size());
+			for (final Map<String, PriceContract> byList : byInnerByList.values()) {
+				final PriceContract best = pickBestByPriority(byList.values(), accompanyingPriorityIndex, null);
+				if (best != null) {
+					pricesToSum.add(best);
+				}
+			}
+			if (pricesToSum.isEmpty()) {
+				result.put(accompanyingPrice.priceName(), empty());
+				continue;
+			}
+			// if the components from the priority list don't cover all the inner records that participate in
+			// the selling cumulated price, complete the missing records from the original cumulated price so the
+			// returned accompanying price still represents the same product configuration
+			if (priceForSale instanceof CumulatedPrice cumulatedPrice
+				&& pricesToSum.size() < cumulatedPrice.innerRecordPrices().size()) {
+				final Set<Integer> covered = CollectionUtils.createHashSet(pricesToSum.size());
+				for (final PriceContract p : pricesToSum) {
+					covered.add(p.innerRecordId());
+				}
+				for (final Map.Entry<Integer, PriceContract> entry : cumulatedPrice.innerRecordPrices().entrySet()) {
+					if (!covered.contains(entry.getKey())) {
+						pricesToSum.add(entry.getValue());
+					}
+				}
+			}
+			result.put(accompanyingPrice.priceName(), of(calculateSumPrice(pricesToSum)));
+		}
+		return result;
 	}
 
 	/**
@@ -418,12 +607,178 @@ public interface PricesContract extends Versioned, Serializable {
 	 * @return true if the moment is valid based on the price contract validity range, or if no moment is provided; false otherwise.
 	 */
 	private static boolean isValidAtTheMoment(@Nullable OffsetDateTime atTheMoment, @Nonnull PriceContract price) {
-		return ofNullable(atTheMoment)
-			.map(mmt -> {
-				final DateTimeRange validity = price.validity();
-				return validity == null || validity.isValidFor(mmt);
-			})
-			.orElse(true);
+		if (atTheMoment == null) {
+			return true;
+		}
+		final DateTimeRange validity = price.validity();
+		return validity == null || validity.isValidFor(atTheMoment);
+	}
+
+	/**
+	 * Returns true when the given price is a viable candidate for selling-price / accompanying-price
+	 * computation — i.e. it exists, matches the requested `currency`, and is valid at `atTheMoment`.
+	 * Centralises the triple-predicate that previously appeared inline in every per-strategy loop.
+	 */
+	private static boolean isNotCandidate(
+		@Nonnull PriceContract price,
+		@Nonnull Currency currency,
+		@Nullable OffsetDateTime atTheMoment
+	) {
+		return !price.exists() || !currency.equals(price.currency()) || !isValidAtTheMoment(atTheMoment, price);
+	}
+
+	/**
+	 * Returns the inner-record bucketing key for the given price — `0` when no inner record is set, otherwise
+	 * the raw `innerRecordId`. Note: this conflates `null` with an explicit `0` inner record, mirroring the
+	 * previous inline expression; the deferred behavioural fix lives in a separate task.
+	 */
+	private static int innerRecordKey(@Nonnull PriceContract price) {
+		final Integer ird = price.innerRecordId();
+		return ird == null ? 0 : ird;
+	}
+
+	/**
+	 * Decides whether `candidate` should replace `current` as the running best price-for-sale candidate
+	 * under LOWEST_PRICE strategy. The comparison is total and deterministic, independent of input
+	 * iteration order:
+	 *
+	 * 1. lower (or higher, depending on `preferLower`) `priceWithTax` wins,
+	 * 2. on ties, lower `priceId` wins,
+	 * 3. on further ties, lower `innerRecordId` wins (`null` sorts before any non-null id).
+	 *
+	 * Steps 2 and 3 are the deterministic tie-break — they fire only on exact `priceWithTax` equality,
+	 * so they have zero behavioural impact when prices differ. The pre-existing `< 0` / `> 0` semantics
+	 * for `priceWithTax` is preserved (no `<=` flip) — the tie-break only takes effect when the previous
+	 * implementation would have left `current` untouched.
+	 *
+	 * @param current     running best candidate, or `null` before the first comparison
+	 * @param candidate   prospective candidate
+	 * @param preferLower `true` when picking the cheapest (lowest selling price), `false` when picking
+	 *                    the most expensive (highest range bound)
+	 * @return `true` when `candidate` strictly beats `current`
+	 */
+	private static boolean isBetterPriceForSaleCandidate(
+		@Nullable PriceContract current,
+		@Nonnull PriceContract candidate,
+		boolean preferLower
+	) {
+		if (current == null) {
+			return true;
+		}
+		final int byAmount = candidate.priceWithTax().compareTo(current.priceWithTax());
+		if (byAmount != 0) {
+			return preferLower ? byAmount < 0 : byAmount > 0;
+		}
+		// amounts tie — fall back to the priceId / innerRecordId tie-break shared with priority-based picks
+		return isBetterByPriceIdThenInner(candidate, current);
+	}
+
+	/**
+	 * Deterministic tie-break helper used when two candidates already share the same effective priority
+	 * (e.g. price-list priority): lower `priceId` wins, then lower `innerRecordId` (`null` sorts before
+	 * any non-null id). Returns `true` when `candidate` strictly beats `current` under this rule, and
+	 * also when `current` is `null` (no incumbent).
+	 */
+	private static boolean isBetterByPriceIdThenInner(
+		@Nonnull PriceContract candidate,
+		@Nullable PriceContract current
+	) {
+		if (current == null) {
+			return true;
+		}
+		final int byPriceId = Integer.compare(candidate.priceId(), current.priceId());
+		if (byPriceId != 0) {
+			return byPriceId < 0;
+		}
+		final Integer candidateInner = candidate.innerRecordId();
+		final Integer currentInner = current.innerRecordId();
+		if (candidateInner == null && currentInner != null) {
+			return true;
+		}
+		if (candidateInner != null && currentInner == null) {
+			return false;
+		}
+		if (candidateInner != null) {
+			return candidateInner < currentInner;
+		}
+		return false;
+	}
+
+	/**
+	 * Updates the running per-inner-record best-selling-price maps for `price`, skipping non-indexed
+	 * prices and price lists missing from `priorityIndex`. On equal priority a deterministic tie-break is
+	 * applied (lower {@code priceId}, then lower {@code innerRecordId} with {@code null} first) so the
+	 * winner is independent of input iteration order. Shared by the per-inner-record loops of the
+	 * `LOWEST_PRICE` and `SUM` strategies in {@link #computeInternal}.
+	 *
+	 * @param price                 candidate price under consideration
+	 * @param innerKey              inner-record bucket key for {@code price} (already resolved by the caller)
+	 * @param priorityIndex         price-list to priority-rank lookup; lower rank wins
+	 * @param bestPerInner          mutable map of inner-record key to current best price
+	 * @param bestPriorityPerInner  mutable map of inner-record key to current best price's priority
+	 */
+	private static void updateBestPerInner(
+		@Nonnull PriceContract price,
+		int innerKey,
+		@Nonnull Map<String, Integer> priorityIndex,
+		@Nonnull Map<Integer, PriceContract> bestPerInner,
+		@Nonnull Map<Integer, Integer> bestPriorityPerInner
+	) {
+		if (!price.indexed()) {
+			return;
+		}
+		final Integer priorityBoxed = priorityIndex.get(price.priceList());
+		if (priorityBoxed == null) {
+			return;
+		}
+		final int priority = priorityBoxed;
+		final Integer existing = bestPriorityPerInner.get(innerKey);
+		if (existing == null || priority < existing) {
+			bestPriorityPerInner.put(innerKey, priority);
+			bestPerInner.put(innerKey, price);
+		} else if (priority == existing
+			&& isBetterByPriceIdThenInner(price, bestPerInner.get(innerKey))) {
+			bestPerInner.put(innerKey, price);
+		}
+	}
+
+	/**
+	 * Picks the candidate whose price list has the lowest priority in {@code priorityIndex} — i.e. the
+	 * winner of the standard "first matching price list wins" rule. On equal priority a deterministic
+	 * tie-break is applied (lower {@code priceId}, then lower {@code innerRecordId} with {@code null}
+	 * first) so the result is independent of input iteration order. Returns {@code null} when no
+	 * candidate matches the priority index.
+	 *
+	 * @param candidates    candidates to consider; iteration order need not be deterministic
+	 * @param priorityIndex price-list to priority-rank lookup; lower rank wins
+	 * @param filter        optional pre-filter applied before the priority lookup; pass {@code null} to
+	 *                      consider every candidate
+	 */
+	@Nullable
+	private static PriceContract pickBestByPriority(
+		@Nonnull Iterable<PriceContract> candidates,
+		@Nonnull Map<String, Integer> priorityIndex,
+		@Nullable Predicate<PriceContract> filter
+	) {
+		PriceContract best = null;
+		int bestPriority = Integer.MAX_VALUE;
+		for (final PriceContract candidate : candidates) {
+			if (filter != null && !filter.test(candidate)) {
+				continue;
+			}
+			final Integer priorityBoxed = priorityIndex.get(candidate.priceList());
+			if (priorityBoxed == null) {
+				continue;
+			}
+			final int priority = priorityBoxed;
+			if (priority < bestPriority) {
+				bestPriority = priority;
+				best = candidate;
+			} else if (priority == bestPriority && isBetterByPriceIdThenInner(candidate, best)) {
+				best = candidate;
+			}
+		}
+		return best;
 	}
 
 	/**
@@ -435,16 +790,26 @@ public interface PricesContract extends Versioned, Serializable {
 	@Nonnull
 	private static PriceContract calculateSumPrice(@Nonnull List<PriceContract> pricesToSum) {
 		final PriceContract firstPrice = pricesToSum.get(0);
-		// create virtual sum price
+		// allocation-light reduce: avoid creating an intermediate stream pipeline; the seed values are taken from
+		// the first element so the resulting BigDecimal scale matches the original Stream::reduce(BinaryOperator)
+		// behaviour (no identity element, so the seed inherits from the first operand)
+		BigDecimal sumWithoutTax = firstPrice.priceWithoutTax();
+		BigDecimal sumWithTax = firstPrice.priceWithTax();
+		final BigDecimal taxRate = firstPrice.taxRate();
+		final Map<Integer, PriceContract> innerRecordPrices = CollectionUtils.createHashMap(pricesToSum.size());
+		innerRecordPrices.put(firstPrice.innerRecordId(), firstPrice);
+		for (int i = 1; i < pricesToSum.size(); i++) {
+			final PriceContract price = pricesToSum.get(i);
+			Assert.isTrue(
+				taxRate.compareTo(price.taxRate()) == 0,
+				"Prices have to have same tax rate in order to compute selling price!"
+			);
+			sumWithoutTax = sumWithoutTax.add(price.priceWithoutTax());
+			sumWithTax = sumWithTax.add(price.priceWithTax());
+			innerRecordPrices.put(price.innerRecordId(), price);
+		}
 		return new CumulatedPrice(
-			1, firstPrice.priceKey(),
-			pricesToSum.stream().collect(Collectors.toMap(PriceContract::innerRecordId, Function.identity())),
-			pricesToSum.stream().map(PriceContract::priceWithoutTax).reduce(BigDecimal::add).orElse(BigDecimal.ZERO),
-			pricesToSum.stream().map(PriceContract::taxRate).reduce((tax, tax2) -> {
-				Assert.isTrue(tax.compareTo(tax2) == 0, "Prices have to have same tax rate in order to compute selling price!");
-				return tax;
-			}).orElse(BigDecimal.ZERO),
-			pricesToSum.stream().map(PriceContract::priceWithTax).reduce(BigDecimal::add).orElse(BigDecimal.ZERO)
+			1, firstPrice.priceKey(), innerRecordPrices, sumWithoutTax, taxRate, sumWithTax
 		);
 	}
 
@@ -470,6 +835,7 @@ public interface PricesContract extends Versioned, Serializable {
 	 * another price for the very same inner record is using different price lists setting and not taking the sellability
 	 * of the price into an account.
 	 *
+	 * @param prices             collection of all entity prices
 	 * @param mapper             transformer function for the result type of the method
 	 * @param currency           currency used for price for sale calculation
 	 * @param atTheMoment        moment used for price for sale calculation
@@ -488,38 +854,51 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nonnull AccompanyingPrice... accompanyingPrices
 	) {
 		final Map<String, Integer> priorityIndex = getPriceListPriorityIndex(priceListPriority);
-		final Map<Integer, List<PriceContract>> pricesByInnerId = prices
-			.stream()
-			.filter(PriceContract::exists)
-			.filter(it -> currency.equals(it.currency()))
-			.filter(it -> ofNullable(atTheMoment).map(mmt -> it.validity() == null || it.validity().isValidFor(mmt)).orElse(true))
-			.collect(Collectors.groupingBy(it -> ofNullable(it.innerRecordId()).orElse(0)));
-		return pricesByInnerId
-			.values()
-			.stream()
-			.map(thePrices -> thePrices.stream()
-				.filter(PriceContract::indexed)
-				.filter(it -> priorityIndex.containsKey(it.priceList()))
-				.min(Comparator.comparing(o -> priorityIndex.get(o.priceList())))
-				.orElse(null))
-			.filter(Objects::nonNull)
-			.sorted(
-				Comparator.comparing(PriceContract::priceId)
-					.thenComparing(
-						PriceContract::innerRecordId,
-						Comparator.nullsLast(Integer::compareTo)
-					)
-			)
-			.map(
-				priceContract -> new PriceForSaleWithAccompanyingPrices(
-					priceContract,
-					calculateAccompanyingPricesForLowestPriceInnerRecordHandling(
-						pricesByInnerId.get(priceContract.innerRecordId()), accompanyingPrices
-					)
+		// group all currency / valid-in matching prices by inner record id (null → 0) in a single pass.
+		// Outer map sized for the estimated number of distinct inner records (≈ N/L); inner buckets presized
+		// for one price per priority entry plus reserve.
+		final int innerBucketEstimate = Math.max(2, priceListPriority.length + 2);
+		final int distinctInnerEstimate = Math.max(
+			2, prices.size() / Math.max(1, priceListPriority.length) + 2
+		);
+		final Map<Integer, List<PriceContract>> pricesByInnerId = CollectionUtils.createHashMap(distinctInnerEstimate);
+		for (final PriceContract price : prices) {
+			if (isNotCandidate(price, currency, atTheMoment)) {
+				continue;
+			}
+			pricesByInnerId.computeIfAbsent(innerRecordKey(price), k -> new ArrayList<>(innerBucketEstimate)).add(price);
+		}
+		// pick the best indexed candidate per inner record (lowest priority wins). On equal priority — which
+		// can happen if the same price-list contains multiple matching prices for the same inner record — the
+		// deterministic tie-break inside pickBestByPriority ensures the winner is independent of input
+		// iteration order.
+		final List<PriceContract> winners = new ArrayList<>(pricesByInnerId.size());
+		for (final List<PriceContract> innerGroup : pricesByInnerId.values()) {
+			final PriceContract best = pickBestByPriority(innerGroup, priorityIndex, PriceContract::indexed);
+			if (best != null) {
+				winners.add(best);
+			}
+		}
+		// deterministic ordering of the resulting list — by priceId, then by innerRecordId (null last)
+		winners.sort(
+			Comparator.comparing(PriceContract::priceId)
+				.thenComparing(
+					PriceContract::innerRecordId,
+					Comparator.nullsLast(Integer::compareTo)
 				)
-			)
-			.map(mapper)
-			.toList();
+		);
+		final List<T> result = new ArrayList<>(winners.size());
+		for (final PriceContract winner : winners) {
+			final List<PriceContract> innerGroup = pricesByInnerId.getOrDefault(
+				innerRecordKey(winner), Collections.emptyList()
+			);
+			final PriceForSaleWithAccompanyingPrices wrapped = new PriceForSaleWithAccompanyingPrices(
+				winner,
+				selectAccompanyingPrices(innerGroup, accompanyingPrices)
+			);
+			result.add(mapper.apply(wrapped));
+		}
+		return result;
 	}
 
 	/**
@@ -624,6 +1003,12 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nullable OffsetDateTime atTheMoment,
 		@Nonnull String... priceListPriority
 	) throws ContextMissingException {
+		// share work with subsequent getPriceRangeForSale / getAccompanyingPrice calls when context matches —
+		// the cache populates the rich computation lazily and every derived view reads from the same slot
+		final PriceForSaleContext context = getPriceForSaleContext().orElse(null);
+		if (context instanceof PriceForSaleContextWithCachedResult pfscwcr && pfscwcr.matches(currency, atTheMoment, priceListPriority)) {
+			return pfscwcr.computePriceForSale(getPrices(), getPriceInnerRecordHandling());
+		}
 		return computePriceForSale(getPrices(), getPriceInnerRecordHandling(), currency, atTheMoment, priceListPriority, Objects::nonNull);
 	}
 
@@ -875,6 +1260,115 @@ public interface PricesContract extends Versioned, Serializable {
 				accompanyingPricesRequest
 			);
 		}
+	}
+
+	/**
+	 * Returns the full price range for which the entity could be sold (lowest price, highest price, selling price).
+	 * Equivalent to {@link #getPriceForSale()} but additionally exposes the range bounds.
+	 *
+	 * Strategy semantics — see {@link PriceRangeForSale}.
+	 *
+	 * @throws ContextMissingException when entity is not related to any {@link Query} or the query
+	 *                                 lacks price related constraints
+	 */
+	@Nonnull
+	Optional<PriceRangeForSale> getPriceRangeForSale() throws ContextMissingException;
+
+	/**
+	 * Returns the full price range for which the entity could be sold. Behaves like
+	 * {@link #getPriceRangeForSale()} but returns an empty optional when the price-for-sale context is not
+	 * available (instead of throwing).
+	 */
+	@Nonnull
+	Optional<PriceRangeForSale> getPriceRangeForSaleIfAvailable();
+
+	/**
+	 * See {@link #getPriceRangeForSale()}; this overload additionally accepts explicit currency / valid-in
+	 * / price-list inputs instead of resolving them from the query context. Mirrors
+	 * {@link #getPriceForSale(Currency, OffsetDateTime, String...)}.
+	 *
+	 * @param currency          identification of the currency
+	 * @param atTheMoment       moment when the entity is about to be sold
+	 * @param priceListPriority identification of the price list priority (either external or internal)
+	 * @throws ContextMissingException when the prices were not fetched along with entity but might exist
+	 */
+	@Nonnull
+	default Optional<PriceRangeForSale> getPriceRangeForSale(
+		@Nonnull Currency currency,
+		@Nullable OffsetDateTime atTheMoment,
+		@Nonnull String... priceListPriority
+	) throws ContextMissingException {
+		// share work with prior / subsequent getPriceForSale / getAccompanyingPrice calls when context matches —
+		// fulfils the proposal contract that the range costs ~the same as the selling price
+		final PriceForSaleContext context = getPriceForSaleContext().orElse(null);
+		if (context instanceof PriceForSaleContextWithCachedResult pfscwcr && pfscwcr.matches(currency, atTheMoment, priceListPriority)) {
+			return pfscwcr.computeRange(getPrices(), getPriceInnerRecordHandling());
+		}
+		return computePriceRangeForSale(
+			getPrices(), getPriceInnerRecordHandling(), currency, atTheMoment, priceListPriority, Objects::nonNull
+		);
+	}
+
+	/**
+	 * See {@link #getPriceRangeForSale()}; this overload additionally returns the requested accompanying
+	 * prices. The accompanying-price map is computed exactly as for
+	 * {@link #getPriceForSaleWithAccompanyingPrices(AccompanyingPrice[])} — the only difference is the
+	 * additional range information.
+	 *
+	 * @param accompanyingPricesRequest array of requirements for accompanying prices
+	 * @throws ContextMissingException when entity is not related to any {@link Query} or the query
+	 *                                 lacks price related constraints
+	 */
+	@Nonnull
+	default Optional<PriceRangeForSaleWithAccompanyingPrices> getPriceRangeForSaleWithAccompanyingPrices(
+		@Nonnull AccompanyingPrice[] accompanyingPricesRequest
+	) throws ContextMissingException {
+		final PriceForSaleContext context = getPriceForSaleContext().orElseThrow(ContextMissingException::new);
+		// share work with prior / subsequent calls — the rich cache holds the per-bucket bookkeeping needed
+		// to (re)derive accompanying-price selections without a fresh full pass
+		if (context instanceof PriceForSaleContextWithCachedResult pfscwcr) {
+			return pfscwcr.computeRangeWithAccompanyingPrices(
+				getPrices(), getPriceInnerRecordHandling(), accompanyingPricesRequest
+			);
+		}
+		return computePriceRangeForSale(
+			getPrices(), getPriceInnerRecordHandling(),
+			context.currency().orElseThrow(ContextMissingException::new),
+			context.atTheMoment().orElse(null),
+			context.priceListPriority().orElseThrow(ContextMissingException::new),
+			Objects::nonNull,
+			accompanyingPricesRequest
+		);
+	}
+
+	/**
+	 * See {@link #getPriceRangeForSale()}; this overload additionally accepts explicit currency / valid-in
+	 * / price-list inputs together with accompanying-price requirements.
+	 *
+	 * @param currency           identification of the currency
+	 * @param atTheMoment        moment when the entity is about to be sold
+	 * @param priceListPriority  identification of the price list priority
+	 * @param accompanyingPrices array of accompanying-price requirements
+	 * @throws ContextMissingException when the prices were not fetched along with entity but might exist
+	 */
+	@Nonnull
+	default Optional<PriceRangeForSaleWithAccompanyingPrices> getPriceRangeForSaleWithAccompanyingPrices(
+		@Nonnull Currency currency,
+		@Nullable OffsetDateTime atTheMoment,
+		@Nonnull String[] priceListPriority,
+		@Nonnull AccompanyingPrice[] accompanyingPrices
+	) throws ContextMissingException {
+		// share work with prior / subsequent calls when context matches
+		final PriceForSaleContext context = getPriceForSaleContext().orElse(null);
+		if (context instanceof PriceForSaleContextWithCachedResult pfscwcr && pfscwcr.matches(currency, atTheMoment, priceListPriority)) {
+			return pfscwcr.computeRangeWithAccompanyingPrices(
+				getPrices(), getPriceInnerRecordHandling(), accompanyingPrices
+			);
+		}
+		return computePriceRangeForSale(
+			getPrices(), getPriceInnerRecordHandling(), currency, atTheMoment, priceListPriority, Objects::nonNull,
+			accompanyingPrices
+		);
 	}
 
 	/**
@@ -1135,6 +1629,28 @@ public interface PricesContract extends Versioned, Serializable {
 	@Nonnull
 	PriceInnerRecordHandling getPriceInnerRecordHandling();
 
+	/**
+	 * Captures the inputs that drive a price-for-sale computation for a single entity within one query
+	 * evaluation: the price-list priority list, the currency, the optional valid-in moment, and the optional
+	 * set of accompanying-price requirements. Together these four values fully determine which entity
+	 * prices are considered, how they are ranked, and which non-selling prices are exposed alongside the
+	 * winner.
+	 *
+	 * The context is materialised by the engine when a query carries price-related constraints (e.g.
+	 * `priceInPriceLists`, `priceInCurrency`, `priceValidIn`, `accompanyingPriceContent`) and is attached to
+	 * each fetched entity via {@link PricesContract#getPriceForSaleContext()}. Calls to the no-arg
+	 * {@link PricesContract#getPriceForSale()} / {@link PricesContract#getPriceRangeForSale()} family read
+	 * their parameters from this context; absence of the context is what triggers
+	 * {@link io.evitadb.api.exception.ContextMissingException} on those methods.
+	 *
+	 * Implementations are expected to be value-like: equal context inputs must produce equal results across
+	 * repeated reads. {@link PriceForSaleContextWithCachedResult} is the canonical implementation — it adds
+	 * a per-entity cache so that selling-price, range, and accompanying-price views derived from the same
+	 * inputs share a single underlying computation pass. Callers wishing to query prices with explicit
+	 * inputs (rather than the query-derived ones) bypass the context and use the parameterised overloads
+	 * directly.
+	 */
+	@SuppressWarnings("InterfaceWithOnlyOneDirectInheritor")
 	interface PriceForSaleContext {
 
 		/**
@@ -1255,6 +1771,55 @@ public interface PricesContract extends Versioned, Serializable {
 			int result = this.priceForSale.hashCode();
 			result = 31 * result + this.accompanyingPrices.hashCode();
 			return result;
+		}
+	}
+
+	/**
+	 * Internal carrier of the per-strategy `priceForSale` / range bounds together with the accompanying-
+	 * price bookkeeping needed to compute requested accompanying prices on demand. Stored only inside this
+	 * contract; not exposed to callers.
+	 *
+	 * For NONE / LOWEST_PRICE: `accompanyingCandidates` holds the pre-filtered candidate collection and
+	 * `sumAccompanyingByInner` is `null`.
+	 *
+	 * For SUM: `accompanyingCandidates` is unused (empty list) and `sumAccompanyingByInner` holds the
+	 * per-inner-record / per-price-list lookup needed to sum component prices for the accompanying-price
+	 * calculation.
+	 *
+	 * @apiNote internal — not part of the public API; subject to change without notice.
+	 */
+	record PriceForSaleComputationResult(
+		@Nonnull PriceInnerRecordHandling innerRecordHandling,
+		@Nonnull PriceContract priceForSale,
+		@Nonnull PriceContract lowestPrice,
+		@Nonnull PriceContract highestPrice,
+		@Nonnull List<PriceContract> accompanyingCandidates,
+		@Nullable Map<Integer, Map<String, PriceContract>> sumAccompanyingByInner
+	) {
+
+		/**
+		 * Computes the accompanying-price map for this computation result based on the strategy that produced
+		 * it. The candidate collection is reused — for NONE / LOWEST_PRICE the same candidate list also feeds
+		 * the shared {@link #selectAccompanyingPrices(Collection, AccompanyingPrice[])} helper; for SUM the
+		 * pre-built per-inner-record map is consumed by the SUM-specific resolver.
+		 */
+		@Nonnull
+		Map<String, Optional<PriceContract>> calculateAccompanyingPrices(
+			@Nonnull AccompanyingPrice[] accompanyingPrices
+		) {
+			if (accompanyingPrices.length == 0) {
+				return Collections.emptyMap();
+			}
+			return switch (this.innerRecordHandling) {
+				case NONE, LOWEST_PRICE -> selectAccompanyingPrices(this.accompanyingCandidates, accompanyingPrices);
+				case SUM -> resolveSumAccompanyingPrices(
+					this.priceForSale,
+					this.sumAccompanyingByInner == null ? Collections.emptyMap() : this.sumAccompanyingByInner,
+					accompanyingPrices
+				);
+				case UNKNOWN ->
+					throw new GenericEvitaInternalError("Cannot compute accompanying prices for UNKNOWN inner record handling.");
+			};
 		}
 	}
 

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
@@ -100,7 +100,8 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nonnull AccompanyingPrice[] accompanyingPrices
 	) {
 		final PriceForSaleComputationResult computation = computeInternal(
-			entityPrices, innerRecordHandling, currency, atTheMoment, priceListPriority, filterPredicate
+			entityPrices, innerRecordHandling, currency, atTheMoment,
+			getPriceListPriorityIndex(priceListPriority), filterPredicate
 		);
 		if (computation == null) {
 			return empty();
@@ -120,6 +121,10 @@ public interface PricesContract extends Versioned, Serializable {
 	 * callers must use the public {@code computePriceForSale} / {@code computePriceRangeForSale} entry
 	 * points instead — this method is part of the cache plumbing.
 	 *
+	 * The caller passes a pre-computed {@code priorityIndex} (built once via
+	 * {@link #getPriceListPriorityIndex}) so that long-lived cache instances do not rebuild the same
+	 * `priceList -> priority` map on every call.
+	 *
 	 * @apiNote internal — not part of the public API; subject to change without notice.
 	 */
 	@Nullable
@@ -128,10 +133,10 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nonnull PriceInnerRecordHandling innerRecordHandling,
 		@Nonnull Currency currency,
 		@Nullable OffsetDateTime atTheMoment,
-		@Nonnull String[] priceListPriority,
+		@Nonnull Map<String, Integer> priorityIndex,
 		@Nonnull Predicate<PriceContract> filterPredicate
 	) {
-		return computeInternal(entityPrices, innerRecordHandling, currency, atTheMoment, priceListPriority, filterPredicate);
+		return computeInternal(entityPrices, innerRecordHandling, currency, atTheMoment, priorityIndex, filterPredicate);
 	}
 
 	/**
@@ -174,7 +179,8 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nonnull AccompanyingPrice[] accompanyingPrices
 	) {
 		final PriceForSaleComputationResult computation = computeInternal(
-			entityPrices, innerRecordHandling, currency, atTheMoment, priceListPriority, filterPredicate
+			entityPrices, innerRecordHandling, currency, atTheMoment,
+			getPriceListPriorityIndex(priceListPriority), filterPredicate
 		);
 		if (computation == null) {
 			return empty();
@@ -282,21 +288,20 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nonnull PriceInnerRecordHandling innerRecordHandling,
 		@Nonnull Currency currency,
 		@Nullable OffsetDateTime atTheMoment,
-		@Nonnull String[] priceListPriority,
+		@Nonnull Map<String, Integer> priorityIndex,
 		@Nonnull Predicate<PriceContract> filterPredicate
 	) {
 		if (entityPrices.isEmpty()) {
 			return null;
 		}
 
-		// hoisted out of the hot loop
-		final Map<String, Integer> priorityIndex = getPriceListPriorityIndex(priceListPriority);
 		// presize estimates: assume each inner record carries roughly one price per priority list, so the
 		// number of distinct inner records ≈ N/L. A small reserve absorbs noise (entities with extra price
 		// lists outside the priority, or sparse inner records).
-		final int innerBucketEstimate = Math.max(2, priceListPriority.length + 2);
+		final int priorityCount = Math.max(1, priorityIndex.size());
+		final int innerBucketEstimate = Math.max(2, priorityCount + 2);
 		final int distinctInnerEstimate = Math.max(
-			2, entityPrices.size() / Math.max(1, priceListPriority.length) + 2
+			2, entityPrices.size() / priorityCount + 2
 		);
 
 		return switch (innerRecordHandling) {
@@ -498,7 +503,9 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nonnull Currency currency,
 		@Nullable OffsetDateTime atTheMoment
 	) {
-		final List<PriceContract> result = new ArrayList<>(entityPrices.size());
+		// see the matching `candidates` allocation in `computeInternal#NONE` — same multi-currency
+		// survival-rate heuristic
+		final List<PriceContract> result = new ArrayList<>(entityPrices.size() / 2 + 2);
 		for (final PriceContract price : entityPrices) {
 			if (isNotCandidate(price, currency, atTheMoment)) {
 				continue;
@@ -524,7 +531,9 @@ public interface PricesContract extends Versioned, Serializable {
 		@Nonnull Currency currency,
 		@Nullable OffsetDateTime atTheMoment
 	) {
-		final List<PriceContract> result = new ArrayList<>(entityPrices.size());
+		// see the matching `candidates` allocation in `computeInternal#NONE` — same multi-currency
+		// survival-rate heuristic
+		final List<PriceContract> result = new ArrayList<>(entityPrices.size() / 2 + 2);
 		for (final PriceContract price : entityPrices) {
 			if (isNotCandidate(price, currency, atTheMoment)) {
 				continue;
@@ -849,12 +858,19 @@ public interface PricesContract extends Versioned, Serializable {
 
 	/**
 	 * Creates a map of price list priorities where the key is the price list and the value is the priority.
+	 * The result is a pure function of the input array — the same input always yields an equivalent map.
+	 * Long-lived cache instances (e.g. {@link PriceForSaleContextWithCachedResult}) build the index once and
+	 * reuse it across calls; callers without their own cache can hand the array directly to the public
+	 * {@code computePriceForSale*} / {@code computePriceRangeForSale*} entry points, which handle the
+	 * conversion internally.
 	 *
 	 * @param priceListPriority array of price list priorities
 	 * @return map of price list priorities
+	 * @apiNote internal — exposed across {@code io.evitadb.api.requestResponse.data} only; subject to
+	 * change without notice.
 	 */
 	@Nonnull
-	private static Map<String, Integer> getPriceListPriorityIndex(@Nonnull String[] priceListPriority) {
+	static Map<String, Integer> getPriceListPriorityIndex(@Nonnull String[] priceListPriority) {
 		final Map<String, Integer> pLists = createHashMap(priceListPriority.length);
 		for (int i = 0; i < priceListPriority.length; i++) {
 			final String pList = priceListPriority[i];

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/PricesContract.java
@@ -256,7 +256,7 @@ public interface PricesContract extends Versioned, Serializable {
 				accompanyingPrices
 			);
 			case LOWEST_PRICE -> selectAccompanyingPrices(
-				filterCandidatesByInnerRecordRelation(entityPrices, priceForSale),
+				filterCandidatesByInnerRecordRelation(entityPrices, priceForSale, currency, atTheMoment),
 				accompanyingPrices
 			);
 			case SUM -> calculateAccompanyingPricesForSumInnerRecordHandling(
@@ -395,8 +395,17 @@ public interface PricesContract extends Versioned, Serializable {
 						continue;
 					}
 					final int innerKey = innerRecordKey(price);
-					byInnerByListAll.computeIfAbsent(innerKey, k -> CollectionUtils.createHashMap(innerBucketEstimate))
-						.put(price.priceList(), price);
+					// merge with deterministic tie-break: when two prices share `(innerRecord, priceList)` —
+					// possible when `atTheMoment == null` and several prices have non-overlapping but currently
+					// valid validity ranges — the winner is decided by `isBetterByPriceIdThenInner` (lower
+					// priceId then lower innerRecordId), matching the per-bucket selection used everywhere else.
+					byInnerByListAll
+						.computeIfAbsent(innerKey, k -> CollectionUtils.createHashMap(innerBucketEstimate))
+						.merge(
+							price.priceList(),
+							price,
+							(existing, candidate) -> isBetterByPriceIdThenInner(candidate, existing) ? candidate : existing
+						);
 					updateBestPerInner(price, innerKey, priorityIndex, bestPerInner, bestPriorityPerInner);
 				}
 				if (bestPerInner.isEmpty()) {
@@ -493,16 +502,26 @@ public interface PricesContract extends Versioned, Serializable {
 	}
 
 	/**
-	 * Filters the supplied prices to those that share an inner record with the supplied selling price. Used as
-	 * the candidate basis for accompanying-price calculation under `LOWEST_PRICE`.
+	 * Filters the supplied prices to those that (a) exist, (b) match the requested `currency`, (c) are valid
+	 * at `atTheMoment`, and (d) share an inner record with the supplied selling price. Used as the candidate
+	 * basis for accompanying-price calculation under `LOWEST_PRICE`. The currency / validity gate keeps this
+	 * helper consistent with the NONE branch (which calls
+	 * {@link #filterCandidatesByCurrencyAndValidity}) and with the {@link #computeInternal} fast path that
+	 * already applies {@link #isNotCandidate} before bucketing — the `entityPrices` collection passed by
+	 * external callers may contain prices in other currencies / dropped or out-of-validity prices.
 	 */
 	@Nonnull
 	private static List<PriceContract> filterCandidatesByInnerRecordRelation(
 		@Nonnull Collection<PriceContract> entityPrices,
-		@Nonnull PriceContract priceForSale
+		@Nonnull PriceContract priceForSale,
+		@Nonnull Currency currency,
+		@Nullable OffsetDateTime atTheMoment
 	) {
 		final List<PriceContract> result = new ArrayList<>(entityPrices.size());
 		for (final PriceContract price : entityPrices) {
+			if (isNotCandidate(price, currency, atTheMoment)) {
+				continue;
+			}
 			if (Objects.equals(priceForSale.innerRecordId(), price.innerRecordId())) {
 				result.add(price);
 			}
@@ -546,8 +565,16 @@ public interface PricesContract extends Versioned, Serializable {
 				continue;
 			}
 			final int innerKey = innerRecordKey(price);
-			byInnerByList.computeIfAbsent(innerKey, k -> CollectionUtils.createHashMap(4))
-				.put(price.priceList(), price);
+			// see byInnerByListAll merge comment in computeInternal — same deterministic tie-break for
+			// `(innerRecord, priceList)` collisions that arise from multiple non-overlapping validities
+			// when `atTheMoment` is `null`.
+			byInnerByList
+				.computeIfAbsent(innerKey, k -> CollectionUtils.createHashMap(4))
+				.merge(
+					price.priceList(),
+					price,
+					(existing, candidate) -> isBetterByPriceIdThenInner(candidate, existing) ? candidate : existing
+				);
 		}
 		return resolveSumAccompanyingPrices(priceForSale, byInnerByList, accompanyingPrices);
 	}

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/EntityDecorator.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/EntityDecorator.java
@@ -38,6 +38,7 @@ import io.evitadb.api.requestResponse.data.EntityClassifierWithParent;
 import io.evitadb.api.requestResponse.data.EntityEditor.EntityBuilder;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.api.requestResponse.data.PriceRangeForSale;
 import io.evitadb.api.requestResponse.data.PricesContract;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
 import io.evitadb.api.requestResponse.data.SealedEntity;
@@ -1438,6 +1439,40 @@ public class EntityDecorator implements SealedEntity {
 			// method context available does NullPointer check
 			// noinspection DataFlowIssue
 			return getPriceForSale(
+				this.pricePredicate.getCurrency(),
+				this.pricePredicate.getValidIn(),
+				this.pricePredicate.getPriceLists()
+			);
+		} else {
+			return empty();
+		}
+	}
+
+	@Nonnull
+	@Override
+	public Optional<PriceRangeForSale> getPriceRangeForSale() throws ContextMissingException {
+		if (this.pricePredicate.isContextAvailable()) {
+			this.pricePredicate.checkPricesFetched();
+			// method context available does NullPointer check
+			// noinspection DataFlowIssue
+			return SealedEntity.super.getPriceRangeForSale(
+				this.pricePredicate.getCurrency(),
+				this.pricePredicate.getValidIn(),
+				this.pricePredicate.getPriceLists()
+			);
+		} else {
+			throw new ContextMissingException();
+		}
+	}
+
+	@Nonnull
+	@Override
+	public Optional<PriceRangeForSale> getPriceRangeForSaleIfAvailable() {
+		if (this.pricePredicate.isContextAvailable()) {
+			this.pricePredicate.checkPricesFetched();
+			// method context available does NullPointer check
+			// noinspection DataFlowIssue
+			return SealedEntity.super.getPriceRangeForSale(
 				this.pricePredicate.getCurrency(),
 				this.pricePredicate.getValidIn(),
 				this.pricePredicate.getPriceLists()

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/ExistingPricesBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/ExistingPricesBuilder.java
@@ -32,6 +32,7 @@ import io.evitadb.api.query.require.QueryPriceMode;
 import io.evitadb.api.requestResponse.data.Droppable;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.api.requestResponse.data.PriceRangeForSale;
 import io.evitadb.api.requestResponse.data.PricesEditor.PricesBuilder;
 import io.evitadb.api.requestResponse.data.mutation.LocalMutation;
 import io.evitadb.api.requestResponse.data.mutation.price.PriceMutation;
@@ -193,6 +194,7 @@ public class ExistingPricesBuilder implements PricesBuilder {
 		if (mutation instanceof UpsertPriceMutation upsertPriceMutation) {
 			final PriceKey priceKey = upsertPriceMutation.getPriceKey();
 			assertPricesAllowed(this.entitySchema, priceKey.currency());
+			InitialPricesBuilder.assertInnerRecordIdValid(upsertPriceMutation.getInnerRecordId());
 			final PriceContract existingValue = this.basePrices
 				.getPriceWithoutSchemaCheck(priceKey)
 				.orElse(null);
@@ -514,6 +516,44 @@ public class ExistingPricesBuilder implements PricesBuilder {
 		assertPricesFetched(PriceContentMode.RESPECTING_FILTER);
 		if (this.pricePredicate.getCurrency() != null && !ArrayUtils.isEmpty(this.pricePredicate.getPriceLists())) {
 			return getPriceForSale(
+				this.pricePredicate.getCurrency(),
+				this.pricePredicate.getValidIn(),
+				this.pricePredicate.getPriceLists()
+			);
+		} else {
+			return empty();
+		}
+	}
+
+	/**
+	 * Returns the full price range (lowest, highest, selling price) for the active predicate context.
+	 *
+	 * @throws ContextMissingException when predicate lacks currency or price lists
+	 */
+	@Nonnull
+	@Override
+	public Optional<PriceRangeForSale> getPriceRangeForSale() throws ContextMissingException {
+		assertPricesFetched(PriceContentMode.RESPECTING_FILTER);
+		if (this.pricePredicate.getCurrency() != null && !ArrayUtils.isEmpty(this.pricePredicate.getPriceLists())) {
+			return getPriceRangeForSale(
+				this.pricePredicate.getCurrency(),
+				this.pricePredicate.getValidIn(),
+				this.pricePredicate.getPriceLists()
+			);
+		} else {
+			throw new ContextMissingException();
+		}
+	}
+
+	/**
+	 * Same as {@link #getPriceRangeForSale()} but never throws, returning empty when context is missing.
+	 */
+	@Nonnull
+	@Override
+	public Optional<PriceRangeForSale> getPriceRangeForSaleIfAvailable() {
+		assertPricesFetched(PriceContentMode.RESPECTING_FILTER);
+		if (this.pricePredicate.getCurrency() != null && !ArrayUtils.isEmpty(this.pricePredicate.getPriceLists())) {
+			return getPriceRangeForSale(
 				this.pricePredicate.getCurrency(),
 				this.pricePredicate.getValidIn(),
 				this.pricePredicate.getPriceLists()

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/InitialPricesBuilder.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/InitialPricesBuilder.java
@@ -30,6 +30,7 @@ import io.evitadb.api.exception.UnexpectedResultCountException;
 import io.evitadb.api.query.require.QueryPriceMode;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.api.requestResponse.data.PriceRangeForSale;
 import io.evitadb.api.requestResponse.data.PricesEditor.PricesBuilder;
 import io.evitadb.api.requestResponse.data.mutation.LocalMutation;
 import io.evitadb.api.requestResponse.data.mutation.price.PriceMutation;
@@ -160,6 +161,7 @@ public class InitialPricesBuilder implements PricesBuilder {
 		boolean indexed
 	) {
 		assertPricesAllowed(this.entitySchema, currency);
+		assertInnerRecordIdValid(innerRecordId);
 		final PriceKey priceKey = new PriceKey(priceId, priceList, currency);
 		final Price thePrice = new Price(
 			priceKey, innerRecordId, priceWithoutTax, taxRate, priceWithTax, null, indexed);
@@ -190,6 +192,7 @@ public class InitialPricesBuilder implements PricesBuilder {
 		@Nullable DateTimeRange validity, boolean indexed
 	) {
 		assertPricesAllowed(this.entitySchema, currency);
+		assertInnerRecordIdValid(innerRecordId);
 		final PriceKey priceKey = new PriceKey(priceId, priceList, currency);
 		final Price thePrice = new Price(
 			priceKey, innerRecordId, priceWithoutTax, taxRate, priceWithTax, validity, indexed);
@@ -334,6 +337,18 @@ public class InitialPricesBuilder implements PricesBuilder {
 
 	@Nonnull
 	@Override
+	public Optional<PriceRangeForSale> getPriceRangeForSale() throws ContextMissingException {
+		throw new ContextMissingException();
+	}
+
+	@Nonnull
+	@Override
+	public Optional<PriceRangeForSale> getPriceRangeForSaleIfAvailable() {
+		return empty();
+	}
+
+	@Nonnull
+	@Override
 	public List<PriceContract> getAllPricesForSale() {
 		throw new ContextMissingException();
 	}
@@ -421,6 +436,27 @@ public class InitialPricesBuilder implements PricesBuilder {
 			() -> new InvalidMutationException(
 				"Entity `" + schema.getName() + "` doesn't support currency `" + currency + "`, cannot set price in this currency! " +
 					"You need to update entity schema to allow adding this currency first."
+			)
+		);
+	}
+
+	/**
+	 * Verifies that the supplied {@code innerRecordId} is acceptable for storage. The value `0` is reserved as
+	 * the in-memory sentinel for "no inner record" (see {@link io.evitadb.api.requestResponse.data.PricesContract}
+	 * grouping logic), so accepting an explicit `0` from the caller would silently merge that price into the
+	 * `null` bucket and corrupt {@code priceForSale} / range computations under
+	 * {@link PriceInnerRecordHandling#LOWEST_PRICE} and {@link PriceInnerRecordHandling#SUM}. A `null` value
+	 * means "no inner record" and is the only legal way to express that.
+	 *
+	 * @param innerRecordId optional inner record id to validate
+	 * @throws InvalidMutationException when {@code innerRecordId} equals `0`
+	 */
+	static void assertInnerRecordIdValid(@Nullable Integer innerRecordId) {
+		Assert.isTrue(
+			innerRecordId == null || innerRecordId.intValue() != 0,
+			() -> new InvalidMutationException(
+				"Inner record id `0` is reserved as the sentinel for no-inner-record prices; " +
+					"use `null` instead to signal that the price has no inner record id."
 			)
 		);
 	}

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/Price.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/Price.java
@@ -89,7 +89,7 @@ public record Price(
 	private static final String PRICE_WITHOUT_TAX_IS_MANDATORY_VALUE = "Price without tax is mandatory value!";
 	private static final String PRICE_TAX_IS_MANDATORY_VALUE = "Price tax is mandatory value!";
 	private static final String PRICE_WITH_TAX_IS_MANDATORY_VALUE = "Price with tax is mandatory value!";
-	private static final String PRICE_INNER_RECORD_ID_MUST_BE_POSITIVE_VALUE = "Price inner record id must be positive value!";
+	private static final String PRICE_INNER_RECORD_ID_MUST_BE_POSITIVE_VALUE = "Price inner record id must be a positive value (use `null` for no inner record id; `0` is reserved as the no-inner-record sentinel)!";
 
 	public Price {
 		Assert.notNull(priceKey, PRICE_KEY_IS_MANDATORY_VALUE);

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/Prices.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/Prices.java
@@ -34,6 +34,7 @@ import io.evitadb.api.query.require.QueryPriceMode;
 import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.api.requestResponse.data.PriceRangeForSale;
 import io.evitadb.api.requestResponse.data.PricesContract;
 import io.evitadb.api.requestResponse.data.Versioned;
 import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
@@ -253,21 +254,57 @@ public class Prices implements PricesContract, Versioned, ContentComparator<Pric
 	@Nonnull
 	@Override
 	public Optional<PriceContract> getPriceForSale() throws ContextMissingException {
-		return this.getPriceForSaleContext()
-			.map(
-				it -> getPriceForSale(
-					it.currency().orElseThrow(ContextMissingException::new),
-					it.atTheMoment().orElse(null),
-					it.priceListPriority().orElseThrow(ContextMissingException::new)
-				)
-			)
+		final PriceForSaleContext context = this.getPriceForSaleContext()
 			.orElseThrow(ContextMissingException::new);
+		return getPriceForSale(
+			context.currency().orElseThrow(ContextMissingException::new),
+			context.atTheMoment().orElse(null),
+			context.priceListPriority().orElseThrow(ContextMissingException::new)
+		);
 	}
 
 	@Nonnull
 	@Override
 	public Optional<PriceContract> getPriceForSaleIfAvailable() {
-		return Optional.empty();
+		return this.getPriceForSaleContext()
+			.flatMap(context -> {
+				final Optional<Currency> currency = context.currency();
+				final Optional<String[]> priceListPriority = context.priceListPriority();
+				if (currency.isEmpty() || priceListPriority.isEmpty()) {
+					return Optional.empty();
+				}
+				return getPriceForSale(
+					currency.get(), context.atTheMoment().orElse(null), priceListPriority.get()
+				);
+			});
+	}
+
+	@Nonnull
+	@Override
+	public Optional<PriceRangeForSale> getPriceRangeForSale() throws ContextMissingException {
+		final PriceForSaleContext context = this.getPriceForSaleContext()
+			.orElseThrow(ContextMissingException::new);
+		return getPriceRangeForSale(
+			context.currency().orElseThrow(ContextMissingException::new),
+			context.atTheMoment().orElse(null),
+			context.priceListPriority().orElseThrow(ContextMissingException::new)
+		);
+	}
+
+	@Nonnull
+	@Override
+	public Optional<PriceRangeForSale> getPriceRangeForSaleIfAvailable() {
+		return this.getPriceForSaleContext()
+			.flatMap(context -> {
+				final Optional<Currency> currency = context.currency();
+				final Optional<String[]> priceListPriority = context.priceListPriority();
+				if (currency.isEmpty() || priceListPriority.isEmpty()) {
+					return Optional.empty();
+				}
+				return getPriceRangeForSale(
+					currency.get(), context.atTheMoment().orElse(null), priceListPriority.get()
+				);
+			});
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/spi/store/engine/model/CatalogInventoryDivergence.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/engine/model/CatalogInventoryDivergence.java
@@ -47,9 +47,12 @@ import java.util.List;
  * - **autoDiscovered** — names whose storage is present but unknown to the engine state. Drained as
  *   `RestoreCatalogSchemaMutation` (the operator registers them as `INACTIVE`).
  *
- * All lists are deterministically ordered (alphabetically) so repeated boots over the same backing-store inventory
- * produce an identical WAL trail. Apply order is `becomeMissing` first (frees up names), then `reappeared`, then
- * `autoDiscovered` — see `Evita`'s drain loop for the rationale.
+ * All lists are deterministically ordered (alphabetically) so the divergence record itself is reproducible across
+ * boots over the same backing-store inventory. The WAL trail produced by draining is only partially ordered:
+ * `becomeMissing` mutations are applied (and committed to the WAL) before any restore is dispatched — Phase 1 is
+ * awaited to completion before Phase 2 begins. `reappeared` and `autoDiscovered` are then dispatched in parallel
+ * (they operate on disjoint name sets), so their relative WAL order is non-deterministic. See `Evita`'s drain loop
+ * for the rationale.
  *
  * @param becomeMissing  catalogs to mark as missing, alphabetically ordered; never null
  * @param reappeared     catalogs to move from missing back to inactive, alphabetically ordered; never null

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/model/EntityDescriptor.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/model/EntityDescriptor.java
@@ -110,14 +110,44 @@ public interface EntityDescriptor extends VersionedDescriptor, AttributesProvide
             """)
         .type(nullableRef(PriceDescriptor.THIS))
         .build();
+    PropertyDescriptor PRICE_FOR_SALE_MIN = PropertyDescriptor.builder()
+        .name("priceForSaleMin")
+        .description("""
+            Lowest price for which the entity could be sold — a concrete, indexed inner-record price that satisfies
+            the same currency / valid-in / price-list filters as the resolved `priceForSale`. For `NONE` price inner
+            record handling collapses to `priceForSale`; for `LOWEST_PRICE` it equals `priceForSale` (cheapest
+            per-inner-record selling price); for `SUM` it is the cheapest per-inner-record component price (while
+            `priceForSale` is the cumulated sum).
+
+            This property can be used only when appropriate price related constraints are present or appropriate
+            arguments are passed so that `currency` and `priceList` priority can be extracted. The moment is either
+            extracted from the query as well (if present) or current date and time is used.
+            """)
+        .type(nullableRef(PriceDescriptor.THIS))
+        .build();
+    PropertyDescriptor PRICE_FOR_SALE_MAX = PropertyDescriptor.builder()
+        .name("priceForSaleMax")
+        .description("""
+            Highest price for which the entity could be sold — a concrete, indexed inner-record price that satisfies
+            the same currency / valid-in / price-list filters as the resolved `priceForSale`. For `NONE` price inner
+            record handling collapses to `priceForSale`; for `LOWEST_PRICE` it is the most expensive per-inner-record
+            selling price; for `SUM` it is the most expensive per-inner-record component price (while `priceForSale`
+            is the cumulated sum).
+
+            This property can be used only when appropriate price related constraints are present or appropriate
+            arguments are passed so that `currency` and `priceList` priority can be extracted. The moment is either
+            extracted from the query as well (if present) or current date and time is used.
+            """)
+        .type(nullableRef(PriceDescriptor.THIS))
+        .build();
     PropertyDescriptor MULTIPLE_PRICES_FOR_SALE_AVAILABLE = PropertyDescriptor.builder()
         .name("multiplePricesForSaleAvailable")
         .description("""
 			Whether the entity could be sold for multiple prices or not. This method can be used only when appropriate
-            price related constraints are present in query so that `currency` and `priceList`
-            priority can be extracted.
-            
-            For actual prices, the `allPricesForSale` field can be used.
+			price related constraints are present in query so that `currency` and `priceList`
+			priority can be extracted.
+
+			For actual prices, the `allPricesForSale` field can be used.
 			""")
         .type(nullable(Boolean.class))
         .build();

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/entity/EntityObjectPriceDecorator.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/entity/EntityObjectPriceDecorator.java
@@ -29,6 +29,7 @@ import graphql.schema.GraphQLObjectType.Builder;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.externalApi.api.catalog.dataApi.model.EntityDescriptor;
 import io.evitadb.externalApi.api.catalog.dataApi.model.PriceDescriptor;
+import io.evitadb.externalApi.api.model.PropertyDescriptor;
 import io.evitadb.externalApi.graphql.api.builder.BuiltFieldDescriptor;
 import io.evitadb.externalApi.graphql.api.catalog.builder.CatalogGraphQLSchemaBuildingContext;
 import io.evitadb.externalApi.graphql.api.catalog.dataApi.builder.CollectionGraphQLSchemaBuildingContext;
@@ -46,6 +47,7 @@ import io.evitadb.externalApi.graphql.api.catalog.dataApi.resolver.dataFetcher.e
 import io.evitadb.externalApi.graphql.api.catalog.dataApi.resolver.dataFetcher.entity.MultiplePricesForSaleAvailableDataFetcher;
 import io.evitadb.externalApi.graphql.api.catalog.dataApi.resolver.dataFetcher.entity.PriceBigDecimalDataFetcher;
 import io.evitadb.externalApi.graphql.api.catalog.dataApi.resolver.dataFetcher.entity.PriceDataFetcher;
+import io.evitadb.externalApi.graphql.api.catalog.dataApi.resolver.dataFetcher.entity.PriceForSaleBoundDataFetcher;
 import io.evitadb.externalApi.graphql.api.catalog.dataApi.resolver.dataFetcher.entity.PriceForSaleDataFetcher;
 import io.evitadb.externalApi.graphql.api.catalog.dataApi.resolver.dataFetcher.entity.PricesDataFetcher;
 import io.evitadb.externalApi.graphql.api.model.ObjectDescriptorToGraphQLObjectTransformer;
@@ -115,6 +117,16 @@ public class EntityObjectPriceDecorator implements EntityObjectDecorator {
 				entityObjectName,
 				entityObjectBuilder,
 				buildEntityPriceForSaleField()
+			);
+			this.buildingContext.registerFieldToObject(
+				entityObjectName,
+				entityObjectBuilder,
+				buildEntityPriceForSaleMinField()
+			);
+			this.buildingContext.registerFieldToObject(
+				entityObjectName,
+				entityObjectBuilder,
+				buildEntityPriceForSaleMaxField()
 			);
 			this.buildingContext.registerFieldToObject(
 				entityObjectName,
@@ -227,6 +239,50 @@ public class EntityObjectPriceDecorator implements EntityObjectDecorator {
 		}
 
 		return new BuiltFieldDescriptor(fieldBuilder.build(), PriceForSaleDataFetcher.getInstance());
+	}
+
+	@Nonnull
+	private BuiltFieldDescriptor buildEntityPriceForSaleMinField() {
+		return new BuiltFieldDescriptor(
+			buildPriceForSaleBoundFieldBuilder(GraphQLEntityDescriptor.PRICE_FOR_SALE_MIN).build(),
+			PriceForSaleBoundDataFetcher.getMinInstance()
+		);
+	}
+
+	@Nonnull
+	private BuiltFieldDescriptor buildEntityPriceForSaleMaxField() {
+		return new BuiltFieldDescriptor(
+			buildPriceForSaleBoundFieldBuilder(GraphQLEntityDescriptor.PRICE_FOR_SALE_MAX).build(),
+			PriceForSaleBoundDataFetcher.getMaxInstance()
+		);
+	}
+
+	/**
+	 * Shared argument set for the `priceForSaleMin` / `priceForSaleMax` fields — same as `priceForSale` so
+	 * clients have a uniform calling convention.
+	 */
+	@Nonnull
+	private GraphQLFieldDefinition.Builder buildPriceForSaleBoundFieldBuilder(
+		@Nonnull PropertyDescriptor descriptor
+	) {
+		final GraphQLFieldDefinition.Builder fieldBuilder = descriptor
+			.to(this.fieldBuilderTransformer)
+			.argument(PriceForSaleFieldHeaderDescriptor.PRICE_LISTS
+				          .to(this.argumentBuilderTransformer))
+			.argument(PriceForSaleFieldHeaderDescriptor.CURRENCY
+				          .to(this.argumentBuilderTransformer)
+				          .type(typeRef(CURRENCY_ENUM.name())))
+			.argument(PriceForSaleFieldHeaderDescriptor.VALID_IN
+				          .to(this.argumentBuilderTransformer))
+			.argument(PriceForSaleFieldHeaderDescriptor.VALID_NOW
+				          .to(this.argumentBuilderTransformer));
+
+		if (!this.buildingContext.getSupportedLocales().isEmpty()) {
+			fieldBuilder.argument(PriceForSaleFieldHeaderDescriptor.LOCALE
+				                      .to(this.argumentBuilderTransformer)
+				                      .type(typeRef(LOCALE_ENUM.name())));
+		}
+		return fieldBuilder;
 	}
 
 	@Nonnull

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/model/GraphQLEntityDescriptor.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/model/GraphQLEntityDescriptor.java
@@ -65,6 +65,36 @@ public interface GraphQLEntityDescriptor extends EntityDescriptor {
 	PropertyDescriptor PRICE_FOR_SALE = PropertyDescriptor.from(EntityDescriptor.PRICE_FOR_SALE)
 		.type(nullableRef(PriceForSaleDescriptor.THIS))
 		.build();
+	PropertyDescriptor PRICE_FOR_SALE_MIN = PropertyDescriptor.builder()
+		.name("priceForSaleMin")
+		.description("""
+            Lowest price for which the entity could be sold — a concrete, indexed inner-record price that satisfies
+            the same currency / valid-in / price-list filters as the resolved `priceForSale`. Useful for master
+            products with variants where the front store wants to render the price span alongside the canonical
+            selling price in a single round-trip.
+
+            For `NONE` price inner record handling this collapses to `priceForSale`; for `LOWEST_PRICE` it equals
+            `priceForSale` (cheapest per-inner-record selling price); for `SUM` it is the cheapest per-inner-record
+            component price (`priceForSale` is the cumulated sum). Arguments may be supplied explicitly or inherited
+            from the surrounding query constraints.
+            """)
+		.type(nullableRef(PriceForSaleDescriptor.THIS))
+		.build();
+	PropertyDescriptor PRICE_FOR_SALE_MAX = PropertyDescriptor.builder()
+		.name("priceForSaleMax")
+		.description("""
+            Highest price for which the entity could be sold — a concrete, indexed inner-record price that satisfies
+            the same currency / valid-in / price-list filters as the resolved `priceForSale`. Useful for master
+            products with variants where the front store wants to render the price span alongside the canonical
+            selling price in a single round-trip.
+
+            For `NONE` price inner record handling this collapses to `priceForSale`; for `LOWEST_PRICE` it is the
+            most expensive per-inner-record selling price; for `SUM` it is the most expensive per-inner-record
+            component price (`priceForSale` is the cumulated sum). Arguments may be supplied explicitly or inherited
+            from the surrounding query constraints.
+            """)
+		.type(nullableRef(PriceForSaleDescriptor.THIS))
+		.build();
 	PropertyDescriptor ALL_PRICES_FOR_SALE = PropertyDescriptor.builder()
 		.name("allPricesForSale")
 		.description("""

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/constraint/EntityFetchRequireResolver.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/constraint/EntityFetchRequireResolver.java
@@ -67,6 +67,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -94,6 +95,8 @@ public class EntityFetchRequireResolver {
 
 	private static final Set<String> PRICE_FOR_SALE_FIELDS = Set.of(
 		GraphQLEntityDescriptor.PRICE_FOR_SALE.name(),
+		GraphQLEntityDescriptor.PRICE_FOR_SALE_MIN.name(),
+		GraphQLEntityDescriptor.PRICE_FOR_SALE_MAX.name(),
 		GraphQLEntityDescriptor.ALL_PRICES_FOR_SALE.name()
 	);
 	private static final Set<String> CUSTOM_PRICE_FIELDS = Set.of(
@@ -362,27 +365,38 @@ public class EntityFetchRequireResolver {
 	}
 
 	/**
-	 * Resolves {@link AccompanyingPriceContent} for default `priceForSale` field (i.e., without parameters). Custom
-	 * `priceForSale` fields are computed during serialization manually.
+	 * Resolves {@link AccompanyingPriceContent} for default `priceForSale` / `priceForSaleMin` / `priceForSaleMax`
+	 * / `allPricesForSale` fields (i.e., without parameters). Custom price-for-sale fields are computed during
+	 * serialization manually.
+	 *
+	 * `priceForSaleMin` / `priceForSaleMax` are now flat siblings of `priceForSale`, so their `accompanyingPrice`
+	 * selection sits directly under each — same shape as `priceForSale`. Selections are deduplicated by name so
+	 * the engine does not compute the same accompanying price multiple times.
 	 */
 	@Nonnull
 	private static List<AccompanyingPriceContent> resolveAccompanyingPriceContents(@Nonnull SelectionSetAggregator selectionSetAggregator) {
-		return selectionSetAggregator.getImmediateFields(PRICE_FOR_SALE_FIELDS)
-			.stream()
-			.filter(f -> f.getArguments().isEmpty())
-			.flatMap(f -> SelectionSetAggregator.getImmediateFields(PriceForSaleDescriptor.ACCOMPANYING_PRICE.name(), f.getSelectionSet())
-				.stream()
-				.map(apf -> {
-					final String priceName = apf.getAlias() != null ? apf.getAlias() : apf.getName();
-					if (apf.getArguments().isEmpty()) {
-						return accompanyingPriceContent(priceName);
-					} else {
-						//noinspection unchecked
-						final String[] priceLists = ((List<String>) apf.getArguments().get(AccompanyingPriceFieldHeaderDescriptor.PRICE_LISTS.name())).toArray(String[]::new);
-						return accompanyingPriceContent(priceName, priceLists);
-					}
-				}))
-			.toList();
+		final Map<String, AccompanyingPriceContent> deduplicated = new LinkedHashMap<>();
+		for (final SelectedField priceForSaleField : selectionSetAggregator.getImmediateFields(PRICE_FOR_SALE_FIELDS)) {
+			if (!priceForSaleField.getArguments().isEmpty()) {
+				// custom price for sale → accompanying prices are computed during serialization manually
+				continue;
+			}
+
+			for (final SelectedField apf : SelectionSetAggregator.getImmediateFields(PriceForSaleDescriptor.ACCOMPANYING_PRICE.name(), priceForSaleField.getSelectionSet())) {
+				final String priceName = apf.getAlias() != null ? apf.getAlias() : apf.getName();
+				final AccompanyingPriceContent content;
+				if (apf.getArguments().isEmpty()) {
+					content = accompanyingPriceContent(priceName);
+				} else {
+					//noinspection unchecked
+					final String[] priceLists = ((List<String>) apf.getArguments().get(AccompanyingPriceFieldHeaderDescriptor.PRICE_LISTS.name())).toArray(String[]::new);
+					content = accompanyingPriceContent(priceName, priceLists);
+				}
+				// same `priceName` across sibling price-for-sale fields ⇒ same accompanying price; engine only needs to compute it once
+				deduplicated.putIfAbsent(priceName, content);
+			}
+		}
+		return List.copyOf(deduplicated.values());
 	}
 
 	@Nonnull

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/dataFetcher/entity/PriceForSaleBoundDataFetcher.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/dataFetcher/entity/PriceForSaleBoundDataFetcher.java
@@ -1,0 +1,118 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.graphql.api.catalog.dataApi.resolver.dataFetcher.entity;
+
+import io.evitadb.api.requestResponse.data.PriceContract;
+import io.evitadb.api.requestResponse.data.PriceRangeForSale;
+import io.evitadb.api.requestResponse.data.PriceRangeForSaleWithAccompanyingPrices;
+import io.evitadb.api.requestResponse.data.PricesContract.AccompanyingPrice;
+import io.evitadb.api.requestResponse.data.PricesContract.PriceForSaleWithAccompanyingPrices;
+import io.evitadb.api.requestResponse.data.structure.EntityDecorator;
+import io.evitadb.externalApi.graphql.api.catalog.dataApi.dto.PrefetchedPriceForSale;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.OffsetDateTime;
+import java.util.Currency;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Fetches a single bound (lowest or highest) of the price-for-sale range for an entity. Two singleton instances
+ * back the flattened sibling fields `priceForSaleMin` and `priceForSaleMax` exposed on the GraphQL entity type.
+ *
+ * The bound is wrapped in a {@link PrefetchedPriceForSale} so that the existing
+ * {@link AccompanyingPriceDataFetcher} keeps serving `accompanyingPrice` selections unchanged. Argument
+ * resolution (currency, validIn, priceLists, locale, accompanying-price requests) is inherited from
+ * {@link AbstractPriceForSaleDataFetcher}.
+ *
+ * The underlying engine call computes the full {@link PriceRangeForSale}; the per-entity request-scoped cache on
+ * {@link io.evitadb.api.requestResponse.data.PriceForSaleContextWithCachedResult} ensures that fetching both
+ * `priceForSaleMin` and `priceForSaleMax` on the same entity runs the price-for-sale computation once.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public final class PriceForSaleBoundDataFetcher extends AbstractPriceForSaleDataFetcher<PriceContract> {
+
+	private static final PriceForSaleBoundDataFetcher MIN_INSTANCE = new PriceForSaleBoundDataFetcher(true);
+	private static final PriceForSaleBoundDataFetcher MAX_INSTANCE = new PriceForSaleBoundDataFetcher(false);
+
+	/**
+	 * `true` to expose the lowest bound, `false` for the highest.
+	 */
+	private final boolean lowest;
+
+	private PriceForSaleBoundDataFetcher(boolean lowest) {
+		this.lowest = lowest;
+	}
+
+	@Nonnull
+	public static PriceForSaleBoundDataFetcher getMinInstance() {
+		return MIN_INSTANCE;
+	}
+
+	@Nonnull
+	public static PriceForSaleBoundDataFetcher getMaxInstance() {
+		return MAX_INSTANCE;
+	}
+
+	@Nullable
+	@Override
+	protected PriceContract computeDefaultPrices(@Nonnull EntityDecorator entity) {
+		final Optional<PriceRangeForSale> range = entity.getPriceRangeForSaleIfAvailable();
+		if (range.isEmpty()) {
+			return null;
+		}
+		// reuse the engine-pre-resolved accompanying prices that were requested via `accompanyingPriceContent`
+		// in the require clause — they are cached on the price-for-sale context and shared across both bounds
+		final Map<String, Optional<PriceContract>> accompanyingPrices = entity
+			.getPriceForSaleWithAccompanyingPricesIfAvailable()
+			.map(PriceForSaleWithAccompanyingPrices::accompanyingPrices)
+			.orElse(Map.of());
+		return new PrefetchedPriceForSale(pickBound(range.get()), entity, accompanyingPrices);
+	}
+
+	@Nullable
+	@Override
+	protected PriceContract computePrices(@Nonnull EntityDecorator entity,
+	                                      @Nonnull String[] desiredPriceLists,
+	                                      @Nonnull Currency desiredCurrency,
+	                                      @Nullable OffsetDateTime desiredValidIn,
+	                                      @Nonnull AccompanyingPrice[] desiredAccompanyingPrices) {
+		final Optional<PriceRangeForSaleWithAccompanyingPrices> range = entity.getPriceRangeForSaleWithAccompanyingPrices(
+			desiredCurrency,
+			desiredValidIn,
+			desiredPriceLists,
+			desiredAccompanyingPrices
+		);
+		return range
+			.map(it -> new PrefetchedPriceForSale(pickBound(it.priceRange()), entity, it.accompanyingPrices()))
+			.orElse(null);
+	}
+
+	@Nonnull
+	private PriceContract pickBound(@Nonnull PriceRangeForSale range) {
+		return this.lowest ? range.lowestPrice() : range.highestPrice();
+	}
+}

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/dataFetcher/entity/PriceForSaleBoundDataFetcher.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/resolver/dataFetcher/entity/PriceForSaleBoundDataFetcher.java
@@ -51,6 +51,14 @@ import java.util.Optional;
  * {@link io.evitadb.api.requestResponse.data.PriceForSaleContextWithCachedResult} ensures that fetching both
  * `priceForSaleMin` and `priceForSaleMax` on the same entity runs the price-for-sale computation once.
  *
+ * Accompanying-price scope: when a client queries `priceForSaleMin { accompanyingPrice(...) }` or
+ * `priceForSaleMax { accompanyingPrice(...) }`, the accompanying prices returned are those resolved against
+ * the **selling** price's context (under `LOWEST_PRICE` strategy: the cheapest variant's inner record). They
+ * are **not** re-resolved per bound. This mirrors the engine's single-pass computation and matches the
+ * `accompanyingPrices` field on {@link PriceRangeForSaleWithAccompanyingPrices}. Clients needing
+ * accompanying prices for a specific variant should query that variant entity directly rather than reading
+ * them off a bound field.
+ *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 public final class PriceForSaleBoundDataFetcher extends AbstractPriceForSaleDataFetcher<PriceContract> {

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntity.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcEntity.java
@@ -148,7 +148,7 @@ public final class GrpcEntity {
       "air\022\025\n\rreferenceName\030\001 \001(\t\022\022\n\nprimaryKey" +
       "\030\002 \001(\005\022\"\n\032originalInternalPrimaryKey\030\003 \001" +
       "(\005\022$\n\034reassignedInternalPrimaryKey\030\004 \001(\005" +
-      "\"\205\021\n\020GrpcSealedEntity\022\022\n\nentityType\030\001 \001(" +
+      "\"\233\022\n\020GrpcSealedEntity\022\022\n\nentityType\030\001 \001(" +
       "\t\022\022\n\nprimaryKey\030\002 \001(\005\022\017\n\007version\030\003 \001(\005\022\025" +
       "\n\rschemaVersion\030\004 \001(\005\022+\n\006parent\030\005 \001(\0132\033." +
       "google.protobuf.Int32Value\022]\n\017parentRefe" +
@@ -184,60 +184,64 @@ public final class GrpcEntity {
       "nceOffsetAndLimitsEntry\022k\n\022accompanyingP" +
       "rices\030\023 \003(\0132O.io.evitadb.externalApi.grp" +
       "c.generated.GrpcSealedEntity.Accompanyin" +
-      "gPricesEntry\032n\n\025GlobalAttributesEntry\022\013\n" +
-      "\003key\030\001 \001(\t\022D\n\005value\030\002 \001(\01325.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcEvitaValue" +
-      ":\0028\001\032y\n\030LocalizedAttributesEntry\022\013\n\003key\030" +
-      "\001 \001(\t\022L\n\005value\030\002 \001(\0132=.io.evitadb.extern" +
-      "alApi.grpc.generated.GrpcLocalizedAttrib" +
-      "ute:\0028\001\032\200\001\n\031GlobalAssociatedDataEntry\022\013\n" +
-      "\003key\030\001 \001(\t\022R\n\005value\030\002 \001(\0132C.io.evitadb.e" +
-      "xternalApi.grpc.generated.GrpcEvitaAssoc" +
-      "iatedDataValue:\0028\001\032\202\001\n\034LocalizedAssociat" +
-      "edDataEntry\022\013\n\003key\030\001 \001(\t\022Q\n\005value\030\002 \001(\0132" +
-      "B.io.evitadb.externalApi.grpc.generated." +
-      "GrpcLocalizedAssociatedData:\0028\001\032z\n\035Refer" +
-      "enceOffsetAndLimitsEntry\022\013\n\003key\030\001 \001(\t\022H\n" +
-      "\005value\030\002 \001(\01329.io.evitadb.externalApi.gr" +
-      "pc.generated.GrpcOffsetAndLimit:\0028\001\032k\n\027A" +
-      "ccompanyingPricesEntry\022\013\n\003key\030\001 \001(\t\022?\n\005v" +
-      "alue\030\002 \001(\01320.io.evitadb.externalApi.grpc" +
-      ".generated.GrpcPrice:\0028\001\"\347\001\n\020GrpcBinaryE" +
-      "ntity\022\022\n\nentityType\030\001 \001(\t\022\022\n\nprimaryKey\030" +
-      "\002 \001(\005\022\025\n\rschemaVersion\030\003 \001(\005\022\031\n\021entitySt" +
-      "oragePart\030\004 \001(\014\022\035\n\025attributeStorageParts" +
-      "\030\005 \003(\014\022\"\n\032associatedDataStorageParts\030\006 \003" +
-      "(\014\022\030\n\020priceStoragePart\030\007 \001(\014\022\034\n\024referenc" +
-      "eStoragePart\030\010 \001(\014\"\356\007\n\rGrpcReference\022\025\n\r" +
-      "referenceName\030\001 \001(\t\022\017\n\007version\030\002 \001(\005\022]\n\031" +
-      "referencedEntityReference\030\003 \001(\0132:.io.evi" +
-      "tadb.externalApi.grpc.generated.GrpcEnti" +
-      "tyReference\022Q\n\020referencedEntity\030\004 \001(\01327." +
+      "gPricesEntry\022I\n\017priceForSaleMin\030\024 \001(\01320." +
       "io.evitadb.externalApi.grpc.generated.Gr" +
-      "pcSealedEntity\022d\n\036groupReferencedEntityR" +
-      "eference\030\005 \001(\0132:.io.evitadb.externalApi." +
-      "grpc.generated.GrpcEntityReferenceH\000\022X\n\025" +
-      "groupReferencedEntity\030\006 \001(\01327.io.evitadb" +
+      "pcPrice\022I\n\017priceForSaleMax\030\025 \001(\01320.io.ev" +
+      "itadb.externalApi.grpc.generated.GrpcPri" +
+      "ce\032n\n\025GlobalAttributesEntry\022\013\n\003key\030\001 \001(\t" +
+      "\022D\n\005value\030\002 \001(\01325.io.evitadb.externalApi" +
+      ".grpc.generated.GrpcEvitaValue:\0028\001\032y\n\030Lo" +
+      "calizedAttributesEntry\022\013\n\003key\030\001 \001(\t\022L\n\005v" +
+      "alue\030\002 \001(\0132=.io.evitadb.externalApi.grpc" +
+      ".generated.GrpcLocalizedAttribute:\0028\001\032\200\001" +
+      "\n\031GlobalAssociatedDataEntry\022\013\n\003key\030\001 \001(\t" +
+      "\022R\n\005value\030\002 \001(\0132C.io.evitadb.externalApi" +
+      ".grpc.generated.GrpcEvitaAssociatedDataV" +
+      "alue:\0028\001\032\202\001\n\034LocalizedAssociatedDataEntr" +
+      "y\022\013\n\003key\030\001 \001(\t\022Q\n\005value\030\002 \001(\0132B.io.evita" +
+      "db.externalApi.grpc.generated.GrpcLocali" +
+      "zedAssociatedData:\0028\001\032z\n\035ReferenceOffset" +
+      "AndLimitsEntry\022\013\n\003key\030\001 \001(\t\022H\n\005value\030\002 \001" +
+      "(\01329.io.evitadb.externalApi.grpc.generat" +
+      "ed.GrpcOffsetAndLimit:\0028\001\032k\n\027Accompanyin" +
+      "gPricesEntry\022\013\n\003key\030\001 \001(\t\022?\n\005value\030\002 \001(\013" +
+      "20.io.evitadb.externalApi.grpc.generated" +
+      ".GrpcPrice:\0028\001\"\347\001\n\020GrpcBinaryEntity\022\022\n\ne" +
+      "ntityType\030\001 \001(\t\022\022\n\nprimaryKey\030\002 \001(\005\022\025\n\rs" +
+      "chemaVersion\030\003 \001(\005\022\031\n\021entityStoragePart\030" +
+      "\004 \001(\014\022\035\n\025attributeStorageParts\030\005 \003(\014\022\"\n\032" +
+      "associatedDataStorageParts\030\006 \003(\014\022\030\n\020pric" +
+      "eStoragePart\030\007 \001(\014\022\034\n\024referenceStoragePa" +
+      "rt\030\010 \001(\014\"\356\007\n\rGrpcReference\022\025\n\rreferenceN" +
+      "ame\030\001 \001(\t\022\017\n\007version\030\002 \001(\005\022]\n\031referenced" +
+      "EntityReference\030\003 \001(\0132:.io.evitadb.exter" +
+      "nalApi.grpc.generated.GrpcEntityReferenc" +
+      "e\022Q\n\020referencedEntity\030\004 \001(\01327.io.evitadb" +
       ".externalApi.grpc.generated.GrpcSealedEn" +
-      "tityH\000\022d\n\020globalAttributes\030\007 \003(\0132J.io.ev" +
-      "itadb.externalApi.grpc.generated.GrpcRef" +
-      "erence.GlobalAttributesEntry\022j\n\023localize" +
-      "dAttributes\030\010 \003(\0132M.io.evitadb.externalA" +
-      "pi.grpc.generated.GrpcReference.Localize" +
-      "dAttributesEntry\022T\n\024referenceCardinality" +
-      "\030\t \001(\01626.io.evitadb.externalApi.grpc.gen" +
-      "erated.GrpcCardinality\022\032\n\022internalPrimar" +
-      "yKey\030\n \001(\005\032n\n\025GlobalAttributesEntry\022\013\n\003k" +
-      "ey\030\001 \001(\t\022D\n\005value\030\002 \001(\01325.io.evitadb.ext" +
-      "ernalApi.grpc.generated.GrpcEvitaValue:\002" +
-      "8\001\032y\n\030LocalizedAttributesEntry\022\013\n\003key\030\001 " +
-      "\001(\t\022L\n\005value\030\002 \001(\0132=.io.evitadb.external" +
-      "Api.grpc.generated.GrpcLocalizedAttribut" +
-      "e:\0028\001B\024\n\022groupReferenceType\"y\n\022GrpcOffse" +
-      "tAndLimit\022\016\n\006offset\030\001 \001(\005\022\r\n\005limit\030\002 \001(\005" +
-      "\022\022\n\npageNumber\030\003 \001(\005\022\026\n\016lastPageNumber\030\004" +
-      " \001(\005\022\030\n\020totalRecordCount\030\005 \001(\005B\014P\001\252\002\007Evi" +
-      "taDBb\006proto3"
+      "tity\022d\n\036groupReferencedEntityReference\030\005" +
+      " \001(\0132:.io.evitadb.externalApi.grpc.gener" +
+      "ated.GrpcEntityReferenceH\000\022X\n\025groupRefer" +
+      "encedEntity\030\006 \001(\01327.io.evitadb.externalA" +
+      "pi.grpc.generated.GrpcSealedEntityH\000\022d\n\020" +
+      "globalAttributes\030\007 \003(\0132J.io.evitadb.exte" +
+      "rnalApi.grpc.generated.GrpcReference.Glo" +
+      "balAttributesEntry\022j\n\023localizedAttribute" +
+      "s\030\010 \003(\0132M.io.evitadb.externalApi.grpc.ge" +
+      "nerated.GrpcReference.LocalizedAttribute" +
+      "sEntry\022T\n\024referenceCardinality\030\t \001(\01626.i" +
+      "o.evitadb.externalApi.grpc.generated.Grp" +
+      "cCardinality\022\032\n\022internalPrimaryKey\030\n \001(\005" +
+      "\032n\n\025GlobalAttributesEntry\022\013\n\003key\030\001 \001(\t\022D" +
+      "\n\005value\030\002 \001(\01325.io.evitadb.externalApi.g" +
+      "rpc.generated.GrpcEvitaValue:\0028\001\032y\n\030Loca" +
+      "lizedAttributesEntry\022\013\n\003key\030\001 \001(\t\022L\n\005val" +
+      "ue\030\002 \001(\0132=.io.evitadb.externalApi.grpc.g" +
+      "enerated.GrpcLocalizedAttribute:\0028\001B\024\n\022g" +
+      "roupReferenceType\"y\n\022GrpcOffsetAndLimit\022" +
+      "\016\n\006offset\030\001 \001(\005\022\r\n\005limit\030\002 \001(\005\022\022\n\npageNu" +
+      "mber\030\003 \001(\005\022\026\n\016lastPageNumber\030\004 \001(\005\022\030\n\020to" +
+      "talRecordCount\030\005 \001(\005B\014P\001\252\002\007EvitaDBb\006prot" +
+      "o3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -278,7 +282,7 @@ public final class GrpcEntity {
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcSealedEntity_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcSealedEntity_descriptor,
-        new java.lang.String[] { "EntityType", "PrimaryKey", "Version", "SchemaVersion", "Parent", "ParentReference", "ParentEntity", "GlobalAttributes", "LocalizedAttributes", "Prices", "PriceForSale", "PriceInnerRecordHandling", "References", "GlobalAssociatedData", "LocalizedAssociatedData", "Locales", "Scope", "ReferenceOffsetAndLimits", "AccompanyingPrices", });
+        new java.lang.String[] { "EntityType", "PrimaryKey", "Version", "SchemaVersion", "Parent", "ParentReference", "ParentEntity", "GlobalAttributes", "LocalizedAttributes", "Prices", "PriceForSale", "PriceInnerRecordHandling", "References", "GlobalAssociatedData", "LocalizedAssociatedData", "Locales", "Scope", "ReferenceOffsetAndLimits", "AccompanyingPrices", "PriceForSaleMin", "PriceForSaleMax", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcSealedEntity_GlobalAttributesEntry_descriptor =
       internal_static_io_evitadb_externalApi_grpc_generated_GrpcSealedEntity_descriptor.getNestedTypes().get(0);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcSealedEntity_GlobalAttributesEntry_fieldAccessorTable = new

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSealedEntity.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSealedEntity.java
@@ -1173,6 +1173,112 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue) {
     return map.get(key);
   }
 
+  public static final int PRICEFORSALEMIN_FIELD_NUMBER = 20;
+  private io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin_;
+  /**
+   * <pre>
+   * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+   * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+   * @return Whether the priceForSaleMin field is set.
+   */
+  @java.lang.Override
+  public boolean hasPriceForSaleMin() {
+    return ((bitField0_ & 0x00000010) != 0);
+  }
+  /**
+   * <pre>
+   * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+   * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+   * @return The priceForSaleMin.
+   */
+  @java.lang.Override
+  public io.evitadb.externalApi.grpc.generated.GrpcPrice getPriceForSaleMin() {
+    return priceForSaleMin_ == null ? io.evitadb.externalApi.grpc.generated.GrpcPrice.getDefaultInstance() : priceForSaleMin_;
+  }
+  /**
+   * <pre>
+   * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+   * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+   */
+  @java.lang.Override
+  public io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder getPriceForSaleMinOrBuilder() {
+    return priceForSaleMin_ == null ? io.evitadb.externalApi.grpc.generated.GrpcPrice.getDefaultInstance() : priceForSaleMin_;
+  }
+
+  public static final int PRICEFORSALEMAX_FIELD_NUMBER = 21;
+  private io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax_;
+  /**
+   * <pre>
+   * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+   * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+   * @return Whether the priceForSaleMax field is set.
+   */
+  @java.lang.Override
+  public boolean hasPriceForSaleMax() {
+    return ((bitField0_ & 0x00000020) != 0);
+  }
+  /**
+   * <pre>
+   * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+   * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+   * @return The priceForSaleMax.
+   */
+  @java.lang.Override
+  public io.evitadb.externalApi.grpc.generated.GrpcPrice getPriceForSaleMax() {
+    return priceForSaleMax_ == null ? io.evitadb.externalApi.grpc.generated.GrpcPrice.getDefaultInstance() : priceForSaleMax_;
+  }
+  /**
+   * <pre>
+   * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+   * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+   */
+  @java.lang.Override
+  public io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder getPriceForSaleMaxOrBuilder() {
+    return priceForSaleMax_ == null ? io.evitadb.externalApi.grpc.generated.GrpcPrice.getDefaultInstance() : priceForSaleMax_;
+  }
+
   private byte memoizedIsInitialized = -1;
   @java.lang.Override
   public final boolean isInitialized() {
@@ -1262,6 +1368,12 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue) {
         internalGetAccompanyingPrices(),
         AccompanyingPricesDefaultEntryHolder.defaultEntry,
         19);
+    if (((bitField0_ & 0x00000010) != 0)) {
+      output.writeMessage(20, getPriceForSaleMin());
+    }
+    if (((bitField0_ & 0x00000020) != 0)) {
+      output.writeMessage(21, getPriceForSaleMax());
+    }
     getUnknownFields().writeTo(output);
   }
 
@@ -1382,6 +1494,14 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue) {
       size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(19, accompanyingPrices__);
     }
+    if (((bitField0_ & 0x00000010) != 0)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeMessageSize(20, getPriceForSaleMin());
+    }
+    if (((bitField0_ & 0x00000020) != 0)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeMessageSize(21, getPriceForSaleMax());
+    }
     size += getUnknownFields().getSerializedSize();
     memoizedSize = size;
     return size;
@@ -1445,6 +1565,16 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue) {
         other.internalGetReferenceOffsetAndLimits())) return false;
     if (!internalGetAccompanyingPrices().equals(
         other.internalGetAccompanyingPrices())) return false;
+    if (hasPriceForSaleMin() != other.hasPriceForSaleMin()) return false;
+    if (hasPriceForSaleMin()) {
+      if (!getPriceForSaleMin()
+          .equals(other.getPriceForSaleMin())) return false;
+    }
+    if (hasPriceForSaleMax() != other.hasPriceForSaleMax()) return false;
+    if (hasPriceForSaleMax()) {
+      if (!getPriceForSaleMax()
+          .equals(other.getPriceForSaleMax())) return false;
+    }
     if (!getUnknownFields().equals(other.getUnknownFields())) return false;
     return true;
   }
@@ -1519,6 +1649,14 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue) {
     if (!internalGetAccompanyingPrices().getMap().isEmpty()) {
       hash = (37 * hash) + ACCOMPANYINGPRICES_FIELD_NUMBER;
       hash = (53 * hash) + internalGetAccompanyingPrices().hashCode();
+    }
+    if (hasPriceForSaleMin()) {
+      hash = (37 * hash) + PRICEFORSALEMIN_FIELD_NUMBER;
+      hash = (53 * hash) + getPriceForSaleMin().hashCode();
+    }
+    if (hasPriceForSaleMax()) {
+      hash = (37 * hash) + PRICEFORSALEMAX_FIELD_NUMBER;
+      hash = (53 * hash) + getPriceForSaleMax().hashCode();
     }
     hash = (29 * hash) + getUnknownFields().hashCode();
     memoizedHashCode = hash;
@@ -1705,6 +1843,8 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue) {
         getPriceForSaleFieldBuilder();
         getReferencesFieldBuilder();
         getLocalesFieldBuilder();
+        getPriceForSaleMinFieldBuilder();
+        getPriceForSaleMaxFieldBuilder();
       }
     }
     @java.lang.Override
@@ -1764,6 +1904,16 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue) {
       scope_ = 0;
       internalGetMutableReferenceOffsetAndLimits().clear();
       internalGetMutableAccompanyingPrices().clear();
+      priceForSaleMin_ = null;
+      if (priceForSaleMinBuilder_ != null) {
+        priceForSaleMinBuilder_.dispose();
+        priceForSaleMinBuilder_ = null;
+      }
+      priceForSaleMax_ = null;
+      if (priceForSaleMaxBuilder_ != null) {
+        priceForSaleMaxBuilder_.dispose();
+        priceForSaleMaxBuilder_ = null;
+      }
       return this;
     }
 
@@ -1888,6 +2038,18 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue) {
       }
       if (((from_bitField0_ & 0x00040000) != 0)) {
         result.accompanyingPrices_ = internalGetAccompanyingPrices().build(AccompanyingPricesDefaultEntryHolder.defaultEntry);
+      }
+      if (((from_bitField0_ & 0x00080000) != 0)) {
+        result.priceForSaleMin_ = priceForSaleMinBuilder_ == null
+            ? priceForSaleMin_
+            : priceForSaleMinBuilder_.build();
+        to_bitField0_ |= 0x00000010;
+      }
+      if (((from_bitField0_ & 0x00100000) != 0)) {
+        result.priceForSaleMax_ = priceForSaleMaxBuilder_ == null
+            ? priceForSaleMax_
+            : priceForSaleMaxBuilder_.build();
+        to_bitField0_ |= 0x00000020;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -2064,6 +2226,12 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue) {
       internalGetMutableAccompanyingPrices().mergeFrom(
           other.internalGetAccompanyingPrices());
       bitField0_ |= 0x00040000;
+      if (other.hasPriceForSaleMin()) {
+        mergePriceForSaleMin(other.getPriceForSaleMin());
+      }
+      if (other.hasPriceForSaleMax()) {
+        mergePriceForSaleMax(other.getPriceForSaleMax());
+      }
       this.mergeUnknownFields(other.getUnknownFields());
       onChanged();
       return this;
@@ -2241,6 +2409,20 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue) {
               bitField0_ |= 0x00040000;
               break;
             } // case 154
+            case 162: {
+              input.readMessage(
+                  getPriceForSaleMinFieldBuilder().getBuilder(),
+                  extensionRegistry);
+              bitField0_ |= 0x00080000;
+              break;
+            } // case 162
+            case 170: {
+              input.readMessage(
+                  getPriceForSaleMaxFieldBuilder().getBuilder(),
+                  extensionRegistry);
+              bitField0_ |= 0x00100000;
+              break;
+            } // case 170
             default: {
               if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                 done = true; // was an endgroup tag
@@ -5393,6 +5575,410 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue) {
         builderMap.put(key, entry);
       }
       return (io.evitadb.externalApi.grpc.generated.GrpcPrice.Builder) entry;
+    }
+
+    private io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin_;
+    private com.google.protobuf.SingleFieldBuilderV3<
+        io.evitadb.externalApi.grpc.generated.GrpcPrice, io.evitadb.externalApi.grpc.generated.GrpcPrice.Builder, io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder> priceForSaleMinBuilder_;
+    /**
+     * <pre>
+     * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+     * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+     * @return Whether the priceForSaleMin field is set.
+     */
+    public boolean hasPriceForSaleMin() {
+      return ((bitField0_ & 0x00080000) != 0);
+    }
+    /**
+     * <pre>
+     * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+     * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+     * @return The priceForSaleMin.
+     */
+    public io.evitadb.externalApi.grpc.generated.GrpcPrice getPriceForSaleMin() {
+      if (priceForSaleMinBuilder_ == null) {
+        return priceForSaleMin_ == null ? io.evitadb.externalApi.grpc.generated.GrpcPrice.getDefaultInstance() : priceForSaleMin_;
+      } else {
+        return priceForSaleMinBuilder_.getMessage();
+      }
+    }
+    /**
+     * <pre>
+     * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+     * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+     */
+    public Builder setPriceForSaleMin(io.evitadb.externalApi.grpc.generated.GrpcPrice value) {
+      if (priceForSaleMinBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        priceForSaleMin_ = value;
+      } else {
+        priceForSaleMinBuilder_.setMessage(value);
+      }
+      bitField0_ |= 0x00080000;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+     * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+     */
+    public Builder setPriceForSaleMin(
+        io.evitadb.externalApi.grpc.generated.GrpcPrice.Builder builderForValue) {
+      if (priceForSaleMinBuilder_ == null) {
+        priceForSaleMin_ = builderForValue.build();
+      } else {
+        priceForSaleMinBuilder_.setMessage(builderForValue.build());
+      }
+      bitField0_ |= 0x00080000;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+     * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+     */
+    public Builder mergePriceForSaleMin(io.evitadb.externalApi.grpc.generated.GrpcPrice value) {
+      if (priceForSaleMinBuilder_ == null) {
+        if (((bitField0_ & 0x00080000) != 0) &&
+          priceForSaleMin_ != null &&
+          priceForSaleMin_ != io.evitadb.externalApi.grpc.generated.GrpcPrice.getDefaultInstance()) {
+          getPriceForSaleMinBuilder().mergeFrom(value);
+        } else {
+          priceForSaleMin_ = value;
+        }
+      } else {
+        priceForSaleMinBuilder_.mergeFrom(value);
+      }
+      if (priceForSaleMin_ != null) {
+        bitField0_ |= 0x00080000;
+        onChanged();
+      }
+      return this;
+    }
+    /**
+     * <pre>
+     * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+     * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+     */
+    public Builder clearPriceForSaleMin() {
+      bitField0_ = (bitField0_ & ~0x00080000);
+      priceForSaleMin_ = null;
+      if (priceForSaleMinBuilder_ != null) {
+        priceForSaleMinBuilder_.dispose();
+        priceForSaleMinBuilder_ = null;
+      }
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+     * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+     */
+    public io.evitadb.externalApi.grpc.generated.GrpcPrice.Builder getPriceForSaleMinBuilder() {
+      bitField0_ |= 0x00080000;
+      onChanged();
+      return getPriceForSaleMinFieldBuilder().getBuilder();
+    }
+    /**
+     * <pre>
+     * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+     * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+     */
+    public io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder getPriceForSaleMinOrBuilder() {
+      if (priceForSaleMinBuilder_ != null) {
+        return priceForSaleMinBuilder_.getMessageOrBuilder();
+      } else {
+        return priceForSaleMin_ == null ?
+            io.evitadb.externalApi.grpc.generated.GrpcPrice.getDefaultInstance() : priceForSaleMin_;
+      }
+    }
+    /**
+     * <pre>
+     * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+     * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+     */
+    private com.google.protobuf.SingleFieldBuilderV3<
+        io.evitadb.externalApi.grpc.generated.GrpcPrice, io.evitadb.externalApi.grpc.generated.GrpcPrice.Builder, io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder> 
+        getPriceForSaleMinFieldBuilder() {
+      if (priceForSaleMinBuilder_ == null) {
+        priceForSaleMinBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+            io.evitadb.externalApi.grpc.generated.GrpcPrice, io.evitadb.externalApi.grpc.generated.GrpcPrice.Builder, io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder>(
+                getPriceForSaleMin(),
+                getParentForChildren(),
+                isClean());
+        priceForSaleMin_ = null;
+      }
+      return priceForSaleMinBuilder_;
+    }
+
+    private io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax_;
+    private com.google.protobuf.SingleFieldBuilderV3<
+        io.evitadb.externalApi.grpc.generated.GrpcPrice, io.evitadb.externalApi.grpc.generated.GrpcPrice.Builder, io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder> priceForSaleMaxBuilder_;
+    /**
+     * <pre>
+     * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+     * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+     * @return Whether the priceForSaleMax field is set.
+     */
+    public boolean hasPriceForSaleMax() {
+      return ((bitField0_ & 0x00100000) != 0);
+    }
+    /**
+     * <pre>
+     * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+     * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+     * @return The priceForSaleMax.
+     */
+    public io.evitadb.externalApi.grpc.generated.GrpcPrice getPriceForSaleMax() {
+      if (priceForSaleMaxBuilder_ == null) {
+        return priceForSaleMax_ == null ? io.evitadb.externalApi.grpc.generated.GrpcPrice.getDefaultInstance() : priceForSaleMax_;
+      } else {
+        return priceForSaleMaxBuilder_.getMessage();
+      }
+    }
+    /**
+     * <pre>
+     * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+     * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+     */
+    public Builder setPriceForSaleMax(io.evitadb.externalApi.grpc.generated.GrpcPrice value) {
+      if (priceForSaleMaxBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        priceForSaleMax_ = value;
+      } else {
+        priceForSaleMaxBuilder_.setMessage(value);
+      }
+      bitField0_ |= 0x00100000;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+     * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+     */
+    public Builder setPriceForSaleMax(
+        io.evitadb.externalApi.grpc.generated.GrpcPrice.Builder builderForValue) {
+      if (priceForSaleMaxBuilder_ == null) {
+        priceForSaleMax_ = builderForValue.build();
+      } else {
+        priceForSaleMaxBuilder_.setMessage(builderForValue.build());
+      }
+      bitField0_ |= 0x00100000;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+     * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+     */
+    public Builder mergePriceForSaleMax(io.evitadb.externalApi.grpc.generated.GrpcPrice value) {
+      if (priceForSaleMaxBuilder_ == null) {
+        if (((bitField0_ & 0x00100000) != 0) &&
+          priceForSaleMax_ != null &&
+          priceForSaleMax_ != io.evitadb.externalApi.grpc.generated.GrpcPrice.getDefaultInstance()) {
+          getPriceForSaleMaxBuilder().mergeFrom(value);
+        } else {
+          priceForSaleMax_ = value;
+        }
+      } else {
+        priceForSaleMaxBuilder_.mergeFrom(value);
+      }
+      if (priceForSaleMax_ != null) {
+        bitField0_ |= 0x00100000;
+        onChanged();
+      }
+      return this;
+    }
+    /**
+     * <pre>
+     * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+     * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+     */
+    public Builder clearPriceForSaleMax() {
+      bitField0_ = (bitField0_ & ~0x00100000);
+      priceForSaleMax_ = null;
+      if (priceForSaleMaxBuilder_ != null) {
+        priceForSaleMaxBuilder_.dispose();
+        priceForSaleMaxBuilder_ = null;
+      }
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+     * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+     */
+    public io.evitadb.externalApi.grpc.generated.GrpcPrice.Builder getPriceForSaleMaxBuilder() {
+      bitField0_ |= 0x00100000;
+      onChanged();
+      return getPriceForSaleMaxFieldBuilder().getBuilder();
+    }
+    /**
+     * <pre>
+     * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+     * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+     */
+    public io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder getPriceForSaleMaxOrBuilder() {
+      if (priceForSaleMaxBuilder_ != null) {
+        return priceForSaleMaxBuilder_.getMessageOrBuilder();
+      } else {
+        return priceForSaleMax_ == null ?
+            io.evitadb.externalApi.grpc.generated.GrpcPrice.getDefaultInstance() : priceForSaleMax_;
+      }
+    }
+    /**
+     * <pre>
+     * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+     * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+     * The exact semantics depend on the price inner record handling strategy:
+     * - `NONE`: equal to `priceForSale`.
+     * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+     * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+     */
+    private com.google.protobuf.SingleFieldBuilderV3<
+        io.evitadb.externalApi.grpc.generated.GrpcPrice, io.evitadb.externalApi.grpc.generated.GrpcPrice.Builder, io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder> 
+        getPriceForSaleMaxFieldBuilder() {
+      if (priceForSaleMaxBuilder_ == null) {
+        priceForSaleMaxBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+            io.evitadb.externalApi.grpc.generated.GrpcPrice, io.evitadb.externalApi.grpc.generated.GrpcPrice.Builder, io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder>(
+                getPriceForSaleMax(),
+                getParentForChildren(),
+                isClean());
+        priceForSaleMax_ = null;
+      }
+      return priceForSaleMaxBuilder_;
     }
     @java.lang.Override
     public final Builder setUnknownFields(

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSealedEntityOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcSealedEntityOrBuilder.java
@@ -710,4 +710,88 @@ io.evitadb.externalApi.grpc.generated.GrpcPrice defaultValue);
    */
   io.evitadb.externalApi.grpc.generated.GrpcPrice getAccompanyingPricesOrThrow(
       java.lang.String key);
+
+  /**
+   * <pre>
+   * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+   * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+   * @return Whether the priceForSaleMin field is set.
+   */
+  boolean hasPriceForSaleMin();
+  /**
+   * <pre>
+   * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+   * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+   * @return The priceForSaleMin.
+   */
+  io.evitadb.externalApi.grpc.generated.GrpcPrice getPriceForSaleMin();
+  /**
+   * <pre>
+   * Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+   * - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMin = 20;</code>
+   */
+  io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder getPriceForSaleMinOrBuilder();
+
+  /**
+   * <pre>
+   * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+   * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+   * @return Whether the priceForSaleMax field is set.
+   */
+  boolean hasPriceForSaleMax();
+  /**
+   * <pre>
+   * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+   * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+   * @return The priceForSaleMax.
+   */
+  io.evitadb.externalApi.grpc.generated.GrpcPrice getPriceForSaleMax();
+  /**
+   * <pre>
+   * Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+   * price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+   * The exact semantics depend on the price inner record handling strategy:
+   * - `NONE`: equal to `priceForSale`.
+   * - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+   * - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcPrice priceForSaleMax = 21;</code>
+   */
+  io.evitadb.externalApi.grpc.generated.GrpcPriceOrBuilder getPriceForSaleMaxOrBuilder();
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/data/EntityConverter.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/data/EntityConverter.java
@@ -43,6 +43,7 @@ import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
 import io.evitadb.api.requestResponse.data.DevelopmentConstants;
 import io.evitadb.api.requestResponse.data.EntityClassifierWithParent;
 import io.evitadb.api.requestResponse.data.PriceContract;
+import io.evitadb.api.requestResponse.data.PriceRangeForSale;
 import io.evitadb.api.requestResponse.data.PricesContract.AccompanyingPrice;
 import io.evitadb.api.requestResponse.data.PricesContract.PriceForSaleWithAccompanyingPrices;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
@@ -407,6 +408,13 @@ public class EntityConverter {
 						);
 					}
 				}
+				// emit price-range bounds whenever the selling price was emitted; the bounds use the same
+				// currency / valid-in / price-list filters as the selling price (see PriceRangeForSale)
+				final Optional<PriceRangeForSale> priceRange = entity.getPriceRangeForSaleIfAvailable();
+				priceRange.ifPresent(range -> {
+					entityBuilder.setPriceForSaleMin(toGrpcPrice(range.lowestPrice()));
+					entityBuilder.setPriceForSaleMax(toGrpcPrice(range.highestPrice()));
+				});
 			});
 		}
 

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEntity.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcEntity.proto
@@ -143,6 +143,20 @@ message GrpcSealedEntity {
   map<string, GrpcOffsetAndLimit> referenceOffsetAndLimits = 18;
   // Contains prices that has been requested to be calculated beside the main price for sale.
   map<string, GrpcPrice> accompanyingPrices = 19;
+  // Lowest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+  // price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+  // The exact semantics depend on the price inner record handling strategy:
+  // - `NONE`: equal to `priceForSale`.
+  // - `LOWEST_PRICE`: equal to `priceForSale` (the cheapest per-inner-record selling price).
+  // - `SUM`: cheapest per-inner-record component price (`priceForSale` is the cumulated sum).
+  GrpcPrice priceForSaleMin = 20;
+  // Highest selling price (or component price for `SUM` strategy) computed with the same currency / valid-in /
+  // price-list filters as `priceForSale`. Populated when the price-range-for-sale is available on the entity.
+  // The exact semantics depend on the price inner record handling strategy:
+  // - `NONE`: equal to `priceForSale`.
+  // - `LOWEST_PRICE`: most expensive per-inner-record selling price.
+  // - `SUM`: most expensive per-inner-record component price (`priceForSale` is the cumulated sum).
+  GrpcPrice priceForSaleMax = 21;
 }
 
 // Response carries entities in a binary format and is part of the PRIVATE API that is used by Java driver. The client

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/builder/EntityObjectBuilder.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/builder/EntityObjectBuilder.java
@@ -136,6 +136,8 @@ public class EntityObjectBuilder {
 		if (!entitySchema.getCurrencies().isEmpty()) {
 			entityObject.property(EntityDescriptor.PRICE_INNER_RECORD_HANDLING.to(this.propertyBuilderTransformer));
 			entityObject.property(EntityDescriptor.PRICE_FOR_SALE.to(this.propertyBuilderTransformer));
+			entityObject.property(EntityDescriptor.PRICE_FOR_SALE_MIN.to(this.propertyBuilderTransformer));
+			entityObject.property(EntityDescriptor.PRICE_FOR_SALE_MAX.to(this.propertyBuilderTransformer));
 			entityObject.property(buildEntityAccompanyingPricesProperty());
 			entityObject.property(EntityDescriptor.MULTIPLE_PRICES_FOR_SALE_AVAILABLE.to(this.propertyBuilderTransformer));
 			entityObject.property(EntityDescriptor.PRICES.to(this.propertyBuilderTransformer));

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/resolver/serializer/EntityJsonSerializer.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/resolver/serializer/EntityJsonSerializer.java
@@ -355,6 +355,17 @@ public class EntityJsonSerializer {
 			entity.getPriceForSaleWithAccompanyingPricesIfAvailable().ifPresent(it -> {
 				rootNode.putIfAbsent(EntityDescriptor.PRICE_FOR_SALE.name(), this.objectJsonSerializer.serializeObject(it.priceForSale()));
 
+				entity.getPriceRangeForSaleIfAvailable().ifPresent(range -> {
+					rootNode.putIfAbsent(
+						EntityDescriptor.PRICE_FOR_SALE_MIN.name(),
+						this.objectJsonSerializer.serializeObject(range.lowestPrice())
+					);
+					rootNode.putIfAbsent(
+						EntityDescriptor.PRICE_FOR_SALE_MAX.name(),
+						this.objectJsonSerializer.serializeObject(range.highestPrice())
+					);
+				});
+
 				final Map<String, Optional<PriceContract>> accompanyingPrices = it.accompanyingPrices();
 				if (!accompanyingPrices.isEmpty()) {
 					final ObjectNode accompanyingPricesNode = this.objectJsonSerializer.objectNode();

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/resolver/serializer/EntityJsonSerializer.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/resolver/serializer/EntityJsonSerializer.java
@@ -355,6 +355,12 @@ public class EntityJsonSerializer {
 			entity.getPriceForSaleWithAccompanyingPricesIfAvailable().ifPresent(it -> {
 				rootNode.putIfAbsent(EntityDescriptor.PRICE_FOR_SALE.name(), this.objectJsonSerializer.serializeObject(it.priceForSale()));
 
+				// Range fields are emitted unconditionally — even under NONE inner-record handling, where
+				// `lowestPrice == highestPrice == priceForSale` and the three values are necessarily identical.
+				// The redundancy is intentional: REST clients receive a stable schema that does not depend on
+				// the entity's strategy, so generated client code can dereference the bounds without nullness or
+				// strategy checks. (Contrast with GraphQL, where the bound fields are opt-in via the selection
+				// set and clients explicitly request them.)
 				entity.getPriceRangeForSaleIfAvailable().ifPresent(range -> {
 					rootNode.putIfAbsent(
 						EntityDescriptor.PRICE_FOR_SALE_MIN.name(),

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResultTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResultTest.java
@@ -31,6 +31,7 @@ import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -39,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Currency;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.evitadb.test.TestTags.CONTRACT;
@@ -87,6 +89,8 @@ class PriceForSaleContextWithCachedResultTest extends AbstractBuilderTest {
 		final PriceForSaleContextWithCachedResult cache = new PriceForSaleContextWithCachedResult(
 			PRICE_LIST_PRIORITY, CZK, null, null
 		);
+		// pre-compute outside the MockedStatic context so the call is not recorded as a matcher invocation
+		final Map<String, Integer> expectedPriorityIndex = PricesContract.getPriceListPriorityIndex(PRICE_LIST_PRIORITY);
 
 		try (MockedStatic<PricesContract> mocked = Mockito.mockStatic(PricesContract.class, Mockito.CALLS_REAL_METHODS)) {
 			// touch every entry point — none should trigger a second underlying pass
@@ -101,12 +105,12 @@ class PriceForSaleContextWithCachedResultTest extends AbstractBuilderTest {
 
 			mocked.verify(
 				() -> PricesContract.computePriceForSaleResult(
-					Mockito.eq(SAMPLE_PRICES),
-					Mockito.eq(PriceInnerRecordHandling.LOWEST_PRICE),
-					Mockito.eq(CZK),
-					Mockito.isNull(),
-					Mockito.eq(PRICE_LIST_PRIORITY),
-					Mockito.any()
+					ArgumentMatchers.eq(SAMPLE_PRICES),
+					ArgumentMatchers.eq(PriceInnerRecordHandling.LOWEST_PRICE),
+					ArgumentMatchers.eq(CZK),
+					ArgumentMatchers.isNull(),
+					ArgumentMatchers.eq(expectedPriorityIndex),
+					ArgumentMatchers.any()
 				),
 				Mockito.times(1)
 			);
@@ -171,7 +175,7 @@ class PriceForSaleContextWithCachedResultTest extends AbstractBuilderTest {
 			new PriceForSaleWithAccompanyingPrices(seedPrice, Collections.emptyMap());
 
 		final PriceForSaleContextWithCachedResult cache = new PriceForSaleContextWithCachedResult(
-			PRICE_LIST_PRIORITY, CZK, null, new AccompanyingPrice[0], seed
+			PRICE_LIST_PRIORITY, CZK, null, AccompanyingPrice.EMPTY_ARRAY, seed
 		);
 
 		// range query fills `cachedComputation` from SAMPLE_PRICES — entirely separate from the seed

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResultTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/PriceForSaleContextWithCachedResultTest.java
@@ -1,0 +1,194 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.data;
+
+import io.evitadb.api.requestResponse.data.PricesContract.AccompanyingPrice;
+import io.evitadb.api.requestResponse.data.PricesContract.PriceForSaleWithAccompanyingPrices;
+import io.evitadb.api.requestResponse.data.structure.AbstractBuilderTest;
+import io.evitadb.api.requestResponse.data.structure.Price;
+import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Currency;
+import java.util.List;
+import java.util.Optional;
+
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.PRICE;
+import static io.evitadb.test.TestTags.QUERY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the cache contract of {@link PriceForSaleContextWithCachedResult}: the underlying
+ * {@link PricesContract#computePriceForSaleResult} pass — which is the expensive part of resolving a
+ * selling price — runs at most once across mixed selling-price / range / accompanying-price calls. This
+ * is the contract promised by issue #1086 ("the range costs ~the same as the selling price").
+ *
+ * Most checks rely on {@code assertSame} reference equality between successive call results — the
+ * underlying computation allocates fresh `PriceContract` instances per call, so getting the same
+ * reference back is direct evidence of cache reuse. One belt-and-suspenders test uses
+ * {@link MockedStatic} with {@link Mockito#CALLS_REAL_METHODS} as a spy / counter on the static entry
+ * point, to guard against future regressions where the impl may begin returning equal-but-distinct
+ * instances and the assertSame coupling would silently break.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("PriceForSaleContextWithCachedResult")
+@Tag(CONTRACT)
+@Tag(QUERY)
+@Tag(PRICE)
+class PriceForSaleContextWithCachedResultTest extends AbstractBuilderTest {
+	private static final Currency CZK = Currency.getInstance("CZK");
+	private static final String BASIC = "basic";
+	private static final String[] PRICE_LIST_PRIORITY = {BASIC};
+
+	private static final List<PriceContract> SAMPLE_PRICES = Arrays.asList(
+		new Price(new PriceKey(1, BASIC, CZK), 1,
+			new BigDecimal("100"), new BigDecimal("21"), new BigDecimal("121"), null, true),
+		new Price(new PriceKey(2, BASIC, CZK), 2,
+			new BigDecimal("200"), new BigDecimal("21"), new BigDecimal("242"), null, true),
+		new Price(new PriceKey(3, BASIC, CZK), 3,
+			new BigDecimal("300"), new BigDecimal("21"), new BigDecimal("363"), null, true)
+	);
+
+	@Test
+	@DisplayName("PricesContract#computePriceForSaleResult runs exactly once across all four entry points")
+	void shouldRunUnderlyingComputationExactlyOnceAcrossAllEntryPoints() {
+		final PriceForSaleContextWithCachedResult cache = new PriceForSaleContextWithCachedResult(
+			PRICE_LIST_PRIORITY, CZK, null, null
+		);
+
+		try (MockedStatic<PricesContract> mocked = Mockito.mockStatic(PricesContract.class, Mockito.CALLS_REAL_METHODS)) {
+			// touch every entry point — none should trigger a second underlying pass
+			cache.compute(SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE);
+			cache.computePriceForSale(SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE);
+			cache.computeRange(SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE);
+			cache.computeRangeWithAccompanyingPrices(
+				SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE,
+				PricesContract.NO_ACCOMPANYING_PRICES
+			);
+			cache.compute(SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE);
+
+			mocked.verify(
+				() -> PricesContract.computePriceForSaleResult(
+					Mockito.eq(SAMPLE_PRICES),
+					Mockito.eq(PriceInnerRecordHandling.LOWEST_PRICE),
+					Mockito.eq(CZK),
+					Mockito.isNull(),
+					Mockito.eq(PRICE_LIST_PRIORITY),
+					Mockito.any()
+				),
+				Mockito.times(1)
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("Repeated computeRange calls return the same PriceContract instances")
+	void shouldReturnIdenticalComputationInstanceOnRepeatedCalls() {
+		final PriceForSaleContextWithCachedResult cache = new PriceForSaleContextWithCachedResult(
+			PRICE_LIST_PRIORITY, CZK, null, null
+		);
+
+		// the first call populates the rich cache; the second must read it back unchanged
+		final Optional<PriceRangeForSale> firstRange = cache.computeRange(SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE);
+		final Optional<PriceRangeForSale> secondRange = cache.computeRange(SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE);
+
+		assertTrue(firstRange.isPresent());
+		assertTrue(secondRange.isPresent());
+		// the underlying allocates fresh PriceContract instances per pass, so reference equality
+		// here proves the second call hit the cache rather than recomputing
+		assertSame(firstRange.get().lowestPrice(), secondRange.get().lowestPrice());
+		assertSame(firstRange.get().highestPrice(), secondRange.get().highestPrice());
+		assertSame(firstRange.get().priceForSale(), secondRange.get().priceForSale());
+	}
+
+	@Test
+	@DisplayName("computePriceForSale and computeRange agree on the priceForSale reference")
+	void shouldExposeIdenticalPriceForSaleAcrossViews() {
+		final PriceForSaleContextWithCachedResult cache = new PriceForSaleContextWithCachedResult(
+			PRICE_LIST_PRIORITY, CZK, null, null
+		);
+
+		// regardless of which entry point fills the cache first, both views must surface
+		// the same selling-price instance — proves the rich computation slot is shared
+		final Optional<PriceContract> direct = cache.computePriceForSale(SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE);
+		final Optional<PriceRangeForSale> range = cache.computeRange(SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE);
+
+		assertTrue(direct.isPresent());
+		assertTrue(range.isPresent());
+		assertEquals(1, direct.get().priceId(), "LOWEST_PRICE → cheapest priceId in SAMPLE_PRICES");
+		assertEquals(1, range.get().lowestPrice().priceId());
+		assertEquals(3, range.get().highestPrice().priceId());
+		assertSame(direct.get(), range.get().priceForSale(),
+			"priceForSale exposed by computePriceForSale and computeRange must be the same instance");
+	}
+
+	@Test
+	@DisplayName("Pre-seeded result is returned by compute() / computePriceForSale() independently of any prior range queries")
+	void shouldHonourPreSeededResultIndependentlyOfRangeQueries() {
+		// gRPC reverse-path scenario: the wire already carries the resolved selling price + accompanying
+		// prices, so the deserializer pre-seeds `cachedResult`. The two cache slots are independent —
+		// `cachedResult` (read by compute / computePriceForSale) and `cachedComputation` (read by range
+		// queries) do not interact. A range query therefore runs a fresh computation against the local
+		// price list (which knows nothing about the seeded selling price), yet the seed must still surface
+		// unchanged from compute() / computePriceForSale().
+		final PriceContract seedPrice = new Price(
+			new PriceKey(99, BASIC, CZK), 1,
+			new BigDecimal("999"), new BigDecimal("21"), new BigDecimal("1208.79"), null, true
+		);
+		final PriceForSaleWithAccompanyingPrices seed =
+			new PriceForSaleWithAccompanyingPrices(seedPrice, Collections.emptyMap());
+
+		final PriceForSaleContextWithCachedResult cache = new PriceForSaleContextWithCachedResult(
+			PRICE_LIST_PRIORITY, CZK, null, new AccompanyingPrice[0], seed
+		);
+
+		// range query fills `cachedComputation` from SAMPLE_PRICES — entirely separate from the seed
+		final Optional<PriceRangeForSale> range = cache.computeRange(SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE);
+		final Optional<PriceForSaleWithAccompanyingPrices> sellingView =
+			cache.compute(SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE);
+		final Optional<PriceContract> sellingPrice =
+			cache.computePriceForSale(SAMPLE_PRICES, PriceInnerRecordHandling.LOWEST_PRICE);
+
+		assertTrue(range.isPresent());
+		// the range bounds reflect SAMPLE_PRICES, not the seed (whose priceId is 99)
+		assertEquals(1, range.get().lowestPrice().priceId());
+		assertEquals(3, range.get().highestPrice().priceId());
+
+		assertTrue(sellingView.isPresent());
+		assertSame(seed, sellingView.get(), "compute() must return the seed instance untouched");
+		assertTrue(sellingPrice.isPresent());
+		assertSame(seedPrice, sellingPrice.get(), "computePriceForSale() must return the seeded price untouched");
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/PricesContractTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/PricesContractTest.java
@@ -1675,6 +1675,102 @@ class PricesContractTest extends AbstractBuilderTest {
 	}
 
 	/**
+	 * Regression guard for the LOWEST_PRICE accompanying-price helper: when the caller supplies an entity-prices
+	 * collection that mixes currencies (the realistic case for a multi-currency catalogue), the chosen accompanying
+	 * price must match the requested `currency`. Without the currency / validity gate added to
+	 * `filterCandidatesByInnerRecordRelation`, the LOWEST_PRICE branch was free to pick a foreign-currency price
+	 * that happened to share the selling price's `innerRecordId` and hit a higher-priority price list.
+	 */
+	@Test
+	@DisplayName("LOWEST_PRICE accompanying-price helper filters foreign-currency candidates")
+	void shouldRejectForeignCurrencyAccompanyingPriceUnderLowestPriceStrategy() {
+		// Inner record 1 carries the cheapest CZK basket; the standard set ships CZK and EUR variants for every
+		// (priceList, innerRecord) combination — exactly the layout that exposed the missing currency filter.
+		final List<PriceContract> mixedCurrencySet = Arrays.asList(
+			ArrayUtils.mergeArrays(
+				createStandardPriceSetWithMultiplier(1, BigDecimal.ONE),
+				createStandardPriceSetWithMultiplier(2, new BigDecimal("2"))
+			)
+		);
+
+		final PriceContract czkSelling = PricesContract.computePriceForSale(
+			mixedCurrencySet, PriceInnerRecordHandling.LOWEST_PRICE,
+			CZK, MOMENT_2020, new String[]{REFERENCE, VIP, LOGGED_ONLY, BASIC},
+			Objects::nonNull
+		).orElseThrow();
+		assertEquals(CZK, czkSelling.currency(), "selling price must be in requested currency");
+
+		final Map<String, Optional<PriceContract>> accompanying = PricesContract.calculateAccompanyingPrices(
+			czkSelling, mixedCurrencySet, PriceInnerRecordHandling.LOWEST_PRICE,
+			CZK, MOMENT_2020,
+			new AccompanyingPrice[]{new AccompanyingPrice("ref", REFERENCE)}
+		);
+
+		final PriceContract acc = accompanying.get("ref").orElseThrow(
+			() -> new AssertionError("accompanying REFERENCE price must be selectable")
+		);
+		assertEquals(CZK, acc.currency(),
+			"accompanying price must honour the requested currency, not leak in EUR siblings");
+	}
+
+	/**
+	 * Regression guard for the SUM accompanying-price helper: when several prices share the same
+	 * `(innerRecord, priceList)` and `atTheMoment` is `null` (so multiple non-overlapping validities all pass
+	 * the validity gate), the per-bucket map must pick the winner deterministically. Before the fix, the raw
+	 * `Map.put` overwrote silently, so the result depended on iteration order and could change between runs.
+	 * The fix uses `merge` with the existing `isBetterByPriceIdThenInner` tie-break (lower priceId wins).
+	 */
+	@Test
+	@DisplayName("SUM accompanying-price helper is deterministic on duplicate (innerRecord, priceList) entries")
+	void shouldDeterministicallyPickAccompanyingPriceWhenDuplicateInnerListEntriesExist() {
+		// Build two prices for inner record 1 / REFERENCE / CZK with non-overlapping validity ranges. With
+		// `atTheMoment == null` both are considered valid, so the SUM accompanying-price map collides on
+		// `(1, REFERENCE)` and the deterministic tie-break (lower priceId) must pick price 200 over 201.
+		final DateTimeRange firstHalf = DateTimeRange.between(
+			LocalDateTime.of(2010, 1, 1, 0, 0, 0, 0),
+			LocalDateTime.of(2010, 6, 30, 23, 59, 59, 0),
+			ZoneOffset.UTC
+		);
+		final DateTimeRange secondHalf = DateTimeRange.between(
+			LocalDateTime.of(2010, 7, 1, 0, 0, 0, 0),
+			LocalDateTime.of(2010, 12, 31, 23, 59, 59, 0),
+			ZoneOffset.UTC
+		);
+		final List<PriceContract> entityPrices = Arrays.asList(
+			// non-colliding base set — needed so SUM has a selling price
+			new Price(new PriceKey(1, BASIC, CZK), 1, new BigDecimal("100"), new BigDecimal("21"), new BigDecimal("121"), null, true),
+			new Price(new PriceKey(2, BASIC, CZK), 2, new BigDecimal("200"), new BigDecimal("21"), new BigDecimal("242"), null, true),
+			// the colliding pair — same (innerRecord 1, REFERENCE, CZK), distinct priceIds, distinct validities
+			new Price(new PriceKey(200, REFERENCE, CZK), 1, new BigDecimal("140"), new BigDecimal("21"), new BigDecimal("169.4"), firstHalf, false),
+			new Price(new PriceKey(201, REFERENCE, CZK), 1, new BigDecimal("180"), new BigDecimal("21"), new BigDecimal("217.8"), secondHalf, false)
+		);
+
+		final PriceContract sumSelling = PricesContract.computePriceForSale(
+			entityPrices, PriceInnerRecordHandling.SUM,
+			CZK, null, new String[]{REFERENCE, BASIC},
+			Objects::nonNull
+		).orElseThrow();
+
+		// repeat the resolution with a reshuffled input — the deterministic tie-break must yield the same
+		// accompanying price regardless of iteration order
+		final List<PriceContract> shuffled = Arrays.asList(
+			entityPrices.get(3), entityPrices.get(0), entityPrices.get(2), entityPrices.get(1)
+		);
+
+		final AccompanyingPrice[] requested = new AccompanyingPrice[]{new AccompanyingPrice("ref", REFERENCE)};
+		final Map<String, Optional<PriceContract>> a = PricesContract.calculateAccompanyingPrices(
+			sumSelling, entityPrices, PriceInnerRecordHandling.SUM, CZK, null, requested
+		);
+		final Map<String, Optional<PriceContract>> b = PricesContract.calculateAccompanyingPrices(
+			sumSelling, shuffled, PriceInnerRecordHandling.SUM, CZK, null, requested
+		);
+
+		final BigDecimal aRef = a.get("ref").orElseThrow().priceWithoutTax();
+		final BigDecimal bRef = b.get("ref").orElseThrow().priceWithoutTax();
+		assertEquals(aRef, bRef, "accompanying price must be deterministic across input orderings");
+	}
+
+	/**
 	 * Verifies that `computePriceRangeForSale` rejects the `UNKNOWN` strategy with `GenericEvitaInternalError`,
 	 * matching the behaviour of `computePriceForSale` and `calculateAccompanyingPrices`. The `UNKNOWN` value is a
 	 * sentinel used during deserialization and must never reach the price-resolution path.

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/PricesContractTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/PricesContractTest.java
@@ -29,13 +29,19 @@ import io.evitadb.api.query.require.QueryPriceMode;
 import io.evitadb.api.requestResponse.data.PricesContract.AccompanyingPrice;
 import io.evitadb.api.requestResponse.data.PricesContract.PriceForSaleWithAccompanyingPrices;
 import io.evitadb.api.requestResponse.data.structure.AbstractBuilderTest;
+import io.evitadb.api.requestResponse.data.structure.CumulatedPrice;
+import io.evitadb.api.requestResponse.data.structure.InitialPricesBuilder;
 import io.evitadb.api.requestResponse.data.structure.Price;
 import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
 import io.evitadb.api.requestResponse.data.structure.Prices;
 import io.evitadb.dataType.DateTimeRange;
+import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.utils.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
@@ -45,20 +51,18 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Currency;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
-import org.junit.jupiter.api.Tag;
 
-import static java.util.Optional.ofNullable;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.evitadb.test.TestTags.CONTRACT;
-import static io.evitadb.test.TestTags.QUERY;
 import static io.evitadb.test.TestTags.PRICE;
+import static io.evitadb.test.TestTags.QUERY;
+import static java.util.Optional.ofNullable;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This test verifies {@link Prices} contract implementation by testing various price handling scenarios.
@@ -1098,8 +1102,11 @@ class PricesContractTest extends AbstractBuilderTest {
 		final PricesContract fewerPrices = new Prices(
 			PRODUCT_SCHEMA,
 			1,
-			Arrays.asList(
-				new Price(new PriceKey(1, BASIC, CZK), null, new BigDecimal("100"), new BigDecimal("21"), new BigDecimal("121"), null, true)
+			List.of(
+				new Price(
+					new PriceKey(1, BASIC, CZK), null, new BigDecimal("100"), new BigDecimal("21"),
+					new BigDecimal("121"), null, true
+				)
 			),
 			PriceInnerRecordHandling.NONE,
 			true
@@ -1135,7 +1142,7 @@ class PricesContractTest extends AbstractBuilderTest {
 		final PricesContract pricesWithNoPrices = new Prices(
 			PRODUCT_SCHEMA,
 			1,
-			Arrays.asList(),
+			List.of(),
 			PriceInnerRecordHandling.NONE,
 			true
 		);
@@ -1389,6 +1396,575 @@ class PricesContractTest extends AbstractBuilderTest {
 			// VIP price is only valid in 2011, not in 2020, so it should be empty
 			assertTrue(result.accompanyingPrices().get("testPrice2").isEmpty());
 		}
+	}
+
+	/**
+	 * Verifies that under {@link PriceInnerRecordHandling#NONE} the price range collapses — the lowest, highest
+	 * and selling price are all the same instance because there is only ever one selling-price candidate.
+	 */
+	@Test
+	@DisplayName("Range for NONE strategy collapses to a single price")
+	void shouldReturnPriceRangeForSaleForNoneStrategy() {
+		final PricesContract prices = new Prices(
+			PRODUCT_SCHEMA,
+			1,
+			Arrays.asList(
+				createStandardPriceSetWithMultiplier(null, BigDecimal.ONE)
+			),
+			PriceInnerRecordHandling.NONE,
+			true
+		);
+
+		final PriceRangeForSale range = prices.getPriceRangeForSale(
+			CZK, MOMENT_2020, REFERENCE, VIP, LOGGED_ONLY, BASIC
+		).orElseThrow();
+
+		// LOGGED_ONLY (price id 3) wins under the chosen priority
+		assertEquals(3, range.priceForSale().priceId());
+		assertEquals(range.priceForSale(), range.lowestPrice());
+		assertEquals(range.priceForSale(), range.highestPrice());
+	}
+
+	/**
+	 * Verifies that under {@link PriceInnerRecordHandling#LOWEST_PRICE} the lowest price equals the selling price
+	 * and the highest price is the most expensive per-inner-record selling price computed with identical filter
+	 * rules.
+	 */
+	@Test
+	@DisplayName("Range for LOWEST_PRICE picks min/max of per-inner-record selling prices")
+	void shouldReturnPriceRangeForSaleForLowestPriceStrategy() {
+		final PricesContract prices = new Prices(
+			PRODUCT_SCHEMA,
+			1,
+			Arrays.asList(
+				ArrayUtils.mergeArrays(
+					createStandardPriceSetWithMultiplier(1, BigDecimal.ONE),
+					createStandardPriceSetWithMultiplier(2, new BigDecimal("2")),
+					createStandardPriceSetWithMultiplier(3, new BigDecimal("0.5"))
+				)
+			),
+			PriceInnerRecordHandling.LOWEST_PRICE,
+			true
+		);
+
+		// LOGGED_ONLY is highest priority that is sellable; per-inner-record selling prices are
+		// 80 (variant 1), 160 (variant 2 = 80 * 2) and 40 (variant 3 = 80 * 0.5)
+		final PriceRangeForSale range = prices.getPriceRangeForSale(
+			CZK, MOMENT_2020, REFERENCE, VIP, LOGGED_ONLY, BASIC
+		).orElseThrow();
+
+		// lowest is the selling price (cheapest variant)
+		assertEquals(range.priceForSale(), range.lowestPrice());
+		assertEquals(3, (int) range.lowestPrice().innerRecordId());
+		assertEquals(0, range.lowestPrice().priceWithoutTax().compareTo(new BigDecimal("40.0")));
+		// highest is the most expensive variant's selling price
+		assertEquals(2, (int) range.highestPrice().innerRecordId());
+		assertEquals(0, range.highestPrice().priceWithoutTax().compareTo(new BigDecimal("160")));
+	}
+
+	/**
+	 * Verifies that under {@link PriceInnerRecordHandling#SUM} the lowest and highest prices are real component
+	 * prices (cheapest and most expensive per-inner-record selling component), while the selling price itself is
+	 * the cumulated sum across all components.
+	 */
+	@Test
+	@DisplayName("Range for SUM exposes component bounds while selling price stays cumulated")
+	void shouldReturnPriceRangeForSaleForSumStrategy() {
+		final PricesContract prices = new Prices(
+			PRODUCT_SCHEMA,
+			1,
+			Arrays.asList(
+				ArrayUtils.mergeArrays(
+					createStandardPriceSetWithMultiplier(1, BigDecimal.ONE),
+					createStandardPriceSetWithMultiplier(2, new BigDecimal("2")),
+					createStandardPriceSetWithMultiplier(3, new BigDecimal("0.5"))
+				)
+			),
+			PriceInnerRecordHandling.SUM,
+			true
+		);
+
+		final PriceRangeForSale range = prices.getPriceRangeForSale(
+			CZK, MOMENT_2020, REFERENCE, VIP, LOGGED_ONLY, BASIC
+		).orElseThrow();
+
+		// LOGGED_ONLY price tier — components are 80, 160, 40 → sum = 280
+		assertInstanceOf(CumulatedPrice.class, range.priceForSale());
+		assertEquals(0, range.priceForSale().priceWithoutTax().compareTo(new BigDecimal("280.0")));
+		assertEquals(3, (int) range.lowestPrice().innerRecordId());
+		assertEquals(0, range.lowestPrice().priceWithoutTax().compareTo(new BigDecimal("40.0")));
+		assertEquals(2, (int) range.highestPrice().innerRecordId());
+		assertEquals(0, range.highestPrice().priceWithoutTax().compareTo(new BigDecimal("160")));
+	}
+
+	/**
+	 * Verifies that when filters eliminate every candidate, all `getPriceRangeForSale*` methods return
+	 * {@link Optional#empty()} — including under each inner-record handling strategy.
+	 */
+	@Test
+	@DisplayName("Range returns empty when filter eliminates everything")
+	void shouldReturnEmptyRangeWhenNothingMatches() {
+		// NONE: ask for GBP that doesn't exist anywhere
+		final PricesContract pricesNone = new Prices(
+			PRODUCT_SCHEMA,
+			1,
+			Arrays.asList(
+				createStandardPriceSetWithMultiplier(null, BigDecimal.ONE)
+			),
+			PriceInnerRecordHandling.NONE,
+			true
+		);
+		assertTrue(pricesNone.getPriceRangeForSale(GBP, MOMENT_2020, REFERENCE, VIP, LOGGED_ONLY, BASIC).isEmpty());
+
+		// LOWEST_PRICE: same — nothing matches GBP
+		final PricesContract pricesLowest = new Prices(
+			PRODUCT_SCHEMA,
+			1,
+			Arrays.asList(
+				ArrayUtils.mergeArrays(
+					createStandardPriceSetWithMultiplier(1, BigDecimal.ONE),
+					createStandardPriceSetWithMultiplier(2, new BigDecimal("2"))
+				)
+			),
+			PriceInnerRecordHandling.LOWEST_PRICE,
+			true
+		);
+		assertTrue(pricesLowest.getPriceRangeForSale(GBP, MOMENT_2020, REFERENCE, VIP, LOGGED_ONLY, BASIC).isEmpty());
+
+		// SUM: only sellable price tier with no matches at all
+		final PricesContract pricesSum = new Prices(
+			PRODUCT_SCHEMA,
+			1,
+			Arrays.asList(
+				ArrayUtils.mergeArrays(
+					createStandardPriceSetWithMultiplier(1, BigDecimal.ONE),
+					createStandardPriceSetWithMultiplier(2, new BigDecimal("2"))
+				)
+			),
+			PriceInnerRecordHandling.SUM,
+			true
+		);
+		// REFERENCE alone leaves no sellable (indexed) candidate at all
+		assertTrue(pricesSum.getPriceRangeForSale(CZK, MOMENT_2020, REFERENCE).isEmpty());
+	}
+
+	/**
+	 * Verifies parity between the new range/accompanying-price API and the existing
+	 * {@link PricesContract#getPriceForSaleWithAccompanyingPrices(Currency, OffsetDateTime, String[], AccompanyingPrice[])}
+	 * — for identical inputs the accompanying-price map and the resolved selling price must match. This is the
+	 * regression guard against future divergence between the two code paths.
+	 */
+	@Test
+	@DisplayName("Accompanying-price parity between range and non-range APIs (all strategies)")
+	void shouldReturnSameAccompanyingPricesAsLegacyApi() {
+		final AccompanyingPrice[] requested = new AccompanyingPrice[]{
+			new AccompanyingPrice("p1", REFERENCE),
+			new AccompanyingPrice("p2", REFERENCE, VIP),
+			new AccompanyingPrice("p3", LOGGED_ONLY, VIP),
+			new AccompanyingPrice("p", VIP)
+		};
+		// NONE
+		assertAccompanyingPriceParity(
+			new Prices(
+				PRODUCT_SCHEMA,
+				1,
+				Arrays.asList(createStandardPriceSetWithMultiplier(null, BigDecimal.ONE)),
+				PriceInnerRecordHandling.NONE,
+				true
+			),
+			CZK, MOMENT_2020, new String[]{REFERENCE, VIP, LOGGED_ONLY, BASIC}, requested
+		);
+		// LOWEST_PRICE
+		assertAccompanyingPriceParity(
+			new Prices(
+				PRODUCT_SCHEMA,
+				1,
+				Arrays.asList(
+					ArrayUtils.mergeArrays(
+						createStandardPriceSetWithMultiplier(1, BigDecimal.ONE),
+						createStandardPriceSetWithMultiplier(2, new BigDecimal("2")),
+						createStandardPriceSetWithMultiplier(3, new BigDecimal("0.5"))
+					)
+				),
+				PriceInnerRecordHandling.LOWEST_PRICE,
+				true
+			),
+			CZK, MOMENT_2020, new String[]{REFERENCE, VIP, LOGGED_ONLY, BASIC}, requested
+		);
+		// SUM
+		assertAccompanyingPriceParity(
+			new Prices(
+				PRODUCT_SCHEMA,
+				1,
+				Arrays.asList(
+					ArrayUtils.mergeArrays(
+						createStandardPriceSetWithMultiplier(1, BigDecimal.ONE),
+						createStandardPriceSetWithMultiplier(2, new BigDecimal("2")),
+						createStandardPriceSetWithMultiplier(3, new BigDecimal("0.5"))
+					)
+				),
+				PriceInnerRecordHandling.SUM,
+				true
+			),
+			CZK, MOMENT_2020, new String[]{REFERENCE, VIP, LOGGED_ONLY, BASIC}, requested
+		);
+	}
+
+	/**
+	 * Direct-test the public shared accompanying-price helper
+	 * {@link PricesContract#calculateAccompanyingPrices} for all three strategies. This is the regression guard
+	 * that the per-strategy handling did not silently re-diverge after the de-duplication rewrite.
+	 */
+	@Test
+	@DisplayName("Shared calculateAccompanyingPrices helper handles all three strategies consistently")
+	void shouldExerciseSharedCalculateAccompanyingPricesHelper() {
+		final AccompanyingPrice[] requested = new AccompanyingPrice[]{
+			new AccompanyingPrice("p1", REFERENCE),
+			new AccompanyingPrice("p3", LOGGED_ONLY, VIP)
+		};
+
+		// NONE — accompanying lookup over the whole entity-prices set
+		final List<PriceContract> noneSet = Arrays.asList(createStandardPriceSetWithMultiplier(null, BigDecimal.ONE));
+		final PriceContract noneSelling = PricesContract.computePriceForSale(
+			noneSet, PriceInnerRecordHandling.NONE,
+			CZK, MOMENT_2020, new String[]{REFERENCE, VIP, LOGGED_ONLY, BASIC},
+			java.util.Objects::nonNull
+		).orElseThrow();
+		final Map<String, Optional<PriceContract>> noneAcc = PricesContract.calculateAccompanyingPrices(
+			noneSelling, noneSet, PriceInnerRecordHandling.NONE, CZK, MOMENT_2020, requested
+		);
+		assertEquals(2, noneAcc.size());
+		assertEquals(7, noneAcc.get("p1").orElseThrow().priceId());
+		assertEquals(3, noneAcc.get("p3").orElseThrow().priceId());
+
+		// LOWEST_PRICE — accompanying restricted to the same inner record as the selling price
+		final List<PriceContract> lowestSet = Arrays.asList(
+			ArrayUtils.mergeArrays(
+				createStandardPriceSetWithMultiplier(1, BigDecimal.ONE),
+				createStandardPriceSetWithMultiplier(2, new BigDecimal("2")),
+				createStandardPriceSetWithMultiplier(3, new BigDecimal("0.5"))
+			)
+		);
+		final PriceContract lowestSelling = PricesContract.computePriceForSale(
+			lowestSet, PriceInnerRecordHandling.LOWEST_PRICE,
+			CZK, MOMENT_2020, new String[]{REFERENCE, VIP, LOGGED_ONLY, BASIC},
+			java.util.Objects::nonNull
+		).orElseThrow();
+		final Map<String, Optional<PriceContract>> lowestAcc = PricesContract.calculateAccompanyingPrices(
+			lowestSelling, lowestSet, PriceInnerRecordHandling.LOWEST_PRICE, CZK, MOMENT_2020, requested
+		);
+		assertEquals(2, lowestAcc.size());
+		// inner record 3 is the cheapest, so accompanying prices must come from inner record 3
+		assertEquals(combineIntoId(3, 7), lowestAcc.get("p1").orElseThrow().priceId());
+		assertEquals(combineIntoId(3, 3), lowestAcc.get("p3").orElseThrow().priceId());
+
+		// SUM — accompanying summed across components, matching the existing behaviour for SUM strategy
+		final PriceContract sumSelling = PricesContract.computePriceForSale(
+			lowestSet, PriceInnerRecordHandling.SUM,
+			CZK, MOMENT_2020, new String[]{REFERENCE, VIP, LOGGED_ONLY, BASIC},
+			java.util.Objects::nonNull
+		).orElseThrow();
+		final Map<String, Optional<PriceContract>> sumAcc = PricesContract.calculateAccompanyingPrices(
+			sumSelling, lowestSet, PriceInnerRecordHandling.SUM, CZK, MOMENT_2020, requested
+		);
+		assertEquals(2, sumAcc.size());
+		// REFERENCE summed over all inner records: 140 + 280 + 70 = 490
+		assertEquals(new BigDecimal("490.0"), sumAcc.get("p1").orElseThrow().priceWithoutTax());
+		// LOGGED_ONLY summed: 80 + 160 + 40 = 280
+		assertEquals(new BigDecimal("280.0"), sumAcc.get("p3").orElseThrow().priceWithoutTax());
+	}
+
+	/**
+	 * Verifies that `computePriceRangeForSale` rejects the `UNKNOWN` strategy with `GenericEvitaInternalError`,
+	 * matching the behaviour of `computePriceForSale` and `calculateAccompanyingPrices`. The `UNKNOWN` value is a
+	 * sentinel used during deserialization and must never reach the price-resolution path.
+	 */
+	@Test
+	@DisplayName("computePriceRangeForSale throws on UNKNOWN inner-record handling")
+	void shouldThrowInternalErrorWhenComputingRangeWithUnknownInnerRecordHandling() {
+		final List<PriceContract> entityPrices = Arrays.asList(
+			createStandardPriceSetWithMultiplier(null, BigDecimal.ONE)
+		);
+
+		final GenericEvitaInternalError thrown = assertThrows(
+			GenericEvitaInternalError.class,
+			() -> PricesContract.computePriceRangeForSale(
+				entityPrices,
+				PriceInnerRecordHandling.UNKNOWN,
+				CZK,
+				MOMENT_2020,
+				new String[]{REFERENCE, VIP, LOGGED_ONLY, BASIC},
+				Objects::nonNull
+			)
+		);
+
+		// the public message hints at the offending strategy so users can locate the corrupted entity
+		assertNotNull(thrown.getMessage());
+		assertTrue(
+			thrown.getMessage().contains("UNKNOWN"),
+			"Error message should mention UNKNOWN strategy, was: " + thrown.getMessage()
+		);
+	}
+
+	/**
+	 * Verifies that `calculateAccompanyingPrices` short-circuits to `Collections.emptyMap()` for every strategy
+	 * when the caller passes `NO_ACCOMPANYING_PRICES`. The empty-map contract must hold across NONE / LOWEST_PRICE
+	 * / SUM so that the no-accompanying-price fast path stays allocation-free regardless of strategy.
+	 */
+	@ParameterizedTest
+	@EnumSource(value = PriceInnerRecordHandling.class, names = {"NONE", "LOWEST_PRICE", "SUM"})
+	@DisplayName("calculateAccompanyingPrices returns empty map when no accompanying prices requested")
+	void shouldReturnEmptyMapWhenNoAccompanyingPricesRequested(
+		@Nonnull final PriceInnerRecordHandling strategy
+	) {
+		// build a price set rich enough to produce a selling price under any of the three strategies
+		final List<PriceContract> entityPrices = Arrays.asList(
+			ArrayUtils.mergeArrays(
+				createStandardPriceSetWithMultiplier(1, BigDecimal.ONE),
+				createStandardPriceSetWithMultiplier(2, new BigDecimal("2")),
+				createStandardPriceSetWithMultiplier(3, new BigDecimal("0.5"))
+			)
+		);
+		final PriceContract sellingPrice = PricesContract.computePriceForSale(
+			entityPrices, strategy, CZK, MOMENT_2020,
+			new String[]{REFERENCE, VIP, LOGGED_ONLY, BASIC}, Objects::nonNull
+		).orElseThrow();
+
+		final Map<String, Optional<PriceContract>> result = PricesContract.calculateAccompanyingPrices(
+			sellingPrice, entityPrices, strategy, CZK, MOMENT_2020,
+			PricesContract.NO_ACCOMPANYING_PRICES
+		);
+
+		assertTrue(result.isEmpty(), "no-accompanying-prices fast path must produce an empty map");
+		// instance equality with Collections.emptyMap() guards the allocation-free fast path
+		assertSame(
+			Collections.emptyMap(),
+			result,
+			"fast path should return Collections.emptyMap() singleton, not an allocated empty map"
+		);
+	}
+
+	/**
+	 * Documents the LOWEST_PRICE collapse — when only a single inner record matches the filter, the resulting
+	 * range degenerates so that `lowestPrice()` and `highestPrice()` reference the same price. The selling price
+	 * coincides with both bounds since LOWEST_PRICE selects the cheapest variant directly.
+	 */
+	@Test
+	@DisplayName("LOWEST_PRICE range collapses to a single point when only one inner record matches")
+	void shouldCollapseRangeWhenLowestPriceStrategyHasSingleInnerRecord() {
+		final PricesContract prices = new Prices(
+			PRODUCT_SCHEMA,
+			1,
+			Arrays.asList(
+				createStandardPriceSetWithMultiplier(7, BigDecimal.ONE)
+			),
+			PriceInnerRecordHandling.LOWEST_PRICE,
+			true
+		);
+
+		final PriceRangeForSale range = prices.getPriceRangeForSale(
+			CZK, MOMENT_2020, REFERENCE, VIP, LOGGED_ONLY, BASIC
+		).orElseThrow();
+
+		// with one inner record, lowest, highest and selling price must all be the same instance
+		assertEquals(range.priceForSale(), range.lowestPrice());
+		assertEquals(range.priceForSale(), range.highestPrice());
+		assertEquals(range.lowestPrice(), range.highestPrice());
+		// inner record id is preserved on the bound prices
+		assertEquals(7, (int) range.lowestPrice().innerRecordId());
+		assertEquals(7, (int) range.highestPrice().innerRecordId());
+	}
+
+	/**
+	 * Documents the SUM degenerate case — even with a single inner record the SUM strategy still wraps the
+	 * selling price into a `CumulatedPrice`, while the lowest / highest bounds collapse onto the only component.
+	 * Guards against a future "skip wrapping when there is only one component" optimisation breaking the
+	 * uniform SUM contract.
+	 */
+	@Test
+	@DisplayName("SUM range exposes a CumulatedPrice and collapsed bounds for a single inner record")
+	void shouldComputeRangeWhenSumStrategyHasSingleInnerRecord() {
+		final PricesContract prices = new Prices(
+			PRODUCT_SCHEMA,
+			1,
+			Arrays.asList(
+				createStandardPriceSetWithMultiplier(4, BigDecimal.ONE)
+			),
+			PriceInnerRecordHandling.SUM,
+			true
+		);
+
+		final PriceRangeForSale range = prices.getPriceRangeForSale(
+			CZK, MOMENT_2020, REFERENCE, VIP, LOGGED_ONLY, BASIC
+		).orElseThrow();
+
+		// the selling price must remain a CumulatedPrice — the SUM contract is wrapper-uniform regardless
+		// of how many components participate
+		assertInstanceOf(
+			CumulatedPrice.class, range.priceForSale(),
+			"SUM strategy must always wrap the selling price into a CumulatedPrice"
+		);
+		// LOGGED_ONLY price tier (without VAT = 80) is the only sellable price for inner record 4
+		assertEquals(0, range.priceForSale().priceWithoutTax().compareTo(new BigDecimal("80")));
+		// with one inner record, the bounds collapse — and reference the underlying component price
+		assertEquals(0, range.lowestPrice().priceWithoutTax().compareTo(new BigDecimal("80")));
+		assertEquals(0, range.highestPrice().priceWithoutTax().compareTo(new BigDecimal("80")));
+		assertEquals(4, (int) range.lowestPrice().innerRecordId());
+		assertEquals(4, (int) range.highestPrice().innerRecordId());
+	}
+
+	/**
+	 * Verifies that under LOWEST_PRICE a `null` inner record id and a numbered inner record id are treated as
+	 * distinct buckets: the cheapest per-bucket candidate becomes `lowestPrice`, the most expensive becomes
+	 * `highestPrice`. The explicit `0` inner record id is rejected at the builder layer (see
+	 * {@link InitialPricesBuilder#assertInnerRecordIdValid}), so no risk of conflation with the synthetic
+	 * `null`-bucket key remains.
+	 */
+	@Test
+	@DisplayName("LOWEST_PRICE keeps null and numbered innerRecordId in distinct buckets")
+	void shouldKeepNullAndNumberedInnerRecordIdInDistinctBucketsUnderLowestPriceStrategy() {
+		final PricesContract prices = new Prices(
+			PRODUCT_SCHEMA,
+			1,
+			Arrays.asList(
+				new Price(new PriceKey(1, BASIC, CZK), null,
+					new BigDecimal("100"), new BigDecimal("21"), new BigDecimal("121"), null, true),
+				new Price(new PriceKey(combineIntoId(1, 1), BASIC, CZK), 1,
+					new BigDecimal("200"), new BigDecimal("21"), new BigDecimal("242"), null, true)
+			),
+			PriceInnerRecordHandling.LOWEST_PRICE,
+			true
+		);
+
+		final PriceRangeForSale range = prices.getPriceRangeForSale(
+			CZK, null, BASIC
+		).orElseThrow();
+
+		// the null-bucket candidate (100 / 121) is the cheapest, the numbered bucket (200 / 242) is the most expensive
+		assertEquals(0, range.lowestPrice().priceWithoutTax().compareTo(new BigDecimal("100")));
+		assertNull(range.lowestPrice().innerRecordId());
+		assertEquals(0, range.highestPrice().priceWithoutTax().compareTo(new BigDecimal("200")));
+		assertEquals(1, (int) range.highestPrice().innerRecordId());
+	}
+
+	/**
+	 * Verifies that under LOWEST_PRICE the supplied `filterPredicate` only constrains the SELLING price
+	 * (== `lowestPrice` under this strategy), never the upper bound of the resulting range. The range
+	 * bounds describe the real catalogue spread and must remain pinned to actual indexed inner-record
+	 * candidates; clipping `highestPrice` by a predicate aimed at the selling price would misrepresent
+	 * the underlying catalogue.
+	 *
+	 * Three inner records with multipliers 0.5 / 1 / 2 yield LOGGED_ONLY selling-price candidates of
+	 * 48.4 / 96.8 / 193.6 with-tax. A predicate rejecting anything above 100 with-tax excludes the
+	 * variant-3 candidate from the selling-price slot, but the variant-3 candidate (193.6) must still
+	 * be the `highestPrice` because it is the most expensive real per-inner-record candidate.
+	 */
+	@Test
+	@DisplayName("LOWEST_PRICE filterPredicate constrains only selling price, not range bounds")
+	void shouldNotConstrainRangeHighestPriceWithFilterPredicate() {
+		final List<PriceContract> entityPrices = Arrays.asList(
+			ArrayUtils.mergeArrays(
+				createStandardPriceSetWithMultiplier(1, new BigDecimal("0.5")),
+				createStandardPriceSetWithMultiplier(2, BigDecimal.ONE),
+				createStandardPriceSetWithMultiplier(3, new BigDecimal("2"))
+			)
+		);
+
+		// reject anything more expensive than 100 with-tax — this excludes the variant-3 LOGGED_ONLY
+		// candidate (priceWithTax = 96.8 * 2 = 193.6) but spares variants 1 and 2
+		final java.util.function.Predicate<PriceContract> filterPredicate = price ->
+			price.priceWithTax().compareTo(new BigDecimal("100")) <= 0;
+
+		final PriceRangeForSale range = PricesContract.computePriceRangeForSale(
+			entityPrices,
+			PriceInnerRecordHandling.LOWEST_PRICE,
+			CZK, MOMENT_2020,
+			new String[]{REFERENCE, VIP, LOGGED_ONLY, BASIC},
+			filterPredicate
+		).orElseThrow();
+
+		// Variant-1 selling price (LOGGED_ONLY priceWithTax = 96.8 * 0.5 = 48.4) is the cheapest predicate-
+		// passing candidate and becomes both the selling price and the lowest range bound
+		assertEquals(0, range.lowestPrice().priceWithTax().compareTo(new BigDecimal("48.400")));
+		assertEquals(1, (int) range.lowestPrice().innerRecordId());
+		// Variant-3 candidate (priceWithTax = 193.6) is the most expensive real per-inner-record candidate
+		// and remains the `highestPrice` even though it would not pass the filterPredicate. The predicate
+		// is scoped to the selling price, not to the range bounds.
+		assertEquals(0, range.highestPrice().priceWithTax().compareTo(new BigDecimal("193.600")));
+		assertEquals(3, (int) range.highestPrice().innerRecordId());
+	}
+
+	/**
+	 * Verifies the deterministic LOWEST_PRICE tie-break order: when two inner records resolve to the
+	 * same `priceWithTax`, the candidate with the lower `priceId` wins (then by lower `innerRecordId`,
+	 * with `null` sorting before non-null). The order is independent of input iteration — swapping
+	 * the order of `entityPrices` produces the same winner.
+	 *
+	 * Concretely: with two inner records `5` and `9` priced identically at `121` with-tax, the
+	 * candidate with the lower `priceId` (inner record `5`, since `combineIntoId(5, 1)` < `combineIntoId(9, 2)`)
+	 * always wins, regardless of which one appears first in `entityPrices`.
+	 */
+	@Test
+	@DisplayName("LOWEST_PRICE breaks priceWithTax ties by lower priceId deterministically")
+	void shouldBreakLowestPriceTieByLowestPriceId() {
+		// two inner records (5 and 9) with identical priceWithTax = 121 in BASIC list — distinct price ids
+		final Price price5 = new Price(new PriceKey(combineIntoId(5, 1), BASIC, CZK), 5,
+			new BigDecimal("100"), new BigDecimal("21"), new BigDecimal("121"), null, true);
+		final Price price9 = new Price(new PriceKey(combineIntoId(9, 2), BASIC, CZK), 9,
+			new BigDecimal("100"), new BigDecimal("21"), new BigDecimal("121"), null, true);
+
+		// natural order: inner 5 first, inner 9 second
+		final PricesContract pricesNatural = new Prices(
+			PRODUCT_SCHEMA, 1, Arrays.asList(price5, price9), PriceInnerRecordHandling.LOWEST_PRICE, true
+		);
+		final PriceRangeForSale rangeNatural = pricesNatural.getPriceRangeForSale(
+			CZK, null, BASIC
+		).orElseThrow();
+
+		// reversed order: inner 9 first, inner 5 second — the deterministic tie-break must still pick
+		// the same winner (lower priceId)
+		final PricesContract pricesReversed = new Prices(
+			PRODUCT_SCHEMA, 1, Arrays.asList(price9, price5), PriceInnerRecordHandling.LOWEST_PRICE, true
+		);
+		final PriceRangeForSale rangeReversed = pricesReversed.getPriceRangeForSale(
+			CZK, null, BASIC
+		).orElseThrow();
+
+		// inner record 5 wins the selling price assignment in BOTH orderings — its priceId
+		// (combineIntoId(5, 1)) is lower than inner record 9's priceId (combineIntoId(9, 2))
+		assertEquals(combineIntoId(5, 1), rangeNatural.priceForSale().priceId());
+		assertEquals(5, (int) rangeNatural.priceForSale().innerRecordId());
+		assertEquals(combineIntoId(5, 1), rangeNatural.lowestPrice().priceId());
+
+		assertEquals(combineIntoId(5, 1), rangeReversed.priceForSale().priceId());
+		assertEquals(5, (int) rangeReversed.priceForSale().innerRecordId());
+		assertEquals(combineIntoId(5, 1), rangeReversed.lowestPrice().priceId());
+
+		// the highestPrice is also subject to tie-break — under tie, the lower priceId still wins
+		// (a single representative candidate is chosen deterministically for the upper bound as well)
+		assertEquals(combineIntoId(5, 1), rangeNatural.highestPrice().priceId());
+		assertEquals(combineIntoId(5, 1), rangeReversed.highestPrice().priceId());
+	}
+
+	/**
+	 * Verifies that the new range API delivers the same accompanying-price map as the legacy API for the same
+	 * input and exposes the same selling price.
+	 */
+	private static void assertAccompanyingPriceParity(
+		@Nonnull PricesContract prices,
+		@Nonnull Currency currency,
+		@Nullable OffsetDateTime moment,
+		@Nonnull String[] priceLists,
+		@Nonnull AccompanyingPrice[] accompanyingPrices
+	) {
+		final PriceForSaleWithAccompanyingPrices legacy = prices.getPriceForSaleWithAccompanyingPrices(
+			currency, moment, priceLists, accompanyingPrices
+		).orElseThrow();
+		final PriceRangeForSaleWithAccompanyingPrices range = prices.getPriceRangeForSaleWithAccompanyingPrices(
+			currency, moment, priceLists, accompanyingPrices
+		).orElseThrow();
+		assertEquals(legacy.priceForSale(), range.priceRange().priceForSale());
+		assertEquals(legacy.accompanyingPrices(), range.accompanyingPrices());
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/ExistingPriceBuilderTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/ExistingPriceBuilderTest.java
@@ -24,6 +24,7 @@
 package io.evitadb.api.requestResponse.data.structure;
 
 import io.evitadb.api.exception.AmbiguousPriceException;
+import io.evitadb.api.exception.InvalidMutationException;
 import io.evitadb.api.requestResponse.data.Droppable;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
@@ -601,6 +602,23 @@ class ExistingPriceBuilderTest extends AbstractBuilderTest {
 				basicPrices.iterator().next().priceId()
 			);
 		}
+
+		@Test
+		@DisplayName("should reject explicit zero inner record id")
+		void shouldRejectExplicitZeroInnerRecordId() {
+			// `0` is reserved as the null sentinel inside per-inner-record bookkeeping; allowing it would
+			// silently merge the price into the `null` bucket and corrupt LOWEST_PRICE/SUM aggregations
+			assertThrows(
+				InvalidMutationException.class,
+				() -> ExistingPriceBuilderTest.this.builder.setPrice(
+					20, "basic", CZK, 0,
+					BigDecimal.ONE,
+					BigDecimal.ZERO,
+					BigDecimal.ONE,
+					true
+				)
+			);
+		}
 	}
 
 	@Nested
@@ -617,7 +635,7 @@ class ExistingPriceBuilderTest extends AbstractBuilderTest {
 			assertTrue(price.isPresent());
 			assertEquals(1, price.get().priceId());
 			assertEquals("basic", price.get().priceList());
-			assertEquals(CZK, price.get().currency());
+			assertSame(CZK, price.get().currency());
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/InitialPricesBuilderTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/InitialPricesBuilderTest.java
@@ -24,6 +24,7 @@
 package io.evitadb.api.requestResponse.data.structure;
 
 import io.evitadb.api.exception.AmbiguousPriceException;
+import io.evitadb.api.exception.InvalidMutationException;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
 import io.evitadb.api.requestResponse.data.PricesContract;
@@ -44,13 +45,10 @@ import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Tag;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.evitadb.test.TestTags.CONTRACT;
 import static io.evitadb.test.TestTags.QUERY;
 import static io.evitadb.test.TestTags.PRICE;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link InitialPricesBuilder} verifying price
@@ -215,6 +213,34 @@ class InitialPricesBuilderTest extends AbstractBuilderTest {
 					.anyMatch(it -> it.priceId() == 2)
 			);
 		}
+
+		@Test
+		@DisplayName("should reject explicit zero inner record id")
+		void shouldRejectExplicitZeroInnerRecordId() {
+			// `0` is reserved as the null sentinel inside per-inner-record bookkeeping; allowing it would
+			// silently merge the price into the `null` bucket and corrupt LOWEST_PRICE/SUM aggregations
+			assertThrows(
+				InvalidMutationException.class,
+				() -> InitialPricesBuilderTest.this.builder.setPrice(
+					1, "basic", CZK, 0,
+					BigDecimal.ONE, BigDecimal.ZERO,
+					BigDecimal.ONE, true
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("should reject explicit zero inner record id when validity is provided")
+		void shouldRejectExplicitZeroInnerRecordIdWithValidity() {
+			assertThrows(
+				InvalidMutationException.class,
+				() -> InitialPricesBuilderTest.this.builder.setPrice(
+					1, "basic", CZK, 0,
+					BigDecimal.ONE, BigDecimal.ZERO,
+					BigDecimal.ONE, null, true
+				)
+			);
+		}
 	}
 
 	@Nested
@@ -372,23 +398,49 @@ class InitialPricesBuilderTest extends AbstractBuilderTest {
 				);
 
 			assertEquals(1, allPricesForSale.size());
-			final PriceContract priceContract =
-				allPricesForSale.get(0);
+			final CumulatedPrice cumulatedPrice =
+				assertInstanceOf(
+					CumulatedPrice.class,
+					allPricesForSale.get(0)
+				);
 
+			// vip wins for buckets 1 & 2 (priceIds 2, 4 = 10 each); bucket 3 falls back to basic
+			// (priceId 5 = 1) because vip is absent for that bucket → cumulated 21 with-tax / without-tax
 			assertEquals(
-				new CumulatedPrice(
-					1,
-					new PriceKey(2, "vip", CZK),
-					Map.of(
-						3,
-						prices.getPrice(3, "basic", CZK)
-							.orElseThrow()
-					),
-					new BigDecimal("21"),
-					BigDecimal.ZERO,
-					new BigDecimal("21")
-				),
-				priceContract
+				0,
+				cumulatedPrice.priceWithoutTax()
+					.compareTo(new BigDecimal("21"))
+			);
+			assertEquals(
+				0,
+				cumulatedPrice.priceWithTax()
+					.compareTo(new BigDecimal("21"))
+			);
+			assertEquals(
+				0,
+				cumulatedPrice.taxRate()
+					.compareTo(BigDecimal.ZERO)
+			);
+			final Map<Integer, PriceContract> innerRecordPrices =
+				cumulatedPrice.innerRecordPrices();
+			assertEquals(3, innerRecordPrices.size());
+			assertEquals(
+				2,
+				innerRecordPrices.get(1).priceId()
+			);
+			assertEquals(
+				4,
+				innerRecordPrices.get(2).priceId()
+			);
+			assertEquals(
+				5,
+				innerRecordPrices.get(3).priceId()
+			);
+			// the anchor priceKey is one of the contributing components — its precise identity is
+			// HashMap-iteration dependent, so we accept any of the three winners (priceId 2, 4 or 5)
+			assertTrue(
+				Set.of(2, 4, 5)
+					.contains(cumulatedPrice.priceKey().priceId())
 			);
 		}
 	}
@@ -488,7 +540,7 @@ class InitialPricesBuilderTest extends AbstractBuilderTest {
 			assertTrue(price.isPresent());
 			assertEquals(1, price.get().priceId());
 			assertEquals("basic", price.get().priceList());
-			assertEquals(CZK, price.get().currency());
+			assertSame(CZK, price.get().currency());
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/EvitaBootDivergenceWalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/EvitaBootDivergenceWalTest.java
@@ -52,6 +52,7 @@ import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -73,7 +74,8 @@ import static io.evitadb.test.TestTags.WAL;
  *
  * - the resulting catalog states (ALIVE/INACTIVE/MISSING),
  * - the engine version (must advance by `becomeMissing + reappeared + autoDiscovered`),
- * - the engine WAL contents (one mutation per divergence entry, applied in the documented order),
+ * - the engine WAL contents (one mutation per divergence entry; `becomeMissing` records strictly precede any
+ *   restore, but `reappeared` and `autoDiscovered` are dispatched in parallel and may appear in either order),
  * - the next-boot idempotency (no further divergence after the first drain).
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
@@ -168,13 +170,13 @@ class EvitaBootDivergenceWalTest implements EvitaTestSupport {
 	}
 
 	@Test
-	@DisplayName("should drain mixed divergence in becomeMissing → reappeared → autoDiscovered order")
-	void shouldDrainMixedDivergenceInDocumentedOrder() throws IOException {
+	@DisplayName("should drain mixed divergence with becomeMissing committed before any restore")
+	void shouldDrainMixedDivergenceWithBecomeMissingBeforeRestores() throws IOException {
 		// Baseline: inactive=[b], missing=[d]. On disk: d, c (c is brand new, b is gone).
 		// Expected drain sequence:
-		// 1) MarkCatalogMissingMutation(b)
-		// 2) RestoreCatalogSchemaMutation(d)
-		// 3) RestoreCatalogSchemaMutation(c)
+		// 1) MarkCatalogMissingMutation(b)                     — Phase 1, awaited to completion
+		// 2) RestoreCatalogSchemaMutation(d) and RestoreCatalogSchemaMutation(c) in EITHER order — Phase 2
+		//    dispatches them in parallel so their relative WAL order is non-deterministic by design.
 		Files.createDirectory(this.storageDirectory.resolve("d"));
 		Files.createDirectory(this.storageDirectory.resolve("c"));
 		final long seedVersion = seedEngineState(2L, ArrayUtils.EMPTY_STRING_ARRAY, new String[]{"b"}, new String[]{"d"});
@@ -189,12 +191,18 @@ class EvitaBootDivergenceWalTest implements EvitaTestSupport {
 
 			final List<EngineMutation<?>> walMutations = readWalMutations(evita, seedVersion + 1);
 			assertEquals(3, walMutations.size());
+			// Phase 1 — strictly first, regardless of Phase 2 races.
 			assertInstanceOf(MarkCatalogMissingMutation.class, walMutations.get(0));
 			assertEquals("b", ((MarkCatalogMissingMutation) walMutations.get(0)).getCatalogName());
+			// Phase 2 — both restores must be present, but their relative order is not guaranteed.
 			assertInstanceOf(RestoreCatalogSchemaMutation.class, walMutations.get(1));
-			assertEquals("d", ((RestoreCatalogSchemaMutation) walMutations.get(1)).getCatalogName());
 			assertInstanceOf(RestoreCatalogSchemaMutation.class, walMutations.get(2));
-			assertEquals("c", ((RestoreCatalogSchemaMutation) walMutations.get(2)).getCatalogName());
+			final Set<String> phase2Names = Set.of(
+				((RestoreCatalogSchemaMutation) walMutations.get(1)).getCatalogName(),
+				((RestoreCatalogSchemaMutation) walMutations.get(2)).getCatalogName()
+			);
+			assertEquals(Set.of("c", "d"), phase2Names,
+				"Phase 2 must restore both 'c' (auto-discovered) and 'd' (reappeared); their WAL order is racy by design.");
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLDataEndpointFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLDataEndpointFunctionalTest.java
@@ -28,6 +28,8 @@ import io.evitadb.api.query.require.AccompanyingPriceContent;
 import io.evitadb.api.requestResponse.data.EntityClassifierWithParent;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
 import io.evitadb.api.requestResponse.data.PriceContract;
+import io.evitadb.api.requestResponse.data.PriceRangeForSale;
+import io.evitadb.api.requestResponse.data.PriceRangeForSaleWithAccompanyingPrices;
 import io.evitadb.api.requestResponse.data.PricesContract.AccompanyingPrice;
 import io.evitadb.api.requestResponse.data.PricesContract.PriceForSaleWithAccompanyingPrices;
 import io.evitadb.api.requestResponse.data.SealedEntity;
@@ -532,6 +534,110 @@ public abstract class CatalogGraphQLDataEndpointFunctionalTest extends GraphQLEn
 						.orElse(null))
 					.build())
 				.toList())
+			.build();
+	}
+
+	@Nonnull
+	protected Map<String, Object> createEntityDtoWithPriceForSaleRange(@Nonnull SealedEntity entity) {
+		final PriceRangeForSale range = entity
+			.getPriceRangeForSale(CURRENCY_CZK, null, PRICE_LIST_BASIC)
+			.orElseThrow();
+		return map()
+			.e(EntityDescriptor.PRIMARY_KEY.name(), entity.getPrimaryKey())
+			.e(EntityDescriptor.TYPE.name(), Entities.PRODUCT)
+			.e(GraphQLEntityDescriptor.PRICE_FOR_SALE.name(), priceMap(range.priceForSale()))
+			.e(GraphQLEntityDescriptor.PRICE_FOR_SALE_MIN.name(), priceMap(range.lowestPrice()))
+			.e(GraphQLEntityDescriptor.PRICE_FOR_SALE_MAX.name(), priceMap(range.highestPrice()))
+			.build();
+	}
+
+	@Nonnull
+	protected Map<String, Object> createEntityDtoWithPriceForSaleRangeForCustomPriceLists(@Nonnull SealedEntity entity,
+	                                                                                      @Nonnull String... priceLists) {
+		final PriceRangeForSale range = entity
+			.getPriceRangeForSale(CURRENCY_CZK, null, priceLists)
+			.orElseThrow();
+		return map()
+			.e(EntityDescriptor.PRIMARY_KEY.name(), entity.getPrimaryKey())
+			.e(EntityDescriptor.TYPE.name(), Entities.PRODUCT)
+			.e(GraphQLEntityDescriptor.PRICE_FOR_SALE.name(), priceMapWithInnerRecord(range.priceForSale()))
+			.e(GraphQLEntityDescriptor.PRICE_FOR_SALE_MIN.name(), priceMapWithInnerRecord(range.lowestPrice()))
+			.e(GraphQLEntityDescriptor.PRICE_FOR_SALE_MAX.name(), priceMapWithInnerRecord(range.highestPrice()))
+			.build();
+	}
+
+	@Nonnull
+	protected Map<String, Object> createEntityDtoWithAccompanyingPricesForPriceForSaleRange(@Nonnull SealedEntity entity) {
+		final String vipPrice = "vipPrice";
+
+		final EntityDecorator entityDecorator = ((EntityDecorator) entity);
+		final PriceRangeForSaleWithAccompanyingPrices priceRangeWithAccompanying = entityDecorator
+			.getPriceRangeForSaleWithAccompanyingPrices(
+				CURRENCY_CZK,
+				null,
+				new String[]{PRICE_LIST_BASIC},
+				new AccompanyingPrice[]{
+					new AccompanyingPrice(PriceForSaleDescriptor.ACCOMPANYING_PRICE.name(), PRICE_LIST_REFERENCE),
+					new AccompanyingPrice(vipPrice, PRICE_LIST_VIP)
+				}
+			)
+			.orElseThrow();
+		final PriceRangeForSale range = priceRangeWithAccompanying.priceRange();
+		final Map<String, Optional<PriceContract>> accompanyingPrices = priceRangeWithAccompanying.accompanyingPrices();
+		assertTrue(accompanyingPrices.get(PriceForSaleDescriptor.ACCOMPANYING_PRICE.name()).isPresent());
+		assertTrue(accompanyingPrices.get(vipPrice).isPresent());
+
+		return map()
+			.e(EntityDescriptor.PRIMARY_KEY.name(), entity.getPrimaryKey())
+			.e(EntityDescriptor.TYPE.name(), Entities.PRODUCT)
+			.e(GraphQLEntityDescriptor.PRICE_FOR_SALE.name(),
+				priceMapWithAccompanyingPrices(range.priceForSale(), accompanyingPrices, vipPrice))
+			.e(GraphQLEntityDescriptor.PRICE_FOR_SALE_MIN.name(),
+				priceMapWithAccompanyingPrices(range.lowestPrice(), accompanyingPrices, vipPrice))
+			.e(GraphQLEntityDescriptor.PRICE_FOR_SALE_MAX.name(),
+				priceMapWithAccompanyingPrices(range.highestPrice(), accompanyingPrices, vipPrice))
+			.build();
+	}
+
+	@Nonnull
+	private static Map<String, Object> priceMap(@Nonnull PriceContract price) {
+		return map()
+			.e(TYPENAME_FIELD, PriceForSaleDescriptor.THIS.name())
+			.e(PriceDescriptor.CURRENCY.name(), price.currency().toString())
+			.e(PriceDescriptor.PRICE_LIST.name(), price.priceList())
+			.e(PriceDescriptor.PRICE_WITH_TAX.name(), price.priceWithTax().toString())
+			.build();
+	}
+
+	@Nonnull
+	private static Map<String, Object> priceMapWithInnerRecord(@Nonnull PriceContract price) {
+		return map()
+			.e(TYPENAME_FIELD, PriceForSaleDescriptor.THIS.name())
+			.e(PriceDescriptor.CURRENCY.name(), price.currency().toString())
+			.e(PriceDescriptor.PRICE_LIST.name(), price.priceList())
+			.e(PriceDescriptor.PRICE_WITH_TAX.name(), price.priceWithTax().toString())
+			.e(PriceDescriptor.INNER_RECORD_ID.name(), price.innerRecordId())
+			.build();
+	}
+
+	@Nonnull
+	private static Map<String, Object> priceMapWithAccompanyingPrices(@Nonnull PriceContract price,
+	                                                                  @Nonnull Map<String, Optional<PriceContract>> accompanyingPrices,
+	                                                                  @Nonnull String vipPriceName) {
+		return map()
+			.e(TYPENAME_FIELD, PriceForSaleDescriptor.THIS.name())
+			.e(PriceDescriptor.PRICE_WITH_TAX.name(), price.priceWithTax().toString())
+			.e(PriceForSaleDescriptor.ACCOMPANYING_PRICE.name(),
+				accompanyingPrices.get(PriceForSaleDescriptor.ACCOMPANYING_PRICE.name())
+					.map(p -> map()
+						.e(TYPENAME_FIELD, PriceDescriptor.THIS.name())
+						.e(PriceDescriptor.PRICE_WITH_TAX.name(), p.priceWithTax().toString()))
+					.orElse(null))
+			.e(vipPriceName, accompanyingPrices.get(vipPriceName)
+				.map(p -> map()
+					.e(TYPENAME_FIELD, PriceDescriptor.THIS.name())
+					.e(PriceDescriptor.PRICE_WITH_TAX.name(), p.priceWithTax().toString()))
+				.orElse(null))
 			.build();
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLQueryEntityQueryFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLQueryEntityQueryFunctionalTest.java
@@ -38,10 +38,13 @@ import io.evitadb.api.requestResponse.data.EntityClassifier;
 import io.evitadb.api.requestResponse.data.EntityContract;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.api.requestResponse.data.PriceRangeForSale;
+import io.evitadb.api.requestResponse.data.PriceRangeForSaleWithAccompanyingPrices;
 import io.evitadb.api.requestResponse.data.PricesContract.AccompanyingPrice;
 import io.evitadb.api.requestResponse.data.PricesContract.PriceForSaleWithAccompanyingPrices;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
 import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.data.structure.EntityDecorator;
 import io.evitadb.api.requestResponse.data.structure.EntityReference;
 import io.evitadb.api.requestResponse.extraResult.AttributeHistogram;
 import io.evitadb.api.requestResponse.extraResult.FacetSummary;
@@ -123,6 +126,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.evitadb.test.TestTags.GRAPHQL;
 import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.PRICE;
 import static io.evitadb.test.TestTags.QUERY;
 
 /**
@@ -3474,6 +3478,475 @@ public class CatalogGraphQLQueryEntityQueryFunctionalTest extends CatalogGraphQL
 				}
 				""",
 				serializeIntArrayToQueryString(desiredEntities))
+			.executeAndExpectErrorsAndThen();
+	}
+
+	@Test
+	@Tag(PRICE)
+	@UseDataSet(GRAPHQL_THOUSAND_PRODUCTS)
+	@DisplayName("Should return price for sale range for products with NONE inner record handling")
+	void shouldReturnPriceForSaleRangeForNoneInnerRecordHandling(GraphQLTester tester,
+		List<SealedEntity> originalProductEntities) {
+		final List<SealedEntity> entities = findEntities(
+			originalProductEntities,
+			it -> it.getPriceInnerRecordHandling().equals(PriceInnerRecordHandling.NONE) &&
+				it.getPrices(CURRENCY_CZK, PRICE_LIST_BASIC).size() == 1,
+			2
+		);
+
+		// sanity: ensure SDK reports the expected NONE-strategy collapse so the test asserts something meaningful
+		entities.forEach(entity -> {
+			final PriceRangeForSale range = entity.getPriceRangeForSale(CURRENCY_CZK, null, PRICE_LIST_BASIC).orElseThrow();
+			assertEquals(range.priceForSale().priceWithTax(), range.lowestPrice().priceWithTax());
+			assertEquals(range.priceForSale().priceWithTax(), range.highestPrice().priceWithTax());
+		});
+
+		final List<Map<String, Object>> expectedBody = entities.stream()
+			.map(this::createEntityDtoWithPriceForSaleRange)
+			.toList();
+
+		tester.test(TEST_CATALOG)
+			.document(
+				"""
+					query {
+						queryProduct(
+							filterBy: {
+								entityPrimaryKeyInSet: [%d, %d]
+								priceInCurrency: CZK
+								priceInPriceLists: "basic"
+							}
+						) {
+							recordPage {
+								data {
+									primaryKey
+									type
+									priceForSale {
+										__typename
+										currency
+										priceList
+										priceWithTax
+									}
+									priceForSaleMin {
+										__typename
+										currency
+										priceList
+										priceWithTax
+									}
+									priceForSaleMax {
+										__typename
+										currency
+										priceList
+										priceWithTax
+									}
+								}
+							}
+						}
+					}
+					""",
+				entities.get(0).getPrimaryKey(),
+				entities.get(1).getPrimaryKey()
+			)
+			.executeAndThen()
+			.statusCode(200)
+			.body(ERRORS_PATH, nullValue())
+			.body(PRODUCT_QUERY_DATA_PATH, equalTo(expectedBody));
+	}
+
+	@Test
+	@Tag(PRICE)
+	@UseDataSet(GRAPHQL_THOUSAND_PRODUCTS)
+	@DisplayName("Should return price for sale range for master products with LOWEST_PRICE inner record handling")
+	void shouldReturnPriceForSaleRangeForLowestPriceInnerRecordHandling(GraphQLTester tester,
+		List<SealedEntity> originalProductEntities) {
+		final List<SealedEntity> entities = findEntities(
+			originalProductEntities,
+			it -> it.getPriceInnerRecordHandling().equals(PriceInnerRecordHandling.LOWEST_PRICE) &&
+				it.getPrices(CURRENCY_CZK)
+					.stream()
+					.filter(PriceContract::indexed)
+					.map(PriceContract::innerRecordId)
+					.distinct()
+					.count() > 1,
+			2
+		);
+
+		final List<String> priceLists = entities.stream()
+			.flatMap(it -> it.getPrices(CURRENCY_CZK).stream().map(PriceContract::priceList))
+			.distinct()
+			.toList();
+
+		// sanity: confirm the strategy actually produces a non-collapsed range for the picked entities
+		entities.forEach(entity -> {
+			final PriceRangeForSale range = entity.getPriceRangeForSale(
+				CURRENCY_CZK, null, priceLists.toArray(String[]::new)
+			).orElseThrow();
+			assertTrue(
+				range.lowestPrice().priceWithTax().compareTo(range.highestPrice().priceWithTax()) <= 0,
+				"Lowest price must be less than or equal to highest price for LOWEST_PRICE strategy."
+			);
+		});
+
+		final List<Map<String, Object>> expectedBody = entities.stream()
+			.map(entity -> createEntityDtoWithPriceForSaleRangeForCustomPriceLists(entity, priceLists.toArray(String[]::new)))
+			.toList();
+
+		tester.test(TEST_CATALOG)
+			.document(
+				"""
+					query {
+						queryProduct(
+							filterBy: {
+								entityPrimaryKeyInSet: [%d, %d]
+								priceInCurrency: CZK
+								priceInPriceLists: %s
+							}
+						) {
+							recordPage {
+								data {
+									primaryKey
+									type
+									priceForSale {
+										__typename
+										currency
+										priceList
+										priceWithTax
+										innerRecordId
+									}
+									priceForSaleMin {
+										__typename
+										currency
+										priceList
+										priceWithTax
+										innerRecordId
+									}
+									priceForSaleMax {
+										__typename
+										currency
+										priceList
+										priceWithTax
+										innerRecordId
+									}
+								}
+							}
+						}
+					}
+					""",
+				entities.get(0).getPrimaryKey(),
+				entities.get(1).getPrimaryKey(),
+				serializeStringArrayToQueryString(priceLists)
+			)
+			.executeAndThen()
+			.statusCode(200)
+			.body(ERRORS_PATH, nullValue())
+			.body(PRODUCT_QUERY_DATA_PATH, equalTo(expectedBody));
+	}
+
+	@Test
+	@Tag(PRICE)
+	@UseDataSet(GRAPHQL_THOUSAND_PRODUCTS)
+	@DisplayName("Should return price for sale range for master products with SUM inner record handling")
+	void shouldReturnPriceForSaleRangeForSumInnerRecordHandling(GraphQLTester tester,
+		List<SealedEntity> originalProductEntities) {
+		final List<SealedEntity> entities = findEntities(
+			originalProductEntities,
+			it -> it.getPriceInnerRecordHandling().equals(PriceInnerRecordHandling.SUM) &&
+				it.getPrices(CURRENCY_CZK)
+					.stream()
+					.filter(PriceContract::indexed)
+					.map(PriceContract::innerRecordId)
+					.distinct()
+					.count() > 1,
+			2
+		);
+
+		final List<String> priceLists = entities.stream()
+			.flatMap(it -> it.getPrices(CURRENCY_CZK).stream().map(PriceContract::priceList))
+			.distinct()
+			.toList();
+
+		// sanity: SUM ⇒ priceForSale (cumulated) >= highestPrice >= lowestPrice (component prices)
+		entities.forEach(entity -> {
+			final PriceRangeForSale range = entity.getPriceRangeForSale(
+				CURRENCY_CZK, null, priceLists.toArray(String[]::new)
+			).orElseThrow();
+			assertTrue(
+				range.lowestPrice().priceWithTax().compareTo(range.highestPrice().priceWithTax()) <= 0,
+				"Lowest component price must be <= highest component price under SUM."
+			);
+			assertTrue(
+				range.priceForSale().priceWithTax().compareTo(range.highestPrice().priceWithTax()) >= 0,
+				"Cumulated SUM price must be >= the highest per-inner-record component price."
+			);
+		});
+
+		tester.test(TEST_CATALOG)
+			.document(
+				"""
+					query {
+						queryProduct(
+							filterBy: {
+								entityPrimaryKeyInSet: [%d, %d]
+								priceInCurrency: CZK
+								priceInPriceLists: %s
+							}
+						) {
+							recordPage {
+								data {
+									primaryKey
+									type
+									priceForSale {
+										priceWithTax
+									}
+									priceForSaleMin {
+										priceWithTax
+									}
+									priceForSaleMax {
+										priceWithTax
+									}
+								}
+							}
+						}
+					}
+					""",
+				entities.get(0).getPrimaryKey(),
+				entities.get(1).getPrimaryKey(),
+				serializeStringArrayToQueryString(priceLists)
+			)
+			.executeAndExpectOkAndThen()
+			.body(PRODUCT_QUERY_DATA_PATH + "[0].priceForSale", notNullValue())
+			.body(PRODUCT_QUERY_DATA_PATH + "[0].priceForSaleMin.priceWithTax",
+				equalTo(entities.get(0).getPriceRangeForSale(CURRENCY_CZK, null, priceLists.toArray(String[]::new))
+					.orElseThrow().lowestPrice().priceWithTax().toString()))
+			.body(PRODUCT_QUERY_DATA_PATH + "[0].priceForSaleMax.priceWithTax",
+				equalTo(entities.get(0).getPriceRangeForSale(CURRENCY_CZK, null, priceLists.toArray(String[]::new))
+					.orElseThrow().highestPrice().priceWithTax().toString()))
+			.body(PRODUCT_QUERY_DATA_PATH + "[0].priceForSale.priceWithTax",
+				equalTo(entities.get(0).getPriceRangeForSale(CURRENCY_CZK, null, priceLists.toArray(String[]::new))
+					.orElseThrow().priceForSale().priceWithTax().toString()));
+	}
+
+	@Test
+	@Tag(PRICE)
+	@UseDataSet(GRAPHQL_THOUSAND_PRODUCTS)
+	@DisplayName("Should return price for sale range with custom field arguments overriding query constraints")
+	void shouldReturnCustomPriceForSaleRangeForProducts(GraphQLTester tester,
+		List<SealedEntity> originalProductEntities) {
+		// pick entities that have prices in both CZK basic AND EUR — to prove the field arguments override
+		// the surrounding query constraint (which here is `priceInCurrency: EUR`).
+		final List<SealedEntity> entities = findEntities(
+			originalProductEntities,
+			it -> it.getPriceInnerRecordHandling().equals(PriceInnerRecordHandling.NONE) &&
+				it.getPrices(CURRENCY_CZK, PRICE_LIST_BASIC).size() == 1 &&
+				it.getPrices(CURRENCY_CZK, PRICE_LIST_BASIC).stream().allMatch(PriceContract::indexed) &&
+				!it.getPrices(CURRENCY_EUR).isEmpty() &&
+				it.getPrices(CURRENCY_EUR).stream().allMatch(PriceContract::indexed),
+			2
+		);
+
+		final List<Map<String, Object>> expectedBody = entities.stream()
+			.map(this::createEntityDtoWithPriceForSaleRange)
+			.toList();
+
+		tester.test(TEST_CATALOG)
+			.document(
+				"""
+					query {
+						queryProduct(
+							filterBy: {
+								entityPrimaryKeyInSet: [%d, %d]
+								priceInCurrency: EUR
+							}
+						) {
+							recordPage {
+								data {
+									primaryKey
+									type
+									priceForSale(currency: CZK, priceLists: ["basic"]) {
+										__typename
+										currency
+										priceList
+										priceWithTax
+									}
+									priceForSaleMin(currency: CZK, priceLists: ["basic"]) {
+										__typename
+										currency
+										priceList
+										priceWithTax
+									}
+									priceForSaleMax(currency: CZK, priceLists: ["basic"]) {
+										__typename
+										currency
+										priceList
+										priceWithTax
+									}
+								}
+							}
+						}
+					}
+					""",
+				entities.get(0).getPrimaryKey(),
+				entities.get(1).getPrimaryKey()
+			)
+			.executeAndThen()
+			.statusCode(200)
+			.body(ERRORS_PATH, nullValue())
+			.body(PRODUCT_QUERY_DATA_PATH, equalTo(expectedBody));
+	}
+
+	@Test
+	@Tag(PRICE)
+	@UseDataSet(GRAPHQL_THOUSAND_PRODUCTS)
+	@DisplayName("Should return accompanying prices nested under each sub-price of price for sale range")
+	void shouldReturnAccompanyingPricesForPriceForSaleRange(Evita evita, GraphQLTester tester,
+		List<SealedEntity> originalProductEntities) {
+		final List<Integer> desiredEntities = originalProductEntities.stream()
+			.filter(entity -> {
+				if (!entity.getPriceInnerRecordHandling().equals(PriceInnerRecordHandling.NONE)) {
+					return false;
+				}
+				final Optional<PriceForSaleWithAccompanyingPrices> prices = entity.getPriceForSaleWithAccompanyingPrices(
+					CURRENCY_CZK,
+					null,
+					new String[]{PRICE_LIST_BASIC},
+					new AccompanyingPrice[]{
+						new AccompanyingPrice(PriceForSaleDescriptor.ACCOMPANYING_PRICE.name(), PRICE_LIST_REFERENCE),
+						new AccompanyingPrice("vipPrice", PRICE_LIST_VIP)
+					}
+				);
+				return prices.isPresent() &&
+					prices.get().accompanyingPrices().get(PriceForSaleDescriptor.ACCOMPANYING_PRICE.name()).isPresent() &&
+					prices.get().accompanyingPrices().get("vipPrice").isPresent();
+			})
+			.map(EntityContract::getPrimaryKey)
+			.toList();
+		assertTrue(desiredEntities.size() > 1);
+
+		final EvitaResponse<SealedEntity> exampleResponse = queryEntities(
+			evita,
+			query(
+				collection(Entities.PRODUCT),
+				filterBy(
+					entityPrimaryKeyInSet(desiredEntities.toArray(Integer[]::new)),
+					priceInPriceLists(PRICE_LIST_BASIC),
+					priceInCurrency(CURRENCY_CZK)
+				),
+				require(
+					entityFetch(
+						priceContent(PriceContentMode.RESPECTING_FILTER, PRICE_LIST_REFERENCE, PRICE_LIST_VIP)
+					)
+				)
+			),
+			SealedEntity.class
+		);
+
+		final List<Map<String, Object>> expectedBody = exampleResponse.getRecordData().stream()
+			.map(this::createEntityDtoWithAccompanyingPricesForPriceForSaleRange)
+			.toList();
+		tester.test(TEST_CATALOG)
+			.document("""
+				query {
+					queryProduct(
+						filterBy: {
+							entityPrimaryKeyInSet: %s,
+							priceInPriceLists: "basic",
+							priceInCurrency: CZK
+						}
+					) {
+						recordPage {
+							data {
+								primaryKey
+								type
+								priceForSale {
+									__typename
+									priceWithTax
+									accompanyingPrice(priceLists: "reference") {
+										__typename
+										priceWithTax
+									}
+									vipPrice: accompanyingPrice(priceLists: "vip") {
+										__typename
+										priceWithTax
+									}
+								}
+								priceForSaleMin {
+									__typename
+									priceWithTax
+									accompanyingPrice(priceLists: "reference") {
+										__typename
+										priceWithTax
+									}
+									vipPrice: accompanyingPrice(priceLists: "vip") {
+										__typename
+										priceWithTax
+									}
+								}
+								priceForSaleMax {
+									__typename
+									priceWithTax
+									accompanyingPrice(priceLists: "reference") {
+										__typename
+										priceWithTax
+									}
+									vipPrice: accompanyingPrice(priceLists: "vip") {
+										__typename
+										priceWithTax
+									}
+								}
+							}
+						}
+					}
+				}
+				""",
+				serializeIntArrayToQueryString(desiredEntities))
+			.executeAndExpectOkAndThen()
+			.body(PRODUCT_QUERY_DATA_PATH, equalTo(expectedBody));
+	}
+
+	/**
+	 * Verifies that the `priceForSaleMin` field rejects callers that provide `priceLists` without an
+	 * accompanying `priceInCurrency` constraint anywhere in the query. The field arguments deliberately allow
+	 * overriding only the surrounding query-level price context, so a missing currency anywhere in the chain
+	 * must surface as a GraphQL error rather than silently using a fallback currency. (Same rule applies to
+	 * `priceForSaleMax`.)
+	 */
+	@Test
+	@Tag(PRICE)
+	@UseDataSet(GRAPHQL_THOUSAND_PRODUCTS)
+	@DisplayName("Should return error when priceForSaleMin arguments lack currency anywhere in the query")
+	void shouldThrowExceptionWhenPriceForSaleRangeArgumentsLackCurrency(GraphQLTester tester,
+		List<SealedEntity> originalProductEntities) {
+		// pick any two entities — the query is expected to fail at validation, before any data fetch
+		final List<SealedEntity> entities = findEntities(
+			originalProductEntities,
+			it -> it.getPriceInnerRecordHandling().equals(PriceInnerRecordHandling.NONE) &&
+				it.getPrices(CURRENCY_CZK, PRICE_LIST_BASIC).size() == 1,
+			2
+		);
+
+		tester.test(TEST_CATALOG)
+			.document(
+				"""
+					query {
+						queryProduct(
+							filterBy: {
+								entityPrimaryKeyInSet: [%d, %d]
+							}
+						) {
+							recordPage {
+								data {
+									primaryKey
+									type
+									priceForSaleMin(priceLists: ["basic"]) {
+										priceWithTax
+									}
+								}
+							}
+						}
+					}
+					""",
+				entities.get(0).getPrimaryKey(),
+				entities.get(1).getPrimaryKey()
+			)
 			.executeAndExpectErrorsAndThen();
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/requestResponse/data/EntityConverterTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/requestResponse/data/EntityConverterTest.java
@@ -24,10 +24,29 @@
 package io.evitadb.externalApi.grpc.requestResponse.data;
 
 import io.evitadb.api.query.order.OrderDirection;
+import io.evitadb.api.query.require.PriceContentMode;
+import io.evitadb.api.query.require.QueryPriceMode;
+import io.evitadb.api.requestResponse.EvitaRequest;
+import io.evitadb.api.requestResponse.data.PriceContract;
+import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.api.requestResponse.data.PriceRangeForSale;
+import io.evitadb.api.requestResponse.data.PricesContract.AccompanyingPrice;
 import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.data.structure.AssociatedData;
 import io.evitadb.api.requestResponse.data.structure.BinaryEntity;
+import io.evitadb.api.requestResponse.data.structure.Entity;
+import io.evitadb.api.requestResponse.data.structure.EntityAttributes;
+import io.evitadb.api.requestResponse.data.structure.EntityDecorator;
 import io.evitadb.api.requestResponse.data.structure.InitialEntityBuilder;
 import io.evitadb.api.requestResponse.data.structure.Price;
+import io.evitadb.api.requestResponse.data.structure.Prices;
+import io.evitadb.api.requestResponse.data.structure.References;
+import io.evitadb.api.requestResponse.data.structure.predicate.AssociatedDataValueSerializablePredicate;
+import io.evitadb.api.requestResponse.data.structure.predicate.AttributeValueSerializablePredicate;
+import io.evitadb.api.requestResponse.data.structure.predicate.HierarchySerializablePredicate;
+import io.evitadb.api.requestResponse.data.structure.predicate.LocaleSerializablePredicate;
+import io.evitadb.api.requestResponse.data.structure.predicate.PriceContractSerializablePredicate;
+import io.evitadb.api.requestResponse.data.structure.predicate.ReferenceContractSerializablePredicate;
 import io.evitadb.api.requestResponse.schema.Cardinality;
 import io.evitadb.api.requestResponse.schema.EvolutionMode;
 import io.evitadb.api.requestResponse.schema.OrderBehaviour;
@@ -47,23 +66,35 @@ import io.evitadb.externalApi.grpc.generated.GrpcSealedEntity;
 import io.evitadb.externalApi.grpc.testUtils.GrpcAssertions;
 import io.evitadb.test.Entities;
 import io.evitadb.utils.VersionUtils.SemVer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Currency;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Tag;
 
 import static io.evitadb.test.TestTags.GRPC;
 import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.PRICE;
 import static io.evitadb.test.TestTags.QUERY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This test verifies functionalities of methods in {@link EntityConverter} class.
@@ -73,7 +104,16 @@ import static io.evitadb.test.TestTags.QUERY;
 @Tag(GRPC)
 @Tag(EXTERNAL_API)
 @Tag(QUERY)
+@Tag(PRICE)
 class EntityConverterTest {
+
+	private static final Currency CZK = Currency.getInstance("CZK");
+	private static final Currency EUR = Currency.getInstance("EUR");
+	private static final String BASIC = "basic";
+	private static final OffsetDateTime MOMENT_2020 = OffsetDateTime.of(
+		2020, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC
+	);
+
 
 	@Test
 	void buildSealedEntityOldVersion() {
@@ -176,5 +216,245 @@ class EntityConverterTest {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Builds an {@link EntityDecorator} populated with the given prices and a synthetic price-for-sale context
+	 * (currency = CZK, valid-in = 2020-12-31, price-list = `basic`). The resulting decorator returns a populated
+	 * {@code priceForSale} via {@link io.evitadb.api.requestResponse.data.PricesContract#getPriceForSale()} and a
+	 * matching {@link PriceRangeForSale} via
+	 * {@link io.evitadb.api.requestResponse.data.PricesContract#getPriceRangeForSaleIfAvailable()} so that
+	 * {@link EntityConverter#toGrpcSealedEntity(SealedEntity, SemVer)} emits the new
+	 * {@code priceForSaleMin} / {@code priceForSaleMax} fields.
+	 */
+	@Nonnull
+	private static EntityDecorator buildDecoratorWithPriceContext(
+		@Nonnull EntitySchema schema,
+		@Nonnull PriceInnerRecordHandling innerRecordHandling,
+		@Nonnull List<PriceContract> prices
+	) {
+		return buildDecoratorWithPriceContext(schema, innerRecordHandling, prices, CZK);
+	}
+
+	/**
+	 * Variant of {@link #buildDecoratorWithPriceContext(EntitySchema, PriceInnerRecordHandling, List)} that lets
+	 * the caller pick the currency advertised by the synthetic {@link EvitaRequest}. Passing a currency that no
+	 * stored price uses lets a test verify the gRPC converter's behaviour when the request predicate filters out
+	 * the selling price.
+	 */
+	@Nonnull
+	private static EntityDecorator buildDecoratorWithPriceContext(
+		@Nonnull EntitySchema schema,
+		@Nonnull PriceInnerRecordHandling innerRecordHandling,
+		@Nonnull List<PriceContract> prices,
+		@Nonnull Currency requestedCurrency
+	) {
+		final EvitaRequest evitaRequest = Mockito.mock(EvitaRequest.class);
+		Mockito.when(evitaRequest.getRequiresEntityPrices()).thenReturn(PriceContentMode.RESPECTING_FILTER);
+		Mockito.when(evitaRequest.getRequiresCurrency()).thenReturn(requestedCurrency);
+		Mockito.when(evitaRequest.getRequiresPriceValidIn()).thenReturn(MOMENT_2020);
+		Mockito.when(evitaRequest.getRequiresPriceLists()).thenReturn(new String[]{BASIC});
+		Mockito.when(evitaRequest.getFetchesAdditionalPriceLists()).thenReturn(new String[0]);
+		Mockito.when(evitaRequest.getAccompanyingPrices()).thenReturn(new AccompanyingPrice[0]);
+		Mockito.when(evitaRequest.getQueryPriceMode()).thenReturn(QueryPriceMode.WITH_TAX);
+
+		final Entity delegate = Entity._internalBuild(
+			1,
+			1,
+			schema,
+			null,
+			new References(schema),
+			new EntityAttributes(schema),
+			new AssociatedData(schema),
+			new Prices(schema, 1, prices, innerRecordHandling),
+			Collections.emptySet(),
+			Scope.DEFAULT_SCOPE,
+			false
+		);
+
+		return new EntityDecorator(
+			delegate,
+			schema,
+			null,
+			new LocaleSerializablePredicate(evitaRequest),
+			new HierarchySerializablePredicate(evitaRequest),
+			new AttributeValueSerializablePredicate(evitaRequest),
+			new AssociatedDataValueSerializablePredicate(evitaRequest),
+			new ReferenceContractSerializablePredicate(evitaRequest),
+			new PriceContractSerializablePredicate(evitaRequest, Boolean.TRUE),
+			MOMENT_2020
+		);
+	}
+
+	/**
+	 * Asserts that the converted gRPC entity carries `priceForSaleMin` / `priceForSaleMax` matching the
+	 * {@link PriceRangeForSale} computed from the source entity for the same currency / valid-in / price-list filters.
+	 */
+	private static void assertPriceRangeRoundTripsThrough(
+		@Nonnull EntityDecorator decorator,
+		@Nonnull GrpcSealedEntity grpcEntity
+	) {
+		assertTrue(grpcEntity.hasPriceForSale(), "priceForSale must be emitted as the prerequisite for the range");
+		assertTrue(grpcEntity.hasPriceForSaleMin(), "priceForSaleMin must be emitted alongside priceForSale");
+		assertTrue(grpcEntity.hasPriceForSaleMax(), "priceForSaleMax must be emitted alongside priceForSale");
+
+		final Optional<PriceRangeForSale> expectedRange = decorator.getPriceRangeForSaleIfAvailable();
+		assertTrue(expectedRange.isPresent(), "source entity must expose a PriceRangeForSale");
+		final PriceRangeForSale range = expectedRange.get();
+
+		GrpcAssertions.assertPrice(range.lowestPrice(), grpcEntity.getPriceForSaleMin());
+		GrpcAssertions.assertPrice(range.highestPrice(), grpcEntity.getPriceForSaleMax());
+		GrpcAssertions.assertPrice(range.priceForSale(), grpcEntity.getPriceForSale());
+	}
+
+	/**
+	 * Builds a price contract with the supplied amount under the default `basic` / CZK / no-validity / indexed setup.
+	 */
+	@Nonnull
+	private static PriceContract priceOf(int priceId, @Nullable Integer innerRecordId, @Nonnull BigDecimal amount) {
+		return new Price(
+			new Price.PriceKey(priceId, BASIC, CZK),
+			innerRecordId,
+			amount,
+			new BigDecimal("21"),
+			amount.multiply(new BigDecimal("1.21")),
+			null,
+			true
+		);
+	}
+
+	@Nested
+	@DisplayName("Price range round-trip via gRPC EntityConverter")
+	class PriceRangeRoundTripTests {
+
+		@Test
+		@DisplayName("NONE strategy collapses range to selling price")
+		void shouldRoundTripPriceRangeForNoneStrategy() {
+			final EntitySchema schema = createEntitySchema();
+			final List<PriceContract> prices = List.of(
+				priceOf(1, null, new BigDecimal("100"))
+			);
+			final EntityDecorator decorator = buildDecoratorWithPriceContext(
+				schema, PriceInnerRecordHandling.NONE, prices
+			);
+
+			final GrpcSealedEntity grpcEntity = EntityConverter.toGrpcSealedEntity(decorator, new SemVer(2025, 4));
+
+			assertPriceRangeRoundTripsThrough(decorator, grpcEntity);
+			// NONE collapses min == max == priceForSale
+			assertEquals(grpcEntity.getPriceForSale(), grpcEntity.getPriceForSaleMin());
+			assertEquals(grpcEntity.getPriceForSale(), grpcEntity.getPriceForSaleMax());
+			// gRPC emits all source prices so the receiver can recompute the same range
+			assertEquals(prices.size(), grpcEntity.getPricesCount());
+		}
+
+		@Test
+		@DisplayName("LOWEST_PRICE strategy: lowest equals priceForSale, highest is most expensive variant")
+		void shouldRoundTripPriceRangeForLowestPriceStrategy() {
+			final EntitySchema schema = createEntitySchema();
+			final List<PriceContract> prices = List.of(
+				priceOf(1, 100, new BigDecimal("80")),
+				priceOf(2, 200, new BigDecimal("120")),
+				priceOf(3, 300, new BigDecimal("150"))
+			);
+			final EntityDecorator decorator = buildDecoratorWithPriceContext(
+				schema, PriceInnerRecordHandling.LOWEST_PRICE, prices
+			);
+
+			final GrpcSealedEntity grpcEntity = EntityConverter.toGrpcSealedEntity(decorator, new SemVer(2025, 4));
+
+			assertPriceRangeRoundTripsThrough(decorator, grpcEntity);
+			// LOWEST_PRICE: min equals priceForSale, max is the most expensive per-inner-record price
+			assertEquals(grpcEntity.getPriceForSale(), grpcEntity.getPriceForSaleMin());
+			assertFalse(
+				grpcEntity.getPriceForSaleMin().equals(grpcEntity.getPriceForSaleMax()),
+				"min and max must differ when there are multiple inner records"
+			);
+			assertEquals(
+				new BigDecimal("80"),
+				priceWithoutTax(grpcEntity.getPriceForSaleMin())
+			);
+			assertEquals(
+				new BigDecimal("150"),
+				priceWithoutTax(grpcEntity.getPriceForSaleMax())
+			);
+			assertEquals(prices.size(), grpcEntity.getPricesCount());
+		}
+
+		@Test
+		@DisplayName("SUM strategy: priceForSale is cumulated, bounds are component prices")
+		void shouldRoundTripPriceRangeForSumStrategy() {
+			final EntitySchema schema = createEntitySchema();
+			final List<PriceContract> prices = List.of(
+				priceOf(1, 100, new BigDecimal("80")),
+				priceOf(2, 200, new BigDecimal("120")),
+				priceOf(3, 300, new BigDecimal("150"))
+			);
+			final EntityDecorator decorator = buildDecoratorWithPriceContext(
+				schema, PriceInnerRecordHandling.SUM, prices
+			);
+
+			final GrpcSealedEntity grpcEntity = EntityConverter.toGrpcSealedEntity(decorator, new SemVer(2025, 4));
+
+			assertPriceRangeRoundTripsThrough(decorator, grpcEntity);
+			// SUM: min / max are component prices (cheapest and most expensive variant)
+			assertEquals(
+				new BigDecimal("80"),
+				priceWithoutTax(grpcEntity.getPriceForSaleMin())
+			);
+			assertEquals(
+				new BigDecimal("150"),
+				priceWithoutTax(grpcEntity.getPriceForSaleMax())
+			);
+			// SUM: priceForSale is cumulated, so it must equal the sum of all three component prices
+			assertEquals(
+				new BigDecimal("350"),
+				priceWithoutTax(grpcEntity.getPriceForSale())
+			);
+			assertEquals(prices.size(), grpcEntity.getPricesCount());
+		}
+
+		/**
+		 * Verifies that when the synthetic {@link EvitaRequest} predicate filters out the selling price (here,
+		 * by requesting EUR while the entity only carries CZK prices), the gRPC converter must NOT emit any of
+		 * `priceForSale`, `priceForSaleMin`, or `priceForSaleMax`. The range bounds are emitted as a
+		 * sibling of the selling price; without a selling price they would be meaningless on the wire.
+		 */
+		@Test
+		@DisplayName("No priceForSale, priceForSaleMin or priceForSaleMax emitted when request filters out the selling price")
+		void shouldNotEmitPriceRangeFieldsWhenPriceForSaleIsAbsent() {
+			final EntitySchema schema = createEntitySchema();
+			// stored prices are in CZK only — request currency EUR will filter them all out
+			final List<PriceContract> prices = List.of(
+				priceOf(1, 100, new BigDecimal("80")),
+				priceOf(2, 200, new BigDecimal("120")),
+				priceOf(3, 300, new BigDecimal("150"))
+			);
+			final EntityDecorator decorator = buildDecoratorWithPriceContext(
+				schema, PriceInnerRecordHandling.LOWEST_PRICE, prices, EUR
+			);
+
+			final GrpcSealedEntity grpcEntity = EntityConverter.toGrpcSealedEntity(decorator, new SemVer(2025, 4));
+
+			// the selling price guard must short-circuit emission of all three fields
+			assertFalse(grpcEntity.hasPriceForSale(), "priceForSale must not be emitted when the selling price is absent");
+			assertFalse(
+				grpcEntity.hasPriceForSaleMin(),
+				"priceForSaleMin must not be emitted without a selling price"
+			);
+			assertFalse(
+				grpcEntity.hasPriceForSaleMax(),
+				"priceForSaleMax must not be emitted without a selling price"
+			);
+		}
+	}
+
+	/**
+	 * Extracts the price-without-tax from a {@link GrpcPrice} for assertions.
+	 */
+	@Nonnull
+	private static BigDecimal priceWithoutTax(@Nonnull GrpcPrice grpcPrice) {
+		return io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter
+			.toBigDecimal(grpcPrice.getPriceWithoutTax());
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/CatalogRestDataEndpointFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/CatalogRestDataEndpointFunctionalTest.java
@@ -371,6 +371,11 @@ public abstract class CatalogRestDataEndpointFunctionalTest extends RestEndpoint
 			entity.getPriceForSaleWithAccompanyingPricesIfAvailable().ifPresent(price -> {
 				entityDto.e(EntityDescriptor.PRICE_FOR_SALE.name(), createEntityPriceDto(price.priceForSale()));
 
+				entity.getPriceRangeForSaleIfAvailable().ifPresent(range -> {
+					entityDto.e(EntityDescriptor.PRICE_FOR_SALE_MIN.name(), createEntityPriceDto(range.lowestPrice()));
+					entityDto.e(EntityDescriptor.PRICE_FOR_SALE_MAX.name(), createEntityPriceDto(range.highestPrice()));
+				});
+
 				final Map<String, Optional<PriceContract>> accompanyingPrices = price.accompanyingPrices();
 				if (!accompanyingPrices.isEmpty()) {
 					final MapBuilder accompanyingPricesObject = map();

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/CatalogRestQueryEntityQueryFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/CatalogRestQueryEntityQueryFunctionalTest.java
@@ -41,6 +41,7 @@ import io.evitadb.api.requestResponse.data.EntityClassifier;
 import io.evitadb.api.requestResponse.data.EntityContract;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.api.requestResponse.data.PriceRangeForSale;
 import io.evitadb.api.requestResponse.data.SealedEntity;
 import io.evitadb.api.requestResponse.data.structure.EntityReference;
 import io.evitadb.api.requestResponse.extraResult.AttributeHistogram;
@@ -105,6 +106,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.evitadb.test.TestTags.REST;
 import static io.evitadb.test.TestTags.EXTERNAL_API;
 import static io.evitadb.test.TestTags.QUERY;
+import static io.evitadb.test.TestTags.PRICE;
 
 /**
  * Tests for REST catalog entity list query.
@@ -1868,6 +1870,280 @@ class CatalogRestQueryEntityQueryFunctionalTest extends CatalogRestDataEndpointF
 			.executeAndThen()
 			.statusCode(200)
 			.body(DATA_PATH, equalTo(createEntityDtos(entities)));
+	}
+
+	@Test
+	@Tag(PRICE)
+	@UseDataSet(REST_THOUSAND_PRODUCTS)
+	@DisplayName("Should return price for sale range for products with NONE inner record handling")
+	void shouldReturnPriceForSaleRangeForNoneInnerRecordHandling(
+		Evita evita, RestTester tester, List<SealedEntity> originalProductEntities
+	) {
+		final Integer[] pks = findEntityPks(
+			originalProductEntities,
+			it -> it.getPriceInnerRecordHandling().equals(PriceInnerRecordHandling.NONE) &&
+				it.getPrices(CURRENCY_CZK, PRICE_LIST_BASIC).size() == 1,
+			2
+		);
+
+		final List<EntityClassifier> entities = getEntities(
+			evita,
+			query(
+				collection(Entities.PRODUCT),
+				filterBy(
+					entityPrimaryKeyInSet(pks),
+					priceInCurrency(CURRENCY_CZK),
+					priceInPriceLists(PRICE_LIST_BASIC)
+				),
+				require(
+					entityFetch(
+						priceContentRespectingFilter()
+					)
+				)
+			)
+		);
+
+		// sanity: ensure SDK reports the expected NONE-strategy collapse so the test asserts something meaningful
+		entities.forEach(classifier -> {
+			final SealedEntity entity = (SealedEntity) classifier;
+			final PriceRangeForSale range = entity.getPriceRangeForSale().orElseThrow();
+			assertEqualPrices(range.lowestPrice(), range.priceForSale());
+			assertEqualPrices(range.highestPrice(), range.priceForSale());
+		});
+
+		tester.test(TEST_CATALOG)
+			.urlPathSuffix("/PRODUCT/query")
+			.httpMethod(Request.METHOD_POST)
+			.requestBody(
+				"""
+					{
+						"filterBy": {
+						    "entityPrimaryKeyInSet": %s,
+						    "priceInCurrency": "CZK",
+						    "priceInPriceLists": ["basic"]
+						},
+						"require": {
+						    "entityFetch": {
+						        "priceContent": {
+						            "contentMode": "RESPECTING_FILTER"
+					            }
+						    }
+						}
+					}
+					""",
+				serializeIntArrayToQueryString(pks)
+			)
+			.executeAndThen()
+			.statusCode(200)
+			.body(DATA_PATH, equalTo(createEntityDtos(entities)))
+			.body(
+				DATA_PATH + "[0]." + EntityDescriptor.PRICE_FOR_SALE_MIN.name(),
+				notNullValue()
+			)
+			.body(
+				DATA_PATH + "[0]." + EntityDescriptor.PRICE_FOR_SALE_MAX.name(),
+				notNullValue()
+			);
+	}
+
+	@Test
+	@Tag(PRICE)
+	@UseDataSet(REST_THOUSAND_PRODUCTS)
+	@DisplayName("Should return price for sale range for master products with LOWEST_PRICE inner record handling")
+	void shouldReturnPriceForSaleRangeForLowestPriceInnerRecordHandling(
+		Evita evita, RestTester tester, List<SealedEntity> originalProductEntities
+	) {
+		final Integer[] pks = findEntityPks(
+			originalProductEntities,
+			it -> it.getPriceInnerRecordHandling().equals(PriceInnerRecordHandling.LOWEST_PRICE) &&
+				it.getPrices(CURRENCY_CZK)
+					.stream()
+					.filter(PriceContract::indexed)
+					.map(PriceContract::innerRecordId)
+					.distinct()
+					.count() > 1,
+			2
+		);
+
+		final Set<Integer> pksSet = Arrays.stream(pks).collect(Collectors.toSet());
+		final List<String> priceLists = originalProductEntities.stream()
+			.filter(it -> pksSet.contains(it.getPrimaryKey()))
+			.flatMap(it -> it.getPrices(CURRENCY_CZK).stream().map(PriceContract::priceList))
+			.distinct()
+			.toList();
+
+		final List<EntityClassifier> entities = getEntities(
+			evita,
+			query(
+				collection(Entities.PRODUCT),
+				filterBy(
+					entityPrimaryKeyInSet(pks),
+					priceInCurrency(CURRENCY_CZK),
+					priceInPriceLists(priceLists.toArray(String[]::new))
+				),
+				require(
+					entityFetch(
+						priceContentRespectingFilter()
+					)
+				)
+			)
+		);
+
+		// sanity: ensure SDK reports lowest == priceForSale and highest >= priceForSale for LOWEST_PRICE strategy
+		entities.forEach(classifier -> {
+			final SealedEntity entity = (SealedEntity) classifier;
+			final PriceRangeForSale range = entity.getPriceRangeForSale().orElseThrow();
+			assertEqualPrices(range.lowestPrice(), range.priceForSale());
+			assertTrue(
+				range.highestPrice().priceWithTax().compareTo(range.lowestPrice().priceWithTax()) >= 0,
+				"Highest price must be greater than or equal to the lowest price for LOWEST_PRICE strategy."
+			);
+		});
+
+		tester.test(TEST_CATALOG)
+			.urlPathSuffix("/PRODUCT/query")
+			.httpMethod(Request.METHOD_POST)
+			.requestBody(
+				"""
+					{
+						"filterBy": {
+						    "entityPrimaryKeyInSet": %s,
+						    "priceInCurrency": "CZK",
+						    "priceInPriceLists": %s
+						},
+						"require": {
+						    "entityFetch": {
+						        "priceContent": {
+						            "contentMode": "RESPECTING_FILTER"
+					            }
+						    }
+						}
+					}
+					""",
+				serializeIntArrayToQueryString(pks),
+				serializeStringArrayToQueryString(priceLists)
+			)
+			.executeAndThen()
+			.statusCode(200)
+			.body(DATA_PATH, equalTo(createEntityDtos(entities)))
+			.body(
+				DATA_PATH + "[0]." + EntityDescriptor.PRICE_FOR_SALE_MIN.name(),
+				notNullValue()
+			)
+			.body(
+				DATA_PATH + "[0]." + EntityDescriptor.PRICE_FOR_SALE_MAX.name(),
+				notNullValue()
+			);
+	}
+
+	@Test
+	@Tag(PRICE)
+	@UseDataSet(REST_THOUSAND_PRODUCTS)
+	@DisplayName("Should return price for sale range for master products with SUM inner record handling")
+	void shouldReturnPriceForSaleRangeForSumInnerRecordHandling(
+		Evita evita, RestTester tester, List<SealedEntity> originalProductEntities
+	) {
+		final Integer[] pks = findEntityPks(
+			originalProductEntities,
+			it -> it.getPriceInnerRecordHandling().equals(PriceInnerRecordHandling.SUM) &&
+				it.getPrices(CURRENCY_CZK)
+					.stream()
+					.filter(PriceContract::indexed)
+					.map(PriceContract::innerRecordId)
+					.distinct()
+					.count() > 1,
+			2
+		);
+
+		final Set<Integer> pksSet = Arrays.stream(pks).collect(Collectors.toSet());
+		final List<String> priceLists = originalProductEntities.stream()
+			.filter(it -> pksSet.contains(it.getPrimaryKey()))
+			.flatMap(it -> it.getPrices(CURRENCY_CZK).stream().map(PriceContract::priceList))
+			.distinct()
+			.toList();
+
+		final List<EntityClassifier> entities = getEntities(
+			evita,
+			query(
+				collection(Entities.PRODUCT),
+				filterBy(
+					entityPrimaryKeyInSet(pks),
+					priceInCurrency(CURRENCY_CZK),
+					priceInPriceLists(priceLists.toArray(String[]::new))
+				),
+				require(
+					entityFetch(
+						priceContentRespectingFilter()
+					)
+				)
+			)
+		);
+
+		// sanity: ensure SDK reports component prices for SUM strategy bounded by priceForSale
+		entities.forEach(classifier -> {
+			final SealedEntity entity = (SealedEntity) classifier;
+			final PriceRangeForSale range = entity.getPriceRangeForSale().orElseThrow();
+			assertTrue(
+				range.lowestPrice().priceWithTax().compareTo(range.highestPrice().priceWithTax()) <= 0,
+				"Lowest price must be less than or equal to the highest price for SUM strategy."
+			);
+			assertTrue(
+				range.priceForSale().priceWithTax().compareTo(range.highestPrice().priceWithTax()) >= 0,
+				"Cumulated SUM price must be at least as large as the highest component price."
+			);
+		});
+
+		tester.test(TEST_CATALOG)
+			.urlPathSuffix("/PRODUCT/query")
+			.httpMethod(Request.METHOD_POST)
+			.requestBody(
+				"""
+					{
+						"filterBy": {
+						    "entityPrimaryKeyInSet": %s,
+						    "priceInCurrency": "CZK",
+						    "priceInPriceLists": %s
+						},
+						"require": {
+						    "entityFetch": {
+						        "priceContent": {
+						            "contentMode": "RESPECTING_FILTER"
+					            }
+						    }
+						}
+					}
+					""",
+				serializeIntArrayToQueryString(pks),
+				serializeStringArrayToQueryString(priceLists)
+			)
+			.executeAndThen()
+			.statusCode(200)
+			.body(DATA_PATH, equalTo(createEntityDtos(entities)))
+			.body(
+				DATA_PATH + "[0]." + EntityDescriptor.PRICE_FOR_SALE_MIN.name(),
+				notNullValue()
+			)
+			.body(
+				DATA_PATH + "[0]." + EntityDescriptor.PRICE_FOR_SALE_MAX.name(),
+				notNullValue()
+			);
+	}
+
+	/**
+	 * Asserts the two price contracts represent the same price by comparing their identity tuple
+	 * (priceId, priceList, currency, innerRecordId).
+	 */
+	private static void assertEqualPrices(
+		@Nonnull PriceContract expected, @Nonnull PriceContract actual
+	) {
+		assertTrue(
+			expected.priceId() == actual.priceId() &&
+				expected.priceList().equals(actual.priceList()) &&
+				expected.currency().equals(actual.currency()) &&
+				Objects.equals(expected.innerRecordId(), actual.innerRecordId()),
+			"Expected the same price (priceId/priceList/currency/innerRecordId), but got `" +
+				expected + "` vs `" + actual + "`."
+		);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Adds `priceForSaleMin` / `priceForSaleMax` fields exposing the lowest and highest sellable prices across a master product's variants.
- Introduces `PriceRangeForSale` and `PriceRangeForSaleWithAccompanyingPrices` contracts and wires them through API, GraphQL, REST and gRPC layers.
- Updates documentation with new examples for the price-for-sale range field.

## Test plan
- [x] `mvn clean install` passes
- [x] New unit tests for `PriceForSaleContextWithCachedResult`, `PricesContract`, builder updates, and gRPC `EntityConverter` pass
- [x] GraphQL/REST functional tests covering the new fields pass
- [x] Documentation examples render correctly

Closes #1086