### PR TITLE
fix: make broad referenceSummary histogramStatistics applies-where-defined

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/ReferenceSummaryTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/ReferenceSummaryTranslator.java
@@ -44,12 +44,15 @@ import io.evitadb.core.query.extraResult.translator.reference.producer.Reference
 import io.evitadb.core.query.extraResult.translator.reference.producer.ReferenceSummaryResultAdapter;
 import io.evitadb.core.query.indexSelection.TargetIndexes;
 import io.evitadb.dataType.Scope;
+import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.index.EntityIndex;
 import io.evitadb.index.facet.FacetReferenceIndex;
 import io.evitadb.utils.ArrayUtils;
+import io.evitadb.utils.CollectionUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -76,12 +79,15 @@ import static io.evitadb.core.query.extraResult.translator.reference.ReferenceSu
  * 1. {@link #createProducer} resolves / creates the {@link ReferenceSummaryProducer} and immediately pre-registers
  *    it via {@link ExtraResultPlanningVisitor#registerProducer} so that child translators can look it up.
  * 2. Each {@link io.evitadb.api.query.require.ReferenceHistogramStatistics} child is dispatched via
- *    {@link #dispatchHistogramToMatchingReferences}: the all-references form is strict and requires every
- *    reference in the entity schema to define every requested histogram name in every active scope. Any gap
- *    aborts query planning with {@link io.evitadb.exception.EvitaInvalidUsageException} — users who want the
- *    computation limited to a subset of references must switch to
- *    {@link ReferenceSummaryOfReferenceTranslator} (per-reference form), and users who want it limited to a
- *    subset of scopes must wrap the histogram requirement in
+ *    {@link #dispatchHistogramToMatchingReferences}: the all-references form is **applies-where-defined**
+ *    — references that don't declare a requested histogram name in every active scope are silently skipped,
+ *    and the histogram constraint is narrowed per reference to the names that reference actually declares.
+ *    A typo guard fires when a requested histogram name is not declared on **any** reference in the schema
+ *    (in every active scope) — that case throws {@link io.evitadb.exception.EvitaInvalidUsageException} so
+ *    user typos surface rather than silently producing no histograms. Users who want strict per-reference
+ *    validation must switch to {@link ReferenceSummaryOfReferenceTranslator} (per-reference form, where
+ *    every requested name must exist on the named reference in every active scope), and users who want the
+ *    computation limited to a subset of scopes must wrap the histogram requirement in
  *    {@link io.evitadb.api.query.require.RequireInScope}.
  *
  * All planning operations are cheap; the heavy lifting is deferred to
@@ -89,7 +95,6 @@ import static io.evitadb.core.query.extraResult.translator.reference.ReferenceSu
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-@SuppressWarnings("deprecation")
 public class ReferenceSummaryTranslator
 	implements RequireConstraintTranslator<ReferenceSummary>, SelfTraversingTranslator {
 
@@ -308,13 +313,15 @@ public class ReferenceSummaryTranslator
 		extraResultPlanner.registerProducer(producer);
 		// dispatch nested histogramStatistics children to their translator. This container is a
 		// SelfTraversingTranslator, so children are not walked automatically. The all-references
-		// form is strict — every reference in the entity schema must define every requested
-		// histogram in every active scope; any gap throws EvitaInvalidUsageException.
+		// form is applies-where-defined — references that do not declare a requested histogram in
+		// every active scope are silently skipped; only requested names declared on **no**
+		// reference in the schema raise EvitaInvalidUsageException (typo guard).
 		final EntitySchemaContract schema = extraResultPlanner.getSchema();
+		final Set<Scope> scopes = extraResultPlanner.getProcessingScope().getScopes();
 		for (final RequireConstraint child : referenceSummary.getChildren()) {
 			if (child instanceof ReferenceHistogramStatistics histogramConstraint) {
 				dispatchHistogramToMatchingReferences(
-					histogramConstraint, schema, extraResultPlanner
+					histogramConstraint, schema, scopes, extraResultPlanner
 				);
 			}
 		}
@@ -322,33 +329,123 @@ public class ReferenceSummaryTranslator
 	}
 
 	/**
-	 * Dispatches the constraint to {@link ReferenceHistogramStatisticsTranslator} once per reference in
-	 * the entity schema. The translator's `resolveDescriptor` performs strict per-reference validation
-	 * — it throws {@link io.evitadb.exception.EvitaInvalidUsageException} when a requested histogram is
-	 * not defined on the current reference in any active scope. The loop therefore aborts at the first
-	 * offending reference, surfacing user typos and scope mismatches rather than silently skipping.
+	 * Dispatches the constraint to {@link ReferenceHistogramStatisticsTranslator} once per reference that
+	 * is **applicable** for at least one of the requested histogram names. A `(reference, name)` pair is
+	 * applicable when the reference declares the histogram in every currently active scope. References
+	 * with no applicable name are silently skipped; references with a strict subset of applicable names
+	 * are dispatched a *narrowed* {@link ReferenceHistogramStatistics} carrying only the names they
+	 * actually declare, so the inner translator's strict per-scope check never trips on a missing
+	 * definition for the all-references fan-out.
 	 *
-	 * Users who want the computation limited to a subset of references must switch to the per-reference
-	 * form {@link io.evitadb.api.query.require.ReferenceSummaryOfReference}; users who want it limited
-	 * to a subset of scopes must wrap the histogram requirement in
-	 * {@link io.evitadb.api.query.require.RequireInScope}.
+	 * Typo guard: every requested histogram name must be applicable to at least one reference in the
+	 * schema. A name applicable to no reference (e.g. a misspelling) raises
+	 * {@link EvitaInvalidUsageException} rather than silently producing nothing — that's the only error
+	 * the broad form surfaces. Strict per-reference validation is the responsibility of the per-reference
+	 * form ({@link io.evitadb.api.query.require.ReferenceSummaryOfReference}); scope subsetting belongs
+	 * to {@link io.evitadb.api.query.require.RequireInScope}.
 	 */
 	private static void dispatchHistogramToMatchingReferences(
 		@Nonnull ReferenceHistogramStatistics constraint,
 		@Nonnull EntitySchemaContract schema,
+		@Nonnull Set<Scope> scopes,
 		@Nonnull ExtraResultPlanningVisitor extraResultPlanner
 	) {
-		for (final ReferenceSchemaContract referenceSchema : schema.getReferences().values()) {
+		final String[] requestedNames = constraint.getIndexNames();
+		final Collection<ReferenceSchemaContract> references = schema.getReferences().values();
+
+		// Build per-reference applicable-name lists in iteration order; track which requested names
+		// landed on at least one reference so the post-loop typo guard can flag misspellings.
+		final List<ReferenceDispatchEntry> dispatchPlan = new ArrayList<>(references.size());
+		final Set<String> matchedNames = CollectionUtils.createHashSet(requestedNames.length);
+		for (final ReferenceSchemaContract referenceSchema : references) {
+			List<String> applicableNames = null;
+			for (final String name : requestedNames) {
+				if (isApplicableInAllScopes(referenceSchema, name, scopes)) {
+					if (applicableNames == null) {
+						applicableNames = new ArrayList<>(requestedNames.length);
+					}
+					applicableNames.add(name);
+					matchedNames.add(name);
+				}
+			}
+			if (applicableNames != null) {
+				dispatchPlan.add(new ReferenceDispatchEntry(referenceSchema, applicableNames));
+			}
+		}
+
+		// Typo guard — the broad form silently skips references that don't declare the histogram, but
+		// a name that no reference declares is a user mistake and aborts query planning.
+		if (matchedNames.size() < requestedNames.length) {
+			final List<String> unknown = new ArrayList<>(requestedNames.length - matchedNames.size());
+			for (final String name : requestedNames) {
+				if (!matchedNames.contains(name)) {
+					unknown.add(name);
+				}
+			}
+			throw new EvitaInvalidUsageException(
+				"Histogram " + (unknown.size() == 1 ? "name " : "names ") + unknown +
+					(unknown.size() == 1 ? " is" : " are") +
+					" not defined on any reference of entity `" + schema.getName() +
+					"` in scope" + (scopes.size() == 1 ? " " : "s ") + scopes + "."
+			);
+		}
+
+		final int bucketCount = constraint.getRequestedBucketCount();
+		final HistogramBehavior behavior = constraint.getBehavior();
+		final EntityFetch entityFetch = constraint.getEntityFetch().orElse(null);
+		for (final ReferenceDispatchEntry entry : dispatchPlan) {
+			// reuse the original constraint when this reference declares every requested name —
+			// avoids an unnecessary clone for the common single-reference / fully-covered case.
+			final ReferenceHistogramStatistics narrowed =
+				entry.applicableNames().size() == requestedNames.length
+					? constraint
+					: new ReferenceHistogramStatistics(
+						bucketCount, behavior, entityFetch,
+						entry.applicableNames().toArray(new String[0])
+					);
 			extraResultPlanner.executeInContext(
-				constraint,
-				() -> referenceSchema,
+				narrowed,
+				entry::referenceSchema,
 				() -> null,
 				() -> {
-					constraint.accept(extraResultPlanner);
+					narrowed.accept(extraResultPlanner);
 					return null;
 				}
 			);
 		}
+	}
+
+	/**
+	 * Returns true when the reference declares the named histogram in every currently active scope.
+	 * The broad form skips references that don't fully cover the active scope set — partial coverage
+	 * (declared in some scopes but not others) is treated identically to "not declared at all" so
+	 * fan-out behaviour stays scope-symmetric. Strict per-scope diagnostics remain the responsibility
+	 * of the per-reference form.
+	 */
+	private static boolean isApplicableInAllScopes(
+		@Nonnull ReferenceSchemaContract referenceSchema,
+		@Nonnull String histogramName,
+		@Nonnull Set<Scope> scopes
+	) {
+		if (scopes.isEmpty()) {
+			return false;
+		}
+		for (final Scope scope : scopes) {
+			if (referenceSchema.getHistogramIndexDefinition(scope, histogramName) == null) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * One dispatched per applicable reference: the schema and the subset of requested histogram names
+	 * the reference actually declares in every active scope.
+	 */
+	private record ReferenceDispatchEntry(
+		@Nonnull ReferenceSchemaContract referenceSchema,
+		@Nonnull List<String> applicableNames
+	) {
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/ReferenceSummaryTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/ReferenceSummaryTranslator.java
@@ -374,14 +374,17 @@ public class ReferenceSummaryTranslator
 		}
 
 		// Typo guard — the broad form silently skips references that don't declare the histogram, but
-		// a name that no reference declares is a user mistake and aborts query planning.
-		if (matchedNames.size() < requestedNames.length) {
-			final List<String> unknown = new ArrayList<>(requestedNames.length - matchedNames.size());
-			for (final String name : requestedNames) {
-				if (!matchedNames.contains(name)) {
-					unknown.add(name);
-				}
+		// a name that no reference declares is a user mistake and aborts query planning. The check
+		// must operate on name presence (not array length) because `requestedNames` may carry
+		// duplicates — comparing sizes would falsely throw when the same valid name is listed
+		// multiple times.
+		final Set<String> unknown = CollectionUtils.createLinkedHashSet(requestedNames.length);
+		for (final String name : requestedNames) {
+			if (!matchedNames.contains(name)) {
+				unknown.add(name);
 			}
+		}
+		if (!unknown.isEmpty()) {
 			throw new EvitaInvalidUsageException(
 				"Histogram " + (unknown.size() == 1 ? "name " : "names ") + unknown +
 					(unknown.size() == 1 ? " is" : " are") +

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/ReferenceSummaryTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/ReferenceSummaryTranslator.java
@@ -380,14 +380,18 @@ public class ReferenceSummaryTranslator
 		// a name that no reference declares is a user mistake and aborts query planning. The check
 		// must operate on name presence (not array length) because `requestedNames` may carry
 		// duplicates — comparing sizes would falsely throw when the same valid name is listed
-		// multiple times.
-		final Set<String> unknown = CollectionUtils.createLinkedHashSet(requestedNames.length);
+		// multiple times. The `unknown` set is lazily allocated on the first miss so the happy
+		// path pays no allocation, matching the lazy-init pattern used for `applicableNames`.
+		Set<String> unknown = null;
 		for (final String name : requestedNames) {
 			if (!matchedNames.contains(name)) {
+				if (unknown == null) {
+					unknown = CollectionUtils.createLinkedHashSet(requestedNames.length);
+				}
 				unknown.add(name);
 			}
 		}
-		if (!unknown.isEmpty()) {
+		if (unknown != null) {
 			throw new EvitaInvalidUsageException(
 				"Histogram " + (unknown.size() == 1 ? "name " : "names ") + unknown +
 					(unknown.size() == 1 ? " is" : " are") +

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/ReferenceSummaryTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/ReferenceSummaryTranslator.java
@@ -359,6 +359,7 @@ public class ReferenceSummaryTranslator
 		final Set<String> matchedNames = CollectionUtils.createHashSet(requestedNames.length);
 		for (final ReferenceSchemaContract referenceSchema : references) {
 			List<String> applicableNames = null;
+			boolean fullyCovered = true;
 			for (final String name : requestedNames) {
 				if (isApplicableInAllScopes(referenceSchema, name, scopes)) {
 					if (applicableNames == null) {
@@ -366,10 +367,12 @@ public class ReferenceSummaryTranslator
 					}
 					applicableNames.add(name);
 					matchedNames.add(name);
+				} else {
+					fullyCovered = false;
 				}
 			}
 			if (applicableNames != null) {
-				dispatchPlan.add(new ReferenceDispatchEntry(referenceSchema, applicableNames));
+				dispatchPlan.add(new ReferenceDispatchEntry(referenceSchema, applicableNames, fullyCovered));
 			}
 		}
 
@@ -399,8 +402,10 @@ public class ReferenceSummaryTranslator
 		for (final ReferenceDispatchEntry entry : dispatchPlan) {
 			// reuse the original constraint when this reference declares every requested name —
 			// avoids an unnecessary clone for the common single-reference / fully-covered case.
+			// `fullyCovered` is tracked explicitly during dispatch-plan construction so this
+			// decision stays orthogonal to whether `applicableNames` carries duplicates.
 			final ReferenceHistogramStatistics narrowed =
-				entry.applicableNames().size() == requestedNames.length
+				entry.fullyCovered()
 					? constraint
 					: new ReferenceHistogramStatistics(
 						bucketCount, behavior, entityFetch,
@@ -442,12 +447,16 @@ public class ReferenceSummaryTranslator
 	}
 
 	/**
-	 * One dispatched per applicable reference: the schema and the subset of requested histogram names
-	 * the reference actually declares in every active scope.
+	 * One dispatched per applicable reference: the schema, the subset of requested histogram names
+	 * the reference actually declares in every active scope, and whether that subset covers every
+	 * requested name (i.e. no requested name was skipped for this reference). The `fullyCovered`
+	 * flag drives the constraint-reuse fast path independently of duplicate handling in
+	 * `applicableNames`.
 	 */
 	private record ReferenceDispatchEntry(
 		@Nonnull ReferenceSchemaContract referenceSchema,
-		@Nonnull List<String> applicableNames
+		@Nonnull List<String> applicableNames,
+		boolean fullyCovered
 	) {
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceSummaryHistogramFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceSummaryHistogramFunctionalTest.java
@@ -777,10 +777,10 @@ public class ReferenceSummaryHistogramFunctionalTest extends AbstractReferenceSu
 					final ReferenceGroupStatistics group1 = referenceSummary.getReferenceGroupStatistics(
 						REF_PARAM_VALUES, 1
 					);
-					assertNotNull(group1, "Strict fan-out must populate group 1");
+					assertNotNull(group1, "Fan-out must populate group 1");
 					assertNotNull(
 						group1.getHistogramStatistics(HISTOGRAM_PRICE),
-						"Histogram must be emitted for every reference when every reference defines it"
+						"Histogram must be emitted for every reference that declares it"
 					);
 					return null;
 				}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceSummaryHistogramValidationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceSummaryHistogramValidationTest.java
@@ -366,6 +366,49 @@ public class ReferenceSummaryHistogramValidationTest extends AbstractReferenceSu
 		}
 
 		@Test
+		@UseDataSet(REFERENCE_HISTOGRAM_SMALL)
+		@DisplayName("should not false-typo-guard when the same histogram name is requested twice")
+		void shouldNotFalseTypoGuardOnDuplicateHistogramName(@Nonnull Evita evita) {
+			// Regression for the typo-guard size check: when the requested name list contains
+			// duplicates (e.g. `histogramStatistics(10, "priceBucket", "priceBucket")`), the count
+			// of distinct names landed on at least one reference is strictly less than the
+			// requested-array length even though every requested name exists. The dispatcher must
+			// validate by *name presence*, not by array length, so a duplicate-but-valid request
+			// passes through and produces histograms normally.
+			evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					final EvitaResponse<EntityReferenceContract> result = session.query(
+						query(
+							collection(ENTITY_PRODUCT),
+							require(
+								referenceSummaryWithHistograms(
+									null, null, null,
+									histogramStatistics(10, HISTOGRAM_PRICE, HISTOGRAM_PRICE)
+								)
+							)
+						),
+						EntityReferenceContract.class
+					);
+					final ReferenceSummary referenceSummary =
+						result.getExtraResult(ReferenceSummary.class);
+					assertNotNull(referenceSummary);
+					final ReferenceGroupStatistics group =
+						referenceSummary.getReferenceGroupStatistics(REF_PARAM_VALUES, 1);
+					assertNotNull(
+						group,
+						"Histogram-bearing group must be populated even when the name is duplicated"
+					);
+					assertNotNull(
+						group.getHistogramStatistics(HISTOGRAM_PRICE),
+						"Duplicate histogram name must still resolve to a populated histogram"
+					);
+					return null;
+				}
+			);
+		}
+
+		@Test
 		@DisplayName("should throw when histogram is defined only in LIVE and query targets ARCHIVED scope")
 		void shouldThrowWhenHistogramNotDefinedInQueriedScope() {
 			// Bucketed definitions are per-scope. A schema that declares the histogram only in
@@ -459,16 +502,22 @@ public class ReferenceSummaryHistogramValidationTest extends AbstractReferenceSu
 							"Histogram on REF_PARAM_VALUES must contain at least one bucket entry"
 						);
 
-						// REF_CATEGORIES declares no histogram — its group must exist (the
-						// referenced category was seeded) but must carry no histogram entries.
-						final ReferenceGroupStatistics categoryGroup =
-							referenceSummary.getReferenceGroupStatistics(REF_CATEGORIES, 100);
-						if (categoryGroup != null) {
-							assertTrue(
-								categoryGroup.getHistogramStatistics().isEmpty(),
-								"REF_CATEGORIES must not surface a histogram — it declares none"
-							);
-						}
+						// REF_CATEGORIES declares no histogram. The seeded reference is non-grouped
+						// (no `withGroupTypeRelatedToEntity`) so its statistics live under the
+						// non-grouped overload of `getReferenceGroupStatistics(referenceName)` —
+						// the (referenceName, groupId) overload is keyed by group PK and would
+						// always return null here, silently masking a regression that emits a
+						// histogram on REF_CATEGORIES.
+						final ReferenceGroupStatistics categoryStats =
+							referenceSummary.getReferenceGroupStatistics(REF_CATEGORIES);
+						assertNotNull(
+							categoryStats,
+							"REF_CATEGORIES must surface non-grouped statistics for the seeded reference"
+						);
+						assertTrue(
+							categoryStats.getHistogramStatistics().isEmpty(),
+							"REF_CATEGORIES must not surface a histogram — it declares none"
+						);
 						return null;
 					}
 				)

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceSummaryHistogramValidationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceSummaryHistogramValidationTest.java
@@ -33,7 +33,6 @@ import io.evitadb.api.requestResponse.extraResult.ReferenceSummary;
 import io.evitadb.api.requestResponse.extraResult.ReferenceSummary.ReferenceGroupStatistics;
 import io.evitadb.api.requestResponse.schema.Cardinality;
 import io.evitadb.api.requestResponse.schema.ReferenceIndexedComponents;
-import io.evitadb.api.requestResponse.schema.ReferenceSchemaEditor;
 import io.evitadb.core.Evita;
 import io.evitadb.dataType.Scope;
 import io.evitadb.exception.EvitaInvalidUsageException;
@@ -81,8 +80,9 @@ public class ReferenceSummaryHistogramValidationTest extends AbstractReferenceSu
 	/**
 	 * Schema variant where ENTITY_PRODUCT carries TWO references — the bucketed
 	 * {@link #REF_PARAM_VALUES} and an additional plain {@link #REF_CATEGORIES} that has no
-	 * histogram index defined. Used by the validation test asserting strict all-references
-	 * dispatch refuses to proceed when any reference in the schema lacks the requested histogram.
+	 * histogram index defined. Used by the validation test asserting that the all-references
+	 * fan-out applies the histogram only to references that actually declare it and silently
+	 * skips the others.
 	 */
 	private static void defineSchemaWithExtraPlainReference(@Nonnull EvitaSessionContract session) {
 		session.defineEntitySchema(ENTITY_PARAMETER)
@@ -114,9 +114,43 @@ public class ReferenceSummaryHistogramValidationTest extends AbstractReferenceSu
 			)
 			.withReferenceToEntity(
 				REF_CATEGORIES, ENTITY_PARAMETER, Cardinality.ZERO_OR_MORE,
-				ReferenceSchemaEditor::indexedForFilteringAndPartitioning
+				whichIs -> whichIs
+					.indexedForFilteringAndPartitioning()
+					.faceted()
 			)
 			.updateVia(session);
+	}
+
+	/**
+	 * Seeds a tiny dataset against the {@link #defineSchemaWithExtraPlainReference} schema:
+	 * one parameter group, two parameter values with distinct {@link #ATTR_BASIC_UNIT_VALUE}s,
+	 * one category, and one product that references both. Just enough rows for the all-references
+	 * fan-out to actually populate a histogram on `parameterValues` and surface the absence of
+	 * histogram entries on `categories`.
+	 */
+	private static void seedSchemaWithExtraPlainReference(@Nonnull EvitaSessionContract session) {
+		session.createNewEntity(ENTITY_PARAMETER, 1)
+			.setAttribute(ATTR_NAME, "Width")
+			.upsertVia(session);
+
+		session.createNewEntity(ENTITY_PARAMETER_VALUE, 1)
+			.setAttribute(ATTR_NAME, "10cm")
+			.setAttribute(ATTR_BASIC_UNIT_VALUE, new BigDecimal("10"))
+			.upsertVia(session);
+		session.createNewEntity(ENTITY_PARAMETER_VALUE, 2)
+			.setAttribute(ATTR_NAME, "20cm")
+			.setAttribute(ATTR_BASIC_UNIT_VALUE, new BigDecimal("20"))
+			.upsertVia(session);
+
+		session.createNewEntity(ENTITY_PARAMETER, 100)
+			.setAttribute(ATTR_NAME, "books")
+			.upsertVia(session);
+
+		session.createNewEntity(ENTITY_PRODUCT, 1)
+			.setReference(REF_PARAM_VALUES, 1, whichIs -> whichIs.setGroup(ENTITY_PARAMETER, 1))
+			.setReference(REF_PARAM_VALUES, 2, whichIs -> whichIs.setGroup(ENTITY_PARAMETER, 1))
+			.setReference(REF_CATEGORIES, 100)
+			.upsertVia(session);
 	}
 
 	// ==========================================================================================
@@ -376,21 +410,22 @@ public class ReferenceSummaryHistogramValidationTest extends AbstractReferenceSu
 		}
 
 		@Test
-		@DisplayName("should throw when a reference in the schema does not define the requested histogram (all-references form)")
-		void shouldThrowWhenAnyReferenceInSchemaLacksRequestedHistogram() {
-			// Strict semantics for the all-references form: every reference in the entity schema
-			// must define every requested histogram in every active scope. Here REF_CATEGORIES
-			// exists without any histogram, so the dispatch must refuse rather than silently skip
-			// that reference and emit histograms for REF_PARAM_VALUES only.
+		@DisplayName("should apply histogram only to references that declare it (all-references form, partial coverage)")
+		void shouldApplyHistogramOnlyToReferencesThatDeclareIt() {
+			// Lenient semantics for the all-references form: the dispatch silently skips references
+			// that don't declare the requested histogram name and only emits histogram statistics
+			// for references that do. REF_PARAM_VALUES declares HISTOGRAM_PRICE; REF_CATEGORIES
+			// declares no histogram, so the broad query must succeed and only populate the histogram
+			// on REF_PARAM_VALUES groups — exactly the natural "go through references and pick the
+			// relevant ones" reading of `referenceSummary(...histogramStatistics(...))`.
 			runWithInlineSchema(
 				"referenceSummaryHistogramValidation_partialCoverage",
 				ReferenceSummaryHistogramValidationTest::defineSchemaWithExtraPlainReference,
-				null,
-				evita -> assertThrows(
-					EvitaInvalidUsageException.class,
-					() -> evita.queryCatalog(
-						TEST_CATALOG,
-						(Consumer<EvitaSessionContract>) session -> session.query(
+				ReferenceSummaryHistogramValidationTest::seedSchemaWithExtraPlainReference,
+				evita -> evita.queryCatalog(
+					TEST_CATALOG,
+					session -> {
+						final EvitaResponse<EntityReferenceContract> result = session.query(
 							query(
 								collection(ENTITY_PRODUCT),
 								require(
@@ -401,10 +436,82 @@ public class ReferenceSummaryHistogramValidationTest extends AbstractReferenceSu
 								)
 							),
 							EntityReferenceContract.class
-						)
-					),
-					"All-references form must throw when any reference lacks the requested histogram"
+						);
+						final ReferenceSummary referenceSummary =
+							result.getExtraResult(ReferenceSummary.class);
+						assertNotNull(referenceSummary);
+
+						// REF_PARAM_VALUES declares HISTOGRAM_PRICE — group 1 must surface it.
+						final ReferenceGroupStatistics paramGroup =
+							referenceSummary.getReferenceGroupStatistics(REF_PARAM_VALUES, 1);
+						assertNotNull(
+							paramGroup,
+							"REF_PARAM_VALUES must surface its histogram-bearing group"
+						);
+						final HistogramContract paramHistogram =
+							paramGroup.getHistogramStatistics(HISTOGRAM_PRICE);
+						assertNotNull(
+							paramHistogram,
+							"Histogram must be populated on REF_PARAM_VALUES — it declares the index"
+						);
+						assertTrue(
+							paramHistogram.getOverallCount() > 0,
+							"Histogram on REF_PARAM_VALUES must contain at least one bucket entry"
+						);
+
+						// REF_CATEGORIES declares no histogram — its group must exist (the
+						// referenced category was seeded) but must carry no histogram entries.
+						final ReferenceGroupStatistics categoryGroup =
+							referenceSummary.getReferenceGroupStatistics(REF_CATEGORIES, 100);
+						if (categoryGroup != null) {
+							assertTrue(
+								categoryGroup.getHistogramStatistics().isEmpty(),
+								"REF_CATEGORIES must not surface a histogram — it declares none"
+							);
+						}
+						return null;
+					}
 				)
+			);
+		}
+
+		@Test
+		@DisplayName("should throw when no reference in schema declares the requested histogram (all-references form, typo guard)")
+		void shouldThrowWhenNoReferenceInSchemaDeclaresRequestedHistogram() {
+			// Lenient fan-out still surfaces user typos: when none of the schema's references
+			// declares the requested histogram name (in every active scope), planning aborts with
+			// EvitaInvalidUsageException rather than silently producing nothing — this is the only
+			// validation the broad form keeps from the original strict design.
+			runWithInlineSchema(
+				"referenceSummaryHistogramValidation_typoGuard",
+				ReferenceSummaryHistogramValidationTest::defineSchemaWithExtraPlainReference,
+				null,
+				evita -> {
+					final EvitaInvalidUsageException error = assertThrows(
+						EvitaInvalidUsageException.class,
+						() -> evita.queryCatalog(
+							TEST_CATALOG,
+							(Consumer<EvitaSessionContract>) session -> session.query(
+								query(
+									collection(ENTITY_PRODUCT),
+									require(
+										referenceSummaryWithHistograms(
+											null, null, null,
+											histogramStatistics(10, "nonExistentOnAnyReference")
+										)
+									)
+								),
+								EntityReferenceContract.class
+							)
+						),
+						"Histogram name unknown to every reference must abort query planning"
+					);
+					assertTrue(
+						error.getMessage().contains("nonExistentOnAnyReference"),
+						"Error must surface the offending histogram name, was: "
+							+ error.getMessage()
+					);
+				}
 			);
 		}
 	}
@@ -675,13 +782,13 @@ public class ReferenceSummaryHistogramValidationTest extends AbstractReferenceSu
 
 		@Test
 		@UseDataSet(REFERENCE_HISTOGRAM_LARGE)
-		@DisplayName("should throw when all-references fan-out receives an unknown histogram name (strict per reference)")
+		@DisplayName("should throw when all-references fan-out receives an unknown histogram name (typo guard)")
 		void shouldThrowForUnknownHistogramNameInAllReferencesFanOut(@Nonnull Evita evita) {
-			// `ReferenceSummaryTranslator.dispatchHistogramToMatchingReferences` implements strict
-			// fan-out: each reference is dispatched to `ReferenceHistogramStatisticsTranslator`, which
-			// throws on the first reference that doesn't define the histogram in every active scope.
-			// This test pins the as-implemented behavior; if the engine is later relaxed to skip
-			// references silently, flip this assertion to assertDoesNotThrow.
+			// `ReferenceSummaryTranslator.dispatchHistogramToMatchingReferences` is lenient — it
+			// silently skips references that don't declare the requested histogram. The single
+			// validation it preserves is the typo guard: a name that no reference in the schema
+			// declares (in every active scope) aborts planning with EvitaInvalidUsageException so
+			// misspellings surface rather than silently producing no histograms.
 			assertThrows(
 				EvitaInvalidUsageException.class,
 				() -> evita.queryCatalog(
@@ -699,7 +806,7 @@ public class ReferenceSummaryHistogramValidationTest extends AbstractReferenceSu
 						EntityReferenceContract.class
 					)
 				),
-				"All-references fan-out is strict — an unknown histogram name must raise immediately"
+				"Histogram name unknown to every reference must abort query planning"
 			);
 		}
 	}

--- a/specifications/reference-histogram-statistics/reference-histogram-statistics.md
+++ b/specifications/reference-histogram-statistics/reference-histogram-statistics.md
@@ -170,10 +170,18 @@ constraint provides the first-class carrier for the reference-level slot of G1; 
    Non-localized histograms always pass `null`.
 4. **Index dispatch:** grouped references → `ReducedGroupEntityIndex`; ungrouped →
    `ReferencedTypeEntityIndex`.
-5. **Throw-on-unknown:** unknown histogram index names or any broken assumption throws — never
-   silent skip. Upheld by both the per-reference form (`referenceSummaryOfReference`) and the
-   all-references fan-out (`referenceSummary` dispatches the requirement to every reference in the
-   schema and throws on the first unmatched one).
+5. **Throw-on-unknown — form-asymmetric:** the per-reference form (`referenceSummaryOfReference`)
+   is strict and throws when the named reference does not declare the requested histogram in every
+   active scope; the user named the reference explicitly so a missing definition is unambiguously
+   a usage error. The broad form (`referenceSummary`) is **applies-where-defined**: it silently
+   skips references that don't declare the requested histogram name and only emits histogram
+   statistics for references that do, narrowing the per-reference dispatched constraint to the
+   names each reference actually declares. The broad form keeps a single typo guard — a histogram
+   name that **no reference** in the schema declares (in every active scope) raises
+   `EvitaInvalidUsageException` so misspellings still surface; legitimate partial-coverage schemas
+   (the realistic case where most references carry no histograms) are handled silently. This was
+   tightened from the original "strict on every reference" design after the broad form proved
+   unusable on real schemas — see §3.3 for the rationale.
 6. **Boundary entity count:** ≤ 2 per histogram (min + max). Ties resolved by the parent
    `referenceSummary`'s `orderBy`, fallback to lowest PK.
 7. **Boundary resolution strategy:** cross-reference `FilterIndex.getRecordsEqualTo(minValue|maxValue)`
@@ -265,6 +273,54 @@ constraint provides the first-class carrier for the reference-level slot of G1; 
    against the referenced-group's global index at planning time and asserting it resolves to a
    unique group PK.
 
+### 3.3 Broad-form lenience — supersedes "strict on every reference"
+
+The original §3.1 design decision 5 made the all-references form (`referenceSummary(...,
+histogramStatistics(...))`) strict: every reference in the entity schema had to declare every
+requested histogram name in every active scope, otherwise planning aborted on the first
+non-matching reference. This proved unusable on realistic schemas the moment a user wrote what
+looks like the natural query — "give me all reference summaries plus this histogram, wherever it
+applies". Real catalogs always carry some references with no histograms (categories, brands, tag
+sets, related-product references), so the strict gate fired before any histogram-bearing reference
+got a chance to contribute.
+
+The decision was refined to **applies-where-defined** semantics:
+
+- **Per-reference lenience.** `ReferenceSummaryTranslator.dispatchHistogramToMatchingReferences`
+  pre-filters references whose schema declares the requested histogram in every active scope.
+  References with zero applicable names are silently skipped; references with a non-empty subset
+  are dispatched a *narrowed* `ReferenceHistogramStatistics` carrying only the names they actually
+  declare. The inner `ReferenceHistogramStatisticsTranslator` strict per-scope check therefore
+  never trips on a missing definition for the broad form, because it only ever sees pairs that
+  pre-passed the filter.
+- **Typo guard.** A requested histogram name that no reference in the schema declares (in every
+  active scope) is the only validation the broad form keeps — it raises
+  `EvitaInvalidUsageException` with the offending name(s), so misspellings still surface rather
+  than silently producing nothing.
+- **Per-reference form unchanged.** `referenceSummaryOfReference("name", histogramStatistics(...))`
+  remains strict on the named reference — the user named it explicitly, so a missing definition is
+  unambiguously a usage error and warrants a fail-fast error message that names both the histogram
+  and the offending scope.
+- **Scope subsetting unchanged.** Users who want the histogram limited to a subset of scopes still
+  wrap the requirement in `RequireInScope`. Lenience is per-reference, not per-scope: a reference
+  declares the histogram in *all* active scopes or it's skipped — partial coverage *across scopes*
+  on a reference is treated identically to "not declared at all" so fan-out behaviour stays
+  scope-symmetric. Strict per-scope diagnostics remain the responsibility of the per-reference
+  form.
+
+Test impact (from `ReferenceSummaryHistogramValidationTest`):
+
+- The pre-existing `shouldThrowWhenAnyReferenceInSchemaLacksRequestedHistogram` test, which pinned
+  the strict design, was inverted into `shouldApplyHistogramOnlyToReferencesThatDeclareIt`: a
+  schema with one bucketed reference and one plain reference now produces a histogram on the
+  bucketed reference and no histogram on the plain reference. The plain reference's group is
+  allowed to exist (facets / counts can survive) but must carry no histogram entries.
+- A new `shouldThrowWhenNoReferenceInSchemaDeclaresRequestedHistogram` test pins the typo-guard:
+  the broad form against a schema where no reference declares `nonExistentOnAnyReference` aborts
+  planning with a message that names the unknown histogram.
+- The pre-existing `shouldThrowForUnknownHistogramNameInAllReferencesFanOut` test (LARGE fixture,
+  asks for `nonExistent`) keeps its assertion — typo-guard semantics are preserved.
+
 ---
 
 ## 4. Landed Implementation (historical record)
@@ -305,12 +361,14 @@ superseded by §5 Task 28; everything else stands.
 - Both parent translators were modified to walk their own children looking for
   `ReferenceHistogramStatistics`, push a `ProcessingScope` via
   `extraResultPlanner.executeInContext(...)`, and dispatch back through the visitor. See
-  `ReferenceSummaryOfReferenceTranslator#createProducer` (strict — throws on missing definition,
-  matches design decision 5) and `ReferenceSummaryTranslator#createProducer` /
-  `dispatchHistogramToMatchingReferences` (strict fan-out — dispatches the histogram requirement
-  to every reference in the entity schema and lets
-  `ReferenceHistogramStatisticsTranslator` throw on the first reference that doesn't define the
-  histogram in every active scope; design decision 5 is upheld).
+  `ReferenceSummaryOfReferenceTranslator#createProducer` (strict — throws on missing definition;
+  matches design decision 5, per-reference branch) and `ReferenceSummaryTranslator#createProducer` /
+  `dispatchHistogramToMatchingReferences` (applies-where-defined fan-out — pre-filters references
+  whose schema declares the requested histogram in every active scope, dispatches a per-reference
+  *narrowed* `ReferenceHistogramStatistics` carrying only that reference's applicable names, and
+  silently skips references with no applicable name; design decision 5, broad-form branch). The
+  broad form raises `EvitaInvalidUsageException` only when a requested name is declared on no
+  reference in the schema (typo guard) — every other partial-coverage shape resolves silently.
 - **B.4 extraction** — the translator walks `extraResultPlanner.getFilterBy()` for a
   `userFilter → referenceHaving(refName, …)` subtree whose inner `attributeBetween` targets the
   descriptor's source attribute. Multiple independent matches for the same
@@ -403,8 +461,9 @@ histograms).
   tests green.
 - **Functional tests (hand-crafted small fixture):** `ReferenceHistogramFunctionalTest` (12 tests,
   all green) covers happy-path histogram population per group, boundary-entity population,
-  strict all-references fan-out, `requested` flag end-to-end, validation of unknown histogram
-  names, `QueryConstraints.histogramStatistics` returning `null` for empty index names, and
+  applies-where-defined all-references fan-out (positive partial-coverage case + typo-guard
+  negative case), `requested` flag end-to-end, validation of unknown histogram names,
+  `QueryConstraints.histogramStatistics` returning `null` for empty index names, and
   histogram-only group survival.
 - **Functional E2E tests (60-product deterministic dataset across 3 parameter groups):**
   `ReferenceHistogramE2EFunctionalTest` (15 tests, all green). Nested groups: HappyPath,


### PR DESCRIPTION
## Summary

- The all-references form `referenceSummary(..., histogramStatistics(N, name))` previously dispatched the histogram constraint to every reference in the entity schema and threw `EvitaInvalidUsageException` on the first reference that didn't declare the requested histogram. Realistic schemas always carry some references without histograms (categories, brands, related-product references), so the strict gate fired before any histogram-bearing reference could contribute, making the broad form unusable on real catalogs.
- `ReferenceSummaryTranslator.dispatchHistogramToMatchingReferences` now pre-filters references whose schema declares the requested histogram name in every active scope, dispatches a per-reference **narrowed** `ReferenceHistogramStatistics` carrying only that reference's applicable names, and silently skips references with no applicable name.
- One typo guard is preserved: a histogram name that no reference in the schema declares (in every active scope) aborts planning with `EvitaInvalidUsageException` listing the offending name(s) — misspellings still surface.
- `referenceSummaryOfReference` keeps its strict per-reference contract unchanged — the user named the reference explicitly, so a missing definition is unambiguously a usage error.
- Specification updated: `specifications/reference-histogram-statistics/reference-histogram-statistics.md` design decision §3.1.5 rewritten as form-asymmetric (per-reference strict, broad-form lenient with typo guard), new §3.3 *Broad-form lenience — supersedes "strict on every reference"* documents the rationale and supersedes the original strict intent, Phase B / Phase F status notes refreshed.

## Test plan

- [x] `mvn -pl evita_test/evita_functional_tests test -Dtest='io.evitadb.api.functional.histogram.*Test'` — 45 tests green
- [x] `mvn -pl evita_test/evita_functional_tests test -Dtest='QuerySerializationTest,EvitaQLRequireConstraintVisitorTest,ReferenceSummaryScopeLeakTest'` — 365 tests green (no cross-cutting regression)
- [x] `ReferenceSummaryHistogramValidationTest.shouldApplyHistogramOnlyToReferencesThatDeclareIt` — positive partial-coverage case (REF_PARAM_VALUES bucketed, REF_CATEGORIES plain → histogram only on REF_PARAM_VALUES)
- [x] `ReferenceSummaryHistogramValidationTest.shouldThrowWhenNoReferenceInSchemaDeclaresRequestedHistogram` — typo guard
- [x] `ReferenceSummaryHistogramValidationTest.shouldThrowForUnknownHistogramNameInAllReferencesFanOut` (LARGE fixture) — typo guard preserved
- [x] Manual reproduction: the issue's EvitaQL query against the demo `evita` catalog now returns histograms on every `parameterValues` group and no errors

Closes #1142