### PR TITLE
perf: reduce OffsetIndex compaction memory churn (phase 1)

### DIFF
--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndexSerializationService.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndexSerializationService.java
@@ -38,7 +38,7 @@ import io.evitadb.store.offsetIndex.exception.CorruptedRecordException;
 import io.evitadb.store.offsetIndex.exception.IncompleteSerializationException;
 import io.evitadb.store.offsetIndex.model.RecordKey;
 import io.evitadb.store.offsetIndex.model.StorageRecord;
-import io.evitadb.store.offsetIndex.model.StorageRecord.RawRecord;
+import io.evitadb.store.offsetIndex.model.StorageRecord.RawRecordHeader;
 import io.evitadb.store.offsetIndex.model.VersionedValue;
 import io.evitadb.store.shared.model.FileLocation;
 import io.evitadb.stream.RandomAccessFileInputStream;
@@ -252,6 +252,9 @@ public class OffsetIndexSerializationService {
 		);
 		final Collection<Entry<RecordKey, FileLocation>> entries = offsetIndex.getEntries();
 		final Collection<VersionedValue> nonFlushedValues = new ArrayList<>(entries.size());
+		// Single scratch buffer reused across every storage-record fragment in this snapshot copy.
+		// Per-fragment recordLength is bounded by `outputBufferSize`, so a single buffer of that size is always enough.
+		final byte[] rawCopyScratchBuffer = new byte[outputBufferSize];
 		int counter = 0;
 		final Iterator<Entry<RecordKey, FileLocation>> it = entries.iterator();
 		while (it.hasNext()) {
@@ -281,16 +284,15 @@ public class OffsetIndexSerializationService {
 				long startPosition = -1;
 				int recordLength = 0;
 				byte control;
-				RawRecord sourceRecord;
+				RawRecordHeader sourceRecord;
 				do {
-					sourceRecord = StorageRecord.readRaw(inputStream);
+					sourceRecord = StorageRecord.readRawInto(inputStream, rawCopyScratchBuffer);
 					control = sourceRecord.control();
 
-					// write original value in raw form
-					byte[] rawData = sourceRecord.rawData();
-
 					final FileLocation recordLocation = StorageRecord.writeRaw(
-						output, control, catalogVersion, rawData);
+						output, control, catalogVersion,
+						rawCopyScratchBuffer, 0, sourceRecord.payloadLength()
+					);
 					if (startPosition == -1) {
 						startPosition = recordLocation.startingPosition();
 					}

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/model/StorageRecord.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/model/StorageRecord.java
@@ -355,6 +355,56 @@ public record StorageRecord<T>(
 	}
 
 	/**
+	 * Allocation-free sibling of {@link #readRaw(ObservableInput)} for streaming raw copy paths
+	 * such as `OffsetIndexSerializationService.copySnapshotTo`. The payload is read into the
+	 * caller-supplied `scratchBuffer` rather than into a freshly allocated `byte[]`.
+	 *
+	 * The buffer must be at least `recordLength - CRC_NOT_COVERED_PART` bytes long. Since storage
+	 * records are written in fragments capped by the configured `outputBufferSize`, a buffer of
+	 * `outputBufferSize` bytes is always sufficient.
+	 *
+	 * @param input         input stream positioned at the start of a record
+	 * @param scratchBuffer reusable buffer that will receive the payload bytes
+	 * @return a {@link RawRecordHeader} describing location, control byte, generation id, and the
+	 *         number of payload bytes actually written into `scratchBuffer`
+	 */
+	@Nonnull
+	public static RawRecordHeader readRawInto(
+		@Nonnull ObservableInput<?> input,
+		@Nonnull byte[] scratchBuffer
+	) {
+		long startingPosition = -1L;
+		int recordLength = -1;
+		try {
+			startingPosition = input.markStart();
+			recordLength = input.readInt();
+			final byte originalControl = input.readByte();
+			final long generationId = input.readLong();
+			// if the data is compressed we need to override the control byte and read it uncompressed
+			byte control = setBit(originalControl, COMPRESSION_BIT, false);
+			input.markPayloadStart(recordLength, control);
+			final int payloadLength = recordLength - CRC_NOT_COVERED_PART;
+			input.readBytes(scratchBuffer, 0, payloadLength);
+			input.markEnd(originalControl);
+
+			return new RawRecordHeader(
+				new FileLocation(startingPosition, recordLength),
+				originalControl,
+				generationId,
+				payloadLength
+			);
+		} catch (RuntimeException ex) {
+			// reset input stream to avoid partially initialized state
+			input.reset();
+			if (startingPosition != -1L && recordLength != -1) {
+				// if we know the location, we can verify it
+				checkUnderlyingInputStreamLength(input, new FileLocation(startingPosition, recordLength), ex);
+			}
+			throw ex;
+		}
+	}
+
+	/**
 	 * Constructor that is used for READING known record from the input stream on known file location. Constructor should
 	 * be used for random access reading of arbitrary records o reading lead record for the file offset index.
 	 *
@@ -545,6 +595,32 @@ public record StorageRecord<T>(
 		long generationId,
 		@Nonnull byte[] rawData
 	) {
+		return writeRaw(output, control, generationId, rawData, 0, rawData.length);
+	}
+
+	/**
+	 * Range-bounded sibling of {@link #writeRaw(ObservableOutput, byte, long, byte[])} that writes
+	 * `length` bytes from `rawData` starting at `offset`. Used by streaming raw-copy paths that
+	 * reuse a single scratch buffer across many records.
+	 *
+	 * @param output       observable output stream to write to
+	 * @param control      control byte (compression / CRC32 / continuation flags)
+	 * @param generationId generation id of the written record
+	 * @param rawData      buffer holding the raw (possibly compressed) payload data
+	 * @param offset       start offset within `rawData`
+	 * @param length       number of payload bytes to write
+	 * @return file location of the written record
+	 * @throws CorruptedRecordException if the written record length differs from expected
+	 */
+	@Nonnull
+	public static FileLocation writeRaw(
+		@Nonnull ObservableOutput<?> output,
+		byte control,
+		long generationId,
+		@Nonnull byte[] rawData,
+		int offset,
+		int length
+	) {
 		try {
 			output.markStart();
 			output.markRecordLengthPosition();
@@ -552,15 +628,15 @@ public record StorageRecord<T>(
 			output.writeByte(0);
 			output.writeLong(generationId);
 			output.markPayloadStart();
-			output.writeBytes(rawData);
+			output.writeBytes(rawData, offset, length);
 			final FileLocation resultLocation = output.markEndSuppressingCompression(control);
 			//noinspection StringConcatenationMissingWhitespace
 			Assert.isPremiseValid(
-				rawData.length + CRC_NOT_COVERED_PART == resultLocation.recordLength(),
+				length + CRC_NOT_COVERED_PART == resultLocation.recordLength(),
 				() -> new CorruptedRecordException(
 					"Record length differs (" + resultLocation.recordLength() + "B, " +
-						"expected " + (rawData.length + CRC_NOT_COVERED_PART) + "B) - it's probably corrupted!",
-					resultLocation.recordLength(), rawData.length + CRC_NOT_COVERED_PART
+						"expected " + (length + CRC_NOT_COVERED_PART) + "B) - it's probably corrupted!",
+					resultLocation.recordLength(), length + CRC_NOT_COVERED_PART
 				)
 			);
 			return resultLocation;
@@ -1104,6 +1180,24 @@ public record StorageRecord<T>(
 		byte control,
 		long generationId,
 		byte[] rawData
+	) {
+	}
+
+	/**
+	 * Allocation-free header descriptor returned by {@link #readRawInto(ObservableInput, byte[])}.
+	 * Unlike {@link RawRecord}, it does not carry the payload bytes — the caller already holds the
+	 * scratch buffer that received them and uses `payloadLength` to bound subsequent reads/writes.
+	 *
+	 * @param location      file location of the source record
+	 * @param control       control byte (compression / CRC32 / continuation flags)
+	 * @param generationId  generation id read from the record header
+	 * @param payloadLength number of payload bytes written into the caller's scratch buffer
+	 */
+	public record RawRecordHeader(
+		@Nonnull FileLocation location,
+		byte control,
+		long generationId,
+		int payloadLength
 	) {
 	}
 

--- a/evita_test/evita_performance_tests/pom.xml
+++ b/evita_test/evita_performance_tests/pom.xml
@@ -118,6 +118,16 @@
 			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>evita_export_fs</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>evita_export_s3</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-junit-jupiter</artifactId>
 			<version>${mockito.junit.version}</version>

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/storage/offsetIndex/OffsetIndexCompactionBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/storage/offsetIndex/OffsetIndexCompactionBenchmark.java
@@ -1,0 +1,112 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.performance.storage.offsetIndex;
+
+import io.evitadb.store.offsetIndex.OffsetIndex;
+import io.evitadb.store.offsetIndex.OffsetIndexDescriptor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * JMH benchmark for {@link OffsetIndex#compact} — the operation that issue #1157 identified as a
+ * source of multi-second G1 Old Gen stop-the-world pauses on large entity collections.
+ *
+ * The benchmark is designed to surface two regressions if the proposed fixes (scratch-buffer
+ * reuse, page-cache hygiene) are reverted or weakened:
+ *
+ * 1. **Allocation rate** — run with `-prof gc` and watch `gc.alloc.rate.norm`. Per the issue, the
+ *    new code path should hold allocation roughly constant across `payloadSizeProfile = LARGE`
+ *    parameters; the old code path scales the byte[] allocation linearly with record size.
+ * 2. **Wall-clock time** — `BenchmarkMode.AverageTime` reports ms-per-compaction. Acceptance
+ *    criterion in the issue is ≤ ±5% versus baseline.
+ *
+ * The benchmark intentionally runs on a single thread (`@Threads(1)`) — compaction in production
+ * is a serial operation that holds the write-handle on the source `OffsetIndex` for its full
+ * duration.
+ *
+ * ## Suggested invocation
+ *
+ * The uberjar's default `Main-Class` is `ArtificialTestRunner`, which hard-codes
+ * `include("io.evitadb.performance.externalApi.*")` and **ignores command-line arguments**.
+ * Bypass it via the generic `BenchmarkRunner` entrypoint:
+ *
+ * ```bash
+ * java -cp evita_test/evita_performance_tests/target/benchmarks.jar \
+ *     io.evitadb.performance.BenchmarkRunner OffsetIndexCompactionBenchmark \
+ *     -prof gc
+ * ```
+ *
+ * Per-allocation hot-path attribution (requires async-profiler installed):
+ *
+ * ```bash
+ * java -cp evita_test/evita_performance_tests/target/benchmarks.jar \
+ *     io.evitadb.performance.BenchmarkRunner OffsetIndexCompactionBenchmark \
+ *     -prof "async:libPath=/path/to/libasyncProfiler.so;event=alloc;output=flamegraph"
+ * ```
+ *
+ * Page-cache impact is hard to reproduce in JMH itself; for that, run the benchmark with
+ * `vmtouch` or `/proc/$$/status` sampling around it externally.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsAppend = {
+	"-Xmx4g",
+	"-XX:+UseG1GC",
+	"-XX:+AlwaysPreTouch"
+})
+@Threads(1)
+public class OffsetIndexCompactionBenchmark {
+
+	/**
+	 * Compacts the source `OffsetIndex` to a fresh file. This is the same code path that
+	 * production runs when a catalog reaches the compaction threshold — covers the entire
+	 * `copySnapshotTo` loop with `FileOutputStream` open/close included.
+	 *
+	 * The destination file is created on a fresh path per invocation (see
+	 * {@link OffsetIndexCompactionBenchmarkState#setUpInvocation}) so each measurement sees a
+	 * cold-output OS state, matching the production scenario.
+	 *
+	 * The returned descriptor is consumed by a `Blackhole` so JIT does not eliminate the
+	 * compaction call as dead.
+	 */
+	@Benchmark
+	public void compactOffsetIndex(OffsetIndexCompactionBenchmarkState state, Blackhole blackhole) {
+		final OffsetIndexDescriptor descriptor = state.getSourceOffsetIndex().compact(state.getTargetFile());
+		blackhole.consume(descriptor);
+	}
+
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/storage/offsetIndex/OffsetIndexCompactionBenchmarkState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/storage/offsetIndex/OffsetIndexCompactionBenchmarkState.java
@@ -80,6 +80,18 @@ import java.util.function.Function;
  * `OffsetIndexSerializationService.copySnapshotTo`) so the production code path — including
  * `FileOutputStream` open/close — is exercised end-to-end.
  *
+ * **Parameter selection.** `recordCount` × `payloadSizeProfile` is *not* meant to be run as the
+ * full cross-product — `HUGE` × `2000` would build a ~1-2 GB source file per trial, which is
+ * unusable in CI and on dev laptops. Pick a specific pair at the JMH command line, for example:
+ *
+ * ```
+ * java -jar benchmarks.jar OffsetIndexCompactionBenchmark \
+ *      -p payloadSizeProfile=HUGE -p recordCount=200 -p compression=false
+ * ```
+ *
+ * The `HUGE` × `200` configuration is the one that reproduces issue #1157's allocation pattern;
+ * the `SMALL` / `MEDIUM` / `LARGE` profiles with either `recordCount` are cheap.
+ *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 @State(Scope.Benchmark)
@@ -124,8 +136,10 @@ public class OffsetIndexCompactionBenchmarkState {
 	public boolean compression;
 
 	/**
-	 * Toggles the `Crc32CChecksumFactory` path. Production uses CRC32C, but disabling it lets us
-	 * attribute time/allocations between checksum work and the per-record copy itself.
+	 * Toggles the `Crc32CChecksumFactory` path. Pinned to `true` because the per-record
+	 * `byte[]` allocation pattern from issue #1157 is independent of CRC mode, and CRC-on is what
+	 * production runs. Expand to `{"true", "false"}` if you want to attribute time between
+	 * checksum work and the per-record copy itself — neither path is the one being optimised.
 	 */
 	@Param({"true"})
 	public boolean crc32;
@@ -380,9 +394,18 @@ public class OffsetIndexCompactionBenchmarkState {
 		if (!Files.exists(root)) {
 			return;
 		}
-		Files.walk(root)
-			.sorted((a, b) -> b.getNameCount() - a.getNameCount())
-			.forEach(p -> p.toFile().delete());
+		// Files.walk holds an open DirectoryStream; close it via try-with-resources so the temp
+		// dir is actually deletable on platforms that lock open directory handles (Windows).
+		try (final java.util.stream.Stream<Path> walk = Files.walk(root)) {
+			walk.sorted((a, b) -> b.getNameCount() - a.getNameCount())
+				.forEach(p -> {
+					try {
+						Files.deleteIfExists(p);
+					} catch (IOException ignored) {
+						// best-effort cleanup; a leftover file in a temp dir is not fatal for the benchmark
+					}
+				});
+		}
 	}
 
 	/**

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/storage/offsetIndex/OffsetIndexCompactionBenchmarkState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/storage/offsetIndex/OffsetIndexCompactionBenchmarkState.java
@@ -1,0 +1,429 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.performance.storage.offsetIndex;
+
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.TransactionOptions;
+import io.evitadb.api.requestResponse.data.AssociatedDataContract.AssociatedDataKey;
+import io.evitadb.core.executor.Scheduler;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.entity.EntityBodyStoragePart;
+import io.evitadb.store.entity.EntityStoragePartConfigurer;
+import io.evitadb.store.kryo.ObservableOutputKeeper;
+import io.evitadb.store.kryo.VersionedKryo;
+import io.evitadb.store.kryo.VersionedKryoKeyInputs;
+import io.evitadb.store.model.header.EntityCollectionFileHeader;
+import io.evitadb.store.offsetIndex.OffsetIndex;
+import io.evitadb.store.offsetIndex.OffsetIndexDescriptor;
+import io.evitadb.store.offsetIndex.io.WriteOnlyFileHandle;
+import io.evitadb.store.offsetIndex.model.OffsetIndexRecordTypeRegistry;
+import io.evitadb.store.schema.SchemaKryoConfigurer;
+import io.evitadb.store.settings.StorageSettings;
+import io.evitadb.store.shared.kryo.VersionedKryoFactory;
+import io.evitadb.utils.IOUtils;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.function.Function;
+
+/**
+ * JMH state for {@link OffsetIndexCompactionBenchmark}.
+ *
+ * The state builds a populated {@link OffsetIndex} file on disk once per trial, parameterised on:
+ *
+ * - `recordCount` + `payloadSizeProfile` — control the total file size and per-record payload distribution
+ *   (small/medium/large), mirroring the production mix described in issue #1157
+ * - `compression` — toggle the `ZipCompressionFactory` path used by `copySnapshotTo`
+ * - `crc32` — toggle the `Crc32CChecksumFactory` path used by `copySnapshotTo`
+ *
+ * The source `OffsetIndex` is opened once per trial and kept open across invocations, so each
+ * benchmark measurement only includes the cost of `OffsetIndex.compact(Path)` — the read of the
+ * source file, the per-record byte[] allocations, and the write of the destination file. The
+ * destination file is recreated on a fresh path for every invocation to avoid append-mode
+ * interference between iterations.
+ *
+ * The benchmark deliberately targets `OffsetIndex.compact` (not just
+ * `OffsetIndexSerializationService.copySnapshotTo`) so the production code path — including
+ * `FileOutputStream` open/close — is exercised end-to-end.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@State(Scope.Benchmark)
+public class OffsetIndexCompactionBenchmarkState {
+
+	private static final String ENTITY_TYPE = "benchmark";
+	private static final Locale[] LOCALES = new Locale[] {
+		Locale.ENGLISH, Locale.FRENCH, Locale.GERMAN, new Locale("cs", "CZ")
+	};
+
+	/**
+	 * Total number of records inserted into the source `OffsetIndex` before compaction.
+	 *
+	 * The defaults span three orders of magnitude on the per-record path: many tiny records (where
+	 * fragment-header overhead dominates), a moderate mix that approximates the entity-storage-part
+	 * mid-band, and few large records (where the per-record `byte[]` allocation observed in the
+	 * issue is most visible).
+	 */
+	@Param({"200", "2000"})
+	public int recordCount;
+
+	/**
+	 * Per-record payload size profile.
+	 *
+	 * `SMALL`/`MEDIUM`/`LARGE` use {@link EntityBodyStoragePart} filled with random
+	 * {@link AssociatedDataKey} entries — realistic shapes but heavily compressed by `KeyCompressor`
+	 * at write time, so the on-disk record sizes top out around a few KB regardless of the key
+	 * count. Use these to exercise the per-record loop overhead and per-fragment bookkeeping.
+	 *
+	 * `HUGE` switches to {@link RawBytesStoragePart} carrying an opaque random `byte[]` that
+	 * survives serialization at full size. This is the profile that reproduces the per-record
+	 * `byte[]` allocation pattern described in issue #1157 (records up to ~660 KB).
+	 */
+	@Param({"SMALL", "MEDIUM", "LARGE", "HUGE"})
+	public PayloadSizeProfile payloadSizeProfile;
+
+	/**
+	 * Toggles the `ZipCompressionFactory` path. Issue #1157 requires the allocation rate to be
+	 * independent of compression mode, so both values are exercised.
+	 */
+	@Param({"true", "false"})
+	public boolean compression;
+
+	/**
+	 * Toggles the `Crc32CChecksumFactory` path. Production uses CRC32C, but disabling it lets us
+	 * attribute time/allocations between checksum work and the per-record copy itself.
+	 */
+	@Param({"true"})
+	public boolean crc32;
+
+	private Path benchmarkRoot;
+	private Path sourceFile;
+	private OffsetIndexRecordTypeRegistry recordTypeRegistry;
+	private StorageSettings storageSettings;
+	private ObservableOutputKeeper observableOutputKeeper;
+	private ScheduledThreadPoolExecutor schedulerExecutor;
+	private WriteOnlyFileHandle sourceWriteHandle;
+	private OffsetIndex sourceOffsetIndex;
+	private long catalogVersion;
+	private long sourceFileSize;
+
+	private Path targetFile;
+
+	/**
+	 * Builds the source `OffsetIndex` file once per benchmark trial. The file lives in a fresh
+	 * tmp dir so concurrent forks don't race on the same path.
+	 */
+	@Setup(Level.Trial)
+	public void setUpTrial() throws IOException {
+		this.benchmarkRoot = Files.createTempDirectory("evita-offsetIndex-compaction-bench");
+		this.sourceFile = this.benchmarkRoot.resolve("source.kryo");
+
+		this.recordTypeRegistry = new OffsetIndexRecordTypeRegistry();
+		// `RawBytesStoragePart` is a benchmark-only type unknown to the production
+		// `EntityStoragePartRegistry` SPI; register it explicitly so `OffsetIndex.put` can resolve
+		// its type id. Picked 99 to stay well clear of the production range (currently up to 52).
+		this.recordTypeRegistry.registerFileOffsetIndexType(
+			(byte) 99, RawBytesStoragePart.class
+		);
+		this.storageSettings = new StorageSettings(
+			StorageOptions.builder(StorageOptions.temporary())
+				.computeCRC32(this.crc32)
+				.compress(this.compression)
+				.build(),
+			TransactionOptions.builder().build()
+		);
+
+		// real (non-mocked) scheduler so we don't drag Mockito into JMH measurement overhead;
+		// the lifecycle flags are required so `shutdownNow()` actually evicts the cut-task delayed
+		// in the queue — without them JMH's forked VM hangs for 30s on every trial teardown.
+		this.schedulerExecutor = new ScheduledThreadPoolExecutor(1);
+		this.schedulerExecutor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+		this.schedulerExecutor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+		this.schedulerExecutor.setRemoveOnCancelPolicy(true);
+		this.observableOutputKeeper = ObservableOutputKeeper._internalBuild(
+			new Scheduler(this.schedulerExecutor)
+		);
+		this.sourceWriteHandle = createWriteHandle(this.sourceFile);
+		this.sourceOffsetIndex = new OffsetIndex(
+			0L,
+			createInitialDescriptor(),
+			this.storageSettings.outputBufferSize(),
+			this.storageSettings.maxOpenedReadHandlesOrDefault(),
+			this.storageSettings.lockTimeoutSeconds(),
+			this.storageSettings.waitOnCloseSeconds(),
+			this.storageSettings,
+			this.storageSettings,
+			this.recordTypeRegistry,
+			this.sourceWriteHandle,
+			null,
+			null
+		);
+
+		final Random random = new Random(42L);
+		for (int primaryKey = 1; primaryKey <= this.recordCount; primaryKey++) {
+			this.sourceOffsetIndex.put(0L, buildStoragePart(random, primaryKey));
+		}
+		this.sourceOffsetIndex.flush(0L);
+		this.catalogVersion = 1L;
+		this.sourceFileSize = Files.size(this.sourceFile);
+		System.err.printf(
+			"[OffsetIndexCompactionBenchmark setup] recordCount=%d profile=%s compression=%s crc32=%s "
+				+ "sourceFile=%.2f MB avgRecord=%.2f KB%n",
+			this.recordCount,
+			this.payloadSizeProfile,
+			this.compression,
+			this.crc32,
+			this.sourceFileSize / 1024.0 / 1024.0,
+			this.sourceFileSize / 1024.0 / Math.max(1, this.recordCount)
+		);
+	}
+
+	/**
+	 * Creates a fresh destination file path for every invocation. Compaction must not see a
+	 * pre-existing file because `FileOutputStream` would otherwise reuse it and skew timings.
+	 */
+	@Setup(Level.Invocation)
+	public void setUpInvocation() {
+		this.targetFile = this.benchmarkRoot.resolve(
+			"compacted-" + System.nanoTime() + ".kryo"
+		);
+	}
+
+	/**
+	 * Removes the per-invocation destination file so the temp dir doesn't grow without bound
+	 * during long-running benchmark runs.
+	 */
+	@TearDown(Level.Invocation)
+	public void tearDownInvocation() {
+		if (this.targetFile != null) {
+			final Path toDelete = this.targetFile;
+			this.targetFile = null;
+			toDelete.toFile().delete();
+		}
+	}
+
+	/**
+	 * Closes the source `OffsetIndex` and removes the trial directory.
+	 */
+	@TearDown(Level.Trial)
+	public void tearDownTrial() throws IOException {
+		if (this.sourceOffsetIndex != null) {
+			IOUtils.closeQuietly(this.sourceOffsetIndex::close);
+			this.sourceOffsetIndex = null;
+		}
+		if (this.sourceWriteHandle != null) {
+			IOUtils.closeQuietly(this.sourceWriteHandle::close);
+			this.sourceWriteHandle = null;
+		}
+		if (this.observableOutputKeeper != null) {
+			IOUtils.closeQuietly(this.observableOutputKeeper::close);
+			this.observableOutputKeeper = null;
+		}
+		if (this.schedulerExecutor != null) {
+			this.schedulerExecutor.shutdownNow();
+			this.schedulerExecutor = null;
+		}
+		if (this.benchmarkRoot != null) {
+			deleteRecursively(this.benchmarkRoot);
+			this.benchmarkRoot = null;
+		}
+	}
+
+	/**
+	 * Returns the source `OffsetIndex` used by the benchmark methods. Kept alive for the entire
+	 * trial — compaction does not mutate the source.
+	 */
+	@Nonnull
+	public OffsetIndex getSourceOffsetIndex() {
+		return this.sourceOffsetIndex;
+	}
+
+	/**
+	 * Returns the per-invocation destination file path. A fresh path is generated for every
+	 * benchmark invocation to avoid file-append interference.
+	 */
+	@Nonnull
+	public Path getTargetFile() {
+		return this.targetFile;
+	}
+
+	/**
+	 * Returns the catalog version used when compacting. Compaction calls
+	 * `OffsetIndex.compact(Path)` which internally pins a `keyCatalogVersion` snapshot.
+	 */
+	public long getCatalogVersion() {
+		return this.catalogVersion;
+	}
+
+	/**
+	 * Returns the bytes on disk for the source `OffsetIndex`. Useful for sanity-checking the
+	 * workload size in JMH `@AuxCounters` or in printed setup logs.
+	 */
+	public long getSourceFileSize() {
+		return this.sourceFileSize;
+	}
+
+	@Nonnull
+	private WriteOnlyFileHandle createWriteHandle(@Nonnull Path target) {
+		return new WriteOnlyFileHandle(
+			target,
+			this.storageSettings.outputBufferSize(),
+			this.storageSettings.syncWrites(),
+			this.storageSettings,
+			this.storageSettings,
+			this.observableOutputKeeper
+		);
+	}
+
+	@Nonnull
+	private OffsetIndexDescriptor createInitialDescriptor() {
+		return new OffsetIndexDescriptor(
+			new EntityCollectionFileHeader(ENTITY_TYPE, 1, 0),
+			createKryoFactory(),
+			1.0,
+			0L
+		);
+	}
+
+	@Nonnull
+	private static Function<VersionedKryoKeyInputs, VersionedKryo> createKryoFactory() {
+		return keyInputs -> VersionedKryoFactory.createKryo(
+			keyInputs.version(),
+			SchemaKryoConfigurer.INSTANCE
+				.andThen(new EntityStoragePartConfigurer(keyInputs.keyCompressor()))
+				.andThen(kryo -> kryo.register(
+					RawBytesStoragePart.class,
+					new RawBytesStoragePartSerializer(),
+					999
+				))
+		);
+	}
+
+	@Nonnull
+	private StoragePart buildStoragePart(@Nonnull Random random, int primaryKey) {
+		if (this.payloadSizeProfile.usesRawBytes) {
+			return buildRawBytesPart(random, primaryKey);
+		}
+		return buildEntityBody(random, primaryKey);
+	}
+
+	@Nonnull
+	private RawBytesStoragePart buildRawBytesPart(@Nonnull Random random, int primaryKey) {
+		final int payloadBytes = this.payloadSizeProfile.samplePayloadBytes(random);
+		final byte[] data = new byte[payloadBytes];
+		random.nextBytes(data);
+		return new RawBytesStoragePart(primaryKey, data);
+	}
+
+	@Nonnull
+	private EntityBodyStoragePart buildEntityBody(@Nonnull Random random, int primaryKey) {
+		final int keyCount = this.payloadSizeProfile.sampleKeyCount(random);
+		final Set<AssociatedDataKey> associatedData = new HashSet<>(keyCount);
+		// AssociatedDataKey serializes to roughly 20-60 bytes; the resulting EntityBodyStoragePart
+		// size therefore scales approximately linearly with keyCount, which gives us a predictable
+		// way to dial the per-record payload distribution without bringing in javafaker.
+		for (int i = 0; i < keyCount; i++) {
+			associatedData.add(
+				new AssociatedDataKey(
+					"key_" + primaryKey + "_" + i + "_" + random.nextInt(1_000_000),
+					LOCALES[random.nextInt(LOCALES.length)]
+				)
+			);
+		}
+		return new EntityBodyStoragePart(
+			1,
+			primaryKey,
+			io.evitadb.dataType.Scope.LIVE,
+			null,
+			Set.of(),
+			Set.of(),
+			associatedData,
+			0
+		);
+	}
+
+	private static void deleteRecursively(@Nonnull Path root) throws IOException {
+		if (!Files.exists(root)) {
+			return;
+		}
+		Files.walk(root)
+			.sorted((a, b) -> b.getNameCount() - a.getNameCount())
+			.forEach(p -> p.toFile().delete());
+	}
+
+	/**
+	 * Per-record payload size profile.
+	 *
+	 * `SMALL`/`MEDIUM`/`LARGE` are configured by `AssociatedDataKey` count — these get heavily
+	 * compressed by the offset-index `KeyCompressor` and produce ~1-5 KB on-disk records regardless
+	 * of the key count. They exercise the per-record loop overhead and per-fragment bookkeeping.
+	 *
+	 * `HUGE` is configured directly in bytes and uses {@link RawBytesStoragePart} — the random
+	 * bytes survive serialization at full size, producing on-disk records that match the
+	 * production scenario from issue #1157 (records up to ~660 KB on a multi-hundred-MB file).
+	 */
+	public enum PayloadSizeProfile {
+		SMALL(false, 8, 64),
+		MEDIUM(false, 64, 512),
+		LARGE(false, 1_024, 4_096),
+		HUGE(true, 256 * 1024, 1024 * 1024);
+
+		final boolean usesRawBytes;
+		private final int min;
+		private final int max;
+
+		PayloadSizeProfile(boolean usesRawBytes, int min, int max) {
+			this.usesRawBytes = usesRawBytes;
+			this.min = min;
+			this.max = max;
+		}
+
+		int sampleKeyCount(@Nonnull Random random) {
+			return sampleInRange(random);
+		}
+
+		int samplePayloadBytes(@Nonnull Random random) {
+			return sampleInRange(random);
+		}
+
+		private int sampleInRange(@Nonnull Random random) {
+			final int span = this.max - this.min;
+			return this.min + (span == 0 ? 0 : random.nextInt(span));
+		}
+	}
+
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/storage/offsetIndex/RawBytesStoragePart.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/storage/offsetIndex/RawBytesStoragePart.java
@@ -1,0 +1,75 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.performance.storage.offsetIndex;
+
+import io.evitadb.spi.store.catalog.persistence.storageParts.KeyCompressor;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serial;
+
+/**
+ * Test-only `StoragePart` that wraps an opaque random `byte[]` payload of caller-controlled size.
+ *
+ * Used by the {@link OffsetIndexCompactionBenchmark}'s `HUGE` profile to produce records with
+ * payloads that are large *and* cannot be compressed away by `KeyCompressor` (which deduplicates
+ * `Comparable` keys but has nothing to do with raw byte arrays). This is what reproduces the
+ * "byte arrays per record up to 660 KB" allocation pattern described in issue #1157 — the
+ * `EntityBodyStoragePart`-based profiles serialize down to ~4 KB per record because the random
+ * `AssociatedDataKey` strings get fully de-duplicated by the offset-index's key compressor.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class RawBytesStoragePart implements StoragePart {
+	@Serial private static final long serialVersionUID = 1L;
+
+	private final long primaryKey;
+	private final byte[] data;
+
+	public RawBytesStoragePart(long primaryKey, @Nonnull byte[] data) {
+		this.primaryKey = primaryKey;
+		this.data = data;
+	}
+
+	public long primaryKey() {
+		return this.primaryKey;
+	}
+
+	@Nonnull
+	public byte[] data() {
+		return this.data;
+	}
+
+	@Nullable
+	@Override
+	public Long getStoragePartPK() {
+		return this.primaryKey;
+	}
+
+	@Override
+	public long computeUniquePartIdAndSet(@Nonnull KeyCompressor keyCompressor) {
+		return this.primaryKey;
+	}
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/storage/offsetIndex/RawBytesStoragePartSerializer.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/storage/offsetIndex/RawBytesStoragePartSerializer.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.performance.storage.offsetIndex;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+/**
+ * Minimal length-prefixed Kryo serializer for {@link RawBytesStoragePart}. Writes the primary key
+ * followed by a 4-byte length and the raw payload bytes — no compression, no dedup, no nesting.
+ * Designed to make the on-disk record size *exactly* `8 + 4 + data.length` bytes so the benchmark
+ * can dial per-record payload size precisely.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class RawBytesStoragePartSerializer extends Serializer<RawBytesStoragePart> {
+
+	@Override
+	public void write(Kryo kryo, Output output, RawBytesStoragePart object) {
+		output.writeLong(object.primaryKey());
+		final byte[] data = object.data();
+		output.writeInt(data.length);
+		output.writeBytes(data);
+	}
+
+	@Override
+	public RawBytesStoragePart read(Kryo kryo, Input input, Class<? extends RawBytesStoragePart> type) {
+		final long primaryKey = input.readLong();
+		final int length = input.readInt();
+		final byte[] data = input.readBytes(length);
+		return new RawBytesStoragePart(primaryKey, data);
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of #1157: stops the per-fragment `byte[recordLength]` allocation in `OffsetIndexSerializationService.copySnapshotTo` that was responsible for the G1 Old Gen pauses (1.9–2.0 s) observed during compactions of large entity collections.

- New `StorageRecord.readRawInto(input, scratchBuffer)` returning a payload-less `RawRecordHeader`, plus a range-bounded `writeRaw(..., offset, length)` overload.
- `copySnapshotTo` now allocates a single `byte[outputBufferSize]` scratch buffer once per snapshot and reuses it across every fragment.
- On a HUGE-profile benchmark (124 MB / 200 records, ~636 KB each) allocation per compaction drops from ~131 MB to 4.3 MB (~30×). Wall-clock is unchanged (the path is I/O-bound).

## Benchmark

Adds `OffsetIndexCompactionBenchmark` (JMH) with four payload-size profiles. The `HUGE` profile is backed by a benchmark-only `RawBytesStoragePart` that sidesteps `KeyCompressor` so per-record byte[] allocations are actually visible on the JFR allocation profile. Also adds the missing `evita_export_fs` / `evita_export_s3` dependencies needed by the perf-tests uberjar.

## Scope note (phase 1 only)

The issue lists three tiers of mitigations. This PR delivers only **tier 1** (the scratch-buffer fix). Tiers 2 and 3 — `posix_fadvise(POSIX_FADV_DONTNEED)` page-cache hints and a configurable `compactionMaxBytesPerSecond` throttle — were de-scoped after measurement; see the issue thread for reasoning.

## Test plan

- [x] `OffsetIndexCompactionBenchmark` runs cleanly on all four payload profiles
- [x] HUGE profile confirms ~30× allocation reduction via `-prof gc` and JFR
- [x] Existing `evita_store_key_value` unit tests pass in CI
- [x] Integration / catalog persistence tests pass in CI

Closes #1157