### PR TITLE
fix: OffsetIndex#count undercounts/overcounts for past catalog versions (#1162)

### DIFF
--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
@@ -1880,9 +1880,11 @@ public class OffsetIndex {
 					// which must be included in the subtraction. When catalogVersion precedes all historical
 					// versions (binarySearch returns -1, insertion point 0), every entry must be subtracted
 					final int startIndex = index >= 0 ? index + 1 : -index - 1;
-					for (int ix = hv.length - 1; ix >= startIndex && ix >= 0; ix--) {
+					for (int ix = hv.length - 1; ix >= startIndex; ix--) {
+						// hvValues is the shared ConcurrentHashMap referenced by recordHistoricalVersions;
+						// a concurrent purge can remove an entry after we snapshotted hv under the lock
 						final PastMemory differenceSet = hvValues.get(hv[ix]);
-						diff -= differenceSet.getAddedKeys().size() - differenceSet.getRemovedKeys().size();
+						diff -= differenceSet == null ? 0 : differenceSet.getAddedKeys().size() - differenceSet.getRemovedKeys().size();
 					}
 				}
 			}
@@ -1932,7 +1934,7 @@ public class OffsetIndex {
 					// which must be included in the subtraction. When catalogVersion precedes all historical
 					// versions (binarySearch returns -1, insertion point 0), every entry must be subtracted (issue #1162).
 					final int startIndex = index >= 0 ? index + 1 : -index - 1;
-					for (int ix = hv.length - 1; ix >= startIndex && ix >= 0; ix--) {
+					for (int ix = hv.length - 1; ix >= startIndex; ix--) {
 						final PastMemory differenceSet = hvValues.get(hv[ix]);
 						diff -= differenceSet == null ? 0 : differenceSet.getCountFor(recordTypeId);
 					}

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
@@ -1873,14 +1873,16 @@ public class OffsetIndex {
 				} finally {
 					this.lock.unlock();
 				}
-				if (hv != null) {
-					int index = Arrays.binarySearch(hv, catalogVersion);
-					if (index != -1 && hvValues != null) {
-						final int startIndex = index >= 0 ? index : -index - 1;
-						for (int ix = hv.length - 1; ix > startIndex && ix >= 0; ix--) {
-							final PastMemory differenceSet = hvValues.get(hv[ix]);
-							diff -= differenceSet.getAddedKeys().size() - differenceSet.getRemovedKeys().size();
-						}
+				if (hv != null && hvValues != null) {
+					final int index = Arrays.binarySearch(hv, catalogVersion);
+					// on exact match, skip the matched version (its diff is already reflected in keyToLocations);
+					// on miss, -index-1 is the insertion point — the first version greater than catalogVersion,
+					// which must be included in the subtraction. When catalogVersion precedes all historical
+					// versions (binarySearch returns -1, insertion point 0), every entry must be subtracted
+					final int startIndex = index >= 0 ? index + 1 : -index - 1;
+					for (int ix = hv.length - 1; ix >= startIndex && ix >= 0; ix--) {
+						final PastMemory differenceSet = hvValues.get(hv[ix]);
+						diff -= differenceSet.getAddedKeys().size() - differenceSet.getRemovedKeys().size();
 					}
 				}
 			}
@@ -1924,13 +1926,15 @@ public class OffsetIndex {
 					this.lock.unlock();
 				}
 				if (hv != null && hvValues != null) {
-					int index = Arrays.binarySearch(hv, catalogVersion);
-					if (index != -1) {
-						final int startIndex = index >= 0 ? index : -index - 1;
-						for (int ix = hv.length - 1; ix > startIndex && ix >= 0; ix--) {
-							final PastMemory differenceSet = hvValues.get(hv[ix]);
-							diff -= differenceSet == null ? 0 : differenceSet.getCountFor(recordTypeId);
-						}
+					final int index = Arrays.binarySearch(hv, catalogVersion);
+					// on exact match, skip the matched version (its diff is already reflected in the histogram);
+					// on miss, -index-1 is the insertion point — the first version greater than catalogVersion,
+					// which must be included in the subtraction. When catalogVersion precedes all historical
+					// versions (binarySearch returns -1, insertion point 0), every entry must be subtracted (issue #1162).
+					final int startIndex = index >= 0 ? index + 1 : -index - 1;
+					for (int ix = hv.length - 1; ix >= startIndex && ix >= 0; ix--) {
+						final PastMemory differenceSet = hvValues.get(hv[ix]);
+						diff -= differenceSet == null ? 0 : differenceSet.getCountFor(recordTypeId);
 					}
 				}
 			}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
@@ -705,6 +705,82 @@ class OffsetIndexTest implements EvitaTestSupport {
 		}
 	}
 
+	@DisplayName("count() should return the correct value at a catalog version that was never flushed (issue #1162)")
+	@Test
+	void shouldReturnCorrectCountAtUnflushedCatalogVersionBetweenHistoricalVersions() {
+		final StorageSettings storageSettings = new StorageSettings(
+			StorageOptions.temporary(),
+			DEFAULT_TRANSACTION_OPTIONS
+		);
+		try (final ObservableOutputKeeper observableOutputKeeper = createMockedObservableOutputKeeper()) {
+			final OffsetIndex offsetIndex = createNewOffsetIndex(
+				0L,
+				storageSettings,
+				createWriteOnlyFileHandle(this.targetFile, storageSettings, observableOutputKeeper),
+				this.offsetIndexRecordTypeRegistry
+			);
+			try {
+				// version 1: insert R1, flush
+				offsetIndex.put(1L, new EntityBodyStoragePart(1));
+				offsetIndex.flush(1L);
+				// version 2: insert R2, flush
+				offsetIndex.put(2L, new EntityBodyStoragePart(2));
+				offsetIndex.flush(2L);
+				// no activity at version 3 — create a gap in historicalVersions
+				// version 4: insert R4, flush
+				offsetIndex.put(4L, new EntityBodyStoragePart(4));
+				offsetIndex.flush(4L);
+
+				// sanity: count at each recorded version
+				assertEquals(1, offsetIndex.count(1L), "count at v1 should see only R1");
+				assertEquals(2, offsetIndex.count(2L), "count at v2 should see R1, R2");
+				assertEquals(3, offsetIndex.count(4L), "count at v4 should see R1, R2, R4");
+
+				// the bug: querying the gap version 3 incorrectly returned 3 (the current keyToLocations size)
+				// because the binary search insertion point was excluded from the diff-subtraction loop
+				assertEquals(
+					2,
+					offsetIndex.count(3L),
+					"count at gap version 3 should match count at v2 (no records were added at v3)"
+				);
+			} finally {
+				IOUtils.closeQuietly(offsetIndex::close);
+			}
+		}
+	}
+
+	@DisplayName("count() should return the correct value at a catalog version older than every historical entry (issue #1162)")
+	@Test
+	void shouldReturnCorrectCountAtCatalogVersionPrecedingAllHistoricalVersions() {
+		final StorageSettings storageSettings = new StorageSettings(
+			StorageOptions.temporary(),
+			DEFAULT_TRANSACTION_OPTIONS
+		);
+		try (final ObservableOutputKeeper observableOutputKeeper = createMockedObservableOutputKeeper()) {
+			final OffsetIndex offsetIndex = createNewOffsetIndex(
+				0L,
+				storageSettings,
+				createWriteOnlyFileHandle(this.targetFile, storageSettings, observableOutputKeeper),
+				this.offsetIndexRecordTypeRegistry
+			);
+			try {
+				// only one flushed version — simulates the state right after compaction discards older
+				// historicalVersions while keyToLocations still holds records
+				offsetIndex.put(5L, new EntityBodyStoragePart(1));
+				offsetIndex.put(5L, new EntityBodyStoragePart(2));
+				offsetIndex.flush(5L);
+
+				// querying any catalog version preceding hv[0]=5 should subtract every diff and return
+				// the state that existed before flush(5) — empty
+				assertEquals(0, offsetIndex.count(3L), "count at v3 should be 0 (nothing was added before v5)");
+				assertEquals(0, offsetIndex.count(4L), "count at v4 should be 0 (nothing was added before v5)");
+				assertEquals(2, offsetIndex.count(5L), "count at v5 should see both records");
+			} finally {
+				IOUtils.closeQuietly(offsetIndex::close);
+			}
+		}
+	}
+
 	@DisplayName("No operation should be allowed after close")
 	@Test
 	void shouldRefuseOperationAfterClose() {


### PR DESCRIPTION
## Summary

Fixes #1162 — `OffsetIndex.count(catalogVersion)` returned incorrect values for past snapshots when the queried catalog version was not exactly present in `historicalVersions`.

Two off-by-something bugs in `VolatileValues.countDifference`:

1. **Strict-inequality loop on a binary-search miss.** With `historicalVersions = [1, 2, 4, 5]` and a query for `3`, `binarySearch` returns `-3`; the old code computed `startIndex = -index - 1 = 2` (the insertion point — version `4`) but iterated with `ix > startIndex`, skipping that very index. The diff at version `4` was not subtracted.
2. **Spurious `if (index != -1)` guard.** When `catalogVersion` precedes every historical entry (typical right after a compaction has discarded older history), every recorded diff must be subtracted. The guard short-circuited the loop and returned a zero adjustment, leaving the count equal to `keyToLocations.size()` — the current state, not the past one.

Fix in both `countDifference` overloads (records and per-record-type):
- Normalize `startIndex` to the first index that must be processed (`index + 1` on exact match, `-index - 1` on miss).
- Iterate inclusively with `ix >= startIndex`.
- Drop the `index != -1` guard.

## Test plan

- [x] Two new focused unit tests in `OffsetIndexTest`:
  - `shouldReturnCorrectCountAtUnflushedCatalogVersionBetweenHistoricalVersions` — gap version between two recorded versions (seed 33 scenario).
  - `shouldReturnCorrectCountAtCatalogVersionPrecedingAllHistoricalVersions` — catalog version older than every entry (seed 55 scenario).
- [x] `OffsetIndexTest` — 31/31 pass.
- [x] All tests in `io.evitadb.store.offsetIndex.*` — 189 pass, 18 skipped, 0 failures.
- [x] `DefaultCatalogPersistenceServiceTest` + `DefaultEnginePersistenceServiceTest` — 41/41 pass.
- [x] `LongRunningOffsetIndexTest#generationalProofTest` with the two seeds from the issue: seed `33` and seed `55` both pass (≈300 iterations × 2 compression variants each).
- [x] 15-run randomized sweep of `LongRunningOffsetIndexTest#generationalProofTest` with fresh seeds (40858104, 589422608, 684433506, 1041078244, 976631318, 693874526, 457044742, 370165700, 843757958, 774755956, 930451456, 1014066105, 499984631, 315625562, 272715030) — 15/15 PASS.

## Related change in this PR

`feat: allow reproducing a specific generational seed via -Dtest.seed` (commit `dddfa4bb3`) — small enhancement to `TimeArgumentProvider` so a failing generational seed surfaced in CI or logs can be replayed locally. Was essential for verifying the fix against seeds 33 and 55 and is generally useful.

Closes #1162