### PR TITLE
chore: bump dependencies + fix Bouncy Castle CVEs

### DIFF
--- a/.github/workflows/benchmark-hook.yml
+++ b/.github/workflows/benchmark-hook.yml
@@ -49,7 +49,7 @@ jobs:
         kubectl -n evita logs job/${K8S_JOB_NAME} -c benchmark > /tmp/logs/${K8S_JOB_NAME}-log.txt || :
 
     - name: Archive logs from run
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: logs
         path: /tmp/logs

--- a/.github/workflows/ci-dev-documentation.yml
+++ b/.github/workflows/ci-dev-documentation.yml
@@ -34,7 +34,7 @@ jobs:
          cache: 'maven'
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
         dotnet-version: '8.0.X'    # setup dotnet 8.0.X for building
 
@@ -43,7 +43,7 @@ jobs:
         mvn -T 1C -B package -P documentation -V --fail-at-end -Dmaven.test.skip=false --file pom.xml
 
     - name: Upload test results    # upload XML with unit test results for debugging
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success() || failure()
       with:
         name: test-results

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -50,7 +50,7 @@ jobs:
         jacoco/jacoco-summary.sh jacoco/target/site/jacoco-aggregate/jacoco.csv
 
     - name: Upload test results    # upload XML with unit test results for debugging
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success() || failure()
       with:
         name: test-results
@@ -61,7 +61,7 @@ jobs:
       if: success() || failure()
 
     - name: Upload evitaDB server artifact   # upload `evita-server.jar` for `docker-canary.yml` to deploy to DockerHub
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success()
       with:
         name: evita-server.jar

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -131,7 +131,7 @@ jobs:
 
     # Upload workflow data for the release workflow
     - name: Upload workflow data
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: workflow-data
         path: |

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
 
     - name: Download release branch info
-      uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3 # v16
+      uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
       if: ${{ github.event.workflow_run.conclusion == 'success' }}
       with:
         workflow: ${{ github.event.workflow_run.workflow_id }}
@@ -348,7 +348,7 @@ jobs:
     - name: Cache Claude Code CLI
       id: cache_claude_cli
       if: success()
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.local/bin/claude
@@ -421,7 +421,7 @@ jobs:
     # offline for inspection — even if the PATCH step skipped or failed.
     - name: Upload release-notes.md artifact
       if: always() && hashFiles('release-notes.md') != ''
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: release-notes-${{ steps.release_version.outputs.version }}
         path: release-notes.md
@@ -484,14 +484,14 @@ jobs:
         asset_content_type: application/gzip
 
     - name: Upload evitaDB server artifact
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success()
       with:
         name: evita-server.jar
         path: 'evita_server/target/evita-server.jar'
 
     - name: Upload evitaDB version.txt
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: success()
       with:
         name: version.txt

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -348,7 +348,7 @@ jobs:
     - name: Cache Claude Code CLI
       id: cache_claude_cli
       if: success()
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
           ~/.local/bin/claude

--- a/.github/workflows/docker-canary.yml
+++ b/.github/workflows/docker-canary.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Download a single artifact # download `evita-server.jar` artifact if the workflow we react to was successful
-        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3 # v16
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: evita-server.jar
@@ -46,7 +46,7 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
 
       - name: Login to DockerHub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.CI_REGISTRY_USER }}
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Download a JAR file to deploy # download `evita-server.jar` artifact if the workflow we react to was successful
         if: steps.inputs.outputs.source == 'workflow_artifact'
-        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3 # v16
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: evita-server.jar
@@ -79,7 +79,7 @@ jobs:
 
       - name: Download a version information # download `version.txt` artifact if the workflow we react to was successful
         if: steps.inputs.outputs.source == 'workflow_artifact'
-        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3 # v16
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: version.txt
@@ -115,7 +115,7 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
 
       - name: Login to DockerHub
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ vars.CI_REGISTRY_USER }}
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: mvn -T 1C -B package -P documentation -Dsurefire.reportNameSuffix=documentation -V --fail-at-end -Dmaven.test.skip=false --file pom.xml
 
       - name: Upload test results  # this upload test results but only if something was committed this day
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ env.NEW_COMMIT_COUNT != '0' && always() }}
         with:
           name: test-results

--- a/.github/workflows/long-running-tests.yml
+++ b/.github/workflows/long-running-tests.yml
@@ -53,7 +53,7 @@ jobs:
         run: mvn -T 1C -B package -P longRunning -V --fail-at-end --file pom.xml
 
       - name: Upload test results  # this upload test results but only if something was committed to dev branch in the last week
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ env.NEW_COMMIT_COUNT != '0' && always() }}
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.arch }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -40,7 +40,7 @@ jobs:
           jacoco/jacoco-summary.sh jacoco/target/site/jacoco-aggregate/jacoco.csv
 
       - name: Upload test results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:
           name: test-results

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 		<slf4j.version>2.0.17</slf4j.version>
 		<logback.version>1.5.32</logback.version>
 		<kryo.version>5.6.2</kryo.version>
-		<jackson.version>2.21.1</jackson.version>
+		<jackson.version>2.21.3</jackson.version>
 		<jackson.annotations.version>2.21</jackson.annotations.version>
 		<snakeyaml.version>2.6</snakeyaml.version>
 		<roaringbitmap.version>1.6.12</roaringbitmap.version>
@@ -140,8 +140,8 @@
 		<bouncyCastle.version>1.84</bouncyCastle.version>
 		<swagger.version>2.2.43</swagger.version>
 		<armeria.version>1.39.0</armeria.version>
-		<prometheus.version>1.5.0</prometheus.version>
-		<micrometer.version>1.16.3</micrometer.version>
+		<prometheus.version>1.6.1</prometheus.version>
+		<micrometer.version>1.16.5</micrometer.version>
 		<byteBuddy.version>1.17.8</byteBuddy.version>
 		<graphql.version>25.0</graphql.version>
 		<okhttp.version>5.3.2</okhttp.version>
@@ -312,6 +312,26 @@
 				<groupId>org.junit.platform</groupId>
 				<artifactId>junit-platform-launcher</artifactId>
 				<version>${junit.jupiter.version}</version>
+			</dependency>
+			<!--
+				Force Bouncy Castle to ${bouncyCastle.version} across all modules.
+				Without this, io.minio:minio drags in a vulnerable bcprov-jdk18on
+				transitively into evita_export_s3 (CVE-2026-5598, CVE-2026-0636).
+			-->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>${bouncyCastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>${bouncyCastle.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcutil-jdk18on</artifactId>
+				<version>${bouncyCastle.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -514,7 +534,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.6.1</version>
+					<version>3.6.2</version>
 				</plugin>
 				<plugin>
 					<!--
@@ -594,7 +614,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.5.4</version>
+				<version>3.5.5</version>
 				<configuration>
 					<forkCount>1</forkCount>
 					<reuseForks>true</reuseForks>


### PR DESCRIPTION
## Summary

Bundles the open Dependabot bumps and adds a `dependencyManagement` override to pin transitive `bcprov-jdk18on` to `1.84`, closing **two security advisories**.

## Security fix

`io.minio:minio:8.6.0` drags in vulnerable `bcprov-jdk18on:1.81` into `evita_export_s3`:
- **CVE-2026-5598** (high) — Bouncy Castle covert timing channel
- **CVE-2026-0636** (medium) — Bouncy Castle LDAP injection

The repo already declares `bouncyCastle.version=1.84` but no `dependencyManagement` entry enforced it, so the transitive 1.81 won. This PR adds explicit `dependencyManagement` entries for `bcprov-jdk18on`, `bcpkix-jdk18on`, and `bcutil-jdk18on` keyed off that property. Verified with `mvn dependency:tree` — both `evita_export_s3` and `evita_external_api_core` now resolve BC at 1.84.

## Library bumps (root `pom.xml`)
- `jackson` 2.21.1 → 2.21.3
- `prometheus` 1.5.0 → 1.6.1
- `micrometer` 1.16.3 → 1.16.5
- `maven-surefire-plugin` 3.5.4 → 3.5.5
- `maven-shade-plugin` 3.6.1 → 3.6.2

## GitHub Actions bumps
- `actions/cache` v4 → v5
- `actions/setup-dotnet` 5.1.0 → 5.2.0
- `actions/upload-artifact` 7.0.0 → 7.0.1
- `docker/login-action` 4.0.0 → 4.1.0
- `dawidd6/action-download-artifact` v16 → v21

Supersedes Dependabot PRs #1166-#1175 — these can be closed once this PR merges.

## Test plan
- [x] `mvn compile test-compile -T 1C` passes for the full reactor with all bumps applied
- [x] `mvn dependency:tree -Dincludes=org.bouncycastle` confirms 1.84 in s3 and core modules
- [ ] CI green on this PR (PR-Review pipeline runs full `mvn package -P unitAndFunctional,full`)