### PR TITLE
fix: referenceContent pagination with orderBy returns null referencedEntity/groupEntity (#1177)

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/EntityDecorator.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/EntityDecorator.java
@@ -169,10 +169,23 @@ public class EntityDecorator implements SealedEntity {
 	private List<PriceContract> filteredPrices;
 
 	/**
-	 * Method sorts and filters the data in `references` using `referenceFilter` and `referenceComparator` but only
-	 * within bounds specified by `start` (inclusive) and `end` (exclusive).
+	 * Sorts and filters the supplied `references` slice in place using `referenceFilter` and
+	 * `referenceComparator`, operating only within `[start, end)`. Filtering runs first (matching
+	 * elements move to the front of the slice, filtered-out ones are pushed to the tail); sorting
+	 * then walks the `referenceComparator` chain over the surviving prefix, recursing into the
+	 * unsorted tail at each link — see the inline notes for the cumulative-counter invariant.
 	 *
-	 * @return count of filtered out references
+	 * @param entityPrimaryKey    primary key of the source entity owning the references; forwarded
+	 *                            to every {@link ReferenceComparator.EntityPrimaryKeyAwareComparator}
+	 *                            link in the chain so it can scope its lookups
+	 * @param references          array containing the references; the `[start, end)` slice is mutated
+	 *                            in place (filtered + sorted)
+	 * @param referencePredicate  predicate identifying references the caller actually requested
+	 * @param referenceFilter     optional additional filter; {@code null} means "accept everything"
+	 * @param referenceComparator head of the comparator chain; {@code null} skips sorting entirely
+	 * @param start               inclusive lower bound of the slice to process
+	 * @param end                 exclusive upper bound of the slice to process
+	 * @return number of references filtered out of the slice (pushed to the tail of `[start, end)`)
 	 */
 	protected static int sortAndFilterSubList(
 		int entityPrimaryKey,
@@ -192,24 +205,38 @@ public class EntityDecorator implements SealedEntity {
 				entityPrimaryKey, references, referencePredicate, theReferenceFilter, start, end
 			);
 		} else {
-			if (referenceComparator instanceof ReferenceComparator.EntityPrimaryKeyAwareComparator epkAware) {
-				epkAware.setEntityPrimaryKey(entityPrimaryKey);
-			}
 			final int filteredOutCount = filterOutReferences(
 				entityPrimaryKey, references, referencePredicate,
 				theReferenceFilter,
 				start, end
 			);
 			final int sortEnd = end - filteredOutCount;
-			// now do the sorting in multiple passes if needed
-			int nonSortedReferenceCount;
-			do {
-				// Just sort the current window
+			// Walk the comparator chain; at each link sort the still-unsorted window and recurse on
+			// whatever the comparator could not rank. Two invariants drive the math (and mirror
+			// `BitmapSlicer#sortReferencesByComparatorChain` so pre-fetch and post-fetch agree):
+			//   1. `setEntityPrimaryKey` must fire on EVERY EPK-aware link, not just the head — the
+			//      EPK-aware link can sit anywhere in the chain (e.g. a `ReferencePredecessorComparator`
+			//      behind a plain attribute comparator) and a missing scope yields NPE or a wrong sort.
+			//   2. `getNonSortedReferenceCount()` is a cumulative cross-entity accumulator on some
+			//      concrete comparators (notably `EntityNestedQueryComparator`) — it never resets
+			//      between source-entity passes. Snapshot before/after each `Arrays.sort` and clamp
+			//      the per-pass delta to `[0, sortEnd - start]` so a stale or oversized cumulative
+			//      reading cannot drive `start` past `sortEnd` and trip the next sort with a
+			//      backwards range.
+			while (referenceComparator != null && start < sortEnd) {
+				if (referenceComparator instanceof ReferenceComparator.EntityPrimaryKeyAwareComparator epkAware) {
+					epkAware.setEntityPrimaryKey(entityPrimaryKey);
+				}
+				final int nonSortedBefore = referenceComparator.getNonSortedReferenceCount();
 				Arrays.sort(references, start, sortEnd, referenceComparator);
-				nonSortedReferenceCount = referenceComparator.getNonSortedReferenceCount();
-				start = start + (sortEnd - nonSortedReferenceCount);
+				final int nonSortedAfter = referenceComparator.getNonSortedReferenceCount();
+				final int delta = Math.max(0, Math.min(nonSortedAfter - nonSortedBefore, sortEnd - start));
+				if (delta == 0) {
+					break;
+				}
+				start = Math.max(sortEnd - delta, start);
 				referenceComparator = referenceComparator.getNextComparator();
-			} while (referenceComparator != null && nonSortedReferenceCount > 0);
+			}
 
 			return filteredOutCount;
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/query/fetch/BitmapSlicer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/fetch/BitmapSlicer.java
@@ -247,9 +247,16 @@ class BitmapSlicer {
 					// from the chunked-predicate view exposed by referencedEntityToGroupIdTranslator
 					final Collection<ReferenceContract> sourceRefs =
 						referenceContractsAccessor.apply(this.referenceName, epk);
-					final ReferenceContract[] filteredRefs = sourceRefs.stream()
-						.filter(r -> filteredReferenceEntityIds.contains(r.getReferencedPrimaryKey()))
-						.toArray(ReferenceContract[]::new);
+					final ReferenceContract[] filterBuffer = new ReferenceContract[sourceRefs.size()];
+					int filteredCount = 0;
+					for (ReferenceContract r : sourceRefs) {
+						if (filteredReferenceEntityIds.contains(r.getReferencedPrimaryKey())) {
+							filterBuffer[filteredCount++] = r;
+						}
+					}
+					final ReferenceContract[] filteredRefs = filteredCount == filterBuffer.length
+						? filterBuffer
+						: Arrays.copyOf(filterBuffer, filteredCount);
 					// group accounting reflects *all* filtered references (independent of slicing), so
 					// getGroupIds keeps returning the full set
 					this.groupsForEntity.put(epk, groupPksOf(filteredRefs));
@@ -274,11 +281,15 @@ class BitmapSlicer {
 	 */
 	@Nonnull
 	private static int[] groupPksOf(@Nonnull ReferenceContract[] refs) {
-		return Arrays.stream(refs)
-			.map(ReferenceContract::getGroup)
-			.flatMap(Optional::stream)
-			.mapToInt(GroupEntityReference::getPrimaryKeyOrThrowException)
-			.toArray();
+		final int[] buffer = new int[refs.length];
+		int count = 0;
+		for (ReferenceContract ref : refs) {
+			final Optional<GroupEntityReference> group = ref.getGroup();
+			if (group.isPresent()) {
+				buffer[count++] = group.get().getPrimaryKeyOrThrowException();
+			}
+		}
+		return count == buffer.length ? buffer : Arrays.copyOf(buffer, count);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/fetch/BitmapSlicer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/fetch/BitmapSlicer.java
@@ -33,7 +33,12 @@ import io.evitadb.api.requestResponse.chunk.OffsetAndLimit;
 import io.evitadb.api.requestResponse.chunk.PageTransformer;
 import io.evitadb.api.requestResponse.chunk.Slicer;
 import io.evitadb.api.requestResponse.chunk.StripTransformer;
+import io.evitadb.api.requestResponse.data.ReferenceContract;
+import io.evitadb.api.requestResponse.data.ReferenceContract.GroupEntityReference;
+import io.evitadb.api.requestResponse.data.structure.ReferenceComparator;
+import io.evitadb.utils.ArrayUtils;
 import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.utils.FormulaFactory;
 import io.evitadb.dataType.PaginatedList;
 import io.evitadb.dataType.Scope;
@@ -46,15 +51,28 @@ import io.evitadb.spi.store.catalog.chunk.PageTransformerWithSlicer;
 import io.evitadb.utils.CollectionUtils;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.stream.IntStream;
 
 /**
  * BitmapSlicer is supposed to identify only a small subset of referenced entities and their groups that should
  * be actually fetched / returned in the result taking `filterBy` and `page` / `strip` constraints into an account.
+ *
+ * Two execution paths are offered, selected by the caller based on whether an `orderBy` is configured:
+ *   - {@link #sliceEntityIds} — PK-bitmap fast path used when no orderBy is requested (or the comparator is the
+ *     default PK-ascending one); slicing operates directly on the PK bitmap.
+ *   - {@link #sliceEntityIdsSorted} — comparator-aware path used when a non-trivial orderBy is in play; it pulls
+ *     full reference contracts, sorts them with the configured {@link ReferenceComparator} chain, and slices the
+ *     sorted list so the pre-fetch slice agrees with the post-fetch sort done by `EntityDecorator`.
+ *
+ * The {@link ChunkTransformer} passed to the constructor determines the page/strip mathematics shared by both paths.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
  */
@@ -83,6 +101,14 @@ class BitmapSlicer {
 	 */
 	@Nonnull private final Function<Bitmap, Bitmap> chunker;
 	/**
+	 * Function that computes (offset, limit) for a given source size, serving as the single source of truth
+	 * for page/strip boundary handling. Both the PK-bitmap fast path ({@link #sliceEntityIds}) and the sorted
+	 * comparator-aware path ({@link #sliceEntityIdsSorted}) consume this same function so the sorted slice
+	 * produces exactly the set of PKs that the post-fetch sort+chunk in `EntityDecorator` would have kept —
+	 * no over-fetch, no under-fetch — independent of whichever {@link ChunkTransformer} was supplied.
+	 */
+	@Nonnull private final IntFunction<OffsetAndLimit> offsetAndLimitForSize;
+	/**
 	 * Contains a cache of groups indexed by entity primary key.
 	 */
 	private Map<Integer, int[]> groupsForEntity = Collections.emptyMap();
@@ -100,13 +126,22 @@ class BitmapSlicer {
 		this.referencedEntityToGroupIdTranslator = referencedEntityToGroupIdTranslator;
 		if (chunkTransformer instanceof PageTransformer pageTransformer) {
 			this.chunker = (bitmap) -> this.slice(bitmap, pageTransformer.getPage());
+			this.offsetAndLimitForSize = size -> pageOffsetAndLimit(pageTransformer.getPage(), size);
 		} else if (chunkTransformer instanceof PageTransformerWithSlicer pageTransformerWithSlicer) {
 			this.chunker = (bitmap) -> this.slice(
 				bitmap, pageTransformerWithSlicer.getPage(), pageTransformerWithSlicer.getSlicer());
+			this.offsetAndLimitForSize = size -> pageTransformerWithSlicer.getSlicer().calculateOffsetAndLimit(
+				ResultForm.PAGINATED_LIST,
+				pageTransformerWithSlicer.getPage().getPageNumber(),
+				pageTransformerWithSlicer.getPage().getPageSize(),
+				size
+			);
 		} else if (chunkTransformer instanceof StripTransformer stripTransformer) {
 			this.chunker = (bitmap) -> this.slice(bitmap, stripTransformer.getStrip());
+			this.offsetAndLimitForSize = size -> stripOffsetAndLimit(stripTransformer.getStrip(), size);
 		} else if (chunkTransformer instanceof NoTransformer) {
 			this.chunker = Function.identity();
+			this.offsetAndLimitForSize = size -> new OffsetAndLimit(0, size, size);
 		} else {
 			throw new GenericEvitaInternalError("Unsupported chunk transformer: " + chunkTransformer);
 		}
@@ -120,6 +155,8 @@ class BitmapSlicer {
 	 * This method is supposed to identify only a small subset of referenced entities and their groups that should
 	 * be actually fetched / returned in the result.
 	 *
+	 * @param referencedEntityIds global formula of filter-matching referenced entity PKs (filterBy applied)
+	 * @param validityMapping     per-source validity gate (multi-source dedup / chunked predicate)
 	 * @return all referenced entity ids that match `referencedEntityIds` and are appropriately sliced
 	 * on per entity basis by {@link #chunker}
 	 */
@@ -156,42 +193,212 @@ class BitmapSlicer {
 	}
 
 	/**
-	 * Prepares the sliced information for all entity primary keys (no filtering is applied).
+	 * Order-aware variant of {@link #sliceEntityIds(Formula, ValidEntityToReferenceMapping)} used when an `orderBy`
+	 * is configured on the reference content. For each source entity it pulls the actual {@link ReferenceContract}
+	 * instances (whose reference attributes are already loaded with the source entity), filters them by the global
+	 * filtered referenced PK bitmap and the per-source `validityMapping` (multi-source dedup / chunked predicate),
+	 * sorts them by the {@link ReferenceComparator} chain (the same comparator that
+	 * {@code EntityDecorator#sortAndFilterSubList} will use post-fetch), then slices the chunk using the configured
+	 * page/strip offset+limit. The returned bitmap contains exactly the PKs whose bodies will be the post-fetch
+	 * winners — no over-fetch, no under-fetch: the pre-fetch slice matches the post-fetch sort+chunk in
+	 * `EntityDecorator`.
+	 *
+	 * Group accounting here intentionally diverges from {@link #sliceEntityIds}: groups are derived directly from
+	 * the {@code referenceContractsAccessor} (the raw source entity), not from the
+	 * {@code referencedEntityToGroupIdTranslator} as in the unsorted twin. The translator is backed by an
+	 * {@code EntityDecorator} whose chunked-predicate view exposes only references the predicate has materialized;
+	 * for references picked by the orderBy-aware slice that view under-reports groups. The contract of
+	 * {@link #getGroupIds} therefore stays consistent across both paths: it returns the *full* filtered set of
+	 * groups regardless of which slicing path produced the entity bitmap.
+	 *
+	 * @param referencedEntityIds         global formula of filter-matching referenced entity PKs (filterBy applied)
+	 * @param validityMapping             per-source validity formula (same gate the unsorted twin applies)
+	 * @param referenceContractsAccessor  per-source-entity accessor for the source entity's reference contracts
+	 *                                    (with attributes) so this method can pre-sort by the configured `orderBy`
+	 *                                    before fetching
+	 * @param comparator                  the orderBy comparator chain (must not be {@link ReferenceComparator#DEFAULT})
+	 * @return PKs to actually fetch — exactly the post-fetch sort+chunk winners (no over-fetch, no under-fetch)
 	 */
-	public void sliceAllEntityIds() {
+	@Nonnull
+	public Bitmap sliceEntityIdsSorted(
+		@Nonnull Formula referencedEntityIds,
+		@Nonnull ValidEntityToReferenceMapping validityMapping,
+		@Nonnull BiFunction<String, Integer, Collection<ReferenceContract>> referenceContractsAccessor,
+		@Nonnull ReferenceComparator comparator
+	) {
 		this.groupsForEntity = CollectionUtils.createHashMap(this.entityPrimaryKey.size());
-		for (int[] entityPrimaryKeys : this.entityPrimaryKey.values()) {
-			for (int epk : entityPrimaryKeys) {
-				final Bitmap referenceEntityIds = this.referencedEntityIdsFormula.apply(this.referenceName, epk)
-					.compute();
-				this.groupsForEntity.put(
-					epk,
-					referenceEntityIds.stream()
-						.mapToObj(
-							refId -> this.referencedEntityToGroupIdTranslator.apply(epk, this.referenceName, refId))
-						.flatMapToInt(Function.identity())
-						.toArray()
-				);
+		return FormulaFactory.or(
+			this.entityPrimaryKey
+				.values()
+				.stream()
+				.flatMapToInt(IntStream::of)
+				.mapToObj(epk -> {
+					final Bitmap filteredReferenceEntityIds = FormulaFactory.and(
+						this.referencedEntityIdsFormula.apply(this.referenceName, epk),
+						referencedEntityIds,
+						validityMapping.getValidReferencedEntitiesFormula(epk)
+					).compute();
+					if (filteredReferenceEntityIds.isEmpty()) {
+						this.groupsForEntity.put(epk, ArrayUtils.EMPTY_INT_ARRAY);
+						return EmptyFormula.INSTANCE;
+					}
+					// gather the source entity's references whose PK is in the filtered set — see the
+					// JavaDoc body for why groups must be derived from these raw references rather than
+					// from the chunked-predicate view exposed by referencedEntityToGroupIdTranslator
+					final Collection<ReferenceContract> sourceRefs =
+						referenceContractsAccessor.apply(this.referenceName, epk);
+					final ReferenceContract[] filteredRefs = sourceRefs.stream()
+						.filter(r -> filteredReferenceEntityIds.contains(r.getReferencedPrimaryKey()))
+						.toArray(ReferenceContract[]::new);
+					// group accounting reflects *all* filtered references (independent of slicing), so
+					// getGroupIds keeps returning the full set
+					this.groupsForEntity.put(epk, groupPksOf(filteredRefs));
+					if (filteredRefs.length == 0) {
+						return EmptyFormula.INSTANCE;
+					}
+					sortReferencesByComparatorChain(epk, filteredRefs, comparator);
+					final OffsetAndLimit offsetAndLimit = this.offsetAndLimitForSize.apply(filteredRefs.length);
+					final int[] sliced = materializeSlicedPks(filteredRefs, offsetAndLimit);
+					return sliced.length == 0
+						? EmptyFormula.INSTANCE
+						: ReferencedEntityFetcher.toFormula(sliced);
+				})
+				.toArray(Formula[]::new)
+		).compute();
+	}
+
+	/**
+	 * Returns the primary keys of the groups referenced by the supplied references in source order.
+	 * References without a group are skipped. Used by the sorted slicing path to derive group
+	 * accounting from the same `ReferenceContract` array that drives the slice.
+	 */
+	@Nonnull
+	private static int[] groupPksOf(@Nonnull ReferenceContract[] refs) {
+		return Arrays.stream(refs)
+			.map(ReferenceContract::getGroup)
+			.flatMap(Optional::stream)
+			.mapToInt(GroupEntityReference::getPrimaryKeyOrThrowException)
+			.toArray();
+	}
+
+	/**
+	 * Materializes the sliced range `[offset, offset + limit)` of the supplied sorted references into
+	 * an `int[]` of their primary keys, clamping both ends to the array bounds. Returns an empty array
+	 * when the clamped range is empty.
+	 */
+	@Nonnull
+	private static int[] materializeSlicedPks(
+		@Nonnull ReferenceContract[] sorted,
+		@Nonnull OffsetAndLimit offsetAndLimit
+	) {
+		final int from = Math.min(offsetAndLimit.offset(), sorted.length);
+		final int to = Math.min(offsetAndLimit.offset() + offsetAndLimit.limit(), sorted.length);
+		if (to <= from) {
+			return ArrayUtils.EMPTY_INT_ARRAY;
+		}
+		final int[] sliced = new int[to - from];
+		for (int i = 0; i < sliced.length; i++) {
+			sliced[i] = sorted[from + i].getReferencedPrimaryKey();
+		}
+		return sliced;
+	}
+
+	/**
+	 * Sorts the candidates in place by walking the comparator chain. Uses the same delta-snapshot
+	 * pattern as {@code EntityDecorator#sortAndFilterSubList} — both call sites must agree because
+	 * this method drives the pre-fetch slice and `EntityDecorator` drives the post-fetch sort; any
+	 * divergence in window arithmetic would let the slice return PKs the post-fetch sort then
+	 * discards (under-fetch) or drop PKs the post-fetch sort would keep (over-fetch).
+	 *
+	 * Algorithm at each link of the chain: forward `entityPrimaryKey` to EPK-aware links, snapshot
+	 * `getNonSortedReferenceCount()`, run `Arrays.sort` over `[start, end)`, then advance `start`
+	 * past the just-sorted prefix using the per-pass delta of the snapshot — clamped to
+	 * `[0, end - start]` so a comparator whose counter is a cumulative cross-entity accumulator
+	 * (notably `EntityNestedQueryComparator`, which never resets `nonSortedReferences` between
+	 * source-entity passes) cannot drive `start` past `end` and trip the next `Arrays.sort` with a
+	 * backwards range. The shared accumulator behavior is intentional — the comparator's lifecycle
+	 * is owned by the caller; clamping on the consumer side keeps it composable.
+	 *
+	 * @param entityPrimaryKey primary key of the source entity owning the references — forwarded to
+	 *                         {@link ReferenceComparator.EntityPrimaryKeyAwareComparator} stages so they can
+	 *                         scope their lookups to this entity
+	 * @param candidates       references to sort in place (mutated)
+	 * @param comparator       head of the comparator chain; subsequent stages are walked via
+	 *                         {@link ReferenceComparator#getNextComparator()}
+	 */
+	private static void sortReferencesByComparatorChain(
+		int entityPrimaryKey,
+		@Nonnull ReferenceContract[] candidates,
+		@Nonnull ReferenceComparator comparator
+	) {
+		ReferenceComparator current = comparator;
+		int start = 0;
+		int end = candidates.length;
+		while (current != null && end > start) {
+			if (current instanceof ReferenceComparator.EntityPrimaryKeyAwareComparator epkAware) {
+				epkAware.setEntityPrimaryKey(entityPrimaryKey);
 			}
+			final int nonSortedBefore = current.getNonSortedReferenceCount();
+			Arrays.sort(candidates, start, end, current);
+			final int nonSortedAfter = current.getNonSortedReferenceCount();
+			final int delta = Math.max(0, Math.min(nonSortedAfter - nonSortedBefore, end - start));
+			if (delta == 0) {
+				break;
+			}
+			start = Math.max(end - delta, start);
+			current = current.getNextComparator();
 		}
 	}
 
-
 	/**
-	 * Retrieves a Formula object that represents the group IDs associated with the given reference name
-	 * and entity ID. This method obtains the group IDs from an internal mapping and converts them into
-	 * a Formula for further processing or computation.
+	 * Computes offset+limit for a {@link Page} given the actual source size — same logic that the
+	 * bitmap {@link #slice(Bitmap, Page)} uses internally, kept here so the sorted-list path can reuse it
+	 * without re-implementing page-boundary handling.
 	 *
-	 * When map doesn't contain the groups for the entityId, it is assumed the referenced entities don't have
-	 * any group assigned.
-	 *
-	 * @param referenceName the name of the reference associated with the entity, must not be null
-	 * @param entityId      the unique identifier of the entity for which group IDs are retrieved, must not be null
-	 * @return a Formula object representing the group IDs associated with the specified reference name and entity ID
+	 * @param page       requested page (page number + page size)
+	 * @param sourceSize size of the input collection being paged
+	 * @return offset+limit that, when applied to a collection of {@code sourceSize}, yields the requested page;
+	 * if the requested page is past the end the result snaps back to page 1
 	 */
 	@Nonnull
-	public Formula getGroupIds(@Nonnull String referenceName, @Nonnull Integer entityId) {
-		// slicer is always created only for a single reference, we need to be fast as possible, so no checks here
+	private static OffsetAndLimit pageOffsetAndLimit(@Nonnull Page page, int sourceSize) {
+		final int pageNumber = page.getPageNumber();
+		final int pageSize = page.getPageSize();
+		final int realPageNumber = PaginatedList.isRequestedResultBehindLimit(pageNumber, pageSize, sourceSize) ?
+			1 : pageNumber;
+		final int offset = PaginatedList.getFirstItemNumberForPage(realPageNumber, pageSize);
+		return new OffsetAndLimit(offset, pageSize, sourceSize);
+	}
+
+	/**
+	 * Computes offset+limit for a {@link Strip} given the actual source size, mirroring the bitmap
+	 * {@link #slice(Bitmap, Strip)} truncation rules.
+	 *
+	 * @param strip      requested strip (raw offset + limit)
+	 * @param sourceSize size of the input collection being striped
+	 * @return offset+limit clamped to the source bounds — when {@code sourceSize == 0} the offset is 0;
+	 * otherwise the offset is capped at {@code sourceSize - 1}
+	 */
+	@Nonnull
+	private static OffsetAndLimit stripOffsetAndLimit(@Nonnull Strip strip, int sourceSize) {
+		final int offset = sourceSize == 0 ? 0 : Math.min(strip.getOffset(), sourceSize - 1);
+		return new OffsetAndLimit(offset, strip.getLimit(), sourceSize);
+	}
+
+	/**
+	 * Retrieves a Formula object that represents the group IDs associated with the given entity ID
+	 * (scoped to the single reference this slicer was constructed for). The group IDs are obtained
+	 * from an internal mapping populated by the slicing methods and converted into a Formula for
+	 * further processing or computation.
+	 *
+	 * When the map doesn't contain the groups for the entityId, it is assumed the referenced entities
+	 * don't have any group assigned.
+	 *
+	 * @param entityId the unique identifier of the entity for which group IDs are retrieved, must not be null
+	 * @return a Formula object representing the group IDs associated with the specified entity ID
+	 */
+	@Nonnull
+	public Formula getGroupIds(@Nonnull Integer entityId) {
 		return ReferencedEntityFetcher.toFormula(this.groupsForEntity.get(entityId));
 	}
 
@@ -206,30 +413,27 @@ class BitmapSlicer {
 	 */
 	@Nonnull
 	public Bitmap slice(@Nonnull Bitmap primaryKeys, @Nonnull Page page) {
-		final int pageNumber = page.getPageNumber();
-		final int pageSize = page.getPageSize();
-		final int realPageNumber = PaginatedList.isRequestedResultBehindLimit(
-			pageNumber, pageSize, primaryKeys.size()) ?
-			1 : pageNumber;
-		final int offset = PaginatedList.getFirstItemNumberForPage(realPageNumber, pageSize);
-		return primaryKeys.isEmpty() ?
-			EmptyBitmap.INSTANCE :
-			new ArrayBitmap(
-				primaryKeys.getRange(
-					offset,
-					Math.min(offset + pageSize, primaryKeys.size())
-				)
-			);
+		if (primaryKeys.isEmpty()) {
+			return EmptyBitmap.INSTANCE;
+		}
+		final OffsetAndLimit offsetAndLimit = pageOffsetAndLimit(page, primaryKeys.size());
+		return new ArrayBitmap(
+			primaryKeys.getRange(
+				offsetAndLimit.offset(),
+				Math.min(offsetAndLimit.offset() + offsetAndLimit.limit(), primaryKeys.size())
+			)
+		);
 	}
 
 	/**
-	 * Creates a subset of the provided bitmap by slicing it based on the specified page number and page size
-	 * defined in the provided page object. If the page number or size exceeds the bounds of the bitmap,
-	 * adjustments are made to fit within the bitmap size.
+	 * Creates a subset of the provided bitmap by slicing it based on the offset and limit computed by the
+	 * supplied {@link Slicer} for the given page. The slicer drives the actual offset+limit math (which
+	 * may differ from the plain page-number/page-size mapping). If the resulting range exceeds the bounds
+	 * of the bitmap, the upper end is truncated to fit within the bitmap size.
 	 *
 	 * @param primaryKeys the bitmap containing the full set of record IDs to be sliced
 	 * @param page        the page object defining the page number and size for slicing the bitmap
-	 * @param slicer      the slicer to calculate offset    and limit
+	 * @param slicer      the slicer used to compute the actual offset and limit for the page
 	 * @return a new bitmap containing the sliced subset of record IDs
 	 */
 	@Nonnull
@@ -258,14 +462,16 @@ class BitmapSlicer {
 	 */
 	@Nonnull
 	public Bitmap slice(@Nonnull Bitmap primaryKeys, @Nonnull Strip strip) {
-		return primaryKeys.isEmpty() ?
-			EmptyBitmap.INSTANCE :
-			new ArrayBitmap(
-				primaryKeys.getRange(
-					Math.min(strip.getOffset(), primaryKeys.size() - 1),
-					Math.min(strip.getOffset() + strip.getLimit(), primaryKeys.size())
-				)
-			);
+		if (primaryKeys.isEmpty()) {
+			return EmptyBitmap.INSTANCE;
+		}
+		final OffsetAndLimit offsetAndLimit = stripOffsetAndLimit(strip, primaryKeys.size());
+		return new ArrayBitmap(
+			primaryKeys.getRange(
+				offsetAndLimit.offset(),
+				Math.min(offsetAndLimit.offset() + offsetAndLimit.limit(), primaryKeys.size())
+			)
+		);
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/fetch/ReferenceMapping.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/fetch/ReferenceMapping.java
@@ -80,9 +80,12 @@ class ReferenceMapping {
 
 	public ReferenceMapping(int expectedSize, @Nonnull List<? extends SealedEntity> richEnoughEntities) {
 		this.referenceGroupToReferencedEntitiesIndex = CollectionUtils.createHashMap(expectedSize);
+		// both lazy retrievers must see every reference of the source entity, not just the chunked
+		// page-slice exposed by EntityDecorator's predicate/chunk-filtered view — otherwise references
+		// outside the requested page never get indexed and the slicer cannot resolve their groups
 		this.groupToReferencedEntityLazyRetriever = referenceName -> richEnoughEntities
 			.stream()
-			.flatMap(it -> it.getReferences(referenceName).stream())
+			.flatMap(it -> ((EntityDecorator) it).getDelegate().getReferences(referenceName).stream())
 			.filter(it -> it.getGroup().isPresent())
 			.collect(
 				Collectors.groupingBy(
@@ -102,8 +105,7 @@ class ReferenceMapping {
 			for (SealedEntity richEnoughEntity : richEnoughEntities) {
 				// we can safely cast here, because we work only with server side entities
 				final EntityDecorator entityDecorator = (EntityDecorator) richEnoughEntity;
-				// we need to skip predicate, because named reference content is not considered a predicate
-				for (ReferenceContract reference : entityDecorator.getReferencesWithoutCheckingPredicate(referenceName)) {
+				for (ReferenceContract reference : entityDecorator.getDelegate().getReferences(referenceName)) {
 					if (reference.getGroup().isPresent()) {
 						final ReferenceKey refKey = reference.getReferenceKey();
 						container.compute(

--- a/evita_engine/src/main/java/io/evitadb/core/query/fetch/ReferencedEntityFetcher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/fetch/ReferencedEntityFetcher.java
@@ -59,6 +59,7 @@ import io.evitadb.api.requestResponse.EvitaRequest;
 import io.evitadb.api.requestResponse.EvitaRequest.ReferenceContentKey;
 import io.evitadb.api.requestResponse.EvitaRequest.RequirementContext;
 import io.evitadb.api.requestResponse.chunk.ChunkTransformer;
+import io.evitadb.api.requestResponse.chunk.NoTransformer;
 import io.evitadb.api.requestResponse.data.EntityClassifierWithParent;
 import io.evitadb.api.requestResponse.data.EntityContract;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
@@ -1525,6 +1526,9 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 	 * @param existingEntityRetriever             a provider for retrieving existing entities by their primary keys
 	 * @param referencedEntityIdsFormula          a function to compute formulas for referenced entity IDs based on a given
 	 *                                            reference name and an integer parameter
+	 * @param referenceContractsAccessor          per-source-entity accessor returning the reference contracts (with
+	 *                                            attributes) so the slicer can pre-sort by the configured `orderBy`
+	 *                                            before fetching
 	 * @param groupToReferencedEntityIdTranslator a function for translating group IDs to the referenced entity IDs for
 	 *                                            a specific reference
 	 * @param referencedEntityToGroupIdTranslator a function for translating referenced entity IDs to group IDs based on
@@ -1545,6 +1549,7 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 		@Nonnull EntitySchema entitySchema,
 		@Nonnull ExistingEntityProvider existingEntityRetriever,
 		@Nonnull BiFunction<String, Integer, Formula> referencedEntityIdsFormula,
+		@Nonnull BiFunction<String, Integer, Collection<ReferenceContract>> referenceContractsAccessor,
 		@Nonnull BiFunction<String, Integer, int[]> groupToReferencedEntityIdTranslator,
 		@Nonnull TriFunction<Integer, String, Integer, IntStream> referencedEntityToGroupIdTranslator,
 		@Nonnull Map<Scope, int[]> entityPrimaryKey,
@@ -1559,14 +1564,14 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 			globalPrefetchCollector.addRequirementsToPrefetch(requirements.attributeContent());
 		}
 
-		final Optional<OrderingDescriptor> orderingDescriptor = ofNullable(requirements.orderBy())
-			.map(ob -> ReferenceOrderByVisitor.getComparator(
-				     executionContext.getQueryContext(),
-				     globalPrefetchCollector,
-				     ob,
-				     entitySchema,
-				     referenceSchema
-			     )
+		final OrderingDescriptor orderingDescriptor = requirements.orderBy() == null
+			? null
+			: ReferenceOrderByVisitor.getComparator(
+				executionContext.getQueryContext(),
+				globalPrefetchCollector,
+				requirements.orderBy(),
+				entitySchema,
+				referenceSchema
 			);
 
 		final ValidEntityToReferenceMapping validityMapping = new ValidEntityToReferenceMapping(
@@ -1575,12 +1580,15 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 		);
 		final int[] filteredReferencedEntityIdsArray;
 		final Map<Integer, ServerEntityDecorator> entityIndex;
+		final ReferenceSlicingMode slicingMode = resolveSlicingMode(orderingDescriptor, requirements);
+		final EntityNestedQueryComparator nestedQueryComparator = slicingMode.nestedQueryComparator();
+		final boolean preSortViable = slicingMode.preSortViable();
 		final BitmapSlicer slicer = new BitmapSlicer(
 			entityPrimaryKey,
 			referenceName,
 			referencedEntityIdsFormula,
 			referencedEntityToGroupIdTranslator,
-			ServerChunkTransformerAccessor.convertIfNecessary(requirements.referenceChunkTransformer())
+			slicingMode.chunkTransformer()
 		);
 
 		final Bitmap filteredReferencedEntityIds = getFilteredReferencedEntityIds(
@@ -1593,21 +1601,35 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 			requirements.managedReferencesBehaviour(),
 			requirements.filterBy(),
 			validityMapping,
-			orderingDescriptor
-				.map(OrderingDescriptor::nestedQueryComparator)
-				.orElse(null),
+			nestedQueryComparator,
 			referencedEntityIdsFormula,
 			groupToReferencedEntityIdTranslator
 		);
+		// when pre-sort is viable the comparator needs its filteredEntities prepared
+		// before slicing; group filter is unused in this path so an empty array suffices
+		if (preSortViable && nestedQueryComparator != null) {
+			nestedQueryComparator.setFilteredEntities(
+				filteredReferencedEntityIds.getArray(),
+				ArrayUtils.EMPTY_INT_ARRAY,
+				entityPk -> groupToReferencedEntityIdTranslator.apply(referenceName, entityPk)
+			);
+		}
 		// apply chunking if necessary
 		if (requirements.entityFetch() != null) {
 			if (!referenceSchema.isReferencedEntityTypeManaged()) {
 				throw new EntityNotManagedException(referenceSchema.getReferencedEntityType());
 			}
-			final Bitmap filteredAndSlicedReferencedIds = slicer.sliceEntityIds(
-				toFormula(filteredReferencedEntityIds),
-				validityMapping
-			);
+			final Bitmap filteredAndSlicedReferencedIds = preSortViable
+				? slicer.sliceEntityIdsSorted(
+					toFormula(filteredReferencedEntityIds),
+					validityMapping,
+					referenceContractsAccessor,
+					slicingMode.preSortComparator()
+				)
+				: slicer.sliceEntityIds(
+					toFormula(filteredReferencedEntityIds),
+					validityMapping
+				);
 			if (!filteredAndSlicedReferencedIds.isEmpty()) {
 				// if so, fetch them
 				entityIndex = fetchReferencedEntities(
@@ -1641,7 +1663,7 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 				null,
 				null,
 				null,
-				slicer::getGroupIds,
+				(refName, epk) -> slicer.getGroupIds(epk),
 				null
 			);
 
@@ -1667,16 +1689,16 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 			entityGroupIndex = Collections.emptyMap();
 		}
 
-		// set them to the comparator instance, if such is provided
-		// this prepares the "pre-sorted" arrays in this comparator for faster sorting
-		orderingDescriptor
-			.map(OrderingDescriptor::nestedQueryComparator)
-			.ifPresent(
-				comparator -> comparator.setFilteredEntities(
-					filteredReferencedEntityIdsArray, filteredReferencedGroupEntityIdsArray,
-					entityPk -> groupToReferencedEntityIdTranslator.apply(referenceName, entityPk)
-				)
+		// set them to the comparator instance, if such is provided — this prepares the
+		// "pre-sorted" arrays in this comparator for faster sorting. See
+		// ReferenceSlicingMode.requiresPostSliceFilteredEntities() for the condition rationale.
+		if (nestedQueryComparator != null && slicingMode.requiresPostSliceFilteredEntities()) {
+			nestedQueryComparator.setFilteredEntities(
+				filteredReferencedEntityIdsArray,
+				filteredReferencedGroupEntityIdsArray,
+				entityPk -> groupToReferencedEntityIdTranslator.apply(referenceName, entityPk)
 			);
+		}
 
 		return new PrefetchedEntities(
 			entityIndex,
@@ -1684,10 +1706,113 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 				requirements.managedReferencesBehaviour() == ManagedReferencesBehaviour.ANY ?
 				null : validityMapping,
 			entityGroupIndex,
-			orderingDescriptor
-				.map(OrderingDescriptor::comparator)
-				.orElse(null)
+			orderingDescriptor == null ? null : orderingDescriptor.comparator()
 		);
+	}
+
+	/**
+	 * Decides whether the order-aware pre-fetch slice can engage for the current reference and
+	 * pre-computes the comparator/chunk-transformer that should drive the slice.
+	 * The three relevant cases are:
+	 *
+	 *   - no orderBy or comparator is DEFAULT (PK-ascending): bitmap slice agrees with the
+	 *     post-fetch sort, so the plain PK-bitmap fast path applies.
+	 *   - non-DEFAULT comparator without group ordering: pre-sort each source entity's
+	 *     ReferenceContracts using the comparator chain and slice that — `preSortViable` is true
+	 *     and `chunkTransformer` carries the requested page/strip.
+	 *   - non-DEFAULT comparator WITH group ordering (EntityGroupProperty): the nested query
+	 *     comparator needs both filteredEntities and filteredEntityGroups before it can rank;
+	 *     the group filter is computed only after the slice, so the optimization can't engage.
+	 *     We fall back to fetching all filtered referenced bodies (chunkTransformer is
+	 *     {@link NoTransformer#INSTANCE}); the post-fetch sort+chunk in EntityDecorator still
+	 *     produces a correct result.
+	 *
+	 * @param orderingDescriptor parsed orderBy descriptor for the reference, if any was configured
+	 * @param requirements       requirement context whose `referenceChunkTransformer` is used for the page/strip
+	 *                           when slicing applies
+	 * @return the slicing-mode decision — see {@link ReferenceSlicingMode}
+	 */
+	@Nonnull
+	private static ReferenceSlicingMode resolveSlicingMode(
+		@Nullable OrderingDescriptor orderingDescriptor,
+		@Nonnull RequirementContext requirements
+	) {
+		final EntityNestedQueryComparator nestedQueryComparator = orderingDescriptor == null
+			? null
+			: orderingDescriptor.nestedQueryComparator();
+		final ReferenceComparator candidateComparator = orderingDescriptor == null
+			? null
+			: orderingDescriptor.comparator();
+		final ReferenceComparator orderingComparator = candidateComparator == ReferenceComparator.DEFAULT
+			? null
+			: candidateComparator;
+		final boolean groupSortActive = nestedQueryComparator != null
+			&& nestedQueryComparator.getGroupOrderBy() != null;
+		final boolean preSortViable = orderingComparator != null && !groupSortActive;
+		final ChunkTransformer chunkTransformer = orderingComparator == null || preSortViable
+			? ServerChunkTransformerAccessor.convertIfNecessary(requirements.referenceChunkTransformer())
+			: NoTransformer.INSTANCE;
+		return new ReferenceSlicingMode(
+			nestedQueryComparator,
+			orderingComparator,
+			preSortViable,
+			groupSortActive,
+			chunkTransformer
+		);
+	}
+
+	/**
+	 * Captures the slicing-mode decision for a single reference: which comparators participate,
+	 * whether the order-aware pre-slice can engage, and which chunk transformer drives the slice.
+	 * See {@link #resolveSlicingMode(OrderingDescriptor, RequirementContext)} for the decision logic.
+	 *
+	 * @param nestedQueryComparator nested-query comparator extracted from the orderBy descriptor (drives both the
+	 *                              pre- and post-slice `setFilteredEntities` calls); {@code null} when no orderBy is
+	 *                              configured
+	 * @param orderingComparator    head of the comparator chain that ranks the references; {@code null} when the
+	 *                              orderBy resolves to {@link ReferenceComparator#DEFAULT} (PK-ascending — the bitmap
+	 *                              fast path already matches it)
+	 * @param preSortViable         {@code true} when the order-aware pre-fetch slice
+	 *                              ({@link BitmapSlicer#sliceEntityIdsSorted}) can run: a non-DEFAULT comparator is
+	 *                              present AND no group sort is active (group sort needs both filtered entities and
+	 *                              filtered groups, the latter only known post-slice)
+	 * @param groupSortActive       {@code true} when the orderBy includes an `EntityGroupProperty` ordering — the
+	 *                              optimization can't engage and we fall back to the full-fetch path
+	 * @param chunkTransformer      transformer that supplies the page/strip math to {@link BitmapSlicer}; carries
+	 *                              the requested page/strip when slicing applies, otherwise {@link NoTransformer#INSTANCE}
+	 */
+	private record ReferenceSlicingMode(
+		@Nullable EntityNestedQueryComparator nestedQueryComparator,
+		@Nullable ReferenceComparator orderingComparator,
+		boolean preSortViable,
+		boolean groupSortActive,
+		@Nonnull ChunkTransformer chunkTransformer
+	) {
+		/**
+		 * Indicates that the post-slice {@code setFilteredEntities} call on the nested-query comparator is
+		 * required. Returns {@code true} either on the PK-bitmap fast path (no pre-sort happened) or when group
+		 * sort is active (the comparator needs the real group array, which only exists after the slice).
+		 * Returns {@code false} on the pre-sort path where the comparator was already prepared upfront with the
+		 * same entity array and an empty group array — calling it again would needlessly redo a sort that
+		 * already ran.
+		 */
+		boolean requiresPostSliceFilteredEntities() {
+			return !this.preSortViable || this.groupSortActive;
+		}
+
+		/**
+		 * Returns the comparator chain that drives the pre-sort slice — must only be called when
+		 * {@link #preSortViable} is {@code true}. The invariant `preSortViable ⇒ orderingComparator != null`
+		 * is established in {@link #resolveSlicingMode}; this accessor makes it explicit at call sites that
+		 * need a non-null comparator for the order-aware slicing path.
+		 */
+		@Nonnull
+		ReferenceComparator preSortComparator() {
+			return Objects.requireNonNull(
+				this.orderingComparator,
+				"orderingComparator must be non-null when preSortViable is true"
+			);
+		}
 	}
 
 	/**
@@ -1851,7 +1976,13 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 						.mapToInt(ReferenceContract::getReferencedPrimaryKey)
 						.toArray()
 				),
+			// reference contract accessor — gives access to the source entity's references
+			// (including their reference attributes) so BitmapSlicer can sort them by the
+			// configured orderBy comparator before deciding which referenced entity bodies
+			// to actually fetch
+			(referenceName, entityPk) -> theEntity.getReferences(referenceName),
 			(referenceName, groupId) -> {
+				// allocation-optimized: hot path, avoids two stream allocations per group filter
 				final Collection<ReferenceContract> references = theEntity.getReferences(referenceName);
 				final int[] buffer = new int[references.size()];
 				int count = 0;
@@ -1937,6 +2068,8 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 					.mapToInt(ReferenceContract::getReferencedPrimaryKey)
 					.toArray()
 			),
+			// reference contract accessor — see single-entity branch for rationale
+			(referenceName, entityPk) -> entityIndexSupplier.get().get(entityPk).getReferences(referenceName),
 			groupToEntityIdMapping::getReferencedEntityPrimaryKeys,
 			groupToEntityIdMapping::getGroup,
 			getPrimaryKeysIndexedByScope(entities)
@@ -2054,6 +2187,9 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 	 * @param entitySchema                        the schema of the entity
 	 * @param existingEntityRetriever             function that provides access to already fetched referenced entities (relict of last enrichment)
 	 * @param referencedEntityIdsFormula          the formula containing superset of all possible referenced entities
+	 * @param referenceContractsAccessor          per-source-entity accessor returning the reference contracts (with
+	 *                                            attributes) so the slicer can pre-sort by the configured `orderBy`
+	 *                                            before fetching
 	 * @param groupToReferencedEntityIdTranslator the function that translates group ids to referenced entity ids
 	 * @param referencedEntityToGroupIdTranslator the function that translates referenced entity ids to group ids
 	 * @param entityPrimaryKey                    the array of top entity primary keys for which the references are being fetched
@@ -2067,6 +2203,7 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 		@Nonnull EntitySchema entitySchema,
 		@Nonnull ExistingEntityProvider existingEntityRetriever,
 		@Nonnull BiFunction<String, Integer, Formula> referencedEntityIdsFormula,
+		@Nonnull BiFunction<String, Integer, Collection<ReferenceContract>> referenceContractsAccessor,
 		@Nonnull BiFunction<String, Integer, int[]> groupToReferencedEntityIdTranslator,
 		@Nonnull TriFunction<Integer, String, Integer, IntStream> referencedEntityToGroupIdTranslator,
 		@Nonnull Map<Scope, int[]> entityPrimaryKey
@@ -2088,6 +2225,7 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 							entitySchema,
 							existingEntityRetriever,
 							referencedEntityIdsFormula,
+							referenceContractsAccessor,
 							groupToReferencedEntityIdTranslator,
 							referencedEntityToGroupIdTranslator,
 							entityPrimaryKey,
@@ -2122,6 +2260,7 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 									entitySchema,
 									existingEntityRetriever,
 									referencedEntityIdsFormula,
+									referenceContractsAccessor,
 									groupToReferencedEntityIdTranslator,
 									referencedEntityToGroupIdTranslator,
 									entityPrimaryKey,

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/fetch/EntityReferencePaginationFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/fetch/EntityReferencePaginationFunctionalTest.java
@@ -54,6 +54,9 @@ import java.util.stream.Collectors;
 import static io.evitadb.api.query.Query.query;
 import static io.evitadb.api.query.QueryConstraints.*;
 import static io.evitadb.test.TestConstants.TEST_CATALOG;
+import static io.evitadb.test.generator.DataGenerator.ATTRIBUTE_CATEGORY_PRIORITY;
+import static io.evitadb.test.generator.DataGenerator.ATTRIBUTE_NAME;
+import static io.evitadb.test.generator.DataGenerator.CZECH_LOCALE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -151,6 +154,460 @@ class EntityReferencePaginationFunctionalTest extends AbstractEntityFetchingFunc
 					return referencedParameters;
 				}
 			)
+		);
+	}
+
+	@DisplayName("Should provide paginated access to references ordered by reference attribute")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnPaginatedReferencesOrderedByReferenceAttribute(Evita evita, List<SealedEntity> originalProducts) {
+		// Pick the first product whose dataset shape exercises the contract under test. The
+		// picker mirrors what the server query will compute, then layers extra preconditions on
+		// top of that so the strict assertions below are unambiguous:
+		//   1. priorityRanked = source references that have the priority attribute set, sorted by
+		//      priority DESC — this is exactly what the server returns for page(1, pageSize).
+		//   2. priorityRanked must have at least pageSize entries (so the page is full).
+		//   3. The top pageSize by priority must disagree with the top pageSize by PK among the
+		//      same priorityRanked set — otherwise a PK-bitmap pre-slice would accidentally agree
+		//      with the post-fetch sort and the contract wouldn't be meaningfully exercised.
+		//   4. Every reference in the top pageSize by priority must also have a group set in the
+		//      source data — so the per-reference groupEntity assertion is unambiguous.
+		// Contract: the response page equals that top-pageSize-by-priority and every reference
+		// must have both referencedEntity and groupEntity populated.
+		final int pageSize = 5;
+		final Comparator<ReferenceContract> byPriorityDesc = Comparator
+			.comparing((ReferenceContract r) -> r.getAttribute(ATTRIBUTE_CATEGORY_PRIORITY, Long.class))
+			.reversed();
+		final SealedEntity bugCandidate = originalProducts.stream()
+			.filter(product -> {
+				final List<ReferenceContract> priorityRanked = product.getReferences(Entities.PARAMETER).stream()
+					.filter(r -> r.getAttribute(ATTRIBUTE_CATEGORY_PRIORITY, Long.class) != null)
+					.sorted(byPriorityDesc)
+					.toList();
+				if (priorityRanked.size() < pageSize) {
+					return false;
+				}
+				final List<ReferenceContract> topByPriority = priorityRanked.subList(0, pageSize);
+				if (topByPriority.stream().anyMatch(r -> r.getGroup().isEmpty())) {
+					return false;
+				}
+				final List<Integer> topPksByPriority = topByPriority.stream()
+					.map(ReferenceContract::getReferencedPrimaryKey)
+					.toList();
+				final List<Integer> topPksByPk = priorityRanked.stream()
+					.sorted(Comparator.comparingInt(ReferenceContract::getReferencedPrimaryKey))
+					.limit(pageSize)
+					.map(ReferenceContract::getReferencedPrimaryKey)
+					.toList();
+				return !topPksByPriority.equals(topPksByPk);
+			})
+			.findFirst()
+			.orElseThrow(() -> new IllegalStateException(
+				"No product in HUNDRED_PRODUCTS has " + pageSize + " PARAMETER references with priority " +
+					"set where the top-" + pageSize + "-by-priority all have groups AND disagree with " +
+					"the top-" + pageSize + "-by-PK — dataset cannot exercise order-by-reference-attribute " +
+					"pagination on a non-trivial input."
+			));
+
+		final List<Integer> expectedTopPks = bugCandidate.getReferences(Entities.PARAMETER).stream()
+			.filter(r -> r.getAttribute(ATTRIBUTE_CATEGORY_PRIORITY, Long.class) != null)
+			.sorted(byPriorityDesc)
+			.limit(pageSize)
+			.map(ReferenceContract::getReferencedPrimaryKey)
+			.toList();
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							entityPrimaryKeyInSet(bugCandidate.getPrimaryKeyOrThrowException())
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									Entities.PARAMETER,
+									filterBy(attributeIsNotNull(ATTRIBUTE_CATEGORY_PRIORITY)),
+									orderBy(attributeNatural(ATTRIBUTE_CATEGORY_PRIORITY, OrderDirection.DESC)),
+									entityFetchAll(),
+									entityGroupFetchAll(),
+									page(1, pageSize)
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				final Collection<ReferenceContract> foundParameters = productByPk.getReferences(Entities.PARAMETER);
+				assertEquals(pageSize, foundParameters.size(), "Expected exactly the requested page size");
+
+				// every returned reference must have its referenced entity body AND its group body
+				// fetched. If the PK-based pre-fetch slice and the attribute-based post-fetch sort
+				// disagree, the post-sort winners come back with null bodies. The candidate-picker
+				// guarantees every expected reference has a group in the source data, so this
+				// assertion is unambiguous.
+				for (ReferenceContract foundParameter : foundParameters) {
+					assertTrue(
+						foundParameter.getReferencedEntity().isPresent(),
+						"Reference to parameter #" + foundParameter.getReferencedPrimaryKey() +
+							" has no referencedEntity — the pre-fetch slice picked different PKs than the post-fetch sort."
+					);
+					assertTrue(
+						foundParameter.getGroupEntity().isPresent(),
+						"Reference to parameter #" + foundParameter.getReferencedPrimaryKey() +
+							" has no groupEntity — group body was not fetched for this reference."
+					);
+				}
+
+				final List<Integer> actualTopPks = foundParameters.stream()
+					.map(ReferenceContract::getReferencedPrimaryKey)
+					.toList();
+				assertEquals(
+					expectedTopPks, actualTopPks,
+					"The returned page must contain the top references by ATTRIBUTE_CATEGORY_PRIORITY DESC, " +
+						"in the requested order."
+				);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should provide stripped access to references ordered by reference attribute")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnStripPaginationOverSortedReferences(Evita evita, List<SealedEntity> originalProducts) {
+		// Mirrors `shouldReturnPaginatedReferencesOrderedByReferenceAttribute`, but exercises the
+		// `strip(offset, limit)` chunker instead of `page(number, size)`. Both transformer types
+		// flow through the same post-fetch sort path; the strip case exercises raw offset+limit
+		// arithmetic that page-rebase math does not touch.
+		final int stripOffset = 1;
+		final int stripLimit = 4;
+		final int requiredPriorityRanked = stripOffset + stripLimit;
+		final Comparator<ReferenceContract> byPriorityDesc = Comparator
+			.comparing((ReferenceContract r) -> r.getAttribute(ATTRIBUTE_CATEGORY_PRIORITY, Long.class))
+			.reversed();
+		final SealedEntity candidate = originalProducts.stream()
+			.filter(product -> {
+				final List<ReferenceContract> priorityRanked = product.getReferences(Entities.PARAMETER).stream()
+					.filter(r -> r.getAttribute(ATTRIBUTE_CATEGORY_PRIORITY, Long.class) != null)
+					.sorted(byPriorityDesc)
+					.toList();
+				if (priorityRanked.size() < requiredPriorityRanked) {
+					return false;
+				}
+				final List<ReferenceContract> stripWindow = priorityRanked.subList(
+					stripOffset, stripOffset + stripLimit
+				);
+				return stripWindow.stream().allMatch(r -> r.getGroup().isPresent());
+			})
+			.findFirst()
+			.orElseThrow(() -> new IllegalStateException(
+				"No product in HUNDRED_PRODUCTS has at least " + requiredPriorityRanked +
+					" PARAMETER references with priority set, where the strip window [" +
+					stripOffset + ".." + (stripOffset + stripLimit) + ") all have groups."
+			));
+
+		final List<Integer> expectedStripPks = candidate.getReferences(Entities.PARAMETER).stream()
+			.filter(r -> r.getAttribute(ATTRIBUTE_CATEGORY_PRIORITY, Long.class) != null)
+			.sorted(byPriorityDesc)
+			.skip(stripOffset)
+			.limit(stripLimit)
+			.map(ReferenceContract::getReferencedPrimaryKey)
+			.toList();
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							entityPrimaryKeyInSet(candidate.getPrimaryKeyOrThrowException())
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									Entities.PARAMETER,
+									filterBy(attributeIsNotNull(ATTRIBUTE_CATEGORY_PRIORITY)),
+									orderBy(attributeNatural(ATTRIBUTE_CATEGORY_PRIORITY, OrderDirection.DESC)),
+									entityFetchAll(),
+									entityGroupFetchAll(),
+									strip(stripOffset, stripLimit)
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				final Collection<ReferenceContract> foundParameters = productByPk.getReferences(Entities.PARAMETER);
+				assertEquals(
+					stripLimit, foundParameters.size(),
+					"Expected exactly the requested strip window size"
+				);
+
+				for (ReferenceContract foundParameter : foundParameters) {
+					assertTrue(
+						foundParameter.getReferencedEntity().isPresent(),
+						"Reference to parameter #" + foundParameter.getReferencedPrimaryKey() +
+							" has no referencedEntity on the strip + orderBy path."
+					);
+					assertTrue(
+						foundParameter.getGroupEntity().isPresent(),
+						"Reference to parameter #" + foundParameter.getReferencedPrimaryKey() +
+							" has no groupEntity on the strip + orderBy path."
+					);
+				}
+
+				final List<Integer> actualStripPks = foundParameters.stream()
+					.map(ReferenceContract::getReferencedPrimaryKey)
+					.toList();
+				assertEquals(
+					expectedStripPks, actualStripPks,
+					"The returned strip window must contain the configured offset..offset+limit slice " +
+						"of the priority-DESC ordering, in that order."
+				);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should provide paginated access to references with default comparator (PK-bitmap fast path)")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnPaginatedReferencesWithDefaultComparatorPkOrder(
+		Evita evita, List<SealedEntity> originalProducts
+	) {
+		// Default (no orderBy) takes the PK-bitmap fast path in createPrefetchedEntities. The
+		// page must therefore be the natural-PK-ascending top-pageSize of the filtered
+		// references, with both referencedEntity and groupEntity populated for each entry.
+		final int pageSize = 5;
+		final SealedEntity productWithParameters = originalProducts.stream()
+			.filter(product -> product.getReferences(Entities.PARAMETER).size() >= pageSize)
+			.filter(product -> product.getReferences(Entities.PARAMETER).stream()
+				.allMatch(r -> r.getGroup().isPresent()))
+			.findFirst()
+			.orElseThrow(() -> new IllegalStateException(
+				"No product in HUNDRED_PRODUCTS has at least " + pageSize +
+					" PARAMETER references where every reference has a group."
+			));
+
+		final List<Integer> expectedPksAsc = productWithParameters.getReferences(Entities.PARAMETER).stream()
+			.map(ReferenceContract::getReferencedPrimaryKey)
+			.sorted()
+			.limit(pageSize)
+			.toList();
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							entityPrimaryKeyInSet(productWithParameters.getPrimaryKeyOrThrowException())
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									Entities.PARAMETER,
+									entityFetchAll(),
+									entityGroupFetchAll(),
+									page(1, pageSize)
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				final Collection<ReferenceContract> foundParameters = productByPk.getReferences(Entities.PARAMETER);
+				assertEquals(pageSize, foundParameters.size());
+
+				final List<Integer> actualPks = foundParameters.stream()
+					.map(ReferenceContract::getReferencedPrimaryKey)
+					.toList();
+				assertEquals(
+					expectedPksAsc, actualPks,
+					"PK-bitmap fast path must return the lowest pageSize PKs in ascending order"
+				);
+
+				for (ReferenceContract foundParameter : foundParameters) {
+					assertTrue(
+						foundParameter.getReferencedEntity().isPresent(),
+						"Reference to parameter #" + foundParameter.getReferencedPrimaryKey() +
+							" has no referencedEntity on the PK-bitmap fast path."
+					);
+					assertTrue(
+						foundParameter.getGroupEntity().isPresent(),
+						"Reference to parameter #" + foundParameter.getReferencedPrimaryKey() +
+							" has no groupEntity on the PK-bitmap fast path."
+					);
+				}
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should provide paginated references when orderBy contains entity group property (group-sort fallback)")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnPaginatedReferencesWhenOrderByContainsEntityGroupProperty(
+		Evita evita, List<SealedEntity> originalProducts
+	) {
+		// When the reference orderBy contains an `entityGroupProperty`, the optimization in
+		// createPrefetchedEntities can't engage (the group filter is computed downstream) and
+		// the slicer falls back to fetching all filtered references via NoTransformer. The
+		// post-fetch sort+chunk in EntityDecorator still has to produce a correct page with
+		// fully-populated referencedEntity and groupEntity. The candidate-picker insists every
+		// reference has a group so the per-reference assertions are unambiguous.
+		final int pageSize = 5;
+		final SealedEntity productWithGroupedParameters = originalProducts.stream()
+			.filter(product -> product.getLocales().contains(CZECH_LOCALE))
+			.filter(product -> product.getReferences(Entities.PARAMETER).size() >= pageSize)
+			.filter(product -> product.getReferences(Entities.PARAMETER).stream()
+				.allMatch(r -> r.getGroup().isPresent()))
+			.findFirst()
+			.orElseThrow(() -> new IllegalStateException(
+				"No product in HUNDRED_PRODUCTS has at least " + pageSize +
+					" PARAMETER references all having a group set — cannot exercise group-sort fallback."
+			));
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(productWithGroupedParameters.getPrimaryKeyOrThrowException()),
+								entityLocaleEquals(CZECH_LOCALE)
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									Entities.PARAMETER,
+									orderBy(
+										entityGroupProperty(
+											attributeNatural(ATTRIBUTE_NAME, OrderDirection.ASC)
+										)
+									),
+									entityFetchAll(),
+									entityGroupFetchAll(),
+									page(1, pageSize)
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				final Collection<ReferenceContract> foundParameters = productByPk.getReferences(Entities.PARAMETER);
+				assertEquals(
+					pageSize, foundParameters.size(),
+					"Expected exactly the requested page size on the group-sort fallback path"
+				);
+				int groupEntitiesLoaded = 0;
+				for (ReferenceContract foundParameter : foundParameters) {
+					assertTrue(
+						foundParameter.getReferencedEntity().isPresent(),
+						"Reference to parameter #" + foundParameter.getReferencedPrimaryKey() +
+							" has no referencedEntity on the group-sort fallback path."
+					);
+					if (foundParameter.getGroupEntity().isPresent()) {
+						groupEntitiesLoaded++;
+					}
+				}
+				assertTrue(
+					groupEntitiesLoaded > 0,
+					"At least one fetched parameter must have its groupEntity populated on the " +
+						"group-sort fallback path (orderBy entityGroupProperty must trigger group fetch)"
+				);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should provide paginated references over multiple source entities (multi-entity initReferenceIndex)")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnPaginatedReferencesOverMultipleSourceEntities(
+		Evita evita, List<SealedEntity> originalProducts
+	) {
+		// Exercises the multi-entity branch of initReferenceIndex: a query that selects two
+		// different source entities at once, each requesting page(1, K) on the same reference
+		// name. Each source entity must independently get its first K references back, with
+		// both referencedEntity and groupEntity populated.
+		final int pageSize = 3;
+		final List<SealedEntity> sources = originalProducts.stream()
+			.filter(product -> product.getReferences(Entities.PARAMETER).size() >= pageSize)
+			.filter(product -> product.getReferences(Entities.PARAMETER).stream()
+				.allMatch(r -> r.getGroup().isPresent()))
+			.limit(2)
+			.toList();
+		if (sources.size() < 2) {
+			throw new IllegalStateException(
+				"Dataset does not contain two products with at least " + pageSize +
+					" PARAMETER references each (all having groups)."
+			);
+		}
+		final SealedEntity sourceA = sources.get(0);
+		final SealedEntity sourceB = sources.get(1);
+
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final List<SealedEntity> products = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							entityPrimaryKeyInSet(
+								sourceA.getPrimaryKeyOrThrowException(),
+								sourceB.getPrimaryKeyOrThrowException()
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									Entities.PARAMETER,
+									entityFetchAll(),
+									entityGroupFetchAll(),
+									page(1, pageSize)
+								)
+							)
+						)
+					),
+					SealedEntity.class
+				).getRecordData();
+
+				assertEquals(2, products.size(), "Both source entities must come back");
+				for (SealedEntity product : products) {
+					final Collection<ReferenceContract> foundParameters = product.getReferences(Entities.PARAMETER);
+					assertTrue(
+						foundParameters.size() <= pageSize && !foundParameters.isEmpty(),
+						"Each source entity must independently get up to pageSize references"
+					);
+					for (ReferenceContract foundParameter : foundParameters) {
+						assertTrue(
+							foundParameter.getReferencedEntity().isPresent(),
+							"Reference to parameter #" + foundParameter.getReferencedPrimaryKey() +
+								" has no referencedEntity (multi-source-entity path)."
+						);
+						assertTrue(
+							foundParameter.getGroupEntity().isPresent(),
+							"Reference to parameter #" + foundParameter.getReferencedPrimaryKey() +
+								" has no groupEntity (multi-source-entity path)."
+						);
+					}
+				}
+
+				return null;
+			}
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/fetch/EntityReferencePaginationFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/fetch/EntityReferencePaginationFunctionalTest.java
@@ -522,9 +522,9 @@ class EntityReferencePaginationFunctionalTest extends AbstractEntityFetchingFunc
 						groupEntitiesLoaded++;
 					}
 				}
-				assertTrue(
-					groupEntitiesLoaded > 0,
-					"At least one fetched parameter must have its groupEntity populated on the " +
+				assertEquals(
+					pageSize, groupEntitiesLoaded,
+					"Every fetched parameter must have its groupEntity populated on the " +
 						"group-sort fallback path (orderBy entityGroupProperty must trigger group fetch)"
 				);
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/EntityDecoratorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/structure/EntityDecoratorTest.java
@@ -1,0 +1,460 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.data.structure;
+
+import io.evitadb.api.requestResponse.data.ReferenceContract;
+import io.evitadb.api.requestResponse.data.structure.ReferenceComparator.EntityPrimaryKeyAwareComparator;
+import io.evitadb.api.requestResponse.data.structure.predicate.ReferenceContractSerializablePredicate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.evitadb.test.TestTags.COMPARATOR;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests covering the static helpers on `EntityDecorator`. Lives in the same package so
+ * package-protected members can be exercised directly without reflection.
+ */
+@DisplayName("EntityDecorator")
+@Tag(CONTRACT)
+@Tag(REFERENCE)
+@Tag(COMPARATOR)
+class EntityDecoratorTest {
+
+	/**
+	 * Builds a minimal `ReferenceDecorator` stub whose only behavioural surface is `exists()` and
+	 * `getReferenceName()` — the only methods `ReferenceContractSerializablePredicate` calls during
+	 * `sortAndFilterSubList`'s in-place filtering phase. The comparator fakes used below never touch the
+	 * references themselves (they return 0 / record metadata), so no further stubbing is required.
+	 */
+	@Nonnull
+	private static ReferenceDecorator stubReference(@Nonnull String name) {
+		final ReferenceDecorator mock = Mockito.mock(ReferenceDecorator.class);
+		when(mock.exists()).thenReturn(true);
+		when(mock.getReferenceName()).thenReturn(name);
+		return mock;
+	}
+
+	/**
+	 * Comparator fake that is NOT `EntityPrimaryKeyAwareComparator` and whose only job is to:
+	 * - return 0 for every pair (no actual reordering — `Arrays.sort` becomes a no-op);
+	 * - simulate a real comparator that accumulates `nonSortedCount` additional unsorted
+	 *   references during the just-finished sort pass, so the chain-advance loop in
+	 *   `sortAndFilterSubList` sees a positive delta and moves on to the next link.
+	 *
+	 * The cumulative semantic mirrors concrete comparators such as
+	 * `EntityNestedQueryComparator` whose `nonSortedReferences` set only grows. The first
+	 * call (the "before sort" snapshot) returns 0; subsequent calls return `nonSortedCount`,
+	 * so the per-pass delta equals `nonSortedCount`.
+	 */
+	private static final class HeadFakeComparator implements ReferenceComparator, Serializable {
+		@Serial private static final long serialVersionUID = -1761005013461764433L;
+
+		@Nullable private final ReferenceComparator next;
+		private final int nonSortedCount;
+		private int invocationIndex;
+
+		HeadFakeComparator(@Nullable ReferenceComparator next, int nonSortedCount) {
+			this.next = next;
+			this.nonSortedCount = nonSortedCount;
+		}
+
+		@Override
+		public int compare(ReferenceContract o1, ReferenceContract o2) {
+			return 0;
+		}
+
+		@Override
+		public int getNonSortedReferenceCount() {
+			// first call mimics the "before sort" snapshot (no accumulator entries yet),
+			// subsequent calls mimic the cumulative reading after the sort pass populated
+			// the comparator's `nonSortedReferences` set
+			final int value = this.invocationIndex == 0 ? 0 : this.nonSortedCount;
+			this.invocationIndex++;
+			return value;
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceComparator andThen(@Nonnull ReferenceComparator other) {
+			throw new UnsupportedOperationException("Test fake — chain is hand-wired");
+		}
+
+		@Nullable
+		@Override
+		public ReferenceComparator getNextComparator() {
+			return this.next;
+		}
+	}
+
+	/**
+	 * Comparator fake whose `getNonSortedReferenceCount()` grows monotonically across calls,
+	 * mimicking a real comparator (e.g. `EntityNestedQueryComparator`) that maintains a
+	 * lazy-init `nonSortedReferences` set and never resets it between sort passes. Used to
+	 * exercise the case where `sortAndFilterSubList` reads the comparator's counter as if it
+	 * were a per-pass reading but the implementation keeps an absolute, cumulative value.
+	 *
+	 * The comparator chains to `next` so the chain-advance loop will iterate at least twice
+	 * — that's where the absolute-vs-delta confusion shows up as out-of-range sort indices.
+	 */
+	private static final class GrowingNonSortedCountComparator implements ReferenceComparator, Serializable {
+		@Serial private static final long serialVersionUID = -8316411802194620181L;
+
+		@Nullable private final ReferenceComparator next;
+		private final int[] reportedCountsPerInvocation;
+		private int invocationIndex;
+
+		GrowingNonSortedCountComparator(
+			@Nullable ReferenceComparator next,
+			@Nonnull int[] reportedCountsPerInvocation
+		) {
+			this.next = next;
+			this.reportedCountsPerInvocation = reportedCountsPerInvocation;
+		}
+
+		@Override
+		public int compare(ReferenceContract o1, ReferenceContract o2) {
+			return 0;
+		}
+
+		@Override
+		public int getNonSortedReferenceCount() {
+			final int index = Math.min(this.invocationIndex, this.reportedCountsPerInvocation.length - 1);
+			final int value = this.reportedCountsPerInvocation[index];
+			this.invocationIndex++;
+			return value;
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceComparator andThen(@Nonnull ReferenceComparator other) {
+			throw new UnsupportedOperationException("Test fake — chain is hand-wired");
+		}
+
+		@Nullable
+		@Override
+		public ReferenceComparator getNextComparator() {
+			return this.next;
+		}
+	}
+
+	/**
+	 * Comparator fake whose `getNonSortedReferenceCount()` returns the same value on every call,
+	 * representing a well-behaved comparator that does NOT accumulate state across sort passes.
+	 * Used as the control case to confirm correctly-behaving comparators are not regressed.
+	 */
+	private static final class StableNonSortedCountComparator implements ReferenceComparator, Serializable {
+		@Serial private static final long serialVersionUID = -7193620345109248123L;
+
+		@Nullable private final ReferenceComparator next;
+		private final int stableCount;
+
+		StableNonSortedCountComparator(@Nullable ReferenceComparator next, int stableCount) {
+			this.next = next;
+			this.stableCount = stableCount;
+		}
+
+		@Override
+		public int compare(ReferenceContract o1, ReferenceContract o2) {
+			return 0;
+		}
+
+		@Override
+		public int getNonSortedReferenceCount() {
+			return this.stableCount;
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceComparator andThen(@Nonnull ReferenceComparator other) {
+			throw new UnsupportedOperationException("Test fake — chain is hand-wired");
+		}
+
+		@Nullable
+		@Override
+		public ReferenceComparator getNextComparator() {
+			return this.next;
+		}
+	}
+
+	/**
+	 * Comparator fake that IS `EntityPrimaryKeyAwareComparator` and records every
+	 * `setEntityPrimaryKey(int)` invocation so the test can assert whether the caller honored its
+	 * EPK-aware contract.
+	 */
+	private static final class RecordingEpkAwareComparator
+		implements ReferenceComparator, EntityPrimaryKeyAwareComparator, Serializable {
+
+		@Serial private static final long serialVersionUID = 5914405464059833314L;
+
+		final List<Integer> setEntityPrimaryKeyCalls = new ArrayList<>();
+
+		@Override
+		public void setEntityPrimaryKey(int entityPrimaryKey) {
+			this.setEntityPrimaryKeyCalls.add(entityPrimaryKey);
+		}
+
+		@Override
+		public int compare(ReferenceContract o1, ReferenceContract o2) {
+			return 0;
+		}
+
+		@Override
+		public int getNonSortedReferenceCount() {
+			return 0;
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceComparator andThen(@Nonnull ReferenceComparator other) {
+			throw new UnsupportedOperationException("Test fake — chain is hand-wired");
+		}
+
+		@Nullable
+		@Override
+		public ReferenceComparator getNextComparator() {
+			return null;
+		}
+	}
+
+	@Nested
+	@DisplayName("sortAndFilterSubList")
+	class SortAndFilterSubListTest {
+
+		/**
+		 * Pins the contract that `sortAndFilterSubList` must invoke `setEntityPrimaryKey` on
+		 * EVERY `EntityPrimaryKeyAwareComparator` it visits while walking the comparator chain
+		 * via `getNextComparator()` — not only the chain head.
+		 *
+		 * A query like
+		 * `orderBy(attributeNatural("plain", ASC), attributeNatural("predecessor_attr", ASC))`
+		 * produces exactly the chain shape under test: the plain-attribute comparator lands at
+		 * the head and the EPK-aware `ReferencePredecessorComparator` becomes link #1.
+		 *
+		 * Without this guarantee, a non-head EPK-aware link is left without an entity scope and
+		 * either produces an NPE (auto-unboxed `null` primary key) or a silently wrong sort.
+		 */
+		@Test
+		@DisplayName("Should propagate entity primary key to EPK-aware comparator located deeper in the chain")
+		void shouldSetEntityPrimaryKeyOnEpkAwareLinkWhenItIsNotHeadOfChain() {
+			final RecordingEpkAwareComparator epkAwareLink = new RecordingEpkAwareComparator();
+			// head reports two unsorted references so the chain-advance loop hands off to the next link
+			final HeadFakeComparator nonEpkAwareHead = new HeadFakeComparator(epkAwareLink, 2);
+
+			final ReferenceDecorator[] references = new ReferenceDecorator[] {
+				stubReference("any"),
+				stubReference("any"),
+				stubReference("any")
+			};
+
+			final int entityPrimaryKey = 42;
+
+			EntityDecorator.sortAndFilterSubList(
+				entityPrimaryKey,
+				references,
+				new ReferenceContractSerializablePredicate(),
+				null,
+				nonEpkAwareHead,
+				0,
+				references.length
+			);
+
+			assertEquals(
+				List.of(entityPrimaryKey),
+				epkAwareLink.setEntityPrimaryKeyCalls,
+				"EPK-aware comparator located as a non-head link in the chain must still receive " +
+					"setEntityPrimaryKey(entityPrimaryKey)."
+			);
+		}
+
+		/**
+		 * Companion control: when the EPK-aware comparator IS at the head, `setEntityPrimaryKey`
+		 * does get called — confirming the test fixture is wired correctly and isolating the bug to
+		 * the non-head case.
+		 */
+		@Test
+		@DisplayName("Should propagate entity primary key to EPK-aware comparator at the chain head")
+		void shouldSetEntityPrimaryKeyOnEpkAwareHeadOfChain() {
+			final RecordingEpkAwareComparator epkAwareHead = new RecordingEpkAwareComparator();
+
+			final ReferenceDecorator[] references = new ReferenceDecorator[] {
+				stubReference("any"),
+				stubReference("any")
+			};
+
+			final int entityPrimaryKey = 7;
+
+			EntityDecorator.sortAndFilterSubList(
+				entityPrimaryKey,
+				references,
+				new ReferenceContractSerializablePredicate(),
+				null,
+				epkAwareHead,
+				0,
+				references.length
+			);
+
+			assertEquals(
+				List.of(entityPrimaryKey),
+				epkAwareHead.setEntityPrimaryKeyCalls,
+				"setEntityPrimaryKey must be invoked exactly once for the source entity when the " +
+					"EPK-aware comparator is the chain head."
+			);
+		}
+
+		/**
+		 * `sortAndFilterSubList` reads `referenceComparator.getNonSortedReferenceCount()` against
+		 * a per-pass snapshot taken before `Arrays.sort`. Concrete comparators (e.g.
+		 * `EntityNestedQueryComparator`) maintain a lazy-init `nonSortedReferences` set that ONLY
+		 * grows — it is never reset between sort passes. The chain-advance arithmetic must use
+		 * the per-pass delta (and clamp it to the current window) so that reusing the same
+		 * comparator instance across multiple `sortAndFilterSubList` invocations — the normal
+		 * case when an earlier pre-sort step has already mutated the comparator — cannot drive
+		 * `start` out of the valid `[0, sortEnd]` range and trip the next `Arrays.sort` with a
+		 * backwards range.
+		 */
+		@Test
+		@DisplayName("Should keep sort window within bounds when comparator non-sorted count accumulates across invocations")
+		void shouldKeepSortWindowWithinBoundsWhenComparatorNonSortedCountAccumulatesAcrossInvocations() {
+			// growing counts simulate a comparator whose getNonSortedReferenceCount() value keeps
+			// climbing across sort passes; the second `sortAndFilterSubList` call sees a snapshot
+			// (200) that is far larger than the sort window (3), so the implementation must clamp
+			// the per-pass delta to keep `start` inside [0, sortEnd]
+			final GrowingNonSortedCountComparator growingHead = new GrowingNonSortedCountComparator(
+				new RecordingEpkAwareComparator(),
+				new int[]{1, 200}
+			);
+
+			final ReferenceDecorator[] firstWindow = new ReferenceDecorator[] {
+				stubReference("any"),
+				stubReference("any"),
+				stubReference("any")
+			};
+			final ReferenceDecorator[] secondWindow = new ReferenceDecorator[] {
+				stubReference("any"),
+				stubReference("any"),
+				stubReference("any")
+			};
+
+			// First invocation establishes the comparator's accumulated counter; this call itself
+			// must not throw — the per-pass delta is still small (1) so the window stays in range.
+			EntityDecorator.sortAndFilterSubList(
+				1,
+				firstWindow,
+				new ReferenceContractSerializablePredicate(),
+				null,
+				growingHead,
+				0,
+				firstWindow.length
+			);
+
+			// Second invocation reuses the same comparator instance — the absolute counter (200)
+			// is now far larger than the sort window (3). The delta-snapshot pattern must clamp
+			// the per-pass delta to `sortEnd - start` so the subsequent chain-link sort does not
+			// receive a backwards range.
+			assertDoesNotThrow(
+				() -> EntityDecorator.sortAndFilterSubList(
+					1,
+					secondWindow,
+					new ReferenceContractSerializablePredicate(),
+					null,
+					growingHead,
+					0,
+					secondWindow.length
+				),
+				"Per-pass delta of getNonSortedReferenceCount() must be clamped to the current " +
+					"sort window so cumulative comparator counters cannot drive `start` out of " +
+					"the [0, sortEnd] range."
+			);
+		}
+
+		/**
+		 * Control: a comparator whose `getNonSortedReferenceCount()` returns the same value on
+		 * every call (i.e., it does NOT accumulate across sort passes) must let
+		 * `sortAndFilterSubList` complete successfully across multiple invocations. Pinned so a
+		 * future tightening of the delta-snapshot math cannot regress the common, well-behaved case.
+		 */
+		@Test
+		@DisplayName("Should complete successfully when comparator non-sorted count is stable across invocations")
+		void shouldCompleteSuccessfullyWhenComparatorNonSortedCountIsStableAcrossInvocations() {
+			// stable counter (1) is well below the sort window (3) on every call; the math always
+			// produces a valid `start` in [0, sortEnd] regardless of how many times the comparator
+			// is reused.
+			final StableNonSortedCountComparator stableHead = new StableNonSortedCountComparator(
+				new RecordingEpkAwareComparator(),
+				1
+			);
+
+			final ReferenceDecorator[] firstWindow = new ReferenceDecorator[] {
+				stubReference("any"),
+				stubReference("any"),
+				stubReference("any")
+			};
+			final ReferenceDecorator[] secondWindow = new ReferenceDecorator[] {
+				stubReference("any"),
+				stubReference("any"),
+				stubReference("any")
+			};
+
+			assertDoesNotThrow(
+				() -> {
+					EntityDecorator.sortAndFilterSubList(
+						1,
+						firstWindow,
+						new ReferenceContractSerializablePredicate(),
+						null,
+						stableHead,
+						0,
+						firstWindow.length
+					);
+					EntityDecorator.sortAndFilterSubList(
+						1,
+						secondWindow,
+						new ReferenceContractSerializablePredicate(),
+						null,
+						stableHead,
+						0,
+						secondWindow.length
+					);
+				},
+				"A comparator that does not accumulate non-sorted count across calls must let " +
+					"sortAndFilterSubList complete in the same way on every invocation."
+			);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/fetch/BitmapSlicerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/fetch/BitmapSlicerTest.java
@@ -1,0 +1,1356 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.fetch;
+
+import com.carrotsearch.hppc.IntHashSet;
+import com.carrotsearch.hppc.IntSet;
+import io.evitadb.api.query.require.Page;
+import io.evitadb.api.query.require.Strip;
+import io.evitadb.api.requestResponse.chunk.ChunkTransformer;
+import io.evitadb.api.requestResponse.chunk.NoTransformer;
+import io.evitadb.api.requestResponse.chunk.PageTransformer;
+import io.evitadb.api.requestResponse.chunk.StripTransformer;
+import io.evitadb.api.requestResponse.data.AttributesContract;
+import io.evitadb.api.requestResponse.data.ReferenceContract;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
+import io.evitadb.api.requestResponse.data.structure.ReferenceComparator;
+import io.evitadb.api.requestResponse.data.structure.ReferenceComparator.EntityPrimaryKeyAwareComparator;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
+import io.evitadb.api.requestResponse.schema.dto.ReferenceSchema;
+import io.evitadb.core.query.algebra.Formula;
+import io.evitadb.core.query.algebra.base.ConstantFormula;
+import io.evitadb.core.query.algebra.base.EmptyFormula;
+import io.evitadb.dataType.Scope;
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.function.TriFunction;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.IntStream;
+
+import static io.evitadb.test.TestTags.COMPARATOR;
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link BitmapSlicer} exercising the two slicing entry points and the page/strip
+ * offset arithmetic that backs them. The tests use hand-rolled stubs (no Mockito) so the test data
+ * stays under tight control and the test stays close to the project's existing style.
+ *
+ * Coverage focus areas:
+ *
+ * - Construction: rejection of unsupported transformers and identity behavior for `NoTransformer`.
+ * - `sliceEntityIdsSorted`: empty/single-element/all-equal candidate sets, page-boundary rebasing,
+ *   strip overflow, comparator-chain advance, `EntityPrimaryKeyAwareComparator` callback, group
+ *   accounting derivation (must use `referenceContractsAccessor`, not the group translator),
+ *   validity-mapping enforcement, cross-entity comparator-state leak tolerance, and multi-source-
+ *   entity behavior.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+@DisplayName("BitmapSlicer order-aware reference slicing")
+@Tag(ENGINE)
+@Tag(REFERENCE)
+@Tag(COMPARATOR)
+class BitmapSlicerTest {
+
+	private static final String REFERENCE_NAME = "parameter";
+
+	@Nested
+	@DisplayName("Construction and initialization")
+	class ConstructionTest {
+
+		@Test
+		@DisplayName("Should reject unsupported chunk transformer subtypes at construction time")
+		void shouldRejectUnsupportedChunkTransformer() {
+			final ChunkTransformer unsupported = referenceContracts -> {
+				throw new UnsupportedOperationException("not used");
+			};
+
+			final GenericEvitaInternalError thrown = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> new BitmapSlicer(
+					Collections.singletonMap(Scope.LIVE, new int[]{1}),
+					REFERENCE_NAME,
+					(refName, epk) -> EmptyFormula.INSTANCE,
+					emptyGroupTranslator(),
+					unsupported
+				)
+			);
+
+			assertTrue(
+				thrown.getPrivateMessage().contains("Unsupported chunk transformer"),
+				"Internal error message should mention the unsupported transformer"
+			);
+		}
+
+		@Test
+		@DisplayName("Should treat NoTransformer as an identity chunker (no slicing)")
+		void shouldUseIdentityChunkerForNoTransformer() {
+			// arrange — single source entity owning refs {10, 20, 30}; filter keeps all of them
+			final int sourceEntityPk = 1;
+			final FakeReferenceContract r10 = ref(10);
+			final FakeReferenceContract r20 = ref(20);
+			final FakeReferenceContract r30 = ref(30);
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, r10, r20, r30
+			);
+			final BitmapSlicer slicer = new BitmapSlicer(
+				Collections.singletonMap(Scope.LIVE, new int[]{sourceEntityPk}),
+				REFERENCE_NAME,
+				referencedEntityIdsFormula(refsByEntity),
+				emptyGroupTranslator(),
+				NoTransformer.INSTANCE
+			);
+
+			// act — NoTransformer must not chunk, so the sorted-slice returns all candidates
+			// (sorted) and `sliceEntityIds` returns the full filtered bitmap untouched.
+			final Bitmap allRefs = new BaseBitmap(10, 20, 30);
+			final Bitmap sorted = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(allRefs),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			// assert — all three present, sorted by reversed PK (30, 20, 10)
+			assertArrayEquals(new int[]{30, 20, 10}, sorted.getArray());
+		}
+	}
+
+	@Nested
+	@DisplayName("sliceEntityIdsSorted")
+	class SliceEntityIdsSortedTest {
+
+		@Test
+		@DisplayName("Should return empty bitmap when the source entity owns no references")
+		void shouldReturnEmptyBitmapWhenSourceEntityHasNoMatchingReferences() {
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(sourceEntityPk);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(1, 5));
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				EmptyFormula.INSTANCE,
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			assertTrue(result.isEmpty(), "no filtered references must produce empty result");
+			assertTrue(
+				slicer.getGroupIds(sourceEntityPk).compute().isEmpty(),
+				"group accounting must be empty when no candidates survive"
+			);
+		}
+
+		@Test
+		@DisplayName("Should return empty bitmap when every candidate is filtered out before slicing")
+		void shouldReturnEmptyBitmapWhenCandidatesArrayIsEmptyAfterFilter() {
+			// the source entity has refs {10, 20} but the global filter only accepts {99},
+			// so the filtered intersection is empty even though the entity has references
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20)
+			);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(1, 5));
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(99)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			assertTrue(result.isEmpty());
+		}
+
+		@Test
+		@DisplayName("Should pick the top-K candidates by comparator when the page slice fits the candidate set")
+		void shouldPickTopKByComparatorWhenPageSliceFitsWithinCandidates() {
+			// Candidates sorted by ReversedPK would produce a different page-1 than candidates
+			// sorted by natural PK. The slicer must respect the comparator's ordering, not the
+			// insertion / natural-PK order of the candidate bitmap.
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20), ref(30), ref(40), ref(50), ref(60), ref(70)
+			);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(1, 3));
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30, 40, 50, 60, 70)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			// the bitmap stores keys in ascending order, but the set must be the top-3 by reversed PK
+			final int[] picked = result.getArray();
+			Arrays.sort(picked);
+			assertArrayEquals(new int[]{50, 60, 70}, picked);
+		}
+
+		@Test
+		@DisplayName("Should fall back to the first page when the requested page is beyond the last available")
+		void shouldFallBackToFirstPageWhenRequestedPageBeyondLast() {
+			// requesting page 9 over a 3-element candidate set must rebase to page 1
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20), ref(30)
+			);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(9, 2));
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			// page 1 of 2 over reversed PK [30, 20, 10] -> [30, 20]
+			final int[] picked = result.getArray();
+			Arrays.sort(picked);
+			assertArrayEquals(new int[]{20, 30}, picked);
+		}
+
+		@Test
+		@DisplayName("Should return the last element when the strip offset sits at the end of the candidate range")
+		void shouldReturnLastElementWhenStripOffsetEqualsCandidateSize() {
+			// strip(offset=3, limit=5) with 3 candidates: `stripOffsetAndLimit` clamps offset
+			// to size-1=2, then `Math.min(offset+limit, candidates.length)=3`, producing the
+			// single-element tail of the sorted candidates. Reversed PK order is [30, 20, 10],
+			// index 2 -> 10.
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20), ref(30)
+			);
+			final BitmapSlicer slicer = newStripSlicer(refsByEntity, new Strip(3, 5));
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			assertArrayEquals(new int[]{10}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("Should clamp the strip limit when offset plus limit would overflow the candidate range")
+		void shouldClampLimitWhenStripOffsetPlusLimitOverflowsCandidates() {
+			// strip(offset=1, limit=99) with 3 candidates -> from=1, to=3 -> 2 elements
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20), ref(30)
+			);
+			final BitmapSlicer slicer = newStripSlicer(refsByEntity, new Strip(1, 99));
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			// reversed PK order: [30, 20, 10]; offset=1 limit=99 clamped -> [20, 10]
+			final int[] picked = result.getArray();
+			Arrays.sort(picked);
+			assertArrayEquals(new int[]{10, 20}, picked);
+		}
+
+		@Test
+		@DisplayName("Should return a single-element slice when only one candidate survives filtering")
+		void shouldReturnSingleElementSliceWhenOnlyOneCandidate() {
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(42)
+			);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(1, 5));
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(42)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			assertArrayEquals(new int[]{42}, result.getArray());
+		}
+
+		@Test
+		@DisplayName("Should preserve every candidate when the comparator reports all pairs equal")
+		void shouldKeepAllElementsWhenComparatorReportsAllEqual() {
+			// AllEqualComparator returns 0 for every pair — Arrays.sort is stable so insertion
+			// order is preserved; the page slice must return the full first page in that order.
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20), ref(30)
+			);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(1, 5));
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new AllEqualComparator()
+			);
+
+			final int[] picked = result.getArray();
+			Arrays.sort(picked);
+			assertArrayEquals(new int[]{10, 20, 30}, picked);
+		}
+
+		@Test
+		@DisplayName("Should advance to the next comparator in the chain when the primary leaves an unsorted tail")
+		void shouldAdvanceComparatorChainWhenPrimaryComparatorReportsNonSortedTail() {
+			// PrimaryComparatorWithUnsortedTail sorts only the first 2 elements (the rest are
+			// reported as non-sorted) and chains a ReversedPkComparator as the secondary.
+			// Expected layout after both passes: head of comparator-1 result (sorted by PK),
+			// followed by reversed-PK ordering of the remainder.
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20), ref(30), ref(40)
+			);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(1, 4));
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30, 40)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new PrimaryComparatorWithUnsortedTail(2, new ReversedPkComparator())
+			);
+
+			// all four come back (bitmap stores ascending), but the test is about chain advance
+			final int[] picked = result.getArray();
+			Arrays.sort(picked);
+			assertArrayEquals(new int[]{10, 20, 30, 40}, picked);
+		}
+
+		@Test
+		@DisplayName("Should stop walking the comparator chain when the unsorted range is exhausted")
+		void shouldStopComparatorChainWhenNonSortedRangeIsExhausted() {
+			// Primary comparator reports `getNonSortedReferenceCount() == 0`, so even though a
+			// next comparator is chained, the loop must exit immediately after the first pass.
+			final SpyingComparator next = new SpyingComparator(new ReversedPkComparator());
+			final ReferenceComparator primary = new FullySortingComparator(next);
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20), ref(30)
+			);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(1, 5));
+
+			slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				primary
+			);
+
+			assertEquals(
+				0, next.compareCallCount,
+				"chained comparator must not be invoked when primary reports zero non-sorted refs"
+			);
+		}
+
+		@Test
+		@DisplayName("Should invoke setEntityPrimaryKey on EPK-aware comparators on every chain link")
+		void shouldInvokeSetEntityPrimaryKeyOnEntityPrimaryKeyAwareComparator() {
+			final EpkAwareComparator comparator = new EpkAwareComparator();
+			final int sourceEntityA = 7;
+			final int sourceEntityB = 11;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = new LinkedHashMap<>();
+			refsByEntity.put(sourceEntityA, List.of(ref(10), ref(20)));
+			refsByEntity.put(sourceEntityB, List.of(ref(30), ref(40)));
+			final BitmapSlicer slicer = new BitmapSlicer(
+				Collections.singletonMap(Scope.LIVE, new int[]{sourceEntityA, sourceEntityB}),
+				REFERENCE_NAME,
+				referencedEntityIdsFormula(refsByEntity),
+				emptyGroupTranslator(),
+				new PageTransformer(new Page(1, 5), new io.evitadb.api.requestResponse.EvitaRequest.ConditionalGap[0])
+			);
+
+			slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30, 40)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				comparator
+			);
+
+			assertEquals(
+				List.of(sourceEntityA, sourceEntityB), comparator.observedKeys,
+				"setEntityPrimaryKey must be invoked once per source entity, in iteration order"
+			);
+		}
+
+		@Test
+		@DisplayName("Should compute group accounting over every filtered reference, independent of the slice window")
+		void shouldComputeGroupAccountingOverAllFilteredReferencesIndependentOfSlice() {
+			// 4 candidates, page size 2 — the slicer must keep group accounting for all 4 even
+			// though only the top 2 by reversed PK are returned in the bitmap.
+			final int sourceEntityPk = 1;
+			final FakeReferenceContract r10 = refWithGroup(10, 100);
+			final FakeReferenceContract r20 = refWithGroup(20, 200);
+			final FakeReferenceContract r30 = refWithGroup(30, 300);
+			final FakeReferenceContract r40 = refWithGroup(40, 400);
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, r10, r20, r30, r40
+			);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(1, 2));
+
+			slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30, 40)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			final int[] groupIds = slicer.getGroupIds(sourceEntityPk).compute().getArray();
+			Arrays.sort(groupIds);
+			assertArrayEquals(
+				new int[]{100, 200, 300, 400}, groupIds,
+				"group accounting must include every filtered reference, not only the sliced ones"
+			);
+		}
+
+		@Test
+		@DisplayName("Should slice each source entity independently when their candidate sets are disjoint")
+		void shouldHandleMultipleSourceEntitiesWithDisjointCandidateSets() {
+			final int sourceEntityA = 1;
+			final int sourceEntityB = 2;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = new LinkedHashMap<>();
+			refsByEntity.put(sourceEntityA, List.of(ref(10), ref(20)));
+			refsByEntity.put(sourceEntityB, List.of(ref(30), ref(40)));
+			final BitmapSlicer slicer = new BitmapSlicer(
+				Collections.singletonMap(Scope.LIVE, new int[]{sourceEntityA, sourceEntityB}),
+				REFERENCE_NAME,
+				referencedEntityIdsFormula(refsByEntity),
+				emptyGroupTranslator(),
+				new PageTransformer(new Page(1, 1), new io.evitadb.api.requestResponse.EvitaRequest.ConditionalGap[0])
+			);
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30, 40)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			// each source entity contributes its top-1 by reversed PK -> {20} and {40}
+			final int[] picked = result.getArray();
+			Arrays.sort(picked);
+			assertArrayEquals(new int[]{20, 40}, picked);
+		}
+
+		@Test
+		@DisplayName("Should keep group accounting isolated per source entity when slicing multiple sources together")
+		void shouldKeepGroupAccountingPerSourceEntityWhenSlicingMultipleSourcesTogether() {
+			// Two source entities, each owning two refs with disjoint groups. After slicing, the
+			// per-source `getGroupIds(epk)` accumulator must surface only the groups owned by that
+			// source entity — group accounting must not leak across the `epk` partition.
+			final int sourceEntityA = 1;
+			final int sourceEntityB = 2;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = new LinkedHashMap<>();
+			refsByEntity.put(sourceEntityA, List.of(refWithGroup(10, 100), refWithGroup(20, 200)));
+			refsByEntity.put(sourceEntityB, List.of(refWithGroup(30, 300), refWithGroup(40, 400)));
+			final BitmapSlicer slicer = new BitmapSlicer(
+				Collections.singletonMap(Scope.LIVE, new int[]{sourceEntityA, sourceEntityB}),
+				REFERENCE_NAME,
+				referencedEntityIdsFormula(refsByEntity),
+				emptyGroupTranslator(),
+				new PageTransformer(
+					new Page(1, 1),
+					new io.evitadb.api.requestResponse.EvitaRequest.ConditionalGap[0]
+				)
+			);
+
+			slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30, 40)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			final int[] groupIdsA = slicer.getGroupIds(sourceEntityA).compute().getArray();
+			Arrays.sort(groupIdsA);
+			assertArrayEquals(
+				new int[]{100, 200}, groupIdsA,
+				"groupsForEntity for source A must contain only A's group PKs"
+			);
+			final int[] groupIdsB = slicer.getGroupIds(sourceEntityB).compute().getArray();
+			Arrays.sort(groupIdsB);
+			assertArrayEquals(
+				new int[]{300, 400}, groupIdsB,
+				"groupsForEntity for source B must contain only B's group PKs"
+			);
+		}
+
+		@Test
+		@DisplayName("Should return empty bitmap when source entity references and referencedEntityIdsFormula share no PKs")
+		void shouldReturnEmptyBitmapWhenSourceEntityCandidatesContainNoReferenceWithMatchingPk() {
+			// The source entity exposes refs {10, 20}, but the global referenced-entity formula
+			// resolves to {50} only. Their intersection is empty before any filtering happens, so
+			// the early-return `filteredRefs.length == 0` branch must fire (distinct from the
+			// existing "empty after validity filter" case).
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20)
+			);
+			final BitmapSlicer slicer = new BitmapSlicer(
+				Collections.singletonMap(Scope.LIVE, new int[]{sourceEntityPk}),
+				REFERENCE_NAME,
+				// the global formula deliberately resolves to a PK the source does not own
+				(refName, epk) -> new ConstantFormula(new BaseBitmap(50)),
+				emptyGroupTranslator(),
+				new PageTransformer(
+					new Page(1, 5),
+					new io.evitadb.api.requestResponse.EvitaRequest.ConditionalGap[0]
+				)
+			);
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			assertTrue(
+				result.isEmpty(),
+				"intersection of source refs and referencedEntityIdsFormula is empty -> bitmap empty"
+			);
+		}
+
+		@Test
+		@DisplayName("Should rebase a page past the last to page one over the surviving candidate count, not the raw source size")
+		void shouldRebasePageBeyondLastUsingFilteredCandidateCount() {
+			// Source owns refs {10, 20, 30, 40, 50}; validity mapping allows only ref 30 for the
+			// source entity, so the surviving candidate count is 1. page(99, 2) over 5 raw refs
+			// would NOT be "past the end" — but over the 1 filtered candidate it IS past the end
+			// and must rebase to page 1 (-> the single element).
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20), ref(30), ref(40), ref(50)
+			);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(99, 2));
+			final ValidEntityToReferenceMapping validityMapping = restrictedValidityMapping(
+				Map.of(sourceEntityPk, new int[]{30})
+			);
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30, 40, 50)),
+				validityMapping,
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			assertArrayEquals(
+				new int[]{30}, result.getArray(),
+				"page-rebase math must operate on the filtered candidate count, not the raw source size"
+			);
+		}
+
+		@Test
+		@DisplayName("Should derive group accounting from reference contracts on the sorted path, not from the translator")
+		void shouldDeriveGroupAccountingFromReferenceContractsAccessorNotFromTranslator() {
+			// Pinning the contract: groupsForEntity for the sorted slicing path is built from
+			// `referenceContractsAccessor.apply(...).getGroup()`, not from
+			// `referencedEntityToGroupIdTranslator`. The translator returns empty for every
+			// (epk, refName, refId), yet the slicer must still surface the correct group PKs
+			// because they come from the source references.
+			final int sourceEntityPk = 1;
+			final FakeReferenceContract r10 = refWithGroup(10, 100);
+			final FakeReferenceContract r20 = refWithGroup(20, 200);
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, r10, r20
+			);
+			final BitmapSlicer slicer = new BitmapSlicer(
+				Collections.singletonMap(Scope.LIVE, new int[]{sourceEntityPk}),
+				REFERENCE_NAME,
+				referencedEntityIdsFormula(refsByEntity),
+				(epk, refName, refId) -> IntStream.empty(),
+				new PageTransformer(new Page(1, 5), new io.evitadb.api.requestResponse.EvitaRequest.ConditionalGap[0])
+			);
+
+			slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			final int[] groupIds = slicer.getGroupIds(sourceEntityPk).compute().getArray();
+			Arrays.sort(groupIds);
+			assertArrayEquals(
+				new int[]{100, 200}, groupIds,
+				"sorted slicer must derive groups from ReferenceContract.getGroup(), not from the translator"
+			);
+		}
+
+		@Test
+		@DisplayName("Should exclude references rejected by the validity mapping from the slice")
+		void shouldExcludeReferencesRejectedByValidityMappingFromSlice() {
+			// `sliceEntityIdsSorted` must honor `ValidEntityToReferenceMapping` the same way the
+			// unsorted twin does — references not present in the per-source validity mapping
+			// must be filtered out before sorting and slicing, otherwise the order-aware slice
+			// would surface rows the unsorted path already rejected (e.g. multi-source dedup
+			// winners) and the post-fetch sort would see extra rows.
+			final int sourceEntityPk = 1;
+			final FakeReferenceContract r10 = ref(10);
+			final FakeReferenceContract r20 = ref(20);
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, r10, r20
+			);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(1, 5));
+			// validity mapping allows only ref 20 for the source entity — ref 10 must be dropped
+			final ValidEntityToReferenceMapping validityMapping = restrictedValidityMapping(
+				Map.of(sourceEntityPk, new int[]{20})
+			);
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20)),
+				validityMapping,
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			assertArrayEquals(
+				new int[]{20}, result.getArray(),
+				"sorted slicer must honor validity mapping: ref 10 is excluded by the mapping"
+			);
+		}
+
+		@Test
+		@DisplayName("Should tolerate comparators whose non-sorted count is a cross-entity monotonic accumulator")
+		void shouldToleratePerPassNonSortedCountWithCrossEntityAccumulator() {
+			// Some comparator chains (notably `EntityNestedQueryComparator`) keep their
+			// `nonSortedReferences` IntSet alive across source-entity passes — the count is
+			// monotonically growing, not a per-pass reading. The slicer must therefore work with
+			// the *delta* between the count before and after each `Arrays.sort` invocation and
+			// clamp it to the sorted slice, so a stale accumulator from the first source entity
+			// cannot produce a negative `start` and trip `Arrays.sort` with a backwards range.
+			final int sourceEntityA = 1;
+			final int sourceEntityB = 2;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = new LinkedHashMap<>();
+			refsByEntity.put(sourceEntityA, List.of(ref(10), ref(20), ref(30)));
+			refsByEntity.put(sourceEntityB, List.of(ref(40), ref(50)));
+			final BitmapSlicer slicer = new BitmapSlicer(
+				Collections.singletonMap(Scope.LIVE, new int[]{sourceEntityA, sourceEntityB}),
+				REFERENCE_NAME,
+				referencedEntityIdsFormula(refsByEntity),
+				emptyGroupTranslator(),
+				new PageTransformer(new Page(1, 5), new io.evitadb.api.requestResponse.EvitaRequest.ConditionalGap[0])
+			);
+			final ReferenceComparator chained = new ReversedPkComparator();
+			final ReferenceComparator leaky = new MonotoneNonSortedAccumulator(chained);
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30, 40, 50)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				leaky
+			);
+
+			// the accumulator returns 0 on its primary pass — every ref ends up handed to the
+			// chained reversed-PK comparator, which sorts both entities' refs in descending PK
+			// order; bitmap storage is ascending, so the union of all 5 PKs is returned
+			final int[] picked = result.getArray();
+			Arrays.sort(picked);
+			assertArrayEquals(new int[]{10, 20, 30, 40, 50}, picked);
+		}
+	}
+
+	@Nested
+	@DisplayName("offset and limit helpers behavior (observed through chunker)")
+	class OffsetAndLimitHelpersTest {
+
+		@Test
+		@DisplayName("Should compute the expected offset and limit for an ordinary page request")
+		void shouldComputePageOffsetAndLimitForOrdinaryPage() {
+			// page(2, 3) over 7 refs -> offset 3, limit 3 -> indices [3,4,5]; reversed PK order
+			// of [10..70] is [70..10], so picked are [40, 30, 20].
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20), ref(30), ref(40), ref(50), ref(60), ref(70)
+			);
+			final BitmapSlicer slicer = newPageSlicer(refsByEntity, new Page(2, 3));
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30, 40, 50, 60, 70)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			final int[] picked = result.getArray();
+			Arrays.sort(picked);
+			assertArrayEquals(new int[]{20, 30, 40}, picked);
+		}
+
+		@Test
+		@DisplayName("Should compute the expected offset and limit for a strip request inside the candidate range")
+		void shouldComputeStripOffsetAndLimitWithinBounds() {
+			// strip(offset=1, limit=2) over reversed PK [30, 20, 10] -> [20, 10]
+			final int sourceEntityPk = 1;
+			final Map<Integer, List<ReferenceContract>> refsByEntity = singletonRefMap(
+				sourceEntityPk, ref(10), ref(20), ref(30)
+			);
+			final BitmapSlicer slicer = newStripSlicer(refsByEntity, new Strip(1, 2));
+
+			final Bitmap result = slicer.sliceEntityIdsSorted(
+				new ConstantFormula(new BaseBitmap(10, 20, 30)),
+				permissiveValidityMapping(refsByEntity),
+				referenceContractsAccessor(refsByEntity),
+				new ReversedPkComparator()
+			);
+
+			final int[] picked = result.getArray();
+			Arrays.sort(picked);
+			assertArrayEquals(new int[]{10, 20}, picked);
+		}
+
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// fixtures and helpers
+	// ---------------------------------------------------------------------------------------------
+
+	/**
+	 * Builds a single-entity reference map keyed by the source entity primary key.
+	 */
+	@Nonnull
+	private static Map<Integer, List<ReferenceContract>> singletonRefMap(
+		int sourceEntityPk, @Nonnull FakeReferenceContract... refs
+	) {
+		final Map<Integer, List<ReferenceContract>> map = new HashMap<>();
+		map.put(sourceEntityPk, List.of(refs));
+		return map;
+	}
+
+	/**
+	 * Produces a `referencedEntityIdsFormula` BiFunction that resolves the per-source bitmap of
+	 * referenced PKs from the test's reference map.
+	 */
+	@Nonnull
+	private static BiFunction<String, Integer, Formula> referencedEntityIdsFormula(
+		@Nonnull Map<Integer, List<ReferenceContract>> refsByEntity
+	) {
+		return (refName, epk) -> {
+			final List<ReferenceContract> refs = refsByEntity.getOrDefault(epk, List.of());
+			if (refs.isEmpty()) {
+				return EmptyFormula.INSTANCE;
+			}
+			final int[] pks = refs.stream()
+				.mapToInt(ReferenceContract::getReferencedPrimaryKey)
+				.toArray();
+			return new ConstantFormula(new BaseBitmap(pks));
+		};
+	}
+
+	/**
+	 * Produces a `referenceContractsAccessor` BiFunction that resolves the per-source list of
+	 * reference contracts from the test's reference map.
+	 */
+	@Nonnull
+	private static BiFunction<String, Integer, Collection<ReferenceContract>> referenceContractsAccessor(
+		@Nonnull Map<Integer, List<ReferenceContract>> refsByEntity
+	) {
+		return (refName, epk) -> refsByEntity.getOrDefault(epk, List.of());
+	}
+
+	/**
+	 * Builds a `ValidEntityToReferenceMapping` whose per-source allow-set is exactly the reference
+	 * PKs found in `refsByEntity` for that source entity — equivalent to "no validity restriction
+	 * beyond what the source already exposes". Use this in tests that focus on slicing behavior
+	 * rather than validity filtering.
+	 */
+	@Nonnull
+	private static ValidEntityToReferenceMapping permissiveValidityMapping(
+		@Nonnull Map<Integer, List<ReferenceContract>> refsByEntity
+	) {
+		final ReferenceSchema schema = ReferenceSchema._internalBuild(
+			REFERENCE_NAME, "referenced", false, Cardinality.ZERO_OR_MORE,
+			null, false, null, null
+		);
+		final ValidEntityToReferenceMapping mapping = new ValidEntityToReferenceMapping(
+			refsByEntity.size(), schema
+		);
+		for (Map.Entry<Integer, List<ReferenceContract>> entry : refsByEntity.entrySet()) {
+			final int[] pks = entry.getValue().stream()
+				.mapToInt(ReferenceContract::getReferencedPrimaryKey)
+				.toArray();
+			mapping.setInitialVisibilityForEntity(entry.getKey(), new BaseBitmap(pks));
+		}
+		return mapping;
+	}
+
+	/**
+	 * Builds a `ValidEntityToReferenceMapping` restricted to exactly the given allowed referenced
+	 * PKs per source entity. References not listed for a source entity are rejected by the
+	 * validity gate even if the source entity owns them.
+	 */
+	@Nonnull
+	private static ValidEntityToReferenceMapping restrictedValidityMapping(
+		@Nonnull Map<Integer, int[]> allowedByEntity
+	) {
+		final ReferenceSchema schema = ReferenceSchema._internalBuild(
+			REFERENCE_NAME, "referenced", false, Cardinality.ZERO_OR_MORE,
+			null, false, null, null
+		);
+		final ValidEntityToReferenceMapping mapping = new ValidEntityToReferenceMapping(
+			allowedByEntity.size(), schema
+		);
+		for (Map.Entry<Integer, int[]> entry : allowedByEntity.entrySet()) {
+			mapping.setInitialVisibilityForEntity(entry.getKey(), new BaseBitmap(entry.getValue()));
+		}
+		return mapping;
+	}
+
+	/**
+	 * Returns a default translator that produces no groups for any reference.
+	 */
+	@Nonnull
+	private static TriFunction<Integer, String, Integer, IntStream> emptyGroupTranslator() {
+		return (epk, refName, refId) -> IntStream.empty();
+	}
+
+	/**
+	 * Builds a slicer wired to a `PageTransformer` for the provided page constraint.
+	 */
+	@Nonnull
+	private static BitmapSlicer newPageSlicer(
+		@Nonnull Map<Integer, List<ReferenceContract>> refsByEntity,
+		@Nonnull Page page
+	) {
+		final int[] sourcePks = refsByEntity.keySet().stream().mapToInt(Integer::intValue).sorted().toArray();
+		return new BitmapSlicer(
+			Collections.singletonMap(Scope.LIVE, sourcePks),
+			REFERENCE_NAME,
+			referencedEntityIdsFormula(refsByEntity),
+			emptyGroupTranslator(),
+			new PageTransformer(page, new io.evitadb.api.requestResponse.EvitaRequest.ConditionalGap[0])
+		);
+	}
+
+	/**
+	 * Builds a slicer wired to a `StripTransformer` for the provided strip constraint.
+	 */
+	@Nonnull
+	private static BitmapSlicer newStripSlicer(
+		@Nonnull Map<Integer, List<ReferenceContract>> refsByEntity,
+		@Nonnull Strip strip
+	) {
+		final int[] sourcePks = refsByEntity.keySet().stream().mapToInt(Integer::intValue).sorted().toArray();
+		return new BitmapSlicer(
+			Collections.singletonMap(Scope.LIVE, sourcePks),
+			REFERENCE_NAME,
+			referencedEntityIdsFormula(refsByEntity),
+			emptyGroupTranslator(),
+			new StripTransformer(strip)
+		);
+	}
+
+	/**
+	 * Builds a fake reference contract with the given referenced primary key and no group.
+	 */
+	@Nonnull
+	private static FakeReferenceContract ref(int referencedPk) {
+		return new FakeReferenceContract(referencedPk, null);
+	}
+
+	/**
+	 * Builds a fake reference contract with the given referenced primary key and the given
+	 * group primary key.
+	 */
+	@Nonnull
+	private static FakeReferenceContract refWithGroup(int referencedPk, int groupPk) {
+		return new FakeReferenceContract(referencedPk, groupPk);
+	}
+
+	/**
+	 * Hand-rolled stub that implements only the methods `BitmapSlicer` invokes. Everything
+	 * else throws `UnsupportedOperationException`, which keeps the test failure modes loud
+	 * if the production code starts depending on something new.
+	 */
+	private static final class FakeReferenceContract implements ReferenceContract {
+		@Serial private static final long serialVersionUID = -1161299331361146718L;
+		private final ReferenceKey referenceKey;
+		@Nullable private final GroupEntityReference group;
+
+		FakeReferenceContract(int referencedPk, @Nullable Integer groupPk) {
+			this.referenceKey = new ReferenceKey(REFERENCE_NAME, referencedPk);
+			this.group = groupPk == null ? null : new GroupEntityReference("group", groupPk);
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceKey getReferenceKey() {
+			return this.referenceKey;
+		}
+
+		@Nonnull
+		@Override
+		public Optional<SealedEntity> getReferencedEntity() {
+			return Optional.empty();
+		}
+
+		@Nonnull
+		@Override
+		public String getReferencedEntityType() {
+			return "referenced";
+		}
+
+		@Nonnull
+		@Override
+		public Cardinality getReferenceCardinality() {
+			return Cardinality.ZERO_OR_MORE;
+		}
+
+		@Nonnull
+		@Override
+		public Optional<GroupEntityReference> getGroup() {
+			return Optional.ofNullable(this.group);
+		}
+
+		@Nonnull
+		@Override
+		public Optional<SealedEntity> getGroupEntity() {
+			return Optional.empty();
+		}
+
+		@Nonnull
+		@Override
+		public Optional<ReferenceSchemaContract> getReferenceSchema() {
+			return Optional.empty();
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceSchemaContract getReferenceSchemaOrThrow() {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Override
+		public boolean dropped() {
+			return false;
+		}
+
+		@Override
+		public int version() {
+			return 1;
+		}
+
+		// AttributesContract surface — none of these are touched by BitmapSlicer
+		@Override
+		public boolean attributesAvailable() {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Override
+		public boolean attributesAvailable(@Nonnull java.util.Locale locale) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Override
+		public boolean attributeAvailable(@Nonnull String attributeName) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Override
+		public boolean attributeAvailable(@Nonnull String attributeName, @Nonnull java.util.Locale locale) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nullable
+		@Override
+		public <T extends Serializable> T getAttribute(@Nonnull String attributeName) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nullable
+		@Override
+		public <T extends Serializable> T[] getAttributeArray(@Nonnull String attributeName) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nonnull
+		@Override
+		public Optional<io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue> getAttributeValue(
+			@Nonnull String attributeName) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nullable
+		@Override
+		public <T extends Serializable> T getAttribute(@Nonnull String attributeName, @Nonnull java.util.Locale locale) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nullable
+		@Override
+		public <T extends Serializable> T[] getAttributeArray(
+			@Nonnull String attributeName, @Nonnull java.util.Locale locale) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nonnull
+		@Override
+		public Optional<io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue> getAttributeValue(
+			@Nonnull String attributeName, @Nonnull java.util.Locale locale) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nonnull
+		@Override
+		public Optional<AttributeSchemaContract> getAttributeSchema(@Nonnull String attributeName) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nonnull
+		@Override
+		public Set<String> getAttributeNames() {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nonnull
+		@Override
+		public Set<AttributesContract.AttributeKey> getAttributeKeys() {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nonnull
+		@Override
+		public Optional<AttributesContract.AttributeValue> getAttributeValue(
+			@Nonnull AttributesContract.AttributeKey attributeKey) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nonnull
+		@Override
+		public Collection<AttributesContract.AttributeValue> getAttributeValues() {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nonnull
+		@Override
+		public Collection<AttributesContract.AttributeValue> getAttributeValues(@Nonnull String attributeName) {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Nonnull
+		@Override
+		public Set<java.util.Locale> getAttributeLocales() {
+			throw new UnsupportedOperationException("not used by BitmapSlicer");
+		}
+
+		@Override
+		public boolean differsFrom(@Nullable ReferenceContract otherReference) {
+			return true;
+		}
+	}
+
+	/**
+	 * Comparator that orders references by descending primary key. Used as the canonical
+	 * comparator in tests because it disagrees with PK-bitmap ordering, exposing slicer
+	 * ordering bugs.
+	 */
+	private static final class ReversedPkComparator implements ReferenceComparator, Serializable {
+		@Serial private static final long serialVersionUID = 1049423735946139846L;
+
+		@Override
+		public int compare(ReferenceContract o1, ReferenceContract o2) {
+			return Integer.compare(o2.getReferencedPrimaryKey(), o1.getReferencedPrimaryKey());
+		}
+
+		@Override
+		public int getNonSortedReferenceCount() {
+			return 0;
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceComparator andThen(@Nonnull ReferenceComparator comparatorForUnknownRecords) {
+			throw new UnsupportedOperationException("not used");
+		}
+
+		@Nullable
+		@Override
+		public ReferenceComparator getNextComparator() {
+			return null;
+		}
+	}
+
+	/**
+	 * Comparator that reports every pair as equal. Combined with `Arrays.sort` stability,
+	 * insertion order is preserved.
+	 */
+	private static final class AllEqualComparator implements ReferenceComparator, Serializable {
+		@Serial private static final long serialVersionUID = 2921062812216467221L;
+
+		@Override
+		public int compare(ReferenceContract o1, ReferenceContract o2) {
+			return 0;
+		}
+
+		@Override
+		public int getNonSortedReferenceCount() {
+			return 0;
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceComparator andThen(@Nonnull ReferenceComparator comparatorForUnknownRecords) {
+			throw new UnsupportedOperationException("not used");
+		}
+
+		@Nullable
+		@Override
+		public ReferenceComparator getNextComparator() {
+			return null;
+		}
+	}
+
+	/**
+	 * Primary comparator that successfully sorts only the first `headSize` elements (by PK
+	 * ascending) and reports the rest as non-sorted, chaining to a secondary comparator.
+	 */
+	private static final class PrimaryComparatorWithUnsortedTail implements ReferenceComparator, Serializable {
+		@Serial private static final long serialVersionUID = 1212470114057994610L;
+
+		private final int headSize;
+		private final ReferenceComparator next;
+		private int sortedSoFar;
+
+		PrimaryComparatorWithUnsortedTail(int headSize, @Nonnull ReferenceComparator next) {
+			this.headSize = headSize;
+			this.next = next;
+		}
+
+		@Override
+		public int compare(ReferenceContract o1, ReferenceContract o2) {
+			this.sortedSoFar++;
+			return Integer.compare(o1.getReferencedPrimaryKey(), o2.getReferencedPrimaryKey());
+		}
+
+		@Override
+		public int getNonSortedReferenceCount() {
+			// the comparator chain walks at most `len - headSize` items into the secondary
+			return Math.max(0, this.sortedSoFar - this.headSize);
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceComparator andThen(@Nonnull ReferenceComparator comparatorForUnknownRecords) {
+			throw new UnsupportedOperationException("not used");
+		}
+
+		@Nullable
+		@Override
+		public ReferenceComparator getNextComparator() {
+			return this.next;
+		}
+	}
+
+	/**
+	 * Comparator that fully sorts everything (PK ascending) and reports zero non-sorted refs;
+	 * the slicer must therefore never invoke the chained comparator.
+	 */
+	private static final class FullySortingComparator implements ReferenceComparator, Serializable {
+		@Serial private static final long serialVersionUID = -3439388572083215292L;
+
+		private final ReferenceComparator next;
+
+		FullySortingComparator(@Nonnull ReferenceComparator next) {
+			this.next = next;
+		}
+
+		@Override
+		public int compare(ReferenceContract o1, ReferenceContract o2) {
+			return Integer.compare(o1.getReferencedPrimaryKey(), o2.getReferencedPrimaryKey());
+		}
+
+		@Override
+		public int getNonSortedReferenceCount() {
+			return 0;
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceComparator andThen(@Nonnull ReferenceComparator comparatorForUnknownRecords) {
+			throw new UnsupportedOperationException("not used");
+		}
+
+		@Nullable
+		@Override
+		public ReferenceComparator getNextComparator() {
+			return this.next;
+		}
+	}
+
+	/**
+	 * Comparator that counts `compare` invocations on a wrapped delegate, used to assert
+	 * whether the chain advances or stops.
+	 */
+	private static final class SpyingComparator implements ReferenceComparator, Serializable {
+		@Serial private static final long serialVersionUID = -1109723067085802297L;
+
+		private final ReferenceComparator delegate;
+		int compareCallCount;
+
+		SpyingComparator(@Nonnull ReferenceComparator delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public int compare(ReferenceContract o1, ReferenceContract o2) {
+			this.compareCallCount++;
+			return this.delegate.compare(o1, o2);
+		}
+
+		@Override
+		public int getNonSortedReferenceCount() {
+			return this.delegate.getNonSortedReferenceCount();
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceComparator andThen(@Nonnull ReferenceComparator comparatorForUnknownRecords) {
+			throw new UnsupportedOperationException("not used");
+		}
+
+		@Nullable
+		@Override
+		public ReferenceComparator getNextComparator() {
+			return this.delegate.getNextComparator();
+		}
+	}
+
+	/**
+	 * `EntityPrimaryKeyAwareComparator` whose `setEntityPrimaryKey` callback records each
+	 * invocation in insertion order so tests can assert per-source-entity setup.
+	 */
+	private static final class EpkAwareComparator
+		implements ReferenceComparator, EntityPrimaryKeyAwareComparator, Serializable {
+		@Serial private static final long serialVersionUID = 7880289428338626380L;
+
+		final List<Integer> observedKeys = new ArrayList<>();
+
+		@Override
+		public void setEntityPrimaryKey(int entityPrimaryKey) {
+			this.observedKeys.add(entityPrimaryKey);
+		}
+
+		@Override
+		public int compare(ReferenceContract o1, ReferenceContract o2) {
+			return Integer.compare(o1.getReferencedPrimaryKey(), o2.getReferencedPrimaryKey());
+		}
+
+		@Override
+		public int getNonSortedReferenceCount() {
+			return 0;
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceComparator andThen(@Nonnull ReferenceComparator comparatorForUnknownRecords) {
+			throw new UnsupportedOperationException("not used");
+		}
+
+		@Nullable
+		@Override
+		public ReferenceComparator getNextComparator() {
+			return null;
+		}
+	}
+
+	/**
+	 * Comparator that mimics `EntityNestedQueryComparator`'s lazy-init `IntSet` for tracking
+	 * non-sorted refs across `compare` calls. The set accumulates across source entities, so
+	 * the second source entity's pass sees a stale count from the first pass — reproducing
+	 * the comparator-state-leak failure mode.
+	 */
+	private static final class MonotoneNonSortedAccumulator implements ReferenceComparator, Serializable {
+		@Serial private static final long serialVersionUID = -1951359585234161118L;
+
+		private final ReferenceComparator next;
+		private IntSet nonSorted;
+
+		MonotoneNonSortedAccumulator(@Nonnull ReferenceComparator next) {
+			this.next = next;
+		}
+
+		@Override
+		public int compare(ReferenceContract o1, ReferenceContract o2) {
+			if (this.nonSorted == null) {
+				this.nonSorted = new IntHashSet();
+			}
+			this.nonSorted.add(o1.getReferencedPrimaryKey());
+			this.nonSorted.add(o2.getReferencedPrimaryKey());
+			return 0;
+		}
+
+		@Override
+		public int getNonSortedReferenceCount() {
+			return this.nonSorted == null ? 0 : this.nonSorted.size();
+		}
+
+		@Nonnull
+		@Override
+		public ReferenceComparator andThen(@Nonnull ReferenceComparator comparatorForUnknownRecords) {
+			throw new UnsupportedOperationException("not used");
+		}
+
+		@Nullable
+		@Override
+		public ReferenceComparator getNextComparator() {
+			return this.next;
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary

Closes #1177.

Two related fixes for `referenceContent` paginated with an `orderBy`:

1. **Pre-fetch / post-fetch slice alignment** (`d8f3bbba4`) — port of the original fix from `release_2026-1`. When a non-DEFAULT comparator is configured on `referenceContent`, `BitmapSlicer` now pre-sorts each source entity's references with the same comparator chain that `EntityDecorator#sortAndFilterSubList` would apply post-fetch, then slices using the configured page/strip offset+limit. This guarantees the pre-fetch slice and the post-fetch sort agree on the same set of PKs — no over-fetch, no under-fetch — eliminating the `null referencedEntity` symptom reported in #1177. When `orderBy` contains `entityGroupProperty`, the slicer falls back to fetching all filtered references (the group filter is only known post-slice), and the post-fetch sort+chunk in `EntityDecorator` still produces a correct paginated result.

2. **`ReferenceMapping` indexes every source-entity reference, not just the page-slice** (`8d9995416`) — bug uncovered while porting the above. Both lazy retrievers in `ReferenceMapping` iterated the chunked, page-sliced view of source-entity references (`EntityDecorator.getReferences(refName)` and `getReferencesWithoutCheckingPredicate(refName)`, both backed by `getFilteredReferencesByName()`). When a query asked for `referenceContent(.., orderBy(entityGroupProperty(..)), .., page(1, N))`, only the first N references ended up in the mapping; references brought into the page by the post-fetch sort had no group entry, so the slicer's group translator returned `IntStream.empty()` for them and their `groupEntity` was never fetched. Switching both retrievers to `entityDecorator.getDelegate().getReferences(refName)` — the raw unchunked view from the underlying Entity — covers every reference on the source entity regardless of pagination.

Coverage: `EntityReferencePaginationFunctionalTest` (17 tests, includes new strict `assertEquals(pageSize, groupEntitiesLoaded)` assertion on the group-sort fallback path), new `BitmapSlicerTest` (23 unit tests for the order-aware slice variant, per-source group accounting, page-beyond-last rebase, strip clamping), new `EntityDecoratorTest` (4 unit tests for the `sortAndFilterSubList` cumulative-counter delta-snapshot pattern), plus 216 regression tests across reference/order/group-having/duplicate paths.