### PR TITLE
fix: publish OffsetIndex shared state atomically to stop torn reads

### DIFF
--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
@@ -121,7 +121,7 @@ import static java.util.Optional.ofNullable;
  *
  * WRITE:
  * - writes record to the end of the mapped file
- * - stores returned {@link FileLocation} along with key to {@link #keyToLocations}
+ * - stores returned {@link FileLocation} along with key to {@link SharedState#keyToLocations()}
  *
  * READ:
  * - looks up {@link FileLocation} by the passed key (this is expected to be fast)
@@ -129,7 +129,7 @@ import static java.util.Optional.ofNullable;
  * - performance of this operation depends on the OS page cache - so the OS should have enough RAM left for this sake
  *
  * DELETE:
- * - removes record in the {@link #keyToLocations}
+ * - removes record in the {@link SharedState#keyToLocations()}
  * - information about the remove is also tracked in MemoryFragment (when written to disk) so that when OffsetIndex is
  * reconstructed from fragments the record inserted in previous fragments will be ignored as well
  *
@@ -139,7 +139,7 @@ import static java.util.Optional.ofNullable;
 @ThreadSafe
 public class OffsetIndex {
 	/**
-	 * Initial size of the central {@link #keyToLocations} index.
+	 * Initial size of the central {@link SharedState#keyToLocations()} index.
 	 */
 	public static final int KEY_HASH_MAP_INITIAL_SIZE = 65_536;
 	/**
@@ -245,9 +245,15 @@ public class OffsetIndex {
 	 */
 	@Getter private boolean operative = true;
 	/**
-	 * Contains the catalog version that conforms to the values in {@link #keyToLocations} state.
+	 * Immutable holder pairing the main record-location index with the catalog version it conforms to. Both values are
+	 * published atomically through this single volatile reference so that lock-free readers in
+	 * {@link #get(long, long, Class)} (and its sibling lookups) always observe a consistent
+	 * `(keyCatalogVersion, keyToLocations)` pair. Were the two published separately, a reader could observe a freshly
+	 * promoted map alongside a stale version, skip the historical fallback (because `catalogVersion < keyCatalogVersion`
+	 * would evaluate to false) and then filter out the only available - newer - location, spuriously returning
+	 * {@code null} for a record that actually exists.
 	 */
-	private long keyCatalogVersion;
+	private volatile SharedState sharedState;
 	/**
 	 * OffsetIndex descriptor used when creating OffsetIndex instance or created on last {@link #flush(long)} operation.
 	 * Contains all information necessary to read/write data in OffsetIndex instance using {@link Kryo}.
@@ -262,10 +268,17 @@ public class OffsetIndex {
 	 */
 	@Nullable private ReadOnlyKeyCompressorView readOnlyKeyCompressorView;
 	/**
-	 * Main index that keeps track of record keys file locations. Used for persisted record reading.
-	 * This map is completely replaced on each flush, so it could be "non-concurrent" map.
+	 * Immutable pair of the main record-location index and the catalog version it conforms to. See {@link #sharedState}
+	 * for the concurrency rationale. The `keyToLocations` map keeps track of record keys' file locations and is used for
+	 * persisted record reading; it is completely replaced on each flush, so it may be a "non-concurrent" map.
+	 *
+	 * @param keyCatalogVersion the catalog version that conforms to the values in `keyToLocations`
+	 * @param keyToLocations    the main index mapping record keys to their file locations
 	 */
-	private Map<RecordKey, FileLocation> keyToLocations;
+	private record SharedState(
+		long keyCatalogVersion,
+		@Nonnull Map<RecordKey, FileLocation> keyToLocations
+	) {}
 	/**
 	 * This field contains the information about last known position that has been synced to the file on disk and can
 	 * be safely read.
@@ -369,10 +382,12 @@ public class OffsetIndex {
 					readFileOffsetIndex(fileOffsetDescriptor.fileLocation())
 				);
 			}
-			this.keyCatalogVersion = catalogVersion;
-			this.keyToLocations = fileOffsetIndexBuilder
-				.map(CollectingOffsetIndexBuilder::getBuiltIndex)
-				.orElseGet(() -> CollectionUtils.createConcurrentHashMap(KEY_HASH_MAP_INITIAL_SIZE));
+			this.sharedState = new SharedState(
+				catalogVersion,
+				fileOffsetIndexBuilder
+					.map(CollectingOffsetIndexBuilder::getBuiltIndex)
+					.orElseGet(() -> CollectionUtils.createConcurrentHashMap(KEY_HASH_MAP_INITIAL_SIZE))
+			);
 			this.histogram = fileOffsetIndexBuilder
 				.map(CollectingOffsetIndexBuilder::getHistogram)
 				.orElseGet(() -> CollectionUtils.createConcurrentHashMap(HISTOGRAM_INITIAL_CAPACITY));
@@ -450,13 +465,12 @@ public class OffsetIndex {
 				fileLocation,
 				fileOffsetIndexBuilder
 			);
-			this.keyToLocations = fileOffsetIndexBuilder.getBuiltIndex();
+			this.sharedState = new SharedState(catalogVersion, fileOffsetIndexBuilder.getBuiltIndex());
 			this.histogram = fileOffsetIndexBuilder.getHistogram();
 			this.totalSizeBytes.set(fileOffsetIndexBuilder.getTotalSizeBytes());
 			this.maxRecordSizeBytes.set(fileOffsetIndexBuilder.getMaxSizeBytes());
 			this.fileOffsetDescriptor = offsetIndexDescriptorFactory.apply(fileOffsetIndexBuilder, input);
 			this.readOnlyKeyCompressorView = null;
-			this.keyCatalogVersion = catalogVersion;
 			this.readKryoPool = new FileOffsetIndexKryoPool(
 				maxOpenedReadHandlesOrDefault,
 				version -> this.fileOffsetDescriptor.getReadKryoFactory().apply(version)
@@ -517,13 +531,12 @@ public class OffsetIndex {
 			);
 		}
 
-		this.keyToLocations = previousOffsetIndex.keyToLocations;
+		this.sharedState = new SharedState(catalogVersion, previousOffsetIndex.sharedState.keyToLocations());
 		this.histogram = previousOffsetIndex.histogram;
 		this.totalSizeBytes.set(previousOffsetIndex.totalSizeBytes.get());
 		this.maxRecordSizeBytes.set(previousOffsetIndex.getMaxRecordSizeBytes());
 		this.fileOffsetDescriptor = fileOffsetIndexDescriptor;
 		this.readOnlyKeyCompressorView = null;
-		this.keyCatalogVersion = catalogVersion;
 		this.readKryoPool = new FileOffsetIndexKryoPool(
 			maxOpenedReadHandlesOrDefault,
 			version -> this.fileOffsetDescriptor.getReadKryoFactory().apply(version)
@@ -605,7 +618,7 @@ public class OffsetIndex {
 	 */
 	public Collection<Entry<RecordKey, FileLocation>> getEntries() {
 		assertOperative();
-		return Collections.unmodifiableCollection(this.keyToLocations.entrySet());
+		return Collections.unmodifiableCollection(this.sharedState.keyToLocations().entrySet());
 	}
 
 	/**
@@ -613,7 +626,7 @@ public class OffsetIndex {
 	 */
 	public int count(long catalogVersion) {
 		assertOperative();
-		return this.keyToLocations.size() + this.volatileValues.countDifference(catalogVersion);
+		return this.sharedState.keyToLocations().size() + this.volatileValues.countDifference(catalogVersion);
 	}
 
 	/**
@@ -658,7 +671,10 @@ public class OffsetIndex {
 			}
 		}
 
-		if (catalogVersion < this.keyCatalogVersion) {
+		// snapshot the shared state once so the historical-fallback guard and the current-state lookup below always
+		// observe a consistent (version, locations) pair - see the torn-read rationale on #sharedState
+		final SharedState state = this.sharedState;
+		if (catalogVersion < state.keyCatalogVersion()) {
 			final Optional<VolatileValueInformation> volatileValueRef = this.volatileValues.getVolatileValueInformation(catalogVersion, key);
 			if (volatileValueRef.isPresent()) {
 				final VolatileValueInformation volatileValue = volatileValueRef.get();
@@ -676,7 +692,7 @@ public class OffsetIndex {
 			}
 		}
 
-		return ofNullable(this.keyToLocations.get(key))
+		return ofNullable(state.keyToLocations().get(key))
 			.map(it -> doGet(recordType, primaryKey, it))
 			.filter(it -> it.generationId() <= catalogVersion)
 			.map(StorageRecord::payload)
@@ -730,7 +746,10 @@ public class OffsetIndex {
 			}
 		}
 
-		if (catalogVersion < this.keyCatalogVersion) {
+		// snapshot the shared state once so the historical-fallback guard and the current-state lookup below always
+		// observe a consistent (version, locations) pair - see the torn-read rationale on #sharedState
+		final SharedState state = this.sharedState;
+		if (catalogVersion < state.keyCatalogVersion()) {
 			final Optional<VolatileValueInformation> volatileValueRef = this.volatileValues.getVolatileValueInformation(catalogVersion, key);
 			if (volatileValueRef.isPresent()) {
 				final VolatileValueInformation volatileValue = volatileValueRef.get();
@@ -747,7 +766,7 @@ public class OffsetIndex {
 			}
 		}
 
-		return ofNullable(this.keyToLocations.get(key))
+		return ofNullable(state.keyToLocations().get(key))
 			.map(it -> doGetBinary(recordType, primaryKey, it))
 			.filter(it -> it.generationId() <= catalogVersion)
 			.map(StorageRecord::payload)
@@ -785,7 +804,10 @@ public class OffsetIndex {
 			return !nonFlushedValue.removed();
 		}
 
-		if (catalogVersion < this.keyCatalogVersion) {
+		// snapshot the shared state once so the historical-fallback guard and the current-state lookup below always
+		// observe a consistent (version, locations) pair - see the torn-read rationale on #sharedState
+		final SharedState state = this.sharedState;
+		if (catalogVersion < state.keyCatalogVersion()) {
 			final Optional<VolatileValueInformation> volatileValueRef = this.volatileValues.getVolatileValueInformation(catalogVersion, key);
 			if (volatileValueRef.isPresent()) {
 				final VolatileValueInformation volatileValue = volatileValueRef.get();
@@ -793,7 +815,7 @@ public class OffsetIndex {
 			}
 		}
 
-		return this.keyToLocations.containsKey(key);
+		return state.keyToLocations().containsKey(key);
 	}
 
 	/**
@@ -886,8 +908,14 @@ public class OffsetIndex {
 	@Nonnull
 	public OffsetIndexDescriptor flush(long catalogVersion) {
 		assertOperative();
-		this.keyCatalogVersion = catalogVersion;
 		this.fileOffsetDescriptor = doFlush(catalogVersion, this.fileOffsetDescriptor, false);
+		// when there were non-flushed values, doFlush already republished the shared state (version + locations)
+		// atomically; when there was nothing to promote, advance the conforming version while keeping the current
+		// locations, preserving the original invariant that a flush always moves the key catalog version forward
+		final SharedState currentState = this.sharedState;
+		if (currentState.keyCatalogVersion() != catalogVersion) {
+			this.sharedState = new SharedState(catalogVersion, currentState.keyToLocations());
+		}
 		this.readOnlyKeyCompressorView = null;
 		return this.fileOffsetDescriptor;
 	}
@@ -1009,7 +1037,7 @@ public class OffsetIndex {
 				this.fileOffsetDescriptor = doFlush(
 					// if there are any non-flushed values, use their version as the last version
 					this.volatileValues.getLastNonFlushedCatalogVersionIfExists()
-						.orElse(this.keyCatalogVersion),
+						.orElse(this.sharedState.keyCatalogVersion()),
 					this.fileOffsetDescriptor,
 					true
 				);
@@ -1123,7 +1151,7 @@ public class OffsetIndex {
 	 * @return the total size
 	 */
 	public long getTotalSizeBytes() {
-		return this.totalSizeBytes.get() + (long) this.keyToLocations.size() * (long) MEM_TABLE_RECORD_SIZE;
+		return this.totalSizeBytes.get() + (long) this.sharedState.keyToLocations().size() * (long) MEM_TABLE_RECORD_SIZE;
 	}
 
 	/**
@@ -1158,7 +1186,7 @@ public class OffsetIndex {
 	}
 
 	/**
-	 * Creates new file that contains only records directly reachable from {@link #keyToLocations} index. While
+	 * Creates new file that contains only records directly reachable from {@link SharedState#keyToLocations()} index. While
 	 * compacting, the original offset index is locked for writing (but reading is still possible).
 	 *
 	 * Original file remains unchanged and must be removed later manually when the history is no longer needed.
@@ -1169,7 +1197,7 @@ public class OffsetIndex {
 	@Nonnull
 	public OffsetIndexDescriptor compact(@Nonnull Path newFilePath) {
 		try (final FileOutputStream fos = new FileOutputStream(newFilePath.toFile())) {
-			return copySnapshotTo(fos, null, this.keyCatalogVersion);
+			return copySnapshotTo(fos, null, this.sharedState.keyCatalogVersion());
 		} catch (IOException e) {
 			throw new UnexpectedIOException(
 				"Error occurred while compacting the snapshot to the new file: " + e.getMessage(),
@@ -1184,7 +1212,7 @@ public class OffsetIndex {
 	 */
 	Collection<RecordKey> getKeys() {
 		assertOperative();
-		return Collections.unmodifiableCollection(this.keyToLocations.keySet());
+		return Collections.unmodifiableCollection(this.sharedState.keyToLocations().keySet());
 	}
 
 	/**
@@ -1192,7 +1220,7 @@ public class OffsetIndex {
 	 */
 	Collection<FileLocation> getFileLocations() {
 		assertOperative();
-		return Collections.unmodifiableCollection(this.keyToLocations.values());
+		return Collections.unmodifiableCollection(this.sharedState.keyToLocations().values());
 	}
 
 	/**
@@ -1200,7 +1228,7 @@ public class OffsetIndex {
 	 */
 	boolean fileOffsetIndexEquals(@Nonnull OffsetIndex o) {
 		if (this == o) return true;
-		return this.keyToLocations.equals(o.keyToLocations);
+		return this.sharedState.keyToLocations().equals(o.sharedState.keyToLocations());
 	}
 
 	/**
@@ -1240,7 +1268,7 @@ public class OffsetIndex {
 	 */
 	private long getTotalActiveSize() {
 		return this.totalSizeBytes.get() +
-			countFileOffsetTableSize(this.keyToLocations.size(), this.outputBufferSize);
+			countFileOffsetTableSize(this.sharedState.keyToLocations().size(), this.outputBufferSize);
 	}
 
 	/**
@@ -1314,6 +1342,7 @@ public class OffsetIndex {
 					this.lastSyncedPosition = this.writeHandle.getLastWrittenPosition();
 					// now empty all NonFlushedValueSet and move them to current state
 					promoteNonFlushedValuesToSharedState(
+						catalogVersion,
 						nonFlushedValuesWithFileLocation.valueCount(),
 						nonFlushedValuesWithFileLocation.nonFlushedValueSets()
 					);
@@ -1381,17 +1410,25 @@ public class OffsetIndex {
 	}
 
 	/**
-	 * Method moves all `nonFlushedValues` to a `keyToLocations` entries and purges them from the main memory.
+	 * Method moves all `nonFlushedValues` to a `keyToLocations` entries and purges them from the main memory. The new
+	 * locations map and the `catalogVersion` it conforms to are published together through a single
+	 * {@link #sharedState} volatile write, so lock-free readers never observe a torn `(version, locations)` pair.
+	 *
+	 * @param catalogVersion       the catalog version stamped onto the freshly published `keyToLocations` map; this is
+	 *                             the conforming version that readers compare against in {@link #get(long, long, Class)}
+	 * @param valueCount           the number of promoted values, used to pre-size the new locations map
+	 * @param nonFlushedValueSets  the non-flushed value sets to promote to the shared state
 	 */
-	private void promoteNonFlushedValuesToSharedState(int valueCount, @Nonnull Collection<NonFlushedValueSet> nonFlushedValueSets) {
-		this.volatileValues.recordHistoricalVersions(nonFlushedValueSets, this.keyToLocations);
+	private void promoteNonFlushedValuesToSharedState(long catalogVersion, int valueCount, @Nonnull Collection<NonFlushedValueSet> nonFlushedValueSets) {
+		final Map<RecordKey, FileLocation> currentLocations = this.sharedState.keyToLocations();
+		this.volatileValues.recordHistoricalVersions(nonFlushedValueSets, currentLocations);
 		// promote changes to shared state
 		final Map<RecordKey, FileLocation> newKeyToLocations = createHashMap(
-			this.keyToLocations.size() + valueCount
+			currentLocations.size() + valueCount
 		);
 		// we need to start with the original set - this is expensive operation - it would be much better to
 		// have something like persistent map that would allow us to create new instance with reusing the old segments
-		newKeyToLocations.putAll(this.keyToLocations);
+		newKeyToLocations.putAll(currentLocations);
 
 		long workingMaxRecordSize = this.maxRecordSizeBytes.get();
 		long recordLengthDelta = 0;
@@ -1448,8 +1485,9 @@ public class OffsetIndex {
 		for (Entry<Byte, Integer> entry : histogramDiff.entrySet()) {
 			this.histogram.merge(entry.getKey(), entry.getValue(), Integer::sum);
 		}
-		// and the locations finally
-		this.keyToLocations = newKeyToLocations;
+		// and the locations finally - publish the new map together with its conforming catalog version through a
+		// single volatile write, so lock-free readers never observe a torn (version, locations) pair
+		this.sharedState = new SharedState(catalogVersion, newKeyToLocations);
 	}
 
 	/**
@@ -1460,7 +1498,7 @@ public class OffsetIndex {
 		final byte recordType = this.recordTypeRegistry.idFor(value.getClass());
 		final RecordKey key = new RecordKey(recordType, primaryKey);
 
-		final boolean update = this.keyToLocations.containsKey(key);
+		final boolean update = this.sharedState.keyToLocations().containsKey(key);
 		final FileLocation recordLocation = new StorageRecord<>(
 			this.writeKryo,
 			exclusiveWriteAccess,
@@ -1496,7 +1534,10 @@ public class OffsetIndex {
 			}
 		}
 
-		if (catalogVersion < this.keyCatalogVersion) {
+		// snapshot the shared state once so the historical-fallback guard and the current-state lookup below always
+		// observe a consistent (version, locations) pair - see the torn-read rationale on #sharedState
+		final SharedState state = this.sharedState;
+		if (catalogVersion < state.keyCatalogVersion()) {
 			final Optional<VolatileValueInformation> volatileValueRef = this.volatileValues.getVolatileValueInformation(catalogVersion, key);
 			if (volatileValueRef.isPresent()) {
 				final VolatileValueInformation volatileValue = volatileValueRef.get();
@@ -1506,7 +1547,7 @@ public class OffsetIndex {
 			}
 		}
 
-		final FileLocation currentLocation = this.keyToLocations.get(key);
+		final FileLocation currentLocation = state.keyToLocations().get(key);
 		if (currentLocation == null) {
 			return false;
 		} else {
@@ -1975,7 +2016,7 @@ public class OffsetIndex {
 					// on exact match, skip the matched version (its diff is already reflected in the histogram);
 					// on miss, -index-1 is the insertion point — the first version greater than catalogVersion,
 					// which must be included in the subtraction. When catalogVersion precedes all historical
-					// versions (binarySearch returns -1, insertion point 0), every entry must be subtracted (issue #1162).
+					// versions (binarySearch returns -1, insertion point 0), every entry must be subtracted.
 					final int startIndex = index >= 0 ? index + 1 : -index - 1;
 					for (int ix = hv.length - 1; ix >= startIndex; ix--) {
 						final PastMemory differenceSet = hvValues.get(hv[ix]);
@@ -2065,10 +2106,11 @@ public class OffsetIndex {
 				boolean addedInFuture = false;
 				for (int ix = startIndex; ix < hv.length; ix++) {
 					final long examinedVersion = hv[ix];
+					// hvValues is the shared ConcurrentHashMap; a concurrent purge can remove an entry after we
+					// snapshotted the historicalVersions array under the lock, so guard against a missing value
 					final PastMemory pastMemory = hvValues.get(examinedVersion);
-					if (pastMemory.getRemovedKeys().contains(key)) {
-						//noinspection DataFlowIssue
-						addedInFuture = false;
+					if (pastMemory == null) {
+						continue;
 					}
 					if (pastMemory.getAddedKeys().contains(key) && examinedVersion != catalogVersion) {
 						addedInFuture = true;
@@ -2266,7 +2308,7 @@ public class OffsetIndex {
 				Optional.ofNullable(this.volatileValues)
 					.map(vv -> vv.values().stream().mapToLong(it -> MemoryMeasuringConstants.LONG_SIZE + it.getTotalSize()).sum())
 					.orElse(0L)
-				+ MemoryMeasuringConstants.OBJECT_HEADER_SIZE * 4
+				+ (MemoryMeasuringConstants.OBJECT_HEADER_SIZE << 2)
 				+ MemoryMeasuringConstants.INT_SIZE + MemoryMeasuringConstants.LONG_SIZE;
 		}
 
@@ -2277,18 +2319,33 @@ public class OffsetIndex {
 		 */
 		@Nonnull
 		public Optional<OffsetDateTime> getOldestRecordKeptTimestamp() {
-			return ofNullable(this.volatileValues)
-				.map(it -> {
-					final long index = ofNullable(this.historicalVersions)
-						.filter(hv -> !ArrayUtils.isEmpty(hv))
-						.map(hv -> hv[0])
-						.orElse(-1L);
-					return index == -1 ? null :
-						OffsetDateTime.ofInstant(
-							Instant.ofEpochMilli(it.get(index).getTimestamp()),
-							ZoneId.systemDefault()
-						);
-				});
+			// snapshot both fields under the lock - mirrors getVolatileValueInformation/countDifference -
+			// so the head historical version and the volatile values map come from the same consistent state
+			final long[] hv;
+			final ConcurrentHashMap<Long, PastMemory> hvValues;
+			try {
+				this.lock.lock();
+				hvValues = this.volatileValues;
+				hv = this.historicalVersions;
+			} finally {
+				this.lock.unlock();
+			}
+			if (hvValues == null || ArrayUtils.isEmpty(hv)) {
+				return empty();
+			}
+			// the oldest kept record is the head of the historical versions
+			final PastMemory pastMemory = hvValues.get(hv[0]);
+			// a concurrent purge can remove the head entry after we snapshotted the array; the purge
+			// contract guarantees no client needs that version, so an empty result is the correct answer
+			if (pastMemory == null) {
+				return empty();
+			}
+			return of(
+				OffsetDateTime.ofInstant(
+					Instant.ofEpochMilli(pastMemory.getTimestamp()),
+					ZoneId.systemDefault()
+				)
+			);
 		}
 
 		/**

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/OffsetIndex.java
@@ -614,11 +614,13 @@ public class OffsetIndex {
 	}
 
 	/**
-	 * Returns unmodifiable collection of all ACTIVE entries in the OffsetIndex.
+	 * Returns unmodifiable collection of all ACTIVE entries in the OffsetIndex. The entries are wrapped via
+	 * {@link Collections#unmodifiableMap(Map)} so that callers cannot mutate the published - and by the
+	 * {@link SharedState} contract immutable - locations map through {@link Entry#setValue(Object)}.
 	 */
 	public Collection<Entry<RecordKey, FileLocation>> getEntries() {
 		assertOperative();
-		return Collections.unmodifiableCollection(this.sharedState.keyToLocations().entrySet());
+		return Collections.unmodifiableMap(this.sharedState.keyToLocations()).entrySet();
 	}
 
 	/**
@@ -909,11 +911,14 @@ public class OffsetIndex {
 	public OffsetIndexDescriptor flush(long catalogVersion) {
 		assertOperative();
 		this.fileOffsetDescriptor = doFlush(catalogVersion, this.fileOffsetDescriptor, false);
-		// when there were non-flushed values, doFlush already republished the shared state (version + locations)
+		// flush runs under the single-writer model: all writes (including the promotion inside doFlush) are
+		// serialized by the writeHandle ReentrantLock, so no other thread mutates sharedState concurrently here.
+		// When there were non-flushed values, doFlush already republished the shared state (version + locations)
 		// atomically; when there was nothing to promote, advance the conforming version while keeping the current
-		// locations, preserving the original invariant that a flush always moves the key catalog version forward
+		// locations. The guard is strictly monotonic (`<`, not `!=`) so the key catalog version can only move
+		// forward - it never regresses even if this assumption were ever violated.
 		final SharedState currentState = this.sharedState;
-		if (currentState.keyCatalogVersion() != catalogVersion) {
+		if (currentState.keyCatalogVersion() < catalogVersion) {
 			this.sharedState = new SharedState(catalogVersion, currentState.keyToLocations());
 		}
 		this.readOnlyKeyCompressorView = null;
@@ -2115,6 +2120,11 @@ public class OffsetIndex {
 					if (pastMemory.getAddedKeys().contains(key) && examinedVersion != catalogVersion) {
 						addedInFuture = true;
 					}
+					// note: there is intentionally no "removed key resets addedInFuture" branch here. Whenever
+					// addedInFuture is set to true above, the very same iteration immediately falls into the
+					// block below and returns (either via previousValue or via the addedInFuture branch). The
+					// loop can therefore only advance to the next version while addedInFuture is still false, so
+					// a reset tied to getRemovedKeys() would always be a no-op and was removed as dead code.
 					// we must skip the current version, because it contains previous value that was overwritten
 					// not the currently valid one
 					if (examinedVersion != catalogVersion) {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexTest.java
@@ -86,6 +86,7 @@ import static io.evitadb.store.offsetIndex.OffsetIndexSerializationService.compu
 import static io.evitadb.test.TestTags.MANAGEMENT;
 import static io.evitadb.test.TestTags.STORAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -705,7 +706,7 @@ class OffsetIndexTest implements EvitaTestSupport {
 		}
 	}
 
-	@DisplayName("count() should return the correct value at a catalog version that was never flushed (issue #1162)")
+	@DisplayName("count() should return the correct value at a catalog version that was never flushed")
 	@Test
 	void shouldReturnCorrectCountAtUnflushedCatalogVersionBetweenHistoricalVersions() {
 		final StorageSettings storageSettings = new StorageSettings(
@@ -749,7 +750,7 @@ class OffsetIndexTest implements EvitaTestSupport {
 		}
 	}
 
-	@DisplayName("count() should return the correct value at a catalog version older than every historical entry (issue #1162)")
+	@DisplayName("count() should return the correct value at a catalog version older than every historical entry")
 	@Test
 	void shouldReturnCorrectCountAtCatalogVersionPrecedingAllHistoricalVersions() {
 		final StorageSettings storageSettings = new StorageSettings(
@@ -775,6 +776,197 @@ class OffsetIndexTest implements EvitaTestSupport {
 				assertEquals(0, offsetIndex.count(3L), "count at v3 should be 0 (nothing was added before v5)");
 				assertEquals(0, offsetIndex.count(4L), "count at v4 should be 0 (nothing was added before v5)");
 				assertEquals(2, offsetIndex.count(5L), "count at v5 should see both records");
+			} finally {
+				IOUtils.closeQuietly(offsetIndex::close);
+			}
+		}
+	}
+
+	@DisplayName("get() should resolve a record at past catalog versions across flushes")
+	@Test
+	void shouldResolveGetAtPastCatalogVersionAcrossFlushes() {
+		final StorageSettings storageSettings = new StorageSettings(
+			StorageOptions.temporary(),
+			DEFAULT_TRANSACTION_OPTIONS
+		);
+		try (final ObservableOutputKeeper observableOutputKeeper = createMockedObservableOutputKeeper()) {
+			final OffsetIndex offsetIndex = createNewOffsetIndex(
+				0L,
+				storageSettings,
+				createWriteOnlyFileHandle(this.targetFile, storageSettings, observableOutputKeeper),
+				this.offsetIndexRecordTypeRegistry
+			);
+			try {
+				final EntityBodyStoragePart originalR1 = bodyPartWithLocale(1, 1, Locale.ENGLISH);
+				final EntityBodyStoragePart updatedR1 = bodyPartWithLocale(2, 1, Locale.GERMAN);
+
+				// version 1: insert R1, flush
+				offsetIndex.put(1L, originalR1);
+				offsetIndex.flush(1L);
+				// version 2: overwrite R1 with a distinguishable payload, flush
+				offsetIndex.put(2L, updatedR1);
+				offsetIndex.flush(2L);
+				// version 3: remove an unrelated record R2 so the historical state advances again
+				offsetIndex.put(3L, new EntityBodyStoragePart(2));
+				offsetIndex.remove(3L, 2, EntityBodyStoragePart.class);
+				offsetIndex.flush(3L);
+
+				assertEquals(
+					originalR1,
+					offsetIndex.get(1L, 1, EntityBodyStoragePart.class),
+					"get at v1 should return the original payload"
+				);
+				assertEquals(
+					updatedR1,
+					offsetIndex.get(2L, 1, EntityBodyStoragePart.class),
+					"get at v2 should return the overwritten payload"
+				);
+				assertEquals(
+					updatedR1,
+					offsetIndex.get(3L, 1, EntityBodyStoragePart.class),
+					"get at the current version should return the latest payload"
+				);
+			} finally {
+				IOUtils.closeQuietly(offsetIndex::close);
+			}
+		}
+	}
+
+	@DisplayName("contains() should resolve presence at past and future catalog versions")
+	@Test
+	void shouldResolveContainsAtPastAndFutureCatalogVersions() {
+		final StorageSettings storageSettings = new StorageSettings(
+			StorageOptions.temporary(),
+			DEFAULT_TRANSACTION_OPTIONS
+		);
+		try (final ObservableOutputKeeper observableOutputKeeper = createMockedObservableOutputKeeper()) {
+			final OffsetIndex offsetIndex = createNewOffsetIndex(
+				0L,
+				storageSettings,
+				createWriteOnlyFileHandle(this.targetFile, storageSettings, observableOutputKeeper),
+				this.offsetIndexRecordTypeRegistry
+			);
+			try {
+				// establish an earlier flushed version so v1 precedes the record's insertion
+				offsetIndex.put(1L, new EntityBodyStoragePart(9));
+				offsetIndex.flush(1L);
+				// version 2: insert R, flush
+				offsetIndex.put(2L, new EntityBodyStoragePart(1));
+				offsetIndex.flush(2L);
+
+				assertFalse(
+					offsetIndex.contains(1L, 1, EntityBodyStoragePart.class),
+					"contains at v1 should be false (R was added at v2)"
+				);
+				assertTrue(
+					offsetIndex.contains(2L, 1, EntityBodyStoragePart.class),
+					"contains at v2 should be true"
+				);
+
+				// version 3: remove R, flush
+				offsetIndex.remove(3L, 1, EntityBodyStoragePart.class);
+				offsetIndex.flush(3L);
+
+				assertTrue(
+					offsetIndex.contains(2L, 1, EntityBodyStoragePart.class),
+					"contains at v2 should still be true after later removal"
+				);
+				assertFalse(
+					offsetIndex.contains(3L, 1, EntityBodyStoragePart.class),
+					"contains at v3 should be false after removal"
+				);
+			} finally {
+				IOUtils.closeQuietly(offsetIndex::close);
+			}
+		}
+	}
+
+	@DisplayName("getBinary() should resolve a record at past catalog versions across flushes")
+	@Test
+	void shouldResolveGetBinaryAtPastCatalogVersionAcrossFlushes() {
+		final StorageSettings storageSettings = new StorageSettings(
+			StorageOptions.temporary(),
+			DEFAULT_TRANSACTION_OPTIONS
+		);
+		try (final ObservableOutputKeeper observableOutputKeeper = createMockedObservableOutputKeeper()) {
+			final OffsetIndex offsetIndex = createNewOffsetIndex(
+				0L,
+				storageSettings,
+				createWriteOnlyFileHandle(this.targetFile, storageSettings, observableOutputKeeper),
+				this.offsetIndexRecordTypeRegistry
+			);
+			try {
+				final EntityBodyStoragePart originalR1 = bodyPartWithLocale(1, 1, Locale.ENGLISH);
+				final EntityBodyStoragePart updatedR1 = bodyPartWithLocale(2, 1, Locale.GERMAN);
+
+				// version 1: insert R1, flush
+				offsetIndex.put(1L, originalR1);
+				offsetIndex.flush(1L);
+				// version 2: overwrite R1 with a distinguishable payload, flush
+				offsetIndex.put(2L, updatedR1);
+				offsetIndex.flush(2L);
+				// version 3: remove an unrelated record R2 so the historical state advances again
+				offsetIndex.put(3L, new EntityBodyStoragePart(2));
+				offsetIndex.remove(3L, 2, EntityBodyStoragePart.class);
+				offsetIndex.flush(3L);
+
+				final VersionedKryo kryo = createKryo()
+					.apply(new VersionedKryoKeyInputs(offsetIndex.getReadOnlyKeyCompressor(), 1));
+
+				assertEquals(
+					originalR1,
+					deserialize(kryo, offsetIndex.getBinary(1L, 1, EntityBodyStoragePart.class)),
+					"getBinary at v1 should return the original payload"
+				);
+				assertEquals(
+					updatedR1,
+					deserialize(kryo, offsetIndex.getBinary(2L, 1, EntityBodyStoragePart.class)),
+					"getBinary at v2 should return the overwritten payload"
+				);
+				assertEquals(
+					updatedR1,
+					deserialize(kryo, offsetIndex.getBinary(3L, 1, EntityBodyStoragePart.class)),
+					"getBinary at the current version should return the latest payload"
+				);
+			} finally {
+				IOUtils.closeQuietly(offsetIndex::close);
+			}
+		}
+	}
+
+	@DisplayName("flush() with no intervening writes should advance the key catalog version")
+	@Test
+	void shouldAdvanceKeyCatalogVersionOnEmptyFlush() {
+		final StorageSettings storageSettings = new StorageSettings(
+			StorageOptions.temporary(),
+			DEFAULT_TRANSACTION_OPTIONS
+		);
+		try (final ObservableOutputKeeper observableOutputKeeper = createMockedObservableOutputKeeper()) {
+			final OffsetIndex offsetIndex = createNewOffsetIndex(
+				0L,
+				storageSettings,
+				createWriteOnlyFileHandle(this.targetFile, storageSettings, observableOutputKeeper),
+				this.offsetIndexRecordTypeRegistry
+			);
+			try {
+				final EntityBodyStoragePart r1 = new EntityBodyStoragePart(1);
+				// version 1: insert R1, flush
+				offsetIndex.put(1L, r1);
+				offsetIndex.flush(1L);
+				// version 2: empty flush — advances the key catalog version with no writes
+				offsetIndex.flush(2L);
+
+				assertEquals(
+					r1,
+					offsetIndex.get(1L, 1, EntityBodyStoragePart.class),
+					"get at v1 should still return R1 after an empty flush"
+				);
+				assertEquals(
+					r1,
+					offsetIndex.get(2L, 1, EntityBodyStoragePart.class),
+					"get at the advanced version should resolve R1 from current state"
+				);
+				assertEquals(1, offsetIndex.count(2L), "count at v2 should still see R1");
 			} finally {
 				IOUtils.closeQuietly(offsetIndex::close);
 			}
@@ -909,6 +1101,45 @@ class OffsetIndexTest implements EvitaTestSupport {
 			this.offsetIndexRecordTypeRegistry
 		);
 		return createRecordsInFileOffsetIndex(fileOffsetIndex, recordCount, removedRecords, iterationCount);
+	}
+
+	/**
+	 * Builds an {@link EntityBodyStoragePart} that is distinguishable by its `version` and `locales`
+	 * while sharing the supplied `primaryKey`. This lets a test overwrite a record at the same key
+	 * with a payload that is not {@link Object#equals(Object) equal} to the previous one.
+	 *
+	 * @param version    entity version stored in the payload
+	 * @param primaryKey primary key shared across overwrites of the same record
+	 * @param locale     single locale used to make the payload distinguishable
+	 * @return a new, immutable payload instance
+	 */
+	@Nonnull
+	private static EntityBodyStoragePart bodyPartWithLocale(int version, int primaryKey,
+		@Nonnull Locale locale) {
+		return new EntityBodyStoragePart(
+			version,
+			primaryKey,
+			Scope.LIVE,
+			null,
+			new HashSet<>(Set.of(locale)),
+			new HashSet<>(),
+			new HashSet<>(),
+			-1
+		);
+	}
+
+	/**
+	 * Deserializes the binary payload returned by {@link OffsetIndex#getBinary(long, long, Class)}
+	 * back into an {@link EntityBodyStoragePart} using the supplied configured {@link VersionedKryo}.
+	 *
+	 * @param kryo   configured Kryo instance bound to the index key compressor
+	 * @param binary serialized payload (never `null` in the covered scenarios)
+	 * @return the deserialized payload
+	 */
+	@Nonnull
+	private static EntityBodyStoragePart deserialize(@Nonnull VersionedKryo kryo,
+		@Nonnull byte[] binary) {
+		return kryo.readObject(new Input(binary), EntityBodyStoragePart.class);
 	}
 
 	private enum ChecksumCheck {

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/reference/LongRunningTransactionalReferenceTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/reference/LongRunningTransactionalReferenceTest.java
@@ -70,6 +70,11 @@ class LongRunningTransactionalReferenceTest implements TimeBoundedTestSupport {
 				assertStateAfterCommit(
 					transactionalBoolean,
 					original -> {
+						// seed the expected value with the reference's initial state, so that a
+						// transaction performing zero operations still compares against the correct
+						// current value instead of a stale (or null) value from a previous iteration
+						nextBooleanToCompare.set(testState.initialState());
+
 						final int operationsInTransaction = random.nextInt(100);
 						for (int i = 0; i < operationsInTransaction; i++) {
 							if (random.nextBoolean()) {


### PR DESCRIPTION
Closes #1189

Fixes two independent defects surfaced by long-running test run [#26377471824](https://github.com/FgForrest/evitaDB/actions/runs/26377471824).

## 1. `OffsetIndex` torn-read race (product bug)

The conforming catalog version and the record-location map lived in two separate non-volatile fields (`keyCatalogVersion`, `keyToLocations`), published independently while a background trunk-incorporation thread replaces the index on flush. A lock-free reader could observe a freshly promoted map paired with a stale version, skip the historical-fallback path, and then filter out the only available (newer) location by generation — spuriously returning `null` for a record that exists.

**Fix:** combine both values into an immutable `SharedState` record published through a single `volatile` reference. Every lock-free reader (`get`, `getBinary`, `contains`, `doRemove`) snapshots it exactly once, so the fallback guard and the current-state lookup always see a consistent `(version, locations)` pair. `flush` advances the conforming version while preserving the original move-forward invariant.

Also null-guards the historical-version read paths (`getVolatileValueInformation`, `getOldestRecordKeptTimestamp`) against a concurrent `PastMemory` purge — the same race family — and drops a provably-dead `addedInFuture` reset.

## 2. `LongRunningTransactionalReferenceTest` seeding bug (test harness)

The generational proof test never re-seeded `nextBooleanToCompare` on iteration entry. A zero-operation transaction therefore compared the committed value against a stale expectation carried over from a previous iteration, producing a false failure unrelated to `TransactionalReference`.

**Fix:** seed the expected value from the reference's initial state at the start of each in-transaction lambda.

## Verification

- `OffsetIndexTest` + `OffsetIndexSerializationServiceTest`: 36/36 green (incl. 4 new tests covering version resolution across flushes and the empty-flush version-advance invariant).
- `LongRunningOffsetIndexTest`: 2/2 green under churn after the change.
- Original failing seeds for both failures re-run clean.
