### PR TITLE
fix: substitute stale records in transactional change layers on content change

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/ContentComparator.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/ContentComparator.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.api.requestResponse.data;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -40,5 +41,23 @@ public interface ContentComparator<T> {
 	 * equal types.
 	 */
 	boolean differsFrom(@Nullable T otherObject);
+
+	/**
+	 * Returns true when {@code candidate} carries different content than {@code existing}, where both
+	 * are considered identity-equal by some external comparator (typically the equals/hashCode pair
+	 * defined on a primary key). Prefers the explicit {@link ContentComparator} contract; falls back
+	 * to {@link Object#equals} so types whose equals semantics already imply content equality keep
+	 * working as before.
+	 */
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	static <T> boolean contentDiffers(@Nonnull T existing, @Nonnull T candidate) {
+		if (existing == candidate) {
+			return false;
+		}
+		if (candidate instanceof ContentComparator) {
+			return ((ContentComparator) candidate).differsFrom(existing);
+		}
+		return !existing.equals(candidate);
+	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.index.array;
 
+import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.ArrayUtils.InsertionPosition;
 import lombok.Getter;
@@ -35,36 +36,57 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 /**
- * Support class that handles isolated transactional changes upon an Comparable array.
- * This data object is not thread safe and contains modification layer data that can be merged with immutable delegate
- * array to produce new array with requested modifications.
+ * Transactional change layer for a sorted object array. Accumulates insertions and removals made within a
+ * single transaction and produces the merged result on demand via {@link #getMergedArray()}, without modifying
+ * the immutable delegate array seen by concurrent readers.
+ *
+ * The change layer is keyed by the element's *comparator identity* (the same comparator used to maintain
+ * sort order in the delegate). When an element's identity matches an existing entry but its *content* has
+ * changed (detected via {@link io.evitadb.api.requestResponse.data.ContentComparator#differsFrom} when
+ * the type implements it, otherwise via `Object.equals`), the layer records a paired remove + insert that
+ * atomically substitutes the old instance with the new one during the merge step. This prevents a price-index
+ * staleness class of bug where a record removed and re-added in the same transaction with the same
+ * `internalPriceId` but a different `priceWithTax` was silently dropped.
+ *
+ * Typical flow inside a transaction:
+ * 1. {@link TransactionalObjArray#add}/{@link TransactionalObjArray#remove} delegate to
+ *    {@link #addRecordId}/{@link #removeRecordId}.
+ * 2. On commit, {@link #getMergedArray()} is called once; the result is memoized so repeated calls within
+ *    the same transaction are cheap.
+ * 3. The memoized result is invalidated by every subsequent mutation.
+ *
+ * Not thread-safe — one instance is owned by exactly one transaction thread.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
 @NotThreadSafe
 public class ObjArrayChanges<T> {
 	/**
-	 * Unmodifiable underlying array.
+	 * Immutable snapshot of the array as it existed when the transaction opened. Never modified.
 	 */
 	private final T[] delegate;
 	/**
-	 * Array of positions (indexes) in delegate array where insertions are expected to occur.
+	 * Sorted array of delegate positions (zero-based indexes) at which pending insertions should be spliced in.
+	 * Parallel to {@link #insertedValues}: `insertions[i]` is the delegate position for the bucket
+	 * `insertedValues[i]`.
 	 */
 	private int[] insertions = ArrayUtils.EMPTY_INT_ARRAY;
 	/**
-	 * Two-dimensional array where there are recordIds (in second dimension) expected to be inserted at particular
-	 * position in delegate. The position is retrieved from {@link #insertions} on the same index as index of first
-	 * dimension in this array.
+	 * Parallel to {@link #insertions}: for each pending insertion position, the sorted bucket of records to
+	 * splice in at that position. A bucket may contain more than one record when multiple distinct elements sort
+	 * into the same slot between two delegate entries.
 	 */
 	@SuppressWarnings("unchecked")
 	private InsertionBucket<T>[] insertedValues = new InsertionBucket[0];
 	/**
-	 * Array of positions (indexes) in delegate array where removals are expected to occur.
+	 * Sorted array of delegate positions whose original elements have been removed (or replaced) in this
+	 * transaction. When a position appears in both {@link #insertions} and this array, the merge step
+	 * replaces the original element with the new one (content-substitution).
 	 */
 	private int[] removals = ArrayUtils.EMPTY_INT_ARRAY;
 	/**
-	 * Temporary intermediate result of the last {@link #getMergedArray()} operation. Nullified immediately with next
-	 * change.
+	 * Cached result of the most recent {@link #getMergedArray()} call. Nullified on every mutation so
+	 * repeated reads within the same quiescent period are allocation-free.
 	 */
 	@Nullable private T[] memoizedMergedArray;
 
@@ -178,34 +200,105 @@ public class ObjArrayChanges<T> {
 	}
 
 	/**
-	 * Adds new recordId to the array (only when not already present).
-	 * This operation also nullifies previous record id removal (if any).
+	 * Records an insertion of `recordId` into the change layer, with three distinct cases based on the
+	 * relationship between the new record and the base delegate:
+	 *
+	 * **Content substitution** — when the delegate already holds a record with the same comparator key
+	 * but different content (detected via {@link io.evitadb.api.requestResponse.data.ContentComparator#differsFrom}
+	 * when the type implements it, otherwise via `Object.equals`): the original delegate position is marked
+	 * for removal AND the new instance is queued for insertion at the same position. The merge step
+	 * therefore atomically replaces the stale record. This is the fix for the price-index staleness bug
+	 * where a price with an unchanged `internalPriceId` but a modified `priceWithTax` was silently dropped.
+	 *
+	 * **Idempotent re-add** — when a matching record exists in the delegate, was previously marked for
+	 * removal in this transaction, and the new instance carries equal content: the pending removal is
+	 * cancelled, restoring the element.
+	 *
+	 * **Fresh insertion** — when no matching record exists in the delegate: the new instance is appended
+	 * to the appropriate {@link InsertionBucket} in the change layer.
+	 *
+	 * @param recordId   the record to add or substitute; must not be null
+	 * @param comparator the same comparator that governs the sort order of the delegate array
 	 */
 	void addRecordId(@Nonnull T recordId, @Nonnull Comparator<T> comparator) {
 		final InsertionPosition position = ArrayUtils.computeInsertPositionOfObjInOrderedArray(recordId, this.delegate, comparator);
-		// record id was already part of the array, but may have been removed
+		final int positionIndex = position.position();
 		if (position.alreadyPresent()) {
-			int removalIndex = Arrays.binarySearch(this.removals, position.position());
-			if (removalIndex >= 0) {
-				// just remove the position from the removals
+			// base delegate already holds a record with the same comparator key
+			final T existing = this.delegate[positionIndex];
+			final int removalIndex = Arrays.binarySearch(this.removals, positionIndex);
+			if (contentDiffers(existing, recordId)) {
+				// identity matches but content differs - substitute the record:
+				// ensure the original position is marked for removal AND queue an insertion of
+				// the new instance at the same logical position
+				if (removalIndex < 0) {
+					this.removals = ArrayUtils.insertIntIntoOrderedArray(positionIndex, this.removals);
+				}
+				insertIntoChangeLayer(recordId, positionIndex, comparator);
+			} else if (removalIndex >= 0) {
+				// contents are equal - cancel any pending removal
 				this.removals = ArrayUtils.removeIntFromArrayOnIndex(this.removals, removalIndex);
 			}
+			// else: identical record already present and not removed -> no-op
 		} else {
-			// compute expected position of the record
-			final int index = Arrays.binarySearch(this.insertions, position.position());
-			if (index >= 0) {
-				// if there is already waiting array of appended record append also this record id there
-				this.insertedValues[index].addRecord(recordId, comparator);
-			} else {
-				// if not - create new list of additions on expected position
-				final int startIndex = -1 * (index) - 1;
-				this.insertions = ArrayUtils.insertIntIntoArrayOnIndex(position.position(), this.insertions, startIndex);
-				final Class<?> componentType = this.delegate.getClass().getComponentType();
-				this.insertedValues = ArrayUtils.insertRecordIntoArrayOnIndex(new InsertionBucket<>(recordId, componentType), this.insertedValues, startIndex);
-			}
+			insertIntoChangeLayer(recordId, positionIndex, comparator);
 		}
 		// nullify memoized result that becomes obsolete by this operation
 		this.memoizedMergedArray = null;
+	}
+
+	/**
+	 * Appends `recordId` to the {@link InsertionBucket} at `position` in the change layer, creating
+	 * a new bucket if none exists at that position yet.
+	 *
+	 * If the bucket already contains a record with the same comparator identity, the existing entry is
+	 * replaced by the new instance. This is essential for the remove-then-re-add scenario on the change
+	 * layer itself: when a record that was freshly inserted (not yet in the delegate) is removed and
+	 * re-added with updated content, the bucket must hold the latest instance rather than the stale one.
+	 *
+	 * @param recordId   the record to insert or replace within the bucket
+	 * @param position   the insertion slot index in the delegate array (the index before which the bucket
+	 *                   will be placed when building the merged array)
+	 * @param comparator the comparator used to locate the record within the bucket
+	 */
+	private void insertIntoChangeLayer(@Nonnull T recordId, int position, @Nonnull Comparator<T> comparator) {
+		final int index = Arrays.binarySearch(this.insertions, position);
+		if (index >= 0) {
+			this.insertedValues[index].addRecord(recordId, comparator);
+		} else {
+			final int startIndex = -1 * (index) - 1;
+			this.insertions = ArrayUtils.insertIntIntoArrayOnIndex(position, this.insertions, startIndex);
+			final Class<?> componentType = this.delegate.getClass().getComponentType();
+			this.insertedValues = ArrayUtils.insertRecordIntoArrayOnIndex(
+				new InsertionBucket<>(recordId, componentType), this.insertedValues, startIndex
+			);
+		}
+	}
+
+	/**
+	 * Returns `true` when `existing` and `candidate` represent the same logical slot (same comparator
+	 * identity) but their *content* has diverged.
+	 *
+	 * Decision order:
+	 * 1. If both references point to the same object instance — no difference (`false`).
+	 * 2. If `candidate` implements {@link io.evitadb.api.requestResponse.data.ContentComparator}, its
+	 *    {@code differsFrom} method is authoritative (handles the price-record case where `equals` keys
+	 *    only on `internalPriceId` while `differsFrom` also compares amount fields).
+	 * 3. Otherwise falls back to `!existing.equals(candidate)` so plain-`equals` types work unchanged.
+	 *
+	 * @param existing  the record currently in the base delegate
+	 * @param candidate the record being added in the current transaction
+	 * @return `true` if the two records are identity-equal but content-different
+	 */
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	private static <T> boolean contentDiffers(@Nonnull T existing, @Nonnull T candidate) {
+		if (existing == candidate) {
+			return false;
+		}
+		if (candidate instanceof ContentComparator) {
+			return ((ContentComparator) candidate).differsFrom(existing);
+		}
+		return !existing.equals(candidate);
 	}
 
 	/**
@@ -346,9 +439,14 @@ public class ObjArrayChanges<T> {
 	}
 
 	/**
-	 * Bucket contains all records on certain position.
+	 * Sorted mini-array of records pending insertion at a single logical slot in the delegate.
+	 *
+	 * A bucket is created for each distinct insertion position tracked in {@link #insertions}. Most
+	 * buckets hold exactly one record, but two distinct elements that sort between the same pair of
+	 * consecutive delegate entries share one bucket and are kept in comparator order within it.
 	 */
 	private static class InsertionBucket<T> {
+		/** Sorted array of records waiting to be spliced into the merged output at this bucket's position. */
 		@Getter private T[] insertedValues;
 
 		@SuppressWarnings("unchecked")
@@ -357,18 +455,41 @@ public class ObjArrayChanges<T> {
 			this.insertedValues[0] = insertedValue;
 		}
 
+		/**
+		 * Adds `recordId` to the bucket in sorted order.
+		 *
+		 * If a record with the same comparator identity is already present, the existing entry is
+		 * *replaced* by the new instance rather than dropped. This is critical for the case where a
+		 * fresh insertion is removed and re-added within the same transaction with updated content: without
+		 * the replacement the bucket would retain the stale first instance.
+		 *
+		 * @param recordId   the record to insert or replace
+		 * @param comparator the comparator governing sort order within the bucket
+		 */
 		public void addRecord(@Nonnull T recordId, @Nonnull Comparator<T> comparator) {
-			this.insertedValues = ArrayUtils.insertRecordIntoOrderedArray(recordId, this.insertedValues, comparator);
+			final int idx = Arrays.binarySearch(this.insertedValues, recordId, comparator);
+			if (idx >= 0) {
+				// record with the same comparator key is already in the bucket - substitute it,
+				// otherwise the new instance (potentially carrying updated content) would be dropped
+				this.insertedValues[idx] = recordId;
+			} else {
+				this.insertedValues = ArrayUtils.insertRecordIntoArrayOnIndex(recordId, this.insertedValues, -idx - 1);
+			}
 		}
 
+		/**
+		 * Removes `recordId` from the bucket. No-op if the record is not present.
+		 */
 		public void removeRecord(@Nonnull T recordId, @Nonnull Comparator<T> comparator) {
 			this.insertedValues = ArrayUtils.removeRecordFromOrderedArray(recordId, this.insertedValues, comparator);
 		}
 
+		/** Returns `true` when there are no pending insertions remaining in this bucket. */
 		public boolean isEmpty() {
 			return this.insertedValues.length == 0;
 		}
 
+		/** Returns the number of records pending insertion in this bucket. */
 		public int size() {
 			return this.insertedValues.length;
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
@@ -243,7 +243,7 @@ public class ObjArrayChanges<T> {
 			// base delegate already holds a record with the same comparator key
 			final T existing = this.delegate[positionIndex];
 			final int removalIndex = Arrays.binarySearch(this.removals, positionIndex);
-			if (contentDiffers(existing, recordId)) {
+			if (ContentComparator.contentDiffers(existing, recordId)) {
 				// identity matches but content differs - substitute the record:
 				// ensure the original position is marked for removal AND queue an insertion of
 				// the new instance at the same logical position
@@ -254,6 +254,10 @@ public class ObjArrayChanges<T> {
 			} else if (removalIndex >= 0) {
 				// contents are equal - cancel any pending removal
 				this.removals = ArrayUtils.removeIntFromArrayOnIndex(this.removals, removalIndex);
+				// also drop any orphaned substitution bucket that a prior addRecordId may have
+				// queued at this position - otherwise the merge would resurrect the stale
+				// replacement alongside the (now un-removed) delegate record
+				dropInsertionBucketEntry(positionIndex, recordId, comparator);
 			}
 			// else: identical record already present and not removed -> no-op
 		} else {
@@ -292,29 +296,32 @@ public class ObjArrayChanges<T> {
 	}
 
 	/**
-	 * Returns `true` when `existing` and `candidate` represent the same logical slot (same comparator
-	 * identity) but their *content* has diverged.
+	 * Drops the record from the insertion bucket queued at the given delegate position, when present.
+	 * If the bucket becomes empty as a result, the bucket entry is removed from the parallel
+	 * insertions/insertedValues arrays as well.
 	 *
-	 * Decision order:
-	 * 1. If both references point to the same object instance — no difference (`false`).
-	 * 2. If `candidate` implements {@link io.evitadb.api.requestResponse.data.ContentComparator}, its
-	 *    {@code differsFrom} method is authoritative (handles the price-record case where `equals` keys
-	 *    only on `internalPriceId` while `differsFrom` also compares amount fields).
-	 * 3. Otherwise falls back to `!existing.equals(candidate)` so plain-`equals` types work unchanged.
+	 * Used to clean up substitution buckets left over by a prior {@link #addRecordId} when the
+	 * substitution gets reverted (re-adding the original content) or when the record is removed
+	 * outright in the same transaction.
 	 *
-	 * @param existing  the record currently in the base delegate
-	 * @param candidate the record being added in the current transaction
-	 * @return `true` if the two records are identity-equal but content-different
+	 * @param position   the delegate-slot index where the substitution bucket may sit
+	 * @param recordId   the record to evict from the bucket
+	 * @param comparator the comparator used to locate the record within the bucket
 	 */
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private static <T> boolean contentDiffers(@Nonnull T existing, @Nonnull T candidate) {
-		if (existing == candidate) {
-			return false;
+	private void dropInsertionBucketEntry(int position, @Nonnull T recordId, @Nonnull Comparator<T> comparator) {
+		final int insIdx = Arrays.binarySearch(this.insertions, position);
+		if (insIdx < 0) {
+			return;
 		}
-		if (candidate instanceof ContentComparator) {
-			return ((ContentComparator) candidate).differsFrom(existing);
+		final InsertionBucket<T> bucket = this.insertedValues[insIdx];
+		if (Arrays.binarySearch(bucket.getInsertedValues(), recordId, comparator) < 0) {
+			return;
 		}
-		return !existing.equals(candidate);
+		bucket.removeRecord(recordId, comparator);
+		if (bucket.isEmpty()) {
+			this.insertions = ArrayUtils.removeIntFromArrayOnIndex(this.insertions, insIdx);
+			this.insertedValues = ArrayUtils.removeRecordFromArrayOnIndex(this.insertedValues, insIdx);
+		}
 	}
 
 	/**
@@ -329,17 +336,7 @@ public class ObjArrayChanges<T> {
 			this.removals = ArrayUtils.insertIntIntoOrderedArray(position, this.removals);
 			// if a content substitution previously queued a replacement at this position, drop it too -
 			// otherwise the merge would resurrect the (now removed) record from the insertion bucket
-			final int insIdx = Arrays.binarySearch(this.insertions, position);
-			if (insIdx >= 0) {
-				final InsertionBucket<T> bucket = this.insertedValues[insIdx];
-				if (Arrays.binarySearch(bucket.getInsertedValues(), recordId, comparator) >= 0) {
-					bucket.removeRecord(recordId, comparator);
-					if (bucket.isEmpty()) {
-						this.insertions = ArrayUtils.removeIntFromArrayOnIndex(this.insertions, insIdx);
-						this.insertedValues = ArrayUtils.removeRecordFromArrayOnIndex(this.insertedValues, insIdx);
-					}
-				}
-			}
+			dropInsertionBucketEntry(position, recordId, comparator);
 		} else {
 			// record is not part of the original array but might be present on change layer
 			final int changePosition = ArrayUtils.computeInsertPositionOfObjInOrderedArray(recordId, this.delegate, comparator).position();

--- a/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
@@ -188,7 +188,12 @@ public class ObjArrayChanges<T> {
 	boolean contains(@Nonnull T recordId, @Nonnull Comparator<T> comparator) {
 		final int delegateIndex = Arrays.binarySearch(this.delegate, recordId, comparator);
 		if (delegateIndex >= 0) {
-			return Arrays.binarySearch(this.removals, delegateIndex) < 0;
+			if (Arrays.binarySearch(this.removals, delegateIndex) < 0) {
+				return true;
+			}
+			// delegate slot is removed - a content substitution may have queued a replacement with
+			// the same comparator key in the insertion bucket at this position
+			return insertionBucketContains(delegateIndex, recordId, comparator);
 		} else {
 			for (InsertionBucket<T> insertedValue : this.insertedValues) {
 				if (Arrays.binarySearch(insertedValue.getInsertedValues(), recordId, comparator) >= 0) {
@@ -197,6 +202,17 @@ public class ObjArrayChanges<T> {
 			}
 			return false;
 		}
+	}
+
+	/**
+	 * Returns true if the insertion bucket queued at the given delegate position contains a record
+	 * with the same comparator key as `recordId`. Used to recognize a content-substitution replacement
+	 * that sits at a delegate position that is simultaneously marked for removal.
+	 */
+	private boolean insertionBucketContains(int position, @Nonnull T recordId, @Nonnull Comparator<T> comparator) {
+		final int insIdx = Arrays.binarySearch(this.insertions, position);
+		return insIdx >= 0
+			&& Arrays.binarySearch(this.insertedValues[insIdx].getInsertedValues(), recordId, comparator) >= 0;
 	}
 
 	/**
@@ -311,6 +327,19 @@ public class ObjArrayChanges<T> {
 		if (position >= 0) {
 			// if so, mark this position for removal (this operation is idempotent)
 			this.removals = ArrayUtils.insertIntIntoOrderedArray(position, this.removals);
+			// if a content substitution previously queued a replacement at this position, drop it too -
+			// otherwise the merge would resurrect the (now removed) record from the insertion bucket
+			final int insIdx = Arrays.binarySearch(this.insertions, position);
+			if (insIdx >= 0) {
+				final InsertionBucket<T> bucket = this.insertedValues[insIdx];
+				if (Arrays.binarySearch(bucket.getInsertedValues(), recordId, comparator) >= 0) {
+					bucket.removeRecord(recordId, comparator);
+					if (bucket.isEmpty()) {
+						this.insertions = ArrayUtils.removeIntFromArrayOnIndex(this.insertions, insIdx);
+						this.insertedValues = ArrayUtils.removeRecordFromArrayOnIndex(this.insertedValues, insIdx);
+					}
+				}
+			}
 		} else {
 			// record is not part of the original array but might be present on change layer
 			final int changePosition = ArrayUtils.computeInsertPositionOfObjInOrderedArray(recordId, this.delegate, comparator).position();

--- a/evita_engine/src/main/java/io/evitadb/index/price/model/priceRecord/PriceRecordContract.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/model/priceRecord/PriceRecordContract.java
@@ -23,29 +23,52 @@
 
 package io.evitadb.index.price.model.priceRecord;
 
+import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
 import io.evitadb.api.requestResponse.data.structure.Entity;
 import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Comparator;
 
 /**
- * Price record envelopes single price of the entity. This data structure allows translating price ids and inner record
- * ids to entity primary key. Also price amounts are used for sorting by price. Price indexes don't use original
- * {@link PriceContract} to minimize memory consumption (this class contains only primitive types).
+ * Compact, primitive-only representation of a single entity price used inside price indexes.
  *
- * There two specializations of this interface:
+ * Price indexes avoid holding full {@link PriceContract} objects in order to minimize heap usage.
+ * This interface distills only the fields that are needed for price filtering, sorting, and translation
+ * between price ids and entity primary keys.
  *
- * - {@link PriceRecord} - represents a physical price recorded for single entity and present in indexes
- * - {@link CumulatedVirtualPriceRecord} - represents an "on the fly" record with computed prices that are required by
- * {@link PriceInnerRecordHandling#SUM sum price computation strategy}
+ * **Identity vs. content** — this is a critical distinction for the transactional change layer:
+ *
+ * - *Identity* is defined by {@link #internalPriceId()} alone. Both {@link #compareTo} and
+ *   {@link #PRICE_RECORD_COMPARATOR} key on `internalPriceId`, and `equals`/`hashCode` in the
+ *   concrete implementations ({@link PriceRecord}, {@link PriceRecordInnerRecordSpecific}) also key
+ *   only on `internalPriceId`. Two records with the same `internalPriceId` are therefore considered
+ *   the *same price slot* by sorted collections.
+ * - *Content* covers all amount fields (`priceWithTax`, `priceWithoutTax`, `innerRecordId`, etc.).
+ *   The {@link #differsFrom} default method provided by this interface compares full content, allowing
+ *   the transactional index structures ({@link io.evitadb.index.array.ObjArrayChanges},
+ *   {@link io.evitadb.index.set.SetChanges}) to detect a changed price amount and substitute the
+ *   stale record with the updated one — even though identity-based lookup would consider them equal.
+ *
+ * Two specializations exist:
+ *
+ * - {@link PriceRecord} — represents a physical price for a single entity that has no inner record id.
+ * - {@link CumulatedVirtualPriceRecord} — an on-the-fly aggregated record required by
+ *   {@link PriceInnerRecordHandling#SUM the SUM price computation strategy}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
-public interface PriceRecordContract extends Serializable, Comparable<PriceRecordContract> {
+public interface PriceRecordContract extends Serializable, Comparable<PriceRecordContract>, ContentComparator<PriceRecordContract> {
+	/**
+	 * Canonical comparator for sorted collections of price records. Orders by {@link #internalPriceId()}
+	 * only — two records representing the same price slot in the same entity are considered equal by
+	 * this comparator regardless of their amount fields. Used by {@link io.evitadb.index.array.ObjArrayChanges}
+	 * to locate a record's position in the sorted delegate array.
+	 */
 	Comparator<PriceRecordContract> PRICE_RECORD_COMPARATOR = Comparator.comparing(PriceRecordContract::internalPriceId);
 
 	/**
@@ -96,5 +119,38 @@ public interface PriceRecordContract extends Serializable, Comparable<PriceRecor
 	 * @return true if the price relates to the another price
 	 */
 	boolean relatesTo(@Nonnull PriceRecordContract anotherPriceRecord);
+
+	/**
+	 * Performs a deep, field-by-field content comparison that goes beyond the identity check of
+	 * `equals` / {@link #PRICE_RECORD_COMPARATOR}.
+	 *
+	 * Two records with the same {@link #internalPriceId()} are *identity-equal* — they occupy the same
+	 * slot in a price index — but may carry different amounts after a price update (e.g. a discount
+	 * applied mid-transaction). This method returns `true` in that case, enabling the transactional
+	 * change layer ({@link io.evitadb.index.array.ObjArrayChanges},
+	 * {@link io.evitadb.index.set.SetChanges}) to substitute the stale record atomically instead of
+	 * silently dropping the update.
+	 *
+	 * Fields compared: `internalPriceId`, `priceId`, `entityPrimaryKey`, `priceWithTax`,
+	 * `priceWithoutTax`, and `innerRecordId`.
+	 *
+	 * @param otherObject the record to compare against; `null` is treated as "differs" (returns `true`)
+	 * @return `true` if any content field differs from `otherObject`, `false` if all fields match
+	 */
+	@Override
+	default boolean differsFrom(@Nullable PriceRecordContract otherObject) {
+		if (otherObject == this) {
+			return false;
+		}
+		if (otherObject == null) {
+			return true;
+		}
+		return this.internalPriceId() != otherObject.internalPriceId()
+			|| this.priceId() != otherObject.priceId()
+			|| this.entityPrimaryKey() != otherObject.entityPrimaryKey()
+			|| this.priceWithTax() != otherObject.priceWithTax()
+			|| this.priceWithoutTax() != otherObject.priceWithoutTax()
+			|| this.innerRecordId() != otherObject.innerRecordId();
+	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
@@ -133,9 +133,10 @@ public class SetChanges<K> implements Serializable {
 	 */
 	public boolean put(@Nonnull K key) {
 		if (containsCreated(key)) {
-			// already in change layer - replace identity-equal entry if its content has diverged
+			// already in change layer - replace identity-equal entry if its content has diverged;
+			// do NOT cancel a pending removal here: when this key is the "add half" of a delegate
+			// substitution it must stay in removedKeys, otherwise the stale original would resurface
 			replaceInCreatedIfContentDiffers(key);
-			this.removedKeys.remove(key);
 			return false;
 		}
 		if (this.setDelegate.contains(key)) {

--- a/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
@@ -115,9 +115,10 @@ public class SetChanges<K> implements Serializable {
 	 * Records the insertion of `key` into this change layer. The exact behavior depends on where an
 	 * identity-equal element is currently found:
 	 *
-	 * **Key already in the change layer** — if the stored instance's content matches the new one, no
-	 * action is needed beyond cancelling any pending removal for the key; if content has diverged,
-	 * {@link #replaceInCreatedIfContentDiffers} substitutes the stored instance with the new one.
+	 * **Key already in the change layer** — if content has diverged, {@link #replaceInCreatedIfContentDiffers}
+	 * substitutes the stored instance with the new one; otherwise nothing changes. Any pending removal is
+	 * deliberately left untouched: when this key is the add-half of a delegate substitution its removal
+	 * marker must remain, otherwise {@link #createMergedSet} would resurface the stale original.
 	 *
 	 * **Key already in the delegate** — if content is equal, any pending removal is cancelled (idempotent
 	 * re-add); if content has diverged, the original position is added to {@link #removedKeys} AND `key`

--- a/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
@@ -80,33 +80,6 @@ public class SetChanges<K> implements Serializable {
 	 */
 	private final Set<K> createdKeys = new HashSet<>();
 
-	/**
-	 * Returns `true` when `existing` and `candidate` are `equals`-equal (same identity) but carry
-	 * different content.
-	 *
-	 * Decision order:
-	 * 1. Same object reference — no difference (`false`).
-	 * 2. If `candidate` implements {@link ContentComparator}, delegates to
-	 *    {@link ContentComparator#differsFrom} (handles types like `PriceRecordContract` whose `equals`
-	 *    only compares identity fields while `differsFrom` checks all amount fields).
-	 * 3. Falls back to `!existing.equals(candidate)` for plain-value types whose `equals` already
-	 *    implies full content equality.
-	 *
-	 * @param existing  the instance currently stored in the set (delegate or change layer)
-	 * @param candidate the new instance being added in the current transaction
-	 * @return `true` if the two instances are identity-equal but content-different
-	 */
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private static <T> boolean contentDiffers(@Nonnull T existing, @Nonnull T candidate) {
-		if (existing == candidate) {
-			return false;
-		}
-		if (candidate instanceof ContentComparator) {
-			return ((ContentComparator) candidate).differsFrom(existing);
-		}
-		return !existing.equals(candidate);
-	}
-
 	public SetChanges(@Nonnull Set<K> setDelegate) {
 		this.setDelegate = setDelegate;
 	}
@@ -361,7 +334,7 @@ public class SetChanges<K> implements Serializable {
 			return false;
 		}
 		final K existing = findIdentityEqual(this.setDelegate, key);
-		return existing != null && contentDiffers(existing, key);
+		return existing != null && ContentComparator.contentDiffers(existing, key);
 	}
 
 	/**
@@ -380,7 +353,7 @@ public class SetChanges<K> implements Serializable {
 			return;
 		}
 		final K existing = findIdentityEqual(this.createdKeys, key);
-		if (existing != null && contentDiffers(existing, key)) {
+		if (existing != null && ContentComparator.contentDiffers(existing, key)) {
 			this.createdKeys.remove(key); // removes identity-equal entry from the HashSet
 			this.createdKeys.add(key);
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
@@ -23,11 +23,13 @@
 
 package io.evitadb.index.set;
 
+import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import lombok.Getter;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Serial;
 import java.io.Serializable;
@@ -36,8 +38,24 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Contains combination of changes in a Set and removals made upon it. There is no other possible way
- * how to track removals in a map than to keep a set of keys that was removed in it.
+ * Transactional change layer for a {@link java.util.Set}. Tracks insertions (via {@link #createdKeys})
+ * and removals (via {@link #removedKeys}) made within a single transaction, and produces the merged
+ * result on demand via {@link #createMergedSet}.
+ *
+ * **Content-aware substitution.** When an element with the same `equals`-identity as an existing
+ * entry is added but its *content* has diverged (as reported by
+ * {@link io.evitadb.api.requestResponse.data.ContentComparator#differsFrom} when the type implements it),
+ * the change layer encodes the update as a paired removal + insertion: the original key is added to
+ * {@link #removedKeys} and the new instance is added to {@link #createdKeys}. {@link #createMergedSet}
+ * then drops the original and inserts the new instance, so the committed snapshot always reflects the
+ * latest content. This prevents the stale-record class of bugs where a price with an unchanged
+ * `internalPriceId` but a modified amount was silently ignored.
+ *
+ * For types that do not implement {@link io.evitadb.api.requestResponse.data.ContentComparator}, the
+ * behavior is identical to the previous implementation: `equals`-equal elements are treated as
+ * content-equal and no substitution is performed.
+ *
+ * Not thread-safe — one instance is owned by exactly one transaction thread.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2017
  */
@@ -46,64 +64,135 @@ public class SetChanges<K> implements Serializable {
 	@Serial private static final long serialVersionUID = -6370910459056592080L;
 
 	/**
-	 * Contains reference to original immutable set.
+	 * Immutable snapshot of the set as it existed when the transaction opened. Never modified.
 	 */
 	@Getter private final Set<K> setDelegate;
 	/**
-	 * Contains set of removed keys.
+	 * Keys that must be excluded from {@link #setDelegate} when producing the merged result.
+	 * Entries are added either for a plain removal or as the "remove" half of a content-substitution
+	 * pair (where the corresponding "add" half lives in {@link #createdKeys}).
 	 */
 	private final Set<K> removedKeys = new HashSet<>();
 	/**
-	 * Contains set of added keys.
+	 * Keys added or substituted in this transaction. For content-substitution, this set holds the
+	 * *new* instance; the old instance is in {@link #removedKeys}. {@link #createMergedSet} adds
+	 * all entries here on top of the non-removed delegate keys.
 	 */
 	private final Set<K> createdKeys = new HashSet<>();
+
+	/**
+	 * Returns `true` when `existing` and `candidate` are `equals`-equal (same identity) but carry
+	 * different content.
+	 *
+	 * Decision order:
+	 * 1. Same object reference — no difference (`false`).
+	 * 2. If `candidate` implements {@link ContentComparator}, delegates to
+	 *    {@link ContentComparator#differsFrom} (handles types like `PriceRecordContract` whose `equals`
+	 *    only compares identity fields while `differsFrom` checks all amount fields).
+	 * 3. Falls back to `!existing.equals(candidate)` for plain-value types whose `equals` already
+	 *    implies full content equality.
+	 *
+	 * @param existing  the instance currently stored in the set (delegate or change layer)
+	 * @param candidate the new instance being added in the current transaction
+	 * @return `true` if the two instances are identity-equal but content-different
+	 */
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	private static <T> boolean contentDiffers(@Nonnull T existing, @Nonnull T candidate) {
+		if (existing == candidate) {
+			return false;
+		}
+		if (candidate instanceof ContentComparator) {
+			return ((ContentComparator) candidate).differsFrom(existing);
+		}
+		return !existing.equals(candidate);
+	}
 
 	public SetChanges(@Nonnull Set<K> setDelegate) {
 		this.setDelegate = setDelegate;
 	}
 
 	/**
-	 * Method records insertion of the record with particular key. The update is trapped within this object data.
+	 * Records the insertion of `key` into this change layer. The exact behavior depends on where an
+	 * identity-equal element is currently found:
+	 *
+	 * **Key already in the change layer** — if the stored instance's content matches the new one, no
+	 * action is needed beyond cancelling any pending removal for the key; if content has diverged,
+	 * {@link #replaceInCreatedIfContentDiffers} substitutes the stored instance with the new one.
+	 *
+	 * **Key already in the delegate** — if content is equal, any pending removal is cancelled (idempotent
+	 * re-add); if content has diverged, the original position is added to {@link #removedKeys} AND `key`
+	 * is added to {@link #createdKeys}, so {@link #createMergedSet} drops the stale instance and inserts
+	 * the new one.
+	 *
+	 * **Key not present anywhere** — `key` is added to {@link #createdKeys} and any stale removal is
+	 * cleared.
+	 *
+	 * @param key the element to add or substitute; must not be null
+	 * @return `true` if the effective set size grew (i.e., `key` was not already logically present),
+	 *         `false` for a no-op re-add or a content-substitution
 	 */
 	public boolean put(@Nonnull K key) {
-		final boolean wasAdded;
 		if (containsCreated(key)) {
-			wasAdded = false;
-		} else {
-			final boolean isPartOfOriginal = this.setDelegate.contains(key);
-			if (isPartOfOriginal) {
-				wasAdded = false;
-			} else {
-				this.createdKeys.add(key);
-				wasAdded = true;
-			}
+			// already in change layer - replace identity-equal entry if its content has diverged
+			replaceInCreatedIfContentDiffers(key);
+			this.removedKeys.remove(key);
+			return false;
 		}
+		if (this.setDelegate.contains(key)) {
+			// already in original delegate
+			if (contentDiffersFromDelegate(key)) {
+				// substitute: mark the original position for removal AND record the new instance as
+				// created - [createMergedSet] will drop the original and insert the new instance
+				this.removedKeys.add(key);
+				this.createdKeys.add(key);
+			} else {
+				// contents are logically equal - just cancel any pending removal
+				this.removedKeys.remove(key);
+			}
+			return false;
+		}
+		this.createdKeys.add(key);
 		this.removedKeys.remove(key);
-		return wasAdded;
+		return true;
 	}
 
 	/**
-	 * Records the removal of certain key if it's present in the original set or removes previously inserted record
-	 * trapped in this diff layer. If no key is found the call is ignored and returns false.
+	 * Records the removal of `key` from this change layer. The method covers three distinct cases:
+	 *
+	 * - **Key in delegate only** — marks the delegate position for removal via {@link #removedKeys}.
+	 * - **Key in both delegate and change layer** (content-substitution rollback) — drops the pending
+	 *   creation from {@link #createdKeys} and ensures the delegate position remains marked for removal,
+	 *   effectively rolling back the substitution back to a plain removal.
+	 * - **Key only in change layer** (fresh insertion) — removes it from {@link #createdKeys}; the set
+	 *   returns to the state before the insertion.
+	 * - **Key not found anywhere** — no-op, returns `false`.
+	 *
+	 * @param key the element to remove; may be any object (follows {@link java.util.Set#remove} contract)
+	 * @return `true` if the effective set size shrank, `false` if the key was not logically present
 	 */
 	@SuppressWarnings("unchecked")
 	public boolean remove(Object key) {
 		@SuppressWarnings("SuspiciousMethodCalls") final boolean originalContained = this.setDelegate.contains(key);
-		if (originalContained && containsRemoved((K) key)) {
-			// value has been already removed - report false and do nothing
-			return false;
-		}
-		final boolean wasRemoved;
-		if (containsCreated((K) key)) {
+		final boolean wasInCreated = containsCreated((K) key);
+		final boolean wasInRemoved = containsRemoved((K) key);
+
+		// drop any pending creation (covers both fresh adds and substitution replacements)
+		if (wasInCreated) {
 			removeCreatedKey((K) key);
-			wasRemoved = true;
-		} else if (originalContained) {
-			registerRemovedKey((K) key);
-			wasRemoved = true;
-		} else {
-			wasRemoved = false;
 		}
-		return wasRemoved;
+
+		if (originalContained) {
+			if (wasInRemoved && !wasInCreated) {
+				// original already net-removed and no pending substitution to roll back -> no-op
+				return false;
+			}
+			// either this is a removal of an original entry, or a rollback of a "replace" -
+			// in both cases the original delegate position must end up removed
+			registerRemovedKey((K) key);
+			return true;
+		}
+		// not in delegate - only the pending creation (if any) had any effect
+		return wasInCreated;
 	}
 
 	/**
@@ -239,7 +328,6 @@ public class SetChanges<K> implements Serializable {
 		return this.createdKeys;
 	}
 
-
 	/**
 	 * Returns true if particular key is recorded to be removed.
 	 */
@@ -253,6 +341,70 @@ public class SetChanges<K> implements Serializable {
 	void copyState(SetChanges<K> layer) {
 		layer.createdKeys.addAll(this.createdKeys);
 		layer.removedKeys.addAll(this.removedKeys);
+	}
+
+	/**
+	 * Returns `true` when an identity-equal element is already present in {@link #setDelegate} but
+	 * carries different content from `key`.
+	 *
+	 * Returns `false` immediately for types that do not implement
+	 * {@link io.evitadb.api.requestResponse.data.ContentComparator}, because for those types
+	 * `setDelegate.contains(key)` already implies full content equality (their `equals` is
+	 * content-aware).
+	 *
+	 * @param key the candidate element being added in the current transaction
+	 */
+	private boolean contentDiffersFromDelegate(@Nonnull K key) {
+		if (!(key instanceof ContentComparator)) {
+			return false;
+		}
+		final K existing = findIdentityEqual(this.setDelegate, key);
+		return existing != null && contentDiffers(existing, key);
+	}
+
+	/**
+	 * Replaces the stored entry in {@link #createdKeys} with `key` when the stored instance is
+	 * identity-equal to `key` but carries different content.
+	 *
+	 * The substitution is performed by removing the identity-equal entry (via `HashSet.remove`, which
+	 * uses `equals`) and re-adding `key`. No-op when the type does not implement
+	 * {@link io.evitadb.api.requestResponse.data.ContentComparator} or when the content is already
+	 * current.
+	 *
+	 * @param key the new instance to substitute into the change layer
+	 */
+	private void replaceInCreatedIfContentDiffers(@Nonnull K key) {
+		if (!(key instanceof ContentComparator)) {
+			return;
+		}
+		final K existing = findIdentityEqual(this.createdKeys, key);
+		if (existing != null && contentDiffers(existing, key)) {
+			this.createdKeys.remove(key); // removes identity-equal entry from the HashSet
+			this.createdKeys.add(key);
+		}
+	}
+
+	/**
+	 * Scans `haystack` linearly and returns the first element that is `equals`-equal to `needle`, or
+	 * `null` if none is found.
+	 *
+	 * A linear scan is necessary here because `HashSet.get` is not part of the `Set` API: even though
+	 * the set can tell us whether a key is present, it cannot hand back the *stored instance* (which
+	 * may differ in content from `needle`). This method retrieves that stored instance so the caller
+	 * can decide whether a content-substitution is required.
+	 *
+	 * @param haystack the set to search; must not be null
+	 * @param needle   the element whose `equals`-equal counterpart is sought
+	 * @return the stored element that equals `needle`, or `null` if absent
+	 */
+	@Nullable
+	private K findIdentityEqual(@Nonnull Set<K> haystack, @Nonnull K needle) {
+		for (K candidate : haystack) {
+			if (needle.equals(candidate)) {
+				return candidate;
+			}
+		}
+		return null;
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaIndexingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaIndexingTest.java
@@ -48,12 +48,16 @@ import io.evitadb.api.requestResponse.data.mutation.EntityMutation.EntityExisten
 import io.evitadb.api.requestResponse.data.mutation.EntityUpsertMutation;
 import io.evitadb.api.requestResponse.data.mutation.attribute.UpsertAttributeMutation;
 import io.evitadb.api.requestResponse.data.mutation.price.UpsertPriceMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.InsertReferenceMutation;
 import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
+import io.evitadb.api.requestResponse.data.mutation.reference.RemoveReferenceMutation;
 import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
 import io.evitadb.api.requestResponse.data.structure.RepresentativeReferenceKey;
+import io.evitadb.api.requestResponse.schema.AssociatedDataSchemaEditor;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
 import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaEditor;
 import io.evitadb.api.requestResponse.schema.EntityAttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.OrderBehaviour;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
@@ -82,6 +86,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -478,6 +484,130 @@ class EvitaIndexingTest implements EvitaTestSupport {
 		);
 	}
 
+	@DisplayName("Price index must not stay stale when a reference rebuild and a price change share one mutation")
+	@ParameterizedTest(name = "old price {0} -> new price {1}")
+	@CsvSource({"590.00, 295.00", "295.00, 590.00"})
+	void shouldNotLeaveStalePriceIndexWhenReferenceRebuildAndPriceChangeShareOneMutation(
+		@Nonnull BigDecimal oldPrice,
+		@Nonnull BigDecimal newPrice
+	) {
+		// Reproduces #1193: a single EntityUpsertMutation that rebuilds the (filtering+partitioning)
+		// reference FIRST - which re-seeds the reduced reference index from the still-unchanged body -
+		// and only afterwards changes the LOWEST_PRICE inner-record prices reusing their internal price
+		// ids. The transactional change layer used to keep the OLD price record because the new record
+		// is identity-equal (same internal price id) yet content-different, so the index stayed stale.
+		final int productPk = 100;
+		final int categoryPkOld = 500;
+		final int categoryPkNew = 501;
+		final int innerA = 200;
+		final int innerB = 201;
+
+		this.evita.defineCatalog(TEST_CATALOG)
+			.withEntitySchema(
+				Entities.CATEGORY,
+				whichIs -> whichIs.withoutGeneratedPrimaryKey()
+			)
+			.withEntitySchema(
+				Entities.PRODUCT,
+				whichIs -> whichIs
+					.withoutGeneratedPrimaryKey()
+					.withPriceInCurrency(CURRENCY_CZK)
+					.withReferenceToEntity(
+						REFERENCE_PRODUCT_CATEGORY, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
+						thatIs -> thatIs.indexedForFilteringAndPartitioning()
+					)
+			)
+			.updateViaNewSession(this.evita);
+
+		// 1) seed the product with the OLD prices and a reference to the OLD category (warm-up mode)
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, categoryPkOld));
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, categoryPkNew));
+				session.upsertEntity(
+					session.createNewEntity(Entities.PRODUCT, productPk)
+						.setPriceInnerRecordHandling(PriceInnerRecordHandling.LOWEST_PRICE)
+						.setPrice(1, PRICE_LIST_BASIC, CURRENCY_CZK, innerA, oldPrice, BigDecimal.ZERO, oldPrice, true)
+						.setPrice(2, PRICE_LIST_BASIC, CURRENCY_CZK, innerB, oldPrice, BigDecimal.ZERO, oldPrice, true)
+						.setReference(REFERENCE_PRODUCT_CATEGORY, categoryPkOld)
+				);
+			}
+		);
+
+		// switch to transactional mode - only then the mutation travels through the WAL / transaction
+		// apply path (index-first, then body) that produced the divergence
+		this.evita.updateCatalog(TEST_CATALOG, EvitaSessionContract::goLiveAndClose);
+
+		// sanity: the product is found by its OLD price in the OLD category
+		assertTrue(
+			isProductFoundByPriceInCategory(productPk, categoryPkOld, oldPrice),
+			"Pre-condition: product should be indexed with its OLD price in the OLD category"
+		);
+
+		// 2) the offending mutation: rebuild the reference first, then change both prices - all in one tx
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.applyMutation(
+					new EntityUpsertMutation(
+						Entities.PRODUCT,
+						productPk,
+						EntityExistence.MUST_EXIST,
+						List.of(
+							new RemoveReferenceMutation(REFERENCE_PRODUCT_CATEGORY, categoryPkOld),
+							new InsertReferenceMutation(new ReferenceKey(REFERENCE_PRODUCT_CATEGORY, categoryPkNew)),
+							new UpsertPriceMutation(
+								new PriceKey(1, PRICE_LIST_BASIC, CURRENCY_CZK), innerA,
+								newPrice, BigDecimal.ZERO, newPrice, null, true
+							),
+							new UpsertPriceMutation(
+								new PriceKey(2, PRICE_LIST_BASIC, CURRENCY_CZK), innerB,
+								newPrice, BigDecimal.ZERO, newPrice, null, true
+							)
+						)
+					)
+				);
+			}
+		);
+
+		// 3) the index must reflect the new price: the product is found by the NEW price and NOT by the OLD one
+		assertTrue(
+			isProductFoundByPriceInCategory(productPk, categoryPkNew, newPrice),
+			"Product must be found by its NEW price in the NEW category - the index must reflect the change"
+		);
+		assertFalse(
+			isProductFoundByPriceInCategory(productPk, categoryPkNew, oldPrice),
+			"Product must NOT be found by its OLD price - a stale index would still match the original value"
+		);
+	}
+
+	/**
+	 * Queries the catalog through the public API for the given product, filtered by a reference to the
+	 * given category and by an exact price-for-sale. Both the reference filter (reduced reference index)
+	 * and the price filter (price index) are served from the committed indexes, so the result reflects
+	 * whether the indexes carry the expected price.
+	 */
+	private boolean isProductFoundByPriceInCategory(int productPk, int categoryPk, @Nonnull BigDecimal priceWithTax) {
+		return this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				return session.queryOneEntityReference(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							entityPrimaryKeyInSet(productPk),
+							referenceHaving(REFERENCE_PRODUCT_CATEGORY, entityPrimaryKeyInSet(categoryPk)),
+							priceInCurrency(CURRENCY_CZK),
+							priceInPriceLists(PRICE_LIST_BASIC),
+							priceBetween(priceWithTax, priceWithTax)
+						)
+					)
+				).isPresent();
+			}
+		);
+	}
+
 	@DisplayName("Update catalog in warm-up mode with another product - synchronously.")
 	@Test
 	void shouldUpdateCatalogWithAnotherProduct() {
@@ -796,7 +926,7 @@ class EvitaIndexingTest implements EvitaTestSupport {
 							.withAttribute(
 								ATTRIBUTE_CATEGORY_PRIORITY,
 								Long.class,
-								thatIs -> thatIs.sortable()
+								AttributeSchemaEditor::sortable
 							)
 					).updateVia(session);
 
@@ -1369,8 +1499,8 @@ class EvitaIndexingTest implements EvitaTestSupport {
 			session -> {
 				session
 					.defineEntitySchema(Entities.PRODUCT)
-					.withAttribute(ATTRIBUTE_NAME, String.class, whichIs -> whichIs.localized())
-					.withAttribute(ATTRIBUTE_DESCRIPTION, String.class, whichIs -> whichIs.localized())
+					.withAttribute(ATTRIBUTE_NAME, String.class, AttributeSchemaEditor::localized)
+					.withAttribute(ATTRIBUTE_DESCRIPTION, String.class, AttributeSchemaEditor::localized)
 					.updateVia(session);
 
 				session
@@ -1452,14 +1582,14 @@ class EvitaIndexingTest implements EvitaTestSupport {
 						session
 							.defineEntitySchema(Entities.PRODUCT)
 							.withAttribute(ATTRIBUTE_EAN, String.class)
-							.withAttribute(ATTRIBUTE_NAME, String.class, whichIs -> whichIs.localized())
+							.withAttribute(ATTRIBUTE_NAME, String.class, AttributeSchemaEditor::localized)
 							.withAttribute(
 								ATTRIBUTE_DESCRIPTION, String.class, whichIs -> whichIs.localized().nullable())
 							.withReferenceTo(
 								Entities.BRAND, Entities.BRAND, Cardinality.EXACTLY_ONE,
 								thatIs -> thatIs
 									.withAttribute(ATTRIBUTE_BRAND_EAN, String.class)
-									.withAttribute(ATTRIBUTE_BRAND_NAME, String.class, whichIs -> whichIs.localized())
+									.withAttribute(ATTRIBUTE_BRAND_NAME, String.class, AttributeSchemaEditor::localized)
 									.withAttribute(
 										ATTRIBUTE_BRAND_DESCRIPTION, String.class,
 										whichIs -> whichIs.localized().nullable()
@@ -1506,13 +1636,13 @@ class EvitaIndexingTest implements EvitaTestSupport {
 				session
 					.defineEntitySchema(Entities.PRODUCT)
 					.withAttribute(ATTRIBUTE_EAN, String.class)
-					.withAttribute(ATTRIBUTE_NAME, String.class, whichIs -> whichIs.localized())
+					.withAttribute(ATTRIBUTE_NAME, String.class, AttributeSchemaEditor::localized)
 					.withAttribute(ATTRIBUTE_DESCRIPTION, String.class, whichIs -> whichIs.localized().nullable())
 					.withReferenceTo(
 						Entities.BRAND, Entities.BRAND, Cardinality.EXACTLY_ONE,
 						thatIs -> thatIs
 							.withAttribute(ATTRIBUTE_BRAND_EAN, String.class)
-							.withAttribute(ATTRIBUTE_BRAND_NAME, String.class, whichIs -> whichIs.localized())
+							.withAttribute(ATTRIBUTE_BRAND_NAME, String.class, AttributeSchemaEditor::localized)
 							.withAttribute(
 								ATTRIBUTE_BRAND_DESCRIPTION, String.class, whichIs -> whichIs.localized().nullable())
 					)
@@ -2071,7 +2201,7 @@ class EvitaIndexingTest implements EvitaTestSupport {
 					session
 						.defineEntitySchema(Entities.PRODUCT)
 						.withAssociatedData(ATTRIBUTE_EAN, String.class)
-						.withAssociatedData(ATTRIBUTE_NAME, String.class, whichIs -> whichIs.localized())
+						.withAssociatedData(ATTRIBUTE_NAME, String.class, AssociatedDataSchemaEditor::localized)
 						.withAssociatedData(
 							ATTRIBUTE_DESCRIPTION, String.class, whichIs -> whichIs.localized().nullable())
 						.updateVia(session);
@@ -2106,7 +2236,7 @@ class EvitaIndexingTest implements EvitaTestSupport {
 				session
 					.defineEntitySchema(Entities.PRODUCT)
 					.withAssociatedData(ATTRIBUTE_EAN, String.class)
-					.withAssociatedData(ATTRIBUTE_NAME, String.class, whichIs -> whichIs.localized())
+					.withAssociatedData(ATTRIBUTE_NAME, String.class, AssociatedDataSchemaEditor::localized)
 					.withAssociatedData(ATTRIBUTE_DESCRIPTION, String.class, whichIs -> whichIs.localized().nullable())
 					.updateVia(session);
 
@@ -2562,8 +2692,8 @@ class EvitaIndexingTest implements EvitaTestSupport {
 				final String attributeCodeEan = ATTRIBUTE_CODE + StringUtils.capitalize(ATTRIBUTE_EAN);
 				session
 					.defineEntitySchema(Entities.PRODUCT)
-					.withAttribute(ATTRIBUTE_CODE, String.class, whichIs -> whichIs.nullable())
-					.withAttribute(ATTRIBUTE_EAN, String.class, whichIs -> whichIs.nullable())
+					.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::nullable)
+					.withAttribute(ATTRIBUTE_EAN, String.class, AttributeSchemaEditor::nullable)
 					.withSortableAttributeCompound(
 						attributeCodeEan,
 						AttributeElement.attributeElement(
@@ -2686,7 +2816,7 @@ class EvitaIndexingTest implements EvitaTestSupport {
 				final String attributeCodeEan = ATTRIBUTE_CODE + StringUtils.capitalize(ATTRIBUTE_EAN);
 				session
 					.defineEntitySchema(Entities.PRODUCT)
-					.withAttribute(ATTRIBUTE_CODE, String.class, whichIs -> whichIs.nullable())
+					.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::nullable)
 					.withAttribute(ATTRIBUTE_EAN, String.class, whichIs -> whichIs.localized().nullable())
 					.withAttribute(ATTRIBUTE_NAME, String.class, whichIs -> whichIs.localized().nullable())
 					.withSortableAttributeCompound(
@@ -2884,11 +3014,11 @@ class EvitaIndexingTest implements EvitaTestSupport {
 					.defineEntitySchema(Entities.PRODUCT)
 					.withReferenceToEntity(
 						Entities.CATEGORY, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
-						whichIs -> whichIs.indexedForFilteringAndPartitioning()
+						ReferenceSchemaEditor::indexedForFilteringAndPartitioning
 					)
 					.withReferenceToEntity(
 						Entities.BRAND, Entities.BRAND, Cardinality.ZERO_OR_MORE,
-						whichIs -> whichIs.indexedForFilteringAndPartitioning()
+						ReferenceSchemaEditor::indexedForFilteringAndPartitioning
 					)
 					.updateVia(session);
 
@@ -2998,8 +3128,8 @@ class EvitaIndexingTest implements EvitaTestSupport {
 					.withReferenceToEntity(
 						Entities.CATEGORY, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
 						whichIs -> whichIs.indexedForFilteringAndPartitioning()
-							.withAttribute(ATTRIBUTE_CODE, String.class, thatIs -> thatIs.nullable())
-							.withAttribute(ATTRIBUTE_EAN, String.class, thatIs -> thatIs.nullable())
+							.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::nullable)
+							.withAttribute(ATTRIBUTE_EAN, String.class, AttributeSchemaEditor::nullable)
 							.withSortableAttributeCompound(
 								attributeCodeEan,
 								AttributeElement.attributeElement(
@@ -3011,8 +3141,8 @@ class EvitaIndexingTest implements EvitaTestSupport {
 					.withReferenceToEntity(
 						Entities.BRAND, Entities.BRAND, Cardinality.ZERO_OR_MORE,
 						whichIs -> whichIs.indexedForFilteringAndPartitioning()
-							.withAttribute(ATTRIBUTE_CODE, String.class, thatIs -> thatIs.nullable())
-							.withAttribute(ATTRIBUTE_EAN, String.class, thatIs -> thatIs.nullable())
+							.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::nullable)
+							.withAttribute(ATTRIBUTE_EAN, String.class, AttributeSchemaEditor::nullable)
 							.withSortableAttributeCompound(
 								attributeCodeEan,
 								AttributeElement.attributeElement(
@@ -3146,7 +3276,7 @@ class EvitaIndexingTest implements EvitaTestSupport {
 					.withReferenceToEntity(
 						Entities.CATEGORY, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
 						whichIs -> whichIs.indexedForFilteringAndPartitioning()
-							.withAttribute(ATTRIBUTE_CODE, String.class, thatIs -> thatIs.nullable())
+							.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::nullable)
 							.withAttribute(ATTRIBUTE_EAN, String.class, thatIs -> thatIs.localized().nullable())
 							.withAttribute(ATTRIBUTE_NAME, String.class, thatIs -> thatIs.localized().nullable())
 							.withSortableAttributeCompound(
@@ -3160,7 +3290,7 @@ class EvitaIndexingTest implements EvitaTestSupport {
 					.withReferenceToEntity(
 						Entities.BRAND, Entities.BRAND, Cardinality.ZERO_OR_MORE,
 						whichIs -> whichIs.indexedForFilteringAndPartitioning()
-							.withAttribute(ATTRIBUTE_CODE, String.class, thatIs -> thatIs.nullable())
+							.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::nullable)
 							.withAttribute(ATTRIBUTE_EAN, String.class, thatIs -> thatIs.localized().nullable())
 							.withAttribute(ATTRIBUTE_NAME, String.class, thatIs -> thatIs.localized().nullable())
 							.withSortableAttributeCompound(
@@ -3450,7 +3580,7 @@ class EvitaIndexingTest implements EvitaTestSupport {
 						REFERENCE_PRODUCT_CATEGORY, Entities.CATEGORY, Cardinality.ONE_OR_MORE,
 						whichIs -> whichIs.indexedForFilteringAndPartitioning()
 							.withAttribute(
-								ATTRIBUTE_PRODUCT_CATEGORY_VARIANT, Boolean.class, thatIs -> thatIs.filterable())
+								ATTRIBUTE_PRODUCT_CATEGORY_VARIANT, Boolean.class, AttributeSchemaEditor::filterable)
 					)
 					.updateVia(session);
 
@@ -4154,6 +4284,7 @@ class EvitaIndexingTest implements EvitaTestSupport {
 			.server(
 				ServerOptions.builder()
 					.closeSessionsAfterSecondsOfInactivity(inactivityTimeoutInSeconds)
+					.transactionTimeoutInMilliseconds(Long.MAX_VALUE)
 					.build()
 			)
 			.storage(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaIndexingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaIndexingTest.java
@@ -46,6 +46,7 @@ import io.evitadb.api.requestResponse.data.ReferenceContract;
 import io.evitadb.api.requestResponse.data.SealedEntity;
 import io.evitadb.api.requestResponse.data.mutation.EntityMutation.EntityExistence;
 import io.evitadb.api.requestResponse.data.mutation.EntityUpsertMutation;
+import io.evitadb.api.requestResponse.data.mutation.LocalMutation;
 import io.evitadb.api.requestResponse.data.mutation.attribute.UpsertAttributeMutation;
 import io.evitadb.api.requestResponse.data.mutation.price.UpsertPriceMutation;
 import io.evitadb.api.requestResponse.data.mutation.reference.InsertReferenceMutation;
@@ -484,10 +485,10 @@ class EvitaIndexingTest implements EvitaTestSupport {
 		);
 	}
 
-	@DisplayName("Price index must not stay stale when a reference rebuild and a price change share one mutation")
-	@ParameterizedTest(name = "old price {0} -> new price {1}")
+	@DisplayName("Price index must not stay stale when a reference rebuild precedes price change in one mutation")
+	@ParameterizedTest(name = "reference-first, old price {0} -> new price {1}")
 	@CsvSource({"590.00, 295.00", "295.00, 590.00"})
-	void shouldNotLeaveStalePriceIndexWhenReferenceRebuildAndPriceChangeShareOneMutation(
+	void shouldNotLeaveStalePriceIndexWhenReferenceRebuildPrecedesPriceChange(
 		@Nonnull BigDecimal oldPrice,
 		@Nonnull BigDecimal newPrice
 	) {
@@ -496,6 +497,34 @@ class EvitaIndexingTest implements EvitaTestSupport {
 		// and only afterwards changes the LOWEST_PRICE inner-record prices reusing their internal price
 		// ids. The transactional change layer used to keep the OLD price record because the new record
 		// is identity-equal (same internal price id) yet content-different, so the index stayed stale.
+		runStalePriceIndexScenario(oldPrice, newPrice, /*referenceFirst*/ true);
+	}
+
+	@DisplayName("Price index must not stay stale when a price change precedes the reference rebuild in one mutation")
+	@ParameterizedTest(name = "price-first, old price {0} -> new price {1}")
+	@CsvSource({"590.00, 295.00", "295.00, 590.00"})
+	void shouldNotLeaveStalePriceIndexWhenPriceChangePrecedesReferenceRebuild(
+		@Nonnull BigDecimal oldPrice,
+		@Nonnull BigDecimal newPrice
+	) {
+		// Documents that the reverse mutation order (prices changed before the reference swap) also
+		// produces a correct index. The original bug surfaced only with the reference-first order, but
+		// this variant guards against future regressions in the price-first path.
+		runStalePriceIndexScenario(oldPrice, newPrice, /*referenceFirst*/ false);
+	}
+
+	/**
+	 * Common reproducer body shared by the reference-first and price-first variants. The
+	 * {@code referenceFirst} flag toggles only the order in which the reference rebuild and the price
+	 * updates appear inside the single {@link EntityUpsertMutation}; everything else - schema, seed
+	 * data, transactional mode switch and assertions - is identical so both orderings exercise the
+	 * same downstream pipeline.
+	 */
+	private void runStalePriceIndexScenario(
+		@Nonnull BigDecimal oldPrice,
+		@Nonnull BigDecimal newPrice,
+		boolean referenceFirst
+	) {
 		final int productPk = 100;
 		final int categoryPkOld = 500;
 		final int categoryPkNew = 501;
@@ -545,27 +574,31 @@ class EvitaIndexingTest implements EvitaTestSupport {
 			"Pre-condition: product should be indexed with its OLD price in the OLD category"
 		);
 
-		// 2) the offending mutation: rebuild the reference first, then change both prices - all in one tx
+		final RemoveReferenceMutation removeRef =
+			new RemoveReferenceMutation(REFERENCE_PRODUCT_CATEGORY, categoryPkOld);
+		final InsertReferenceMutation insertRef =
+			new InsertReferenceMutation(new ReferenceKey(REFERENCE_PRODUCT_CATEGORY, categoryPkNew));
+		final UpsertPriceMutation upsertPriceA = new UpsertPriceMutation(
+			new PriceKey(1, PRICE_LIST_BASIC, CURRENCY_CZK), innerA,
+			newPrice, BigDecimal.ZERO, newPrice, null, true
+		);
+		final UpsertPriceMutation upsertPriceB = new UpsertPriceMutation(
+			new PriceKey(2, PRICE_LIST_BASIC, CURRENCY_CZK), innerB,
+			newPrice, BigDecimal.ZERO, newPrice, null, true
+		);
+
+		// 2) the offending mutation: rebuild the reference and change both prices in one tx, in the
+		// order determined by the {@code referenceFirst} flag
+		final List<? extends LocalMutation<?, ?>> localMutations =
+			referenceFirst
+				? List.of(removeRef, insertRef, upsertPriceA, upsertPriceB)
+				: List.of(upsertPriceA, upsertPriceB, removeRef, insertRef);
 		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.applyMutation(
 					new EntityUpsertMutation(
-						Entities.PRODUCT,
-						productPk,
-						EntityExistence.MUST_EXIST,
-						List.of(
-							new RemoveReferenceMutation(REFERENCE_PRODUCT_CATEGORY, categoryPkOld),
-							new InsertReferenceMutation(new ReferenceKey(REFERENCE_PRODUCT_CATEGORY, categoryPkNew)),
-							new UpsertPriceMutation(
-								new PriceKey(1, PRICE_LIST_BASIC, CURRENCY_CZK), innerA,
-								newPrice, BigDecimal.ZERO, newPrice, null, true
-							),
-							new UpsertPriceMutation(
-								new PriceKey(2, PRICE_LIST_BASIC, CURRENCY_CZK), innerB,
-								newPrice, BigDecimal.ZERO, newPrice, null, true
-							)
-						)
+						Entities.PRODUCT, productPk, EntityExistence.MUST_EXIST, localMutations
 					)
 				);
 			}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaIndexingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaIndexingTest.java
@@ -4284,7 +4284,6 @@ class EvitaIndexingTest implements EvitaTestSupport {
 			.server(
 				ServerOptions.builder()
 					.closeSessionsAfterSecondsOfInactivity(inactivityTimeoutInSeconds)
-					.transactionTimeoutInMilliseconds(Long.MAX_VALUE)
 					.build()
 			)
 			.storage(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalObjArrayTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalObjArrayTest.java
@@ -484,6 +484,35 @@ class TransactionalObjArrayTest implements TimeBoundedTestSupport {
 	}
 
 	@Test
+	void shouldNotDuplicateRecordWhenSubstitutionIsRevertedToOriginalContent() {
+		// regression: a substitute (content-different add) followed by an add of the
+		// original content used to leave the substitution queued in the insertion bucket
+		// while cancelling the removal, so the merged array contained the record twice -
+		// once from the delegate, once from the orphaned bucket
+		final Box oldA = new Box(1, "OLD-A");
+		final Box newA = new Box(1, "NEW-A");
+		final Box originalAgain = new Box(1, "OLD-A");
+		final TransactionalObjArray<Box> array =
+			new TransactionalObjArray<>(new Box[]{oldA}, Box.BY_ID);
+
+		assertStateAfterCommit(
+			array,
+			original -> {
+				original.add(newA);
+				original.add(originalAgain);
+				assertEquals(1, original.getArray().length,
+					"Reverting a substitution must not leave a duplicate in the change layer");
+			},
+			(original, committed) -> {
+				assertEquals(1, committed.length,
+					"Reverting a substitution must not duplicate the record in the committed array");
+				assertEquals("OLD-A", committed[0].content(),
+					"Reverted content must match the original delegate record");
+			}
+		);
+	}
+
+	@Test
 	void shouldKeepLatestContentWhenSubstitutedRecordIsReplacedAgain() {
 		// substitute (remove old + add new), then add an even newer instance with the same identity -
 		// the committed array must carry the LATEST content

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalObjArrayTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalObjArrayTest.java
@@ -457,6 +457,58 @@ class TransactionalObjArrayTest implements TimeBoundedTestSupport {
 	}
 
 	@Test
+	void shouldRemoveSubstitutedRecordWithinSameTransaction() {
+		// after a content-substitution (remove old + add new, same identity), removing the new record
+		// again in the same transaction must leave the array WITHOUT that record - the substitution
+		// encoding (removed delegate slot + insertion bucket) must not resurrect it
+		final Box oldA = new Box(1, "OLD-A");
+		final Box oldB = new Box(2, "OLD-B");
+		final Box newB = new Box(2, "NEW-B");
+		final TransactionalObjArray<Box> array =
+			new TransactionalObjArray<>(new Box[]{oldA, oldB}, Box.BY_ID);
+
+		assertStateAfterCommit(
+			array,
+			original -> {
+				original.remove(oldB);
+				original.add(newB);
+				// right after substitution the record must be reported present
+				assertTrue(original.contains(newB), "Substituted record must be visible via contains()");
+				// now remove it again - it must disappear entirely
+				original.remove(newB);
+				assertFalse(original.contains(newB), "Removed substituted record must not be present");
+				assertArrayEquals(new Box[]{oldA}, original.getArray());
+			},
+			(original, committed) -> assertArrayEquals(new Box[]{oldA}, committed)
+		);
+	}
+
+	@Test
+	void shouldKeepLatestContentWhenSubstitutedRecordIsReplacedAgain() {
+		// substitute (remove old + add new), then add an even newer instance with the same identity -
+		// the committed array must carry the LATEST content
+		final Box oldA = new Box(1, "OLD-A");
+		final Box v1 = new Box(1, "V1");
+		final Box v2 = new Box(1, "V2");
+		final TransactionalObjArray<Box> array =
+			new TransactionalObjArray<>(new Box[]{oldA}, Box.BY_ID);
+
+		assertStateAfterCommit(
+			array,
+			original -> {
+				original.remove(oldA);
+				original.add(v1);
+				original.add(v2);
+			},
+			(original, committed) -> {
+				assertEquals(1, committed.length);
+				assertEquals("V2", committed[0].content(),
+					"Committed array must carry the latest substituted content");
+			}
+		);
+	}
+
+	@Test
 	void shouldCorrectlyWipeAll() {
 		final TransactionalObjArray<Integer> array = new TransactionalObjArray<>(new Integer[]{36, 59, 179}, Comparator.naturalOrder());
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalObjArrayTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalObjArrayTest.java
@@ -26,7 +26,10 @@ package io.evitadb.index.array;
 import io.evitadb.test.duration.TimeArgumentProvider;
 import io.evitadb.test.duration.TimeArgumentProvider.GenerationalTestInput;
 import io.evitadb.test.duration.TimeBoundedTestSupport;
+import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.utils.ArrayUtils;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -394,6 +397,66 @@ class TransactionalObjArrayTest implements TimeBoundedTestSupport {
 	}
 
 	@Test
+	void shouldReplaceRecordWithSameIdentityButDifferentContentOnRemoveThenAdd() {
+		// reproduces the stale-record bug in ObjArrayChanges#addRecordId: when a record is
+		// removed and then re-added within the same transaction with the same comparator
+		// identity but different content, the merged array must reflect the NEW content
+		final Box oldA = new Box(1, "OLD-A");
+		final Box oldB = new Box(2, "OLD-B");
+		final Box newB = new Box(2, "NEW-B");
+		final TransactionalObjArray<Box> array =
+			new TransactionalObjArray<>(new Box[]{oldA, oldB}, Box.BY_ID);
+
+		assertStateAfterCommit(
+			array,
+			original -> {
+				original.remove(oldB);
+				original.add(newB);
+				final Box[] inTx = original.getArray();
+				assertEquals(2, inTx.length);
+				assertEquals(1, inTx[0].id());
+				assertEquals(2, inTx[1].id());
+				assertEquals("NEW-B", inTx[1].content(),
+					"Transactional view must already reflect the replaced content");
+			},
+			(original, committed) -> {
+				assertEquals(2, committed.length);
+				assertEquals(1, committed[0].id());
+				assertEquals(2, committed[1].id());
+				assertEquals("OLD-A", committed[0].content());
+				assertEquals("NEW-B", committed[1].content(),
+					"Committed array must contain the NEW content, not the stale OLD one");
+			}
+		);
+	}
+
+	@Test
+	void shouldReplaceFreshlyInsertedRecordWithSameIdentityButDifferentContent() {
+		// symmetric scenario: record is first added on the change layer, then removed
+		// and re-added with the same identity but new content – the add path must replace
+		// the previously inserted (not yet committed) value
+		final Box first = new Box(7, "FIRST");
+		final Box second = new Box(7, "SECOND");
+		final TransactionalObjArray<Box> array =
+			new TransactionalObjArray<>(new Box[0], Box.BY_ID);
+
+		assertStateAfterCommit(
+			array,
+			original -> {
+				original.add(first);
+				original.remove(first);
+				original.add(second);
+			},
+			(original, committed) -> {
+				assertEquals(1, committed.length);
+				assertEquals(7, committed[0].id());
+				assertEquals("SECOND", committed[0].content(),
+					"Committed insertion bucket must hold the latest object instance, not the first one");
+			}
+		);
+	}
+
+	@Test
 	void shouldCorrectlyWipeAll() {
 		final TransactionalObjArray<Integer> array = new TransactionalObjArray<>(new Integer[]{36, 59, 179}, Comparator.naturalOrder());
 
@@ -510,6 +573,34 @@ class TransactionalObjArrayTest implements TimeBoundedTestSupport {
 	private record TestState(
 		Integer[] initialArray
 	) {
+	}
+
+	/**
+	 * Identity-based record that mimics PriceRecordContract: equals/hashCode/compareTo
+	 * key only on {@link #id()} while {@link #content()} is logical payload that may
+	 * change without changing identity.
+	 */
+	private record Box(int id, @Nonnull String content) implements ContentComparator<Box> {
+		static final Comparator<Box> BY_ID = Comparator.comparingInt(Box::id);
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (!(o instanceof Box other)) return false;
+			return this.id == other.id;
+		}
+
+		@Override
+		public int hashCode() {
+			return Integer.hashCode(this.id);
+		}
+
+		@Override
+		public boolean differsFrom(@Nullable Box other) {
+			if (other == this) return false;
+			if (other == null) return true;
+			return this.id != other.id || !this.content.equals(other.content);
+		}
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
@@ -559,6 +559,39 @@ class TransactionalSetTest implements TimeBoundedTestSupport {
 	}
 
 	@Test
+	void shouldRevertToOriginalContentWhenSubstitutionFollowedByOriginalAdd() {
+		// regression guard: after substituting with new content and adding the original-content
+		// instance again, the merged set must contain exactly one logical element and the change-layer
+		// bookkeeping (createdKeys / removedKeys) must not double-count or drop the entry
+		final Box oldA = new Box(1, "OLD-A");
+		final Box newA = new Box(1, "NEW-A");
+		final Box originalAgain = new Box(1, "OLD-A");
+		final Box otherB = new Box(2, "B");
+		final Set<Box> underlying = new LinkedHashSet<>();
+		underlying.add(oldA);
+		underlying.add(otherB);
+		final TransactionalSet<Box> set = new TransactionalSet<>(underlying);
+
+		assertStateAfterCommit(
+			set,
+			original -> {
+				original.add(newA);
+				original.add(originalAgain);
+				assertEquals(2, original.size(),
+					"Reverting a substitution must not change the logical size");
+				assertTrue(original.contains(oldA), "Identity must remain present after revert");
+				assertTrue(original.contains(otherB), "Unrelated elements must remain present");
+			},
+			(original, committed) -> {
+				assertEquals(2, committed.size(),
+					"Committed set must contain exactly one entry per identity");
+				assertTrue(committed.contains(oldA), "Identity must survive the substitute-then-revert");
+				assertTrue(committed.contains(otherB), "Unrelated elements must remain in the committed set");
+			}
+		);
+	}
+
+	@Test
 	void shouldRemoveSubstitutedElementWithinSameTransaction() {
 		// after substituting a delegate element, removing it again in the same transaction must leave
 		// the set without that element (the original must end up removed, the replacement dropped)

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
@@ -23,9 +23,13 @@
 
 package io.evitadb.index.set;
 
+import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.test.duration.TimeArgumentProvider;
 import io.evitadb.test.duration.TimeArgumentProvider.GenerationalTestInput;
 import io.evitadb.test.duration.TimeBoundedTestSupport;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -478,9 +482,87 @@ class TransactionalSetTest implements TimeBoundedTestSupport {
 		}
 	}
 
+	@Test
+	void shouldReplaceSameIdentityElementWithDifferentContentOnAdd() {
+		// reproduces the silent-drop bug in SetChanges#put: when an element with the same equals()
+		// identity is added on top of one already in the delegate, the new (potentially modified)
+		// instance must end up in the committed set - not the stale original.
+		final Box oldA = new Box(1, "OLD-A");
+		final Box newA = new Box(1, "NEW-A");
+		final Set<Box> underlying = new LinkedHashSet<>();
+		underlying.add(oldA);
+		final TransactionalSet<Box> set = new TransactionalSet<>(underlying);
+
+		assertStateAfterCommit(
+			set,
+			original -> original.add(newA),
+			(original, committed) -> {
+				assertEquals(1, committed.size());
+				final Box committedBox = committed.iterator().next();
+				assertEquals(1, committedBox.id());
+				assertEquals("NEW-A", committedBox.content(),
+					"Committed set must hold the NEW content, not the stale original instance");
+			}
+		);
+	}
+
+	@Test
+	void shouldReplaceSameIdentityElementOnRemoveThenAdd() {
+		// remove-then-add variant: the original is marked for removal, then a fresh instance with
+		// the same identity but new content is added. The committed set must carry the new content.
+		final Box oldA = new Box(1, "OLD-A");
+		final Box newA = new Box(1, "NEW-A");
+		final Set<Box> underlying = new LinkedHashSet<>();
+		underlying.add(oldA);
+		final TransactionalSet<Box> set = new TransactionalSet<>(underlying);
+
+		assertStateAfterCommit(
+			set,
+			original -> {
+				original.remove(oldA);
+				original.add(newA);
+			},
+			(original, committed) -> {
+				assertEquals(1, committed.size());
+				final Box committedBox = committed.iterator().next();
+				assertEquals(1, committedBox.id());
+				assertEquals("NEW-A", committedBox.content(),
+					"Committed set must hold the NEW content after remove-then-add of same identity");
+			}
+		);
+	}
+
 	private record TestState(
 		StringBuilder code,
 		Set<String> initialSet
 	) {}
+
+	/**
+	 * Identity-based record that mimics PriceRecordContract: equals/hashCode key only on
+	 * {@link #id()} while {@link #content()} is logical payload that may change without changing
+	 * identity. Implements {@link ContentComparator} so a fix in SetChanges can detect content
+	 * divergence and substitute the existing element.
+	 */
+	private record Box(int id, @Nonnull String content) implements ContentComparator<Box> {
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (!(o instanceof Box other)) return false;
+			return this.id == other.id;
+		}
+
+		@Override
+		public int hashCode() {
+			return Integer.hashCode(this.id);
+		}
+
+		@Override
+		public boolean differsFrom(@Nullable Box other) {
+			if (other == this) return false;
+			if (other == null) return true;
+			return this.id != other.id || !this.content.equals(other.content);
+		}
+	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
@@ -532,6 +532,55 @@ class TransactionalSetTest implements TimeBoundedTestSupport {
 		);
 	}
 
+	@Test
+	void shouldKeepLatestContentWhenSubstitutedElementIsAddedAgain() {
+		// substitute a delegate element (add new content over same identity), then add an even newer
+		// instance with the same identity - the committed set must carry the LATEST content and the
+		// stale original must not resurface
+		final Box oldA = new Box(1, "OLD-A");
+		final Box v1 = new Box(1, "V1");
+		final Box v2 = new Box(1, "V2");
+		final Set<Box> underlying = new LinkedHashSet<>();
+		underlying.add(oldA);
+		final TransactionalSet<Box> set = new TransactionalSet<>(underlying);
+
+		assertStateAfterCommit(
+			set,
+			original -> {
+				original.add(v1);
+				original.add(v2);
+			},
+			(original, committed) -> {
+				assertEquals(1, committed.size());
+				assertEquals("V2", committed.iterator().next().content(),
+					"Committed set must hold the latest substituted content");
+			}
+		);
+	}
+
+	@Test
+	void shouldRemoveSubstitutedElementWithinSameTransaction() {
+		// after substituting a delegate element, removing it again in the same transaction must leave
+		// the set without that element (the original must end up removed, the replacement dropped)
+		final Box oldA = new Box(1, "OLD-A");
+		final Box newA = new Box(1, "NEW-A");
+		final Set<Box> underlying = new LinkedHashSet<>();
+		underlying.add(oldA);
+		final TransactionalSet<Box> set = new TransactionalSet<>(underlying);
+
+		assertStateAfterCommit(
+			set,
+			original -> {
+				original.add(newA);
+				assertTrue(original.contains(newA), "Substituted element must be visible via contains()");
+				original.remove(newA);
+				assertFalse(original.contains(newA), "Removed substituted element must not be present");
+			},
+			(original, committed) -> assertTrue(committed.isEmpty(),
+				"Committed set must be empty after substitute-then-remove")
+		);
+	}
+
 	private record TestState(
 		StringBuilder code,
 		Set<String> initialSet


### PR DESCRIPTION
## Summary

Fixes a stale-index bug where a record removed and re-added (or re-added) within a single transaction kept its **old content** when its `equals`/comparator **identity was unchanged but its content differed**.

`PriceRecordContract` keys identity on `internalPriceId` only, so a price change that reuses the same internal price id left the price index stale after a combined reference-rebuild + price-change `EntityUpsertMutation` (the production symptom: super-index keeps the pre-change price, diverging from the entity body and producing wrong price-for-sale / ordering).

## Changes

- **`ObjArrayChanges#addRecordId`** — when identity matches but content differs, keeps/adds a removal **and** queues an insertion of the new instance at the same logical position; the merge substitutes atomically. `InsertionBucket.addRecord` now replaces an identity-equal entry instead of dropping the new instance.
- **`SetChanges#put`/`remove`** — same content-aware substitution (encoded as a paired remove + add that `createMergedSet` honors); `remove` updated to correctly roll back a pending substitution.
- **`PriceRecordContract`** — now implements `ContentComparator<PriceRecordContract>` with a default `differsFrom` comparing all primitive content fields.
- Detection prefers `ContentComparator#differsFrom`, falling back to `Object#equals`, so content-aware-equals types keep their existing behavior.
- JavaDoc updated across all three change classes.

## Tests

- `EvitaIndexingTest#shouldNotLeaveStalePriceIndexWhenReferenceRebuildAndPriceChangeShareOneMutation` — parameterized full-product reproducer (price discount **and** increase), asserting through the public query API that the index reflects the new price and no longer the old one.
- `TransactionalObjArrayTest` — focused unit reproducers for remove-then-add and fresh-insert-then-replace.
- `TransactionalSetTest` — focused unit reproducers for add and remove-then-add of identity-equal-but-content-different elements.

All touched suites pass; `evita_engine` builds.

Closes #1193