### PR TITLE
fix: substitute stale records in transactional change layers on content change

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/ContentComparator.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/ContentComparator.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.api.requestResponse.data;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -40,5 +41,23 @@ public interface ContentComparator<T> {
 	 * equal types.
 	 */
 	boolean differsFrom(@Nullable T otherObject);
+
+	/**
+	 * Returns true when {@code candidate} carries different content than {@code existing}, where both
+	 * are considered identity-equal by some external comparator (typically the equals/hashCode pair
+	 * defined on a primary key). Prefers the explicit {@link ContentComparator} contract; falls back
+	 * to {@link Object#equals} so types whose equals semantics already imply content equality keep
+	 * working as before.
+	 */
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	static <T> boolean contentDiffers(@Nonnull T existing, @Nonnull T candidate) {
+		if (existing == candidate) {
+			return false;
+		}
+		if (candidate instanceof ContentComparator) {
+			return ((ContentComparator) candidate).differsFrom(existing);
+		}
+		return !existing.equals(candidate);
+	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.index.array;
 
+import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.ArrayUtils.InsertionPosition;
 import lombok.Getter;
@@ -186,7 +187,12 @@ public class ObjArrayChanges<T> {
 	boolean contains(@Nonnull T recordId, @Nonnull Comparator<T> comparator) {
 		final int delegateIndex = Arrays.binarySearch(this.delegate, recordId, comparator);
 		if (delegateIndex >= 0) {
-			return Arrays.binarySearch(this.removals, delegateIndex) < 0;
+			if (Arrays.binarySearch(this.removals, delegateIndex) < 0) {
+				return true;
+			}
+			// delegate slot is removed - a content substitution may have queued a replacement with
+			// the same comparator key in the insertion bucket at this position
+			return insertionBucketContains(delegateIndex, recordId, comparator);
 		} else {
 			for (InsertionBucket<T> insertedValue : this.insertedValues) {
 				final int pos = Arrays.binarySearch(
@@ -201,42 +207,96 @@ public class ObjArrayChanges<T> {
 	}
 
 	/**
-	 * Adds new recordId to the array (only when not already present).
-	 * This operation also nullifies previous record id removal (if any).
+	 * Returns true if the insertion bucket queued at the given delegate position contains a record
+	 * with the same comparator key as `recordId`. Used to recognize a content-substitution replacement
+	 * that sits at a delegate position that is simultaneously marked for removal.
+	 */
+	private boolean insertionBucketContains(int position, @Nonnull T recordId, @Nonnull Comparator<T> comparator) {
+		final int insIdx = Arrays.binarySearch(this.insertions, position);
+		return insIdx >= 0
+			&& Arrays.binarySearch(this.insertedValues[insIdx].getInsertedValues(), recordId, comparator) >= 0;
+	}
+
+	/**
+	 * Adds new recordId to the array. Behaviour depends on the relationship to the original array:
+	 *
+	 *  - if a record with the same comparator key is already in the base delegate and the new
+	 *    record carries different content (detected via {@link ContentComparator#differsFrom} when
+	 *    the type implements it, otherwise via {@link Object#equals}), the existing record is
+	 *    substituted — a removal is recorded for its position AND an insertion of the new instance
+	 *    is queued at the same logical position. The merge step combines both operations atomically.
+	 *  - if the record was previously marked for removal and the contents are equal, the removal
+	 *    is cancelled (idempotent re-add).
+	 *  - if the record is not in the base delegate, it is appended to the change layer.
 	 */
 	void addRecordId(@Nonnull T recordId, @Nonnull Comparator<T> comparator) {
 		final InsertionPosition position =
 			ArrayUtils.computeInsertPositionOfObjInOrderedArray(
 				recordId, this.delegate, comparator
 			);
-		// record id was already part of the array, but may have been removed
+		final int positionIndex = position.position();
 		if (position.alreadyPresent()) {
-			final int removalIndex = Arrays.binarySearch(this.removals, position.position());
-			if (removalIndex >= 0) {
-				// just remove the position from the removals
+			// base delegate already holds a record with the same comparator key
+			final T existing = this.delegate[positionIndex];
+			final int removalIndex = Arrays.binarySearch(this.removals, positionIndex);
+			if (contentDiffers(existing, recordId)) {
+				// identity matches but content differs - substitute the record:
+				// ensure the original position is marked for removal AND queue an insertion of
+				// the new instance at the same logical position
+				if (removalIndex < 0) {
+					this.removals = ArrayUtils.insertIntIntoOrderedArray(positionIndex, this.removals);
+				}
+				insertIntoChangeLayer(recordId, positionIndex, comparator);
+			} else if (removalIndex >= 0) {
+				// contents are equal - cancel any pending removal
 				this.removals = ArrayUtils.removeIntFromArrayOnIndex(this.removals, removalIndex);
 			}
+			// else: identical record already present and not removed -> no-op
 		} else {
-			// compute expected position of the record
-			final int index = Arrays.binarySearch(this.insertions, position.position());
-			if (index >= 0) {
-				// if there is already waiting array of appended record append also this record id there
-				this.insertedValues[index].addRecord(recordId, comparator);
-			} else {
-				// if not - create new list of additions on expected position
-				final int startIndex = -1 * (index) - 1;
-				this.insertions = ArrayUtils.insertIntIntoArrayOnIndex(
-					position.position(), this.insertions, startIndex
-				);
-				final Class<?> componentType = this.delegate.getClass().getComponentType();
-				this.insertedValues = ArrayUtils.insertRecordIntoArrayOnIndex(
-					new InsertionBucket<>(recordId, componentType),
-					this.insertedValues, startIndex
-				);
-			}
+			insertIntoChangeLayer(recordId, positionIndex, comparator);
 		}
 		// nullify memoized result that becomes obsolete by this operation
 		this.memoizedMergedArray = null;
+	}
+
+	/**
+	 * Appends a record to the insertion bucket at the given logical position, creating the bucket
+	 * when it does not yet exist. If a same-identity record is already present in the bucket, it is
+	 * replaced with the new instance (so a remove-then-add of an in-flight insertion correctly
+	 * substitutes the content).
+	 */
+	private void insertIntoChangeLayer(@Nonnull T recordId, int position, @Nonnull Comparator<T> comparator) {
+		final int index = Arrays.binarySearch(this.insertions, position);
+		if (index >= 0) {
+			this.insertedValues[index].addRecord(recordId, comparator);
+		} else {
+			final int startIndex = -1 * (index) - 1;
+			this.insertions = ArrayUtils.insertIntIntoArrayOnIndex(
+				position, this.insertions, startIndex
+			);
+			final Class<?> componentType = this.delegate.getClass().getComponentType();
+			this.insertedValues = ArrayUtils.insertRecordIntoArrayOnIndex(
+				new InsertionBucket<>(recordId, componentType),
+				this.insertedValues, startIndex
+			);
+		}
+	}
+
+	/**
+	 * Detects whether the candidate record carries a different content than the existing one in the
+	 * base array, when both are deemed identity-equal by the array comparator. Prefers the explicit
+	 * {@link ContentComparator} contract; falls back to {@link Object#equals} semantics so types with
+	 * content-aware equals keep working as before.
+	 */
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	private static <T> boolean contentDiffers(@Nonnull T existing, @Nonnull T candidate) {
+		if (existing == candidate) {
+			return false;
+		}
+		if (candidate instanceof ContentComparator) {
+			return ((ContentComparator) candidate).differsFrom(existing);
+		}
+		return !existing.equals(candidate);
 	}
 
 	/**
@@ -249,6 +309,19 @@ public class ObjArrayChanges<T> {
 		if (position >= 0) {
 			// if so, mark this position for removal (this operation is idempotent)
 			this.removals = ArrayUtils.insertIntIntoOrderedArray(position, this.removals);
+			// if a content substitution previously queued a replacement at this position, drop it too -
+			// otherwise the merge would resurrect the (now removed) record from the insertion bucket
+			final int insIdx = Arrays.binarySearch(this.insertions, position);
+			if (insIdx >= 0) {
+				final InsertionBucket<T> bucket = this.insertedValues[insIdx];
+				if (Arrays.binarySearch(bucket.getInsertedValues(), recordId, comparator) >= 0) {
+					bucket.removeRecord(recordId, comparator);
+					if (bucket.isEmpty()) {
+						this.insertions = ArrayUtils.removeIntFromArrayOnIndex(this.insertions, insIdx);
+						this.insertedValues = ArrayUtils.removeRecordFromArrayOnIndex(this.insertedValues, insIdx);
+					}
+				}
+			}
 		} else {
 			// record is not part of the original array but might be present on change layer
 			final int changePosition =
@@ -443,9 +516,16 @@ public class ObjArrayChanges<T> {
 		}
 
 		public void addRecord(@Nonnull T recordId, @Nonnull Comparator<T> comparator) {
-			this.insertedValues = ArrayUtils.insertRecordIntoOrderedArray(
-				recordId, this.insertedValues, comparator
-			);
+			final int idx = Arrays.binarySearch(this.insertedValues, recordId, comparator);
+			if (idx >= 0) {
+				// record with the same comparator key is already in the bucket - substitute it,
+				// otherwise the new instance (potentially carrying updated content) would be dropped
+				this.insertedValues[idx] = recordId;
+			} else {
+				this.insertedValues = ArrayUtils.insertRecordIntoArrayOnIndex(
+					recordId, this.insertedValues, -idx - 1
+				);
+			}
 		}
 
 		public void removeRecord(@Nonnull T recordId, @Nonnull Comparator<T> comparator) {

--- a/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
@@ -239,7 +239,7 @@ public class ObjArrayChanges<T> {
 			// base delegate already holds a record with the same comparator key
 			final T existing = this.delegate[positionIndex];
 			final int removalIndex = Arrays.binarySearch(this.removals, positionIndex);
-			if (contentDiffers(existing, recordId)) {
+			if (ContentComparator.contentDiffers(existing, recordId)) {
 				// identity matches but content differs - substitute the record:
 				// ensure the original position is marked for removal AND queue an insertion of
 				// the new instance at the same logical position
@@ -250,6 +250,10 @@ public class ObjArrayChanges<T> {
 			} else if (removalIndex >= 0) {
 				// contents are equal - cancel any pending removal
 				this.removals = ArrayUtils.removeIntFromArrayOnIndex(this.removals, removalIndex);
+				// also drop any orphaned substitution bucket that a prior addRecordId may have
+				// queued at this position - otherwise the merge would resurrect the stale
+				// replacement alongside the (now un-removed) delegate record
+				dropInsertionBucketEntry(positionIndex, recordId, comparator);
 			}
 			// else: identical record already present and not removed -> no-op
 		} else {
@@ -283,20 +287,25 @@ public class ObjArrayChanges<T> {
 	}
 
 	/**
-	 * Detects whether the candidate record carries a different content than the existing one in the
-	 * base array, when both are deemed identity-equal by the array comparator. Prefers the explicit
-	 * {@link ContentComparator} contract; falls back to {@link Object#equals} semantics so types with
-	 * content-aware equals keep working as before.
+	 * Drops the record from the insertion bucket queued at the given delegate position, when
+	 * present. If the bucket becomes empty as a result, the bucket entry is removed from the
+	 * parallel insertions/insertedValues arrays as well. Used to clean up substitution buckets
+	 * left over by a prior add when the substitution gets reverted or removed.
 	 */
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private static <T> boolean contentDiffers(@Nonnull T existing, @Nonnull T candidate) {
-		if (existing == candidate) {
-			return false;
+	private void dropInsertionBucketEntry(int position, @Nonnull T recordId, @Nonnull Comparator<T> comparator) {
+		final int insIdx = Arrays.binarySearch(this.insertions, position);
+		if (insIdx < 0) {
+			return;
 		}
-		if (candidate instanceof ContentComparator) {
-			return ((ContentComparator) candidate).differsFrom(existing);
+		final InsertionBucket<T> bucket = this.insertedValues[insIdx];
+		if (Arrays.binarySearch(bucket.getInsertedValues(), recordId, comparator) < 0) {
+			return;
 		}
-		return !existing.equals(candidate);
+		bucket.removeRecord(recordId, comparator);
+		if (bucket.isEmpty()) {
+			this.insertions = ArrayUtils.removeIntFromArrayOnIndex(this.insertions, insIdx);
+			this.insertedValues = ArrayUtils.removeRecordFromArrayOnIndex(this.insertedValues, insIdx);
+		}
 	}
 
 	/**
@@ -311,17 +320,7 @@ public class ObjArrayChanges<T> {
 			this.removals = ArrayUtils.insertIntIntoOrderedArray(position, this.removals);
 			// if a content substitution previously queued a replacement at this position, drop it too -
 			// otherwise the merge would resurrect the (now removed) record from the insertion bucket
-			final int insIdx = Arrays.binarySearch(this.insertions, position);
-			if (insIdx >= 0) {
-				final InsertionBucket<T> bucket = this.insertedValues[insIdx];
-				if (Arrays.binarySearch(bucket.getInsertedValues(), recordId, comparator) >= 0) {
-					bucket.removeRecord(recordId, comparator);
-					if (bucket.isEmpty()) {
-						this.insertions = ArrayUtils.removeIntFromArrayOnIndex(this.insertions, insIdx);
-						this.insertedValues = ArrayUtils.removeRecordFromArrayOnIndex(this.insertedValues, insIdx);
-					}
-				}
-			}
+			dropInsertionBucketEntry(position, recordId, comparator);
 		} else {
 			// record is not part of the original array but might be present on change layer
 			final int changePosition =

--- a/evita_engine/src/main/java/io/evitadb/index/price/model/priceRecord/PriceRecordContract.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/model/priceRecord/PriceRecordContract.java
@@ -23,33 +23,52 @@
 
 package io.evitadb.index.price.model.priceRecord;
 
+import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
 import io.evitadb.api.requestResponse.data.structure.Entity;
 import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Comparator;
 
 /**
- * Price record envelopes single price of the entity. This data structure allows translating price ids and inner record
- * ids to entity primary key. Also price amounts are used for sorting by price. Price indexes don't use original
- * {@link PriceContract} to minimize memory consumption (this class contains only primitive types).
+ * Compact, primitive-only representation of a single entity price used inside price indexes.
  *
- * There are two specializations of this interface:
+ * Price indexes avoid holding full {@link PriceContract} objects in order to minimize heap usage.
+ * This interface distills only the fields that are needed for price filtering, sorting, and translation
+ * between price ids and entity primary keys.
  *
- * - {@link PriceRecord} - represents a physical price recorded for single entity and present in indexes
- * - {@link CumulatedVirtualPriceRecord} - represents an "on the fly" record with computed prices that are required by
- * {@link PriceInnerRecordHandling#SUM sum price computation strategy}
+ * **Identity vs. content** — this is a critical distinction for the transactional change layer:
+ *
+ * - *Identity* is defined by {@link #internalPriceId()} alone. Both {@link #compareTo} and
+ *   {@link #PRICE_RECORD_COMPARATOR} key on `internalPriceId`, and `equals`/`hashCode` in the
+ *   concrete implementations ({@link PriceRecord}, {@link PriceRecordInnerRecordSpecific}) also key
+ *   only on `internalPriceId`. Two records with the same `internalPriceId` are therefore considered
+ *   the *same price slot* by sorted collections.
+ * - *Content* covers all amount fields (`priceWithTax`, `priceWithoutTax`, `innerRecordId`, etc.).
+ *   The {@link #differsFrom} default method provided by this interface compares full content, allowing
+ *   the transactional index structures ({@link io.evitadb.index.array.ObjArrayChanges},
+ *   {@link io.evitadb.index.set.SetChanges}) to detect a changed price amount and substitute the
+ *   stale record with the updated one — even though identity-based lookup would consider them equal.
+ *
+ * Two specializations exist:
+ *
+ * - {@link PriceRecord} — represents a physical price for a single entity that has no inner record id.
+ * - {@link CumulatedVirtualPriceRecord} — an on-the-fly aggregated record required by
+ * {@link PriceInnerRecordHandling#SUM the SUM price computation strategy}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
-public interface PriceRecordContract extends Serializable, Comparable<PriceRecordContract> {
+public interface PriceRecordContract extends Serializable, Comparable<PriceRecordContract>, ContentComparator<PriceRecordContract> {
 
 	/**
-	 * Comparator that orders {@link PriceRecordContract} instances
-	 * by {@link #internalPriceId()} in ascending order.
+	 * Canonical comparator for sorted collections of price records. Orders by {@link #internalPriceId()}
+	 * only — two records representing the same price slot in the same entity are considered equal by
+	 * this comparator regardless of their amount fields. Used by {@link io.evitadb.index.array.ObjArrayChanges}
+	 * to locate a record's position in the sorted delegate array.
 	 */
 	@Nonnull
 	Comparator<PriceRecordContract> PRICE_RECORD_COMPARATOR =
@@ -103,5 +122,38 @@ public interface PriceRecordContract extends Serializable, Comparable<PriceRecor
 	 * @return true if the price relates to another price
 	 */
 	boolean relatesTo(@Nonnull PriceRecordContract anotherPriceRecord);
+
+	/**
+	 * Performs a deep, field-by-field content comparison that goes beyond the identity check of
+	 * `equals` / {@link #PRICE_RECORD_COMPARATOR}.
+	 *
+	 * Two records with the same {@link #internalPriceId()} are *identity-equal* — they occupy the same
+	 * slot in a price index — but may carry different amounts after a price update (e.g. a discount
+	 * applied mid-transaction). This method returns `true` in that case, enabling the transactional
+	 * change layer ({@link io.evitadb.index.array.ObjArrayChanges},
+	 * {@link io.evitadb.index.set.SetChanges}) to substitute the stale record atomically instead of
+	 * silently dropping the update.
+	 *
+	 * Fields compared: `internalPriceId`, `priceId`, `entityPrimaryKey`, `priceWithTax`,
+	 * `priceWithoutTax`, and `innerRecordId`.
+	 *
+	 * @param otherObject the record to compare against; `null` is treated as "differs" (returns `true`)
+	 * @return `true` if any content field differs from `otherObject`, `false` if all fields match
+	 */
+	@Override
+	default boolean differsFrom(@Nullable PriceRecordContract otherObject) {
+		if (otherObject == this) {
+			return false;
+		}
+		if (otherObject == null) {
+			return true;
+		}
+		return this.internalPriceId() != otherObject.internalPriceId()
+			|| this.priceId() != otherObject.priceId()
+			|| this.entityPrimaryKey() != otherObject.entityPrimaryKey()
+			|| this.priceWithTax() != otherObject.priceWithTax()
+			|| this.priceWithoutTax() != otherObject.priceWithoutTax()
+			|| this.innerRecordId() != otherObject.innerRecordId();
+	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
@@ -144,7 +144,7 @@ public class SetChanges<K> implements Serializable {
 			return false;
 		}
 		final K existing = findIdentityEqual(this.setDelegate, key);
-		return existing != null && contentDiffers(existing, key);
+		return existing != null && ContentComparator.contentDiffers(existing, key);
 	}
 
 	/**
@@ -156,7 +156,7 @@ public class SetChanges<K> implements Serializable {
 			return;
 		}
 		final K existing = findIdentityEqual(getCreatedKeys(), key);
-		if (existing != null && contentDiffers(existing, key)) {
+		if (existing != null && ContentComparator.contentDiffers(existing, key)) {
 			final Set<K> created = getOrCreateCreatedKeys();
 			created.remove(key); // removes identity-equal entry from the HashSet
 			created.add(key);
@@ -176,22 +176,6 @@ public class SetChanges<K> implements Serializable {
 			}
 		}
 		return null;
-	}
-
-	/**
-	 * Detects whether the candidate carries different content than an identity-equal existing element.
-	 * Prefers the explicit {@link ContentComparator} contract; falls back to {@link Object#equals} so
-	 * types with content-aware equals keep working as before.
-	 */
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	private static <T> boolean contentDiffers(@Nonnull T existing, @Nonnull T candidate) {
-		if (existing == candidate) {
-			return false;
-		}
-		if (candidate instanceof ContentComparator) {
-			return ((ContentComparator) candidate).differsFrom(existing);
-		}
-		return !existing.equals(candidate);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.index.set;
 
+import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import lombok.Getter;
@@ -72,17 +73,31 @@ public class SetChanges<K> implements Serializable {
 	}
 
 	/**
-	 * Records the insertion of the given key. The update is trapped
-	 * within this diff layer.
+	 * Records the insertion of the given key. The update is trapped within this diff layer.
+	 *
+	 * When the key implements {@link ContentComparator} and an equal-by-identity element with
+	 * different content is already present (either in the delegate or in the change layer), the
+	 * existing instance is substituted by the new one. For the delegate case this is encoded as a
+	 * paired "remove + add" in the change layer - {@link #createMergedSet} honors both, so the new
+	 * instance ends up in the committed snapshot.
 	 */
 	public boolean put(@Nonnull K key) {
-		final boolean wasRemoved = this.removedKeys != null && this.removedKeys.remove(key);
 		if (containsCreated(key)) {
+			// already in change layer - replace identity-equal entry if its content has diverged
+			replaceInCreatedIfContentDiffers(key);
 			return false;
 		}
-		final boolean isPartOfOriginal = this.setDelegate.contains(key);
-		if (isPartOfOriginal) {
-			return wasRemoved;
+		if (this.setDelegate.contains(key)) {
+			// already in original delegate
+			if (contentDiffersFromDelegate(key)) {
+				// substitute: mark the original position for removal AND record the new instance as
+				// created - createMergedSet will drop the original and insert the new instance
+				getOrCreateRemovedKeys().add(key);
+				getOrCreateCreatedKeys().add(key);
+				return false;
+			}
+			// contents are logically equal - just cancel any pending removal
+			return this.removedKeys != null && this.removedKeys.remove(key);
 		}
 		getOrCreateCreatedKeys().add(key);
 		return true;
@@ -96,21 +111,87 @@ public class SetChanges<K> implements Serializable {
 	@SuppressWarnings("unchecked")
 	public boolean remove(@Nonnull Object key) {
 		@SuppressWarnings("SuspiciousMethodCalls") final boolean originalContained = this.setDelegate.contains(key);
-		if (originalContained && containsRemoved((K) key)) {
-			// value has been already removed - report false
+		final boolean wasInCreated = containsCreated((K) key);
+		final boolean wasInRemoved = containsRemoved((K) key);
+
+		// drop any pending creation (covers both fresh adds and substitution replacements)
+		if (wasInCreated) {
+			removeCreatedKey((K) key);
+		}
+
+		if (originalContained) {
+			if (wasInRemoved && !wasInCreated) {
+				// original already net-removed and no pending substitution to roll back -> no-op
+				return false;
+			}
+			// either this is a removal of an original entry, or a rollback of a "replace" -
+			// in both cases the original delegate position must end up removed
+			registerRemovedKey((K) key);
+			return true;
+		}
+		// not in delegate - only the pending creation (if any) had any effect
+		return wasInCreated;
+	}
+
+	/**
+	 * Detects whether an element identity-equal to {@code key} is already in {@link #setDelegate} but
+	 * carries different content. Returns false for types that do not implement {@link ContentComparator}
+	 * because for them {@link Object#equals} is content-aware and {@code setDelegate.contains} already
+	 * implies equality.
+	 */
+	private boolean contentDiffersFromDelegate(@Nonnull K key) {
+		if (!(key instanceof ContentComparator)) {
 			return false;
 		}
-		final boolean wasRemoved;
-		if (containsCreated((K) key)) {
-			removeCreatedKey((K) key);
-			wasRemoved = true;
-		} else if (originalContained) {
-			registerRemovedKey((K) key);
-			wasRemoved = true;
-		} else {
-			wasRemoved = false;
+		final K existing = findIdentityEqual(this.setDelegate, key);
+		return existing != null && contentDiffers(existing, key);
+	}
+
+	/**
+	 * If an identity-equal entry exists in the change layer with diverging content, substitutes it
+	 * for the new instance. No-op for types whose equals semantics already imply content equality.
+	 */
+	private void replaceInCreatedIfContentDiffers(@Nonnull K key) {
+		if (!(key instanceof ContentComparator)) {
+			return;
 		}
-		return wasRemoved;
+		final K existing = findIdentityEqual(getCreatedKeys(), key);
+		if (existing != null && contentDiffers(existing, key)) {
+			final Set<K> created = getOrCreateCreatedKeys();
+			created.remove(key); // removes identity-equal entry from the HashSet
+			created.add(key);
+		}
+	}
+
+	/**
+	 * Returns the element in {@code haystack} that is identity-equal (by {@link Object#equals}) to
+	 * {@code needle}, or {@code null} when none is present. A linear scan is required because the
+	 * {@link Set} API exposes no way to retrieve the stored instance equal to a probe.
+	 */
+	@Nullable
+	private K findIdentityEqual(@Nonnull Set<K> haystack, @Nonnull K needle) {
+		for (K candidate : haystack) {
+			if (needle.equals(candidate)) {
+				return candidate;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Detects whether the candidate carries different content than an identity-equal existing element.
+	 * Prefers the explicit {@link ContentComparator} contract; falls back to {@link Object#equals} so
+	 * types with content-aware equals keep working as before.
+	 */
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	private static <T> boolean contentDiffers(@Nonnull T existing, @Nonnull T candidate) {
+		if (existing == candidate) {
+			return false;
+		}
+		if (candidate instanceof ContentComparator) {
+			return ((ContentComparator) candidate).differsFrom(existing);
+		}
+		return !existing.equals(candidate);
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/PriceIndexingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/PriceIndexingTest.java
@@ -30,6 +30,14 @@ import io.evitadb.api.requestResponse.data.EntityEditor.EntityBuilder;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
 import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.data.mutation.EntityMutation.EntityExistence;
+import io.evitadb.api.requestResponse.data.mutation.EntityUpsertMutation;
+import io.evitadb.api.requestResponse.data.mutation.price.UpsertPriceMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.InsertReferenceMutation;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
+import io.evitadb.api.requestResponse.data.mutation.reference.RemoveReferenceMutation;
+import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
+import io.evitadb.api.requestResponse.schema.Cardinality;
 import io.evitadb.core.Evita;
 import io.evitadb.test.Entities;
 import io.evitadb.test.EvitaTestSupport;
@@ -38,10 +46,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.util.Currency;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 
 import static io.evitadb.api.query.Query.query;
@@ -175,6 +186,125 @@ class PriceIndexingTest implements EvitaTestSupport, IndexingTestSupport {
 						.getPrices()
 						.size()
 				);
+			}
+		);
+	}
+
+	@DisplayName("Price index must not stay stale when a reference rebuild and a price change share one mutation")
+	@ParameterizedTest(name = "old price {0} -> new price {1}")
+	@CsvSource({"590.00, 295.00", "295.00, 590.00"})
+	void shouldNotLeaveStalePriceIndexWhenReferenceRebuildAndPriceChangeShareOneMutation(
+		@Nonnull BigDecimal oldPrice,
+		@Nonnull BigDecimal newPrice
+	) {
+		// Reproduces #1193: a single EntityUpsertMutation that rebuilds the (filtering+partitioning)
+		// reference FIRST - which re-seeds the reduced reference index from the still-unchanged body -
+		// and only afterwards changes the LOWEST_PRICE inner-record prices reusing their internal price
+		// ids. The transactional change layer used to keep the OLD price record because the new record
+		// is identity-equal (same internal price id) yet content-different, so the index stayed stale.
+		final int productPk = 100;
+		final int categoryPkOld = 500;
+		final int categoryPkNew = 501;
+		final int innerA = 200;
+		final int innerB = 201;
+
+		// define the Category and Product (price + indexed reference) schemas, then seed in warm-up mode
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.CATEGORY)
+					.withoutGeneratedPrimaryKey()
+					.updateVia(session);
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withPriceInCurrency(CURRENCY_CZK)
+					.withReferenceToEntity(
+						REFERENCE_PRODUCT_CATEGORY, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs.indexedForFilteringAndPartitioning()
+					)
+					.updateVia(session);
+
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, categoryPkOld));
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, categoryPkNew));
+				session.upsertEntity(
+					session.createNewEntity(Entities.PRODUCT, productPk)
+						.setPriceInnerRecordHandling(PriceInnerRecordHandling.LOWEST_PRICE)
+						.setPrice(1, PRICE_LIST_BASIC, CURRENCY_CZK, innerA, oldPrice, BigDecimal.ZERO, oldPrice, true)
+						.setPrice(2, PRICE_LIST_BASIC, CURRENCY_CZK, innerB, oldPrice, BigDecimal.ZERO, oldPrice, true)
+						.setReference(REFERENCE_PRODUCT_CATEGORY, categoryPkOld)
+				);
+			}
+		);
+
+		// switch to transactional mode - only then the mutation travels through the WAL / transaction
+		// apply path (index-first, then body) that produced the divergence
+		this.evita.updateCatalog(TEST_CATALOG, EvitaSessionContract::goLiveAndClose);
+
+		// sanity: the product is found by its OLD price in the OLD category
+		assertTrue(
+			isProductFoundByPriceInCategory(productPk, categoryPkOld, oldPrice),
+			"Pre-condition: product should be indexed with its OLD price in the OLD category"
+		);
+
+		// the offending mutation: rebuild the reference first, then change both prices - all in one tx
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.applyMutation(
+					new EntityUpsertMutation(
+						Entities.PRODUCT,
+						productPk,
+						EntityExistence.MUST_EXIST,
+						List.of(
+							new RemoveReferenceMutation(REFERENCE_PRODUCT_CATEGORY, categoryPkOld),
+							new InsertReferenceMutation(new ReferenceKey(REFERENCE_PRODUCT_CATEGORY, categoryPkNew)),
+							new UpsertPriceMutation(
+								new PriceKey(1, PRICE_LIST_BASIC, CURRENCY_CZK), innerA,
+								newPrice, BigDecimal.ZERO, newPrice, null, true
+							),
+							new UpsertPriceMutation(
+								new PriceKey(2, PRICE_LIST_BASIC, CURRENCY_CZK), innerB,
+								newPrice, BigDecimal.ZERO, newPrice, null, true
+							)
+						)
+					)
+				);
+			}
+		);
+
+		// the index must reflect the new price: the product is found by the NEW price and NOT by the OLD one
+		assertTrue(
+			isProductFoundByPriceInCategory(productPk, categoryPkNew, newPrice),
+			"Product must be found by its NEW price in the NEW category - the index must reflect the change"
+		);
+		assertFalse(
+			isProductFoundByPriceInCategory(productPk, categoryPkNew, oldPrice),
+			"Product must NOT be found by its OLD price - a stale index would still match the original value"
+		);
+	}
+
+	/**
+	 * Queries the catalog through the public API for the given product, filtered by a reference to the
+	 * given category and by an exact price-for-sale. Both the reference filter (reduced reference index)
+	 * and the price filter (price index) are served from the committed indexes, so the result reflects
+	 * whether the indexes carry the expected price.
+	 */
+	private boolean isProductFoundByPriceInCategory(int productPk, int categoryPk, @Nonnull BigDecimal priceWithTax) {
+		return this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				return session.queryOneEntityReference(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							entityPrimaryKeyInSet(productPk),
+							referenceHaving(REFERENCE_PRODUCT_CATEGORY, entityPrimaryKeyInSet(categoryPk)),
+							priceInCurrency(CURRENCY_CZK),
+							priceInPriceLists(PRICE_LIST_BASIC),
+							priceBetween(priceWithTax, priceWithTax)
+						)
+					)
+				).isPresent();
 			}
 		);
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/PriceIndexingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/PriceIndexingTest.java
@@ -32,6 +32,7 @@ import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
 import io.evitadb.api.requestResponse.data.SealedEntity;
 import io.evitadb.api.requestResponse.data.mutation.EntityMutation.EntityExistence;
 import io.evitadb.api.requestResponse.data.mutation.EntityUpsertMutation;
+import io.evitadb.api.requestResponse.data.mutation.LocalMutation;
 import io.evitadb.api.requestResponse.data.mutation.price.UpsertPriceMutation;
 import io.evitadb.api.requestResponse.data.mutation.reference.InsertReferenceMutation;
 import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
@@ -190,10 +191,10 @@ class PriceIndexingTest implements EvitaTestSupport, IndexingTestSupport {
 		);
 	}
 
-	@DisplayName("Price index must not stay stale when a reference rebuild and a price change share one mutation")
-	@ParameterizedTest(name = "old price {0} -> new price {1}")
+	@DisplayName("Price index must not stay stale when a reference rebuild precedes price change in one mutation")
+	@ParameterizedTest(name = "reference-first, old price {0} -> new price {1}")
 	@CsvSource({"590.00, 295.00", "295.00, 590.00"})
-	void shouldNotLeaveStalePriceIndexWhenReferenceRebuildAndPriceChangeShareOneMutation(
+	void shouldNotLeaveStalePriceIndexWhenReferenceRebuildPrecedesPriceChange(
 		@Nonnull BigDecimal oldPrice,
 		@Nonnull BigDecimal newPrice
 	) {
@@ -202,6 +203,34 @@ class PriceIndexingTest implements EvitaTestSupport, IndexingTestSupport {
 		// and only afterwards changes the LOWEST_PRICE inner-record prices reusing their internal price
 		// ids. The transactional change layer used to keep the OLD price record because the new record
 		// is identity-equal (same internal price id) yet content-different, so the index stayed stale.
+		runStalePriceIndexScenario(oldPrice, newPrice, /*referenceFirst*/ true);
+	}
+
+	@DisplayName("Price index must not stay stale when a price change precedes the reference rebuild in one mutation")
+	@ParameterizedTest(name = "price-first, old price {0} -> new price {1}")
+	@CsvSource({"590.00, 295.00", "295.00, 590.00"})
+	void shouldNotLeaveStalePriceIndexWhenPriceChangePrecedesReferenceRebuild(
+		@Nonnull BigDecimal oldPrice,
+		@Nonnull BigDecimal newPrice
+	) {
+		// Documents that the reverse mutation order (prices changed before the reference swap) also
+		// produces a correct index. The original bug surfaced only with the reference-first order, but
+		// this variant guards against future regressions in the price-first path.
+		runStalePriceIndexScenario(oldPrice, newPrice, /*referenceFirst*/ false);
+	}
+
+	/**
+	 * Common reproducer body shared by the reference-first and price-first variants. The
+	 * {@code referenceFirst} flag toggles only the order in which the reference rebuild and the price
+	 * updates appear inside the single {@link EntityUpsertMutation}; everything else - schema, seed
+	 * data, transactional mode switch and assertions - is identical so both orderings exercise the
+	 * same downstream pipeline.
+	 */
+	private void runStalePriceIndexScenario(
+		@Nonnull BigDecimal oldPrice,
+		@Nonnull BigDecimal newPrice,
+		boolean referenceFirst
+	) {
 		final int productPk = 100;
 		final int categoryPkOld = 500;
 		final int categoryPkNew = 501;
@@ -246,27 +275,31 @@ class PriceIndexingTest implements EvitaTestSupport, IndexingTestSupport {
 			"Pre-condition: product should be indexed with its OLD price in the OLD category"
 		);
 
-		// the offending mutation: rebuild the reference first, then change both prices - all in one tx
+		final RemoveReferenceMutation removeRef =
+			new RemoveReferenceMutation(REFERENCE_PRODUCT_CATEGORY, categoryPkOld);
+		final InsertReferenceMutation insertRef =
+			new InsertReferenceMutation(new ReferenceKey(REFERENCE_PRODUCT_CATEGORY, categoryPkNew));
+		final UpsertPriceMutation upsertPriceA = new UpsertPriceMutation(
+			new PriceKey(1, PRICE_LIST_BASIC, CURRENCY_CZK), innerA,
+			newPrice, BigDecimal.ZERO, newPrice, null, true
+		);
+		final UpsertPriceMutation upsertPriceB = new UpsertPriceMutation(
+			new PriceKey(2, PRICE_LIST_BASIC, CURRENCY_CZK), innerB,
+			newPrice, BigDecimal.ZERO, newPrice, null, true
+		);
+
+		// the offending mutation: rebuild the reference and change both prices in one tx, in the order
+		// determined by the {@code referenceFirst} flag
+		final List<? extends LocalMutation<?, ?>> localMutations =
+			referenceFirst
+				? List.of(removeRef, insertRef, upsertPriceA, upsertPriceB)
+				: List.of(upsertPriceA, upsertPriceB, removeRef, insertRef);
 		this.evita.updateCatalog(
 			TEST_CATALOG,
 			session -> {
 				session.applyMutation(
 					new EntityUpsertMutation(
-						Entities.PRODUCT,
-						productPk,
-						EntityExistence.MUST_EXIST,
-						List.of(
-							new RemoveReferenceMutation(REFERENCE_PRODUCT_CATEGORY, categoryPkOld),
-							new InsertReferenceMutation(new ReferenceKey(REFERENCE_PRODUCT_CATEGORY, categoryPkNew)),
-							new UpsertPriceMutation(
-								new PriceKey(1, PRICE_LIST_BASIC, CURRENCY_CZK), innerA,
-								newPrice, BigDecimal.ZERO, newPrice, null, true
-							),
-							new UpsertPriceMutation(
-								new PriceKey(2, PRICE_LIST_BASIC, CURRENCY_CZK), innerB,
-								newPrice, BigDecimal.ZERO, newPrice, null, true
-							)
-						)
+						Entities.PRODUCT, productPk, EntityExistence.MUST_EXIST, localMutations
 					)
 				);
 			}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalObjArrayTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalObjArrayTest.java
@@ -1085,6 +1085,35 @@ class TransactionalObjArrayTest {
 		}
 
 		@Test
+		void shouldNotDuplicateRecordWhenSubstitutionIsRevertedToOriginalContent() {
+			// regression: a substitute (content-different add) followed by an add of the
+			// original content used to leave the substitution queued in the insertion bucket
+			// while cancelling the removal, so the merged array contained the record twice -
+			// once from the delegate, once from the orphaned bucket
+			final Box oldA = new Box(1, "OLD-A");
+			final Box newA = new Box(1, "NEW-A");
+			final Box originalAgain = new Box(1, "OLD-A");
+			final TransactionalObjArray<Box> array =
+				new TransactionalObjArray<>(new Box[]{oldA}, Box.BY_ID);
+
+			assertStateAfterCommit(
+				array,
+				original -> {
+					original.add(newA);
+					original.add(originalAgain);
+					assertEquals(1, original.getArray().length,
+						"Reverting a substitution must not leave a duplicate in the change layer");
+				},
+				(original, committed) -> {
+					assertEquals(1, committed.length,
+						"Reverting a substitution must not duplicate the record in the committed array");
+					assertEquals("OLD-A", committed[0].content(),
+						"Reverted content must match the original delegate record");
+				}
+			);
+		}
+
+		@Test
 		void shouldKeepLatestContentWhenSubstitutedRecordIsReplacedAgain() {
 			final Box oldA = new Box(1, "OLD-A");
 			final Box v1 = new Box(1, "V1");

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalObjArrayTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalObjArrayTest.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.index.array;
 
+import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -1003,6 +1005,135 @@ class TransactionalObjArrayTest {
 					);
 				}
 			);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Content substitution (identity-equal, content-different records)")
+	class ContentSubstitutionTest {
+
+		@Test
+		void shouldReplaceRecordWithSameIdentityButDifferentContentOnRemoveThenAdd() {
+			final Box oldA = new Box(1, "OLD-A");
+			final Box oldB = new Box(2, "OLD-B");
+			final Box newB = new Box(2, "NEW-B");
+			final TransactionalObjArray<Box> array =
+				new TransactionalObjArray<>(new Box[]{oldA, oldB}, Box.BY_ID);
+
+			assertStateAfterCommit(
+				array,
+				original -> {
+					original.remove(oldB);
+					original.add(newB);
+					final Box[] inTx = original.getArray();
+					assertEquals(2, inTx.length);
+					assertEquals("NEW-B", inTx[1].content(),
+						"Transactional view must already reflect the replaced content");
+				},
+				(original, committed) -> {
+					assertEquals(2, committed.length);
+					assertEquals("OLD-A", committed[0].content());
+					assertEquals("NEW-B", committed[1].content(),
+						"Committed array must contain the NEW content, not the stale OLD one");
+				}
+			);
+		}
+
+		@Test
+		void shouldReplaceFreshlyInsertedRecordWithSameIdentityButDifferentContent() {
+			final Box first = new Box(7, "FIRST");
+			final Box second = new Box(7, "SECOND");
+			final TransactionalObjArray<Box> array =
+				new TransactionalObjArray<>(new Box[0], Box.BY_ID);
+
+			assertStateAfterCommit(
+				array,
+				original -> {
+					original.add(first);
+					original.remove(first);
+					original.add(second);
+				},
+				(original, committed) -> {
+					assertEquals(1, committed.length);
+					assertEquals("SECOND", committed[0].content(),
+						"Committed insertion bucket must hold the latest object instance");
+				}
+			);
+		}
+
+		@Test
+		void shouldRemoveSubstitutedRecordWithinSameTransaction() {
+			final Box oldA = new Box(1, "OLD-A");
+			final Box oldB = new Box(2, "OLD-B");
+			final Box newB = new Box(2, "NEW-B");
+			final TransactionalObjArray<Box> array =
+				new TransactionalObjArray<>(new Box[]{oldA, oldB}, Box.BY_ID);
+
+			assertStateAfterCommit(
+				array,
+				original -> {
+					original.remove(oldB);
+					original.add(newB);
+					assertTrue(original.contains(newB), "Substituted record must be visible via contains()");
+					original.remove(newB);
+					assertFalse(original.contains(newB), "Removed substituted record must not be present");
+					assertArrayEquals(new Box[]{oldA}, original.getArray());
+				},
+				(original, committed) -> assertArrayEquals(new Box[]{oldA}, committed)
+			);
+		}
+
+		@Test
+		void shouldKeepLatestContentWhenSubstitutedRecordIsReplacedAgain() {
+			final Box oldA = new Box(1, "OLD-A");
+			final Box v1 = new Box(1, "V1");
+			final Box v2 = new Box(1, "V2");
+			final TransactionalObjArray<Box> array =
+				new TransactionalObjArray<>(new Box[]{oldA}, Box.BY_ID);
+
+			assertStateAfterCommit(
+				array,
+				original -> {
+					original.remove(oldA);
+					original.add(v1);
+					original.add(v2);
+				},
+				(original, committed) -> {
+					assertEquals(1, committed.length);
+					assertEquals("V2", committed[0].content(),
+						"Committed array must carry the latest substituted content");
+				}
+			);
+		}
+
+		/**
+		 * Identity-based record that mimics PriceRecordContract: equals/hashCode/compareTo key only on
+		 * {@link #id()} while {@link #content()} is logical payload that may change without changing
+		 * identity. Implements {@link ContentComparator} so the change layer can detect content
+		 * divergence and substitute the stale instance.
+		 */
+		record Box(int id, @Nonnull String content) implements ContentComparator<Box> {
+			static final Comparator<Box> BY_ID = Comparator.comparingInt(Box::id);
+
+			@Override
+			public boolean equals(Object o) {
+				if (this == o) return true;
+				if (!(o instanceof Box other)) return false;
+				return this.id == other.id;
+			}
+
+			@Override
+			public int hashCode() {
+				return Integer.hashCode(this.id);
+			}
+
+			@Override
+			public boolean differsFrom(@Nullable Box other) {
+				if (other == this) return false;
+				if (other == null) return true;
+				return this.id != other.id || !this.content.equals(other.content);
+			}
 		}
 
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.index.set;
 
+import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -1254,6 +1256,128 @@ class TransactionalSetTest {
 			final String entry = it.next();
 			assertTrue(expectedSet.contains(entry));
 		}
+	}
+
+	/**
+	 * Tests content substitution for identity-equal but content-different elements.
+	 */
+	@Nested
+	@DisplayName("Content substitution (identity-equal, content-different elements)")
+	class ContentSubstitutionTest {
+
+		@Test
+		void shouldReplaceSameIdentityElementWithDifferentContentOnAdd() {
+			final Box oldA = new Box(1, "OLD-A");
+			final Box newA = new Box(1, "NEW-A");
+			final Set<Box> underlying = new LinkedHashSet<>();
+			underlying.add(oldA);
+			final TransactionalSet<Box> set = new TransactionalSet<>(underlying);
+
+			assertStateAfterCommit(
+				set,
+				original -> original.add(newA),
+				(original, committed) -> {
+					assertEquals(1, committed.size());
+					assertEquals("NEW-A", committed.iterator().next().content(),
+						"Committed set must hold the NEW content, not the stale original instance");
+				}
+			);
+		}
+
+		@Test
+		void shouldReplaceSameIdentityElementOnRemoveThenAdd() {
+			final Box oldA = new Box(1, "OLD-A");
+			final Box newA = new Box(1, "NEW-A");
+			final Set<Box> underlying = new LinkedHashSet<>();
+			underlying.add(oldA);
+			final TransactionalSet<Box> set = new TransactionalSet<>(underlying);
+
+			assertStateAfterCommit(
+				set,
+				original -> {
+					original.remove(oldA);
+					original.add(newA);
+				},
+				(original, committed) -> {
+					assertEquals(1, committed.size());
+					assertEquals("NEW-A", committed.iterator().next().content(),
+						"Committed set must hold the NEW content after remove-then-add of same identity");
+				}
+			);
+		}
+
+		@Test
+		void shouldKeepLatestContentWhenSubstitutedElementIsAddedAgain() {
+			final Box oldA = new Box(1, "OLD-A");
+			final Box v1 = new Box(1, "V1");
+			final Box v2 = new Box(1, "V2");
+			final Set<Box> underlying = new LinkedHashSet<>();
+			underlying.add(oldA);
+			final TransactionalSet<Box> set = new TransactionalSet<>(underlying);
+
+			assertStateAfterCommit(
+				set,
+				original -> {
+					original.add(v1);
+					original.add(v2);
+				},
+				(original, committed) -> {
+					assertEquals(1, committed.size());
+					assertEquals("V2", committed.iterator().next().content(),
+						"Committed set must hold the latest substituted content");
+				}
+			);
+		}
+
+		@Test
+		void shouldRemoveSubstitutedElementWithinSameTransaction() {
+			final Box oldA = new Box(1, "OLD-A");
+			final Box newA = new Box(1, "NEW-A");
+			final Set<Box> underlying = new LinkedHashSet<>();
+			underlying.add(oldA);
+			final TransactionalSet<Box> set = new TransactionalSet<>(underlying);
+
+			assertStateAfterCommit(
+				set,
+				original -> {
+					original.add(newA);
+					assertTrue(original.contains(newA), "Substituted element must be visible via contains()");
+					original.remove(newA);
+					assertFalse(original.contains(newA), "Removed substituted element must not be present");
+				},
+				(original, committed) -> assertTrue(committed.isEmpty(),
+					"Committed set must be empty after substitute-then-remove")
+			);
+		}
+
+		/**
+		 * Identity-based record that mimics PriceRecordContract: equals/hashCode key only on
+		 * {@link #id()} while {@link #content()} is logical payload that may change without changing
+		 * identity. Implements {@link ContentComparator} so the change layer can detect content
+		 * divergence and substitute the stale instance.
+		 */
+		record Box(int id, @Nonnull String content) implements ContentComparator<Box> {
+
+			@Override
+			public boolean equals(Object o) {
+				if (this == o) return true;
+				if (!(o instanceof Box other)) return false;
+				return this.id == other.id;
+			}
+
+			@Override
+			public int hashCode() {
+				return Integer.hashCode(this.id);
+			}
+
+			@Override
+			public boolean differsFrom(@Nullable Box other) {
+				if (other == this) return false;
+				if (other == null) return true;
+				return this.id != other.id || !this.content.equals(other.content);
+			}
+		}
+
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
@@ -1330,6 +1330,39 @@ class TransactionalSetTest {
 		}
 
 		@Test
+		void shouldRevertToOriginalContentWhenSubstitutionFollowedByOriginalAdd() {
+			// regression guard: after substituting with new content and adding the original-content
+			// instance again, the merged set must contain exactly one logical element and the change-layer
+			// bookkeeping (createdKeys / removedKeys) must not double-count or drop the entry
+			final Box oldA = new Box(1, "OLD-A");
+			final Box newA = new Box(1, "NEW-A");
+			final Box originalAgain = new Box(1, "OLD-A");
+			final Box otherB = new Box(2, "B");
+			final Set<Box> underlying = new LinkedHashSet<>();
+			underlying.add(oldA);
+			underlying.add(otherB);
+			final TransactionalSet<Box> set = new TransactionalSet<>(underlying);
+
+			assertStateAfterCommit(
+				set,
+				original -> {
+					original.add(newA);
+					original.add(originalAgain);
+					assertEquals(2, original.size(),
+						"Reverting a substitution must not change the logical size");
+					assertTrue(original.contains(oldA), "Identity must remain present after revert");
+					assertTrue(original.contains(otherB), "Unrelated elements must remain present");
+				},
+				(original, committed) -> {
+					assertEquals(2, committed.size(),
+						"Committed set must contain exactly one entry per identity");
+					assertTrue(committed.contains(oldA), "Identity must survive the substitute-then-revert");
+					assertTrue(committed.contains(otherB), "Unrelated elements must remain in the committed set");
+				}
+			);
+		}
+
+		@Test
 		void shouldRemoveSubstitutedElementWithinSameTransaction() {
 			final Box oldA = new Box(1, "OLD-A");
 			final Box newA = new Box(1, "NEW-A");


### PR DESCRIPTION
Port of the `release_2026-1` fix (#1193) to `dev`. The bug is present on `dev` too — `ObjArrayChanges#addRecordId` has the same identity-only "already present" handling.

## Summary

A record removed and re-added (or re-added) within a single transaction kept its **old content** when its `equals`/comparator **identity was unchanged but its content differed**. `PriceRecordContract` keys identity on `internalPriceId` only, so a price change that reuses the same internal price id left the price index stale after a combined reference-rebuild + price-change `EntityUpsertMutation` (wrong price-for-sale / ordering).

## Changes

- **`ObjArrayChanges`** — `addRecordId` substitutes the existing delegate record when content diverges (paired removal + insertion at the same position); `InsertionBucket.addRecord` replaces an identity-equal entry instead of dropping it. `contains` and `removeRecordId` are aware of the removed-delegate-slot + replacement-bucket state, so a substituted record is reported present and can be removed without resurfacing on merge.
- **`SetChanges`** — `put`/`remove` apply the same content-aware substitution (paired remove + add honored by `createMergedSet`); the removal marker is preserved while replacing the created half so a repeated add does not resurrect the stale original.
- **`PriceRecordContract`** — implements `ContentComparator` with a default `differsFrom` comparing all primitive content fields. Detection falls back to `Object#equals` otherwise.

These already incorporate the fixes from the review on the release PR (#1194): lookup/removal consistency for substituted array records, and the set substitution-preserving `put`.

## Tests

- `TransactionalObjArrayTest` / `TransactionalSetTest` — new `ContentSubstitutionTest` nested classes covering remove-then-add, fresh-insert replace, remove-after-substitute and repeated substitution.
- `PriceIndexingTest#shouldNotLeaveStalePriceIndexWhenReferenceRebuildAndPriceChangeShareOneMutation` — parameterized functional reproducer (discount and increase) asserting through the public query API.

All touched suites pass; `evita_engine` builds.

Closes #1193