### PR TITLE
CDC backpressure stalls Armeria event loop (#1196)

### DIFF
--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCapturePublisher.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCapturePublisher.java
@@ -34,6 +34,9 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import java.nio.BufferOverflowException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Objects;
@@ -67,6 +70,7 @@ import java.util.function.Consumer;
  * @author Jan Novotný, FG Forrest a.s. (c) 2025
  */
 @Slf4j
+@ThreadSafe
 public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ, RES>
 	implements ChangeCapturePublisher<C> {
 
@@ -134,10 +138,12 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 	/**
 	 * Registers a new subscriber to receive change captures from this publisher.
 	 *
-	 * This method creates an internal subscriber that wraps the provided subscriber,
-	 * initializes the gRPC stream, creates a new subscription, and registers it with
-	 * the publisher. The subscriber will start receiving captures once it requests them
-	 * through the subscription.
+	 * The wiring order matters: the subscription must be attached to the internal
+	 * subscriber and registered with this publisher **before** the gRPC stream
+	 * initializer runs. The server ACK that primes the inbound credit window can
+	 * land on a different thread, and any of the surrounding bookkeeping (cleanup
+	 * on a synchronous init failure, `onNext` dereferencing the subscription
+	 * field) must already be in place when it does.
 	 *
 	 * @param subscriber the subscriber to register
 	 * @throws IllegalStateException if the publisher has been closed
@@ -150,7 +156,8 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 			subscriber,
 			this::deserializeAcknowledgementResponse,
 			this::deserializeCaptureResponse,
-			this.streamingTimeout
+			this.streamingTimeout,
+			this.queueSize
 		);
 
 		final ClientSubscription<C, REQ, RES> subscription = new ClientSubscription<>(
@@ -167,12 +174,17 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 			}
 		);
 
-		// initialize the subscriber
-		this.streamInitializer.accept(internalSubscriber);
-		internalSubscriber.onSubscribe(subscription);
-		// register the subscription with the publisher
+		// attach the subscription to the internal subscriber BEFORE the stream initializer
+		// opens the inbound credit window — otherwise a server ACK that lands on a different
+		// thread between `beforeStart` and `onSubscribe` would dereference a null field
+		internalSubscriber.attachSubscription(subscription);
+		// register the subscription with the publisher BEFORE the stream initializer runs so
+		// a synchronous failure during initialization has the subscription available for cleanup
 		this.subscriptions.add(subscription);
-
+		// initialize the gRPC stream now that the subscription is wired and registered
+		this.streamInitializer.accept(internalSubscriber);
+		// notify the delegate that it has a subscription it can drive
+		internalSubscriber.onSubscribe(subscription);
 	}
 
 	/**
@@ -246,6 +258,7 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 	 * @param <REQ> type of request sent to the server
 	 * @param <RES> type of response received from the server
 	 */
+	@ThreadSafe
 	static class ClientSubscription<C extends ChangeCapture, REQ, RES>
 		implements Subscription, Comparable<ClientSubscription<C, REQ, RES>> {
 		/**
@@ -381,20 +394,27 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 		/**
 		 * Adds a new capture to this subscription's queue.
 		 *
-		 * If the queue is full, the thread is blocked, which applies backpressure to the publisher.
-		 * After adding the item, consumption is triggered if the subscriber has requested items.
+		 * Uses a non-blocking `offer` so the calling thread — typically an Armeria event-loop
+		 * thread carrying every multiplexed gRPC stream for the channel — can never be parked
+		 * by a slow downstream consumer. With manual gRPC flow control in place (see
+		 * `ClientChangeCaptureSubscriber.beforeStart`) the queue cannot fill under normal
+		 * operation; if it ever does, the subscription is marked dead with a
+		 * `BufferOverflowException` instead of stalling the shared event loop.
 		 *
 		 * @param item the capture to add
 		 */
 		public void produce(@Nonnull C item) {
-			if (this.walkingDead.get() == null) {
-				try {
-					this.items.put(item);
-					consume();
-				} catch (InterruptedException ex) {
-					Thread.currentThread().interrupt();
-					this.walkingDead.set(ex);
-				}
+			if (this.walkingDead.get() != null) {
+				return;
+			}
+			if (this.items.offer(item)) {
+				consume();
+			} else {
+				this.walkingDead.compareAndSet(
+					null,
+					new BufferOverflowException()
+				);
+				consume();
 			}
 		}
 
@@ -410,7 +430,7 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 		 * ID
 		 */
 		@Override
-		public int compareTo(ClientSubscription o) {
+		public int compareTo(@Nonnull ClientSubscription<C, REQ, RES> o) {
 			return Long.compare(this.id, o.id);
 		}
 
@@ -433,7 +453,7 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 		 * @return true if the objects are equal, false otherwise
 		 */
 		@Override
-		public final boolean equals(Object o) {
+		public final boolean equals(@Nullable Object o) {
 			if (!(o instanceof final ClientSubscription<?, ?, ?> that))
 				return false;
 
@@ -441,23 +461,41 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 		}
 
 		/**
-		 * Processes buffered items if the subscriber has requested them.
+		 * Drains buffered items into the delegate subscriber while honouring the
+		 * outstanding request count.
 		 *
-		 * This method is executed asynchronously to avoid blocking the publisher.
-		 * It delivers items to the subscriber until either the queue is empty or
-		 * the number of requested items is exhausted.
+		 * Uses a `currentlyConsuming` CAS so at most one executor task drains the
+		 * queue at a time. After the draining loop releases the flag the method
+		 * re-checks both the queue and the `walkingDead` slot: a producer (or
+		 * `produce()` that raised the overflow signal) that lost the CAS while we
+		 * were resetting could otherwise leave its item — or the terminal
+		 * failure — stranded forever. The `!cancelled` guard prevents an
+		 * infinite reschedule loop once the subscription is dead: `walkingDead`
+		 * stays set after the terminal `onError`, but no further work is owed.
+		 *
+		 * If draining throws, the queue is cleared and the exception is parked
+		 * in `walkingDead` so the fall-through delivers it to the subscriber and
+		 * cancels the subscription.
 		 */
 		private void consume() {
-			if (this.walkingDead.get() == null && this.currentlyConsuming.compareAndSet(false, true)) {
+			// the walking-dead path still has to drain — schedule a tick to fire `onError`
+			// even if the queue is currently empty; otherwise we'd silently stall a
+			// subscription whose overflow happened before any consume() was triggered
+			if (this.currentlyConsuming.compareAndSet(false, true)) {
 				try {
 					this.executorService.execute(
 						() -> {
 							try {
-								while (!this.items.isEmpty() && this.requested.getAndUpdate(
-									counter -> counter > 0 ? counter - 1 : 0) > 0) {
+								while (this.walkingDead.get() == null
+									&& !this.items.isEmpty()
+									&& this.requested.getAndUpdate(
+										counter -> counter > 0 ? counter - 1 : 0) > 0) {
 									this.internalSubscriber.onDelegateNext(
 										Objects.requireNonNull(this.items.poll())
 									);
+									// restore one gRPC credit per delivered item — keeps the in-flight
+									// window bounded by `queueSize` without sacrificing throughput
+									this.internalSubscriber.requestOneMore();
 								}
 							} catch (Throwable ex) {
 								// if an error occurs during consumption, we need to report it to the subscriber
@@ -465,16 +503,30 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 								this.items.clear();
 								this.walkingDead.compareAndSet(null, ex);
 							}
-							// if there are no more items in the queue and the walking dead exception is set,
-							// we need to notify the subscriber about the error (which effectively closes the subscription)
-							if (this.items.isEmpty() && this.walkingDead.get() != null) {
-								this.internalSubscriber.onError(
+							// if the walking dead exception is set, notify the subscriber (which closes the
+							// subscription); any unconsumed items are dropped because the stream is doomed.
+							// `notifyClientFailureAndClose` keeps `serverSideClosed=false` so the subsequent
+							// `cancel()` still propagates the cancellation to the gRPC stream — without it
+							// the server would keep pushing into a dead client.
+							if (this.walkingDead.get() != null) {
+								this.items.clear();
+								this.internalSubscriber.notifyClientFailureAndClose(
 									this.walkingDead.get()
 								);
 								this.cancel();
 							}
 							// reset the consuming flag
 							this.currentlyConsuming.set(false);
+							// re-check after releasing the flag — a producer thread that lost the CAS
+							// while we were resetting could otherwise stall its enqueued item or its
+							// freshly raised walking-dead signal forever. The `!cancelled` guard
+							// prevents an infinite reschedule loop once the subscription has already
+							// been terminated (walkingDead stays set, but no further work is owed).
+							if (!this.cancelled.get()
+								&& (this.walkingDead.get() != null
+									|| (!this.items.isEmpty() && this.requested.get() > 0))) {
+								consume();
+							}
 						}
 					);
 				} catch (Exception ex) {

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCapturePublisher.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCapturePublisher.java
@@ -181,8 +181,15 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 		// register the subscription with the publisher BEFORE the stream initializer runs so
 		// a synchronous failure during initialization has the subscription available for cleanup
 		this.subscriptions.add(subscription);
-		// initialize the gRPC stream now that the subscription is wired and registered
-		this.streamInitializer.accept(internalSubscriber);
+		// initialize the gRPC stream now that the subscription is wired and registered;
+		// a synchronous failure here must remove the zombie subscription before rethrowing,
+		// otherwise it would linger in `subscriptions` and keep the publisher from auto-closing
+		try {
+			this.streamInitializer.accept(internalSubscriber);
+		} catch (Throwable ex) {
+			this.subscriptions.remove(subscription);
+			throw ex;
+		}
 		// notify the delegate that it has a subscription it can drive
 		internalSubscriber.onSubscribe(subscription);
 	}
@@ -525,7 +532,7 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 							if (!this.cancelled.get()
 								&& (this.walkingDead.get() != null
 									|| (!this.items.isEmpty() && this.requested.get() > 0))) {
-								consume();
+								this.consume();
 							}
 						}
 					);

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCaptureSubscriber.java
@@ -126,7 +126,10 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 
 	/**
 	 * The subscription that manages the flow control between this subscriber and the publisher.
-	 * This is set in the onSubscribe method when the publisher creates a subscription for this subscriber.
+	 * Set by {@link #attachSubscription} when the publisher creates a subscription for this
+	 * subscriber — deliberately *before* the stream initializer runs so the gRPC inbound
+	 * thread cannot observe a null field. {@link #onSubscribe} only forwards the subscription
+	 * to the delegate; it does not assign this field.
 	 *
 	 * Declared `volatile` so writes from the `subscribe()` thread (via
 	 * {@link #attachSubscription}) are visible to the gRPC inbound thread reading the

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCaptureSubscriber.java
@@ -122,20 +122,29 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	 * This is initialized in the beforeStart method and used to cancel the stream when closing.
 	 */
 	@Nullable
-	private ClientCallStreamObserver<REQ> serverObserver;
+	private volatile ClientCallStreamObserver<REQ> serverObserver;
 
 	/**
 	 * The subscription that manages the flow control between this subscriber and the publisher.
 	 * This is set in the onSubscribe method when the publisher creates a subscription for this subscriber.
+	 *
+	 * Declared `volatile` so writes from the `subscribe()` thread (via
+	 * {@link #attachSubscription}) are visible to the gRPC inbound thread reading the
+	 * field in {@link #onNext} without relying on transitive happens-before through
+	 * gRPC stub internals.
 	 */
 	@Nullable
-	private ClientSubscription<C, REQ, RES> subscription;
+	private volatile ClientSubscription<C, REQ, RES> subscription;
 
 	/**
 	 * The last heartbeat received from the server, used to monitor the connection health.
+	 *
+	 * Declared `volatile` because {@link #toString} may be invoked from arbitrary threads
+	 * (logging, diagnostics) and must observe the most recent value written by the gRPC
+	 * inbound thread in {@link #onNext}.
 	 */
 	@Nullable
-	private HeartBeat lastHeartBeat;
+	private volatile HeartBeat lastHeartBeat;
 
 	/**
 	 * Creates a subscriber bound to a delegate `Flow.Subscriber` and the gRPC-side
@@ -182,15 +191,15 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	 * @throws GenericEvitaInternalError if the subscriber has already been started
 	 */
 	@Override
-	public void beforeStart(ClientCallStreamObserver<REQ> observer) {
+	public void beforeStart(@Nonnull ClientCallStreamObserver<REQ> observer) {
 		Assert.isPremiseValid(
 			this.serverObserver == null,
 			"ClientChangeCaptureSubscriber can only be started once. It is already started."
 		);
 
 		this.serverObserver = observer;
-		// Initialize gRPC flow control by requesting the acknowledgement message.
-		// take over inbound flow control from gRPC defaults so the server cannot outpace us
+		// take over inbound flow control from gRPC defaults so the server cannot outpace us;
+		// explicitly ask for the single ACK message that primes the credit window
 		observer.disableAutoRequestWithInitial(1);
 	}
 
@@ -220,7 +229,7 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	 * @param subscription the subscription created by the publisher
 	 */
 	@Override
-	public void onSubscribe(Subscription subscription) {
+	public void onSubscribe(@Nonnull Subscription subscription) {
 		this.delegate.onSubscribe(subscription);
 	}
 

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCaptureSubscriber.java
@@ -29,17 +29,20 @@ import com.linecorp.armeria.common.util.TimeoutMode;
 import io.evitadb.api.requestResponse.cdc.ChangeCapture;
 import io.evitadb.driver.cdc.ClientChangeCapturePublisher.ClientSubscription;
 import io.evitadb.driver.exception.PublisherClosedByClientException;
+import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.externalApi.grpc.requestResponse.cdc.HeartBeat;
 import io.evitadb.utils.Assert;
 import io.evitadb.utils.ExceptionUtils;
 import io.evitadb.utils.IOUtils;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscription;
@@ -66,7 +69,7 @@ import java.util.function.Function;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
  */
 @Slf4j
-@RequiredArgsConstructor
+@ThreadSafe
 public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	implements Flow.Subscriber<RES>, ClientResponseObserver<REQ, RES>, AutoCloseable {
 
@@ -95,6 +98,15 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	private final Duration streamingTimeout;
 
 	/**
+	 * Size of the in-flight window the server may push without further acknowledgement.
+	 * After the subscription is established this number of credits is requested from the
+	 * server in a single batch and is then topped up by one for every message the client
+	 * consumes — making HTTP/2 flow control the actual backpressure mechanism and preventing
+	 * the bounded item queue from ever overflowing under normal operation.
+	 */
+	private final int flowControlWindow;
+
+	/**
 	 * Flag indicating whether this subscriber has been closed.
 	 * Used to prevent multiple close operations and ensure proper cleanup.
 	 */
@@ -109,18 +121,51 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	 * The gRPC observer that sends requests to and receives responses from the server.
 	 * This is initialized in the beforeStart method and used to cancel the stream when closing.
 	 */
+	@Nullable
 	private ClientCallStreamObserver<REQ> serverObserver;
 
 	/**
 	 * The subscription that manages the flow control between this subscriber and the publisher.
 	 * This is set in the onSubscribe method when the publisher creates a subscription for this subscriber.
 	 */
+	@Nullable
 	private ClientSubscription<C, REQ, RES> subscription;
 
 	/**
 	 * The last heartbeat received from the server, used to monitor the connection health.
 	 */
+	@Nullable
 	private HeartBeat lastHeartBeat;
+
+	/**
+	 * Creates a subscriber bound to a delegate `Flow.Subscriber` and the gRPC-side
+	 * deserialization callbacks supplied by the owning publisher.
+	 *
+	 * @param delegate                       downstream subscriber that receives deserialized captures
+	 * @param deserializeAcknowledgeResponse decodes ACK and heartbeat envelopes
+	 * @param deserializeCaptureResponse     decodes capture payloads
+	 * @param streamingTimeout               per-message response deadline applied after every onNext
+	 * @param flowControlWindow              number of credits requested from the server after ACK and
+	 *                                       the maximum number of in-flight messages allowed at any time
+	 * @throws GenericEvitaInternalError if {@code flowControlWindow <= 0}
+	 */
+	public ClientChangeCaptureSubscriber(
+		@Nonnull Flow.Subscriber<? super C> delegate,
+		@Nonnull Function<RES, Optional<HeartBeat>> deserializeAcknowledgeResponse,
+		@Nonnull Function<RES, Optional<C>> deserializeCaptureResponse,
+		@Nonnull Duration streamingTimeout,
+		int flowControlWindow
+	) {
+		Assert.isPremiseValid(
+			flowControlWindow > 0,
+			"Flow control window must be positive."
+		);
+		this.delegate = delegate;
+		this.deserializeAcknowledgeResponse = deserializeAcknowledgeResponse;
+		this.deserializeCaptureResponse = deserializeCaptureResponse;
+		this.streamingTimeout = streamingTimeout;
+		this.flowControlWindow = flowControlWindow;
+	}
 
 	/**
 	 * Called by gRPC before starting the stream to provide the observer for sending requests to the server.
@@ -128,8 +173,13 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	 * This method initializes the serverObserver field which is later used to cancel the stream when closing.
 	 * It ensures that the subscriber can only be started once.
 	 *
+	 * Inbound auto-flow-control is disabled so the server may only push messages this client
+	 * has explicitly acknowledged. A single credit is requested for the ACK message; the
+	 * `flowControlWindow` is primed after the ACK arrives and refilled one credit at a time
+	 * as messages are drained — see {@link #requestOneMore()}.
+	 *
 	 * @param observer the gRPC observer for sending requests to the server
-	 * @throws IllegalArgumentException if the subscriber has already been started
+	 * @throws GenericEvitaInternalError if the subscriber has already been started
 	 */
 	@Override
 	public void beforeStart(ClientCallStreamObserver<REQ> observer) {
@@ -138,51 +188,89 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 			"ClientChangeCaptureSubscriber can only be started once. It is already started."
 		);
 
-		// Initialize gRPC flow control by requesting the acknowledgement message.
-		// Note: Armeria/Netty may use auto flow control for subsequent messages.
 		this.serverObserver = observer;
-		// Request the acknowledgement message
-		observer.request(1);
+		// Initialize gRPC flow control by requesting the acknowledgement message.
+		// take over inbound flow control from gRPC defaults so the server cannot outpace us
+		observer.disableAutoRequestWithInitial(1);
 	}
 
 	/**
-	 * Called when this subscriber is subscribed to a publisher.
+	 * Wires the owning subscription into this subscriber **before** the stream
+	 * initializer opens the inbound credit window.
 	 *
-	 * This method stores the subscription for later use in flow control and cancellation.
+	 * The gRPC ACK reply can land on a different thread between
+	 * {@link #beforeStart} (which calls `disableAutoRequestWithInitial(1)`) and
+	 * the publisher's call to {@link #onSubscribe}. Without an early field
+	 * assignment {@link #onNext} would dereference a still-null `subscription`.
+	 * {@link #onSubscribe} is reserved for notifying the downstream delegate.
 	 *
 	 * @param subscription the subscription created by the publisher
 	 */
-	@SuppressWarnings("unchecked")
+	void attachSubscription(@Nonnull ClientSubscription<C, REQ, RES> subscription) {
+		this.subscription = subscription;
+	}
+
+	/**
+	 * Forwards the subscription to the delegate.
+	 *
+	 * The field-level binding happens in {@link #attachSubscription} and must
+	 * precede the stream-initialization step that opens the inbound credit
+	 * window; this method intentionally does no field assignment.
+	 *
+	 * @param subscription the subscription created by the publisher
+	 */
 	@Override
 	public void onSubscribe(Subscription subscription) {
-		this.subscription = (ClientSubscription<C, REQ, RES>) subscription;
 		this.delegate.onSubscribe(subscription);
 	}
 
 	/**
 	 * Called when a new response is received from the server.
 	 *
-	 * This method deserializes the response into a change capture object and
-	 * forwards it to the subscription for processing.
+	 * The very first response on a stream must be the subscription
+	 * acknowledgement — it carries the server-assigned subscription id and
+	 * unlocks the full inbound flow-control window. Subsequent responses are
+	 * deserialized into change captures (enqueued onto the subscription) or
+	 * heartbeats (credit restored immediately so periodic heartbeats do not
+	 * starve the capture window).
 	 *
 	 * @param itemResponse the response received from the server
+	 * @throws GenericEvitaInternalError if the first received message is not an
+	 *         acknowledgement
 	 */
 	@Override
 	public void onNext(RES itemResponse) {
+		// pin the @Nullable fields to non-null locals once: gRPC guarantees `beforeStart`
+		// runs before any inbound callback, and the publisher's `subscribe` calls
+		// `attachSubscription` before triggering the stream initializer — so both are
+		// in practice non-null here. The `requireNonNull` calls double as a contract guard
+		// (would surface a violated invariant as a descriptive NPE) and as a hint to the
+		// IDE / static analyzers that the subsequent dereferences are safe.
+		final ClientCallStreamObserver<REQ> observer = Objects.requireNonNull(
+			this.serverObserver,
+			"`serverObserver` must be initialized by `beforeStart` before `onNext` is invoked."
+		);
+		final ClientSubscription<C, REQ, RES> activeSubscription = Objects.requireNonNull(
+			this.subscription,
+			"Subscription must be attached by the publisher before `onNext` is invoked."
+		);
 		// restart the response deadline from now so a silent stream unblocks us within
-		// `streamingTimeout` of the last event, regardless of how many have arrived
-		ClientRequestContext.current().setResponseTimeout(TimeoutMode.SET_FROM_NOW, this.streamingTimeout);
+		// `streamingTimeout` of the last event, regardless of how many have arrived;
+		// `currentOrNull` keeps the subscriber safely callable outside an Armeria request scope
+		final ClientRequestContext requestContext = ClientRequestContext.currentOrNull();
+		if (requestContext != null) {
+			requestContext.setResponseTimeout(TimeoutMode.SET_FROM_NOW, this.streamingTimeout);
+		}
 		// first item is always subscription acknowledge response
 		this.deserializeAcknowledgeResponse.apply(itemResponse)
 			.ifPresent(heartBeat -> {
-				if (this.lastHeartBeat != null) {
-					if (this.lastHeartBeat.index() + 1 != heartBeat.index()) {
-						log.warn(
-							"Missed heartbeat(s)! Last heartbeat index: {}, new heartbeat index: {}",
-							this.lastHeartBeat.index(),
-							heartBeat.index()
-						);
-					}
+				final HeartBeat previous = this.lastHeartBeat;
+				if (previous != null && previous.index() + 1 != heartBeat.index()) {
+					log.warn(
+						"Missed heartbeat(s)! Last heartbeat index: {}, new heartbeat index: {}",
+						previous.index(),
+						heartBeat.index()
+					);
 				}
 				this.lastHeartBeat = heartBeat;
 				if (this.delegate instanceof HeartBeatSensor heartBeatSensor) {
@@ -193,11 +281,44 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 					}
 				}
 			});
-		if (this.subscription.getSubscriptionId() == null) {
-			this.subscription.setSubscriptionId(this.lastHeartBeat.subscriptionId());
+		if (activeSubscription.getSubscriptionId() == null) {
+			// the very first message MUST be the acknowledgement — otherwise the
+			// protocol is being violated and the heartbeat field is still null;
+			// `isPremiseValid` is the project's idiomatic precondition check and
+			// surfaces the violation as `GenericEvitaInternalError` with the descriptive message
+			Assert.isPremiseValid(
+				this.lastHeartBeat != null,
+				"Expected ACKNOWLEDGEMENT as first message but got something else."
+			);
+			// IDE-friendly capture: the assert above already proved non-null, so this
+			// `requireNonNull` is a no-op at runtime but tells static analyzers the dereference is safe
+			final HeartBeat acknowledgement = Objects.requireNonNull(this.lastHeartBeat);
+			activeSubscription.setSubscriptionId(acknowledgement.subscriptionId());
+			// ACK consumed: open the full window so the server may start streaming captures
+			observer.request(this.flowControlWindow);
 		} else {
-			this.deserializeCaptureResponse.apply(itemResponse)
-				.ifPresent(it -> this.subscription.produce(it));
+			final Optional<C> capture = this.deserializeCaptureResponse.apply(itemResponse);
+			if (capture.isPresent()) {
+				// enqueued capture: credit is restored from `consume()` after the delegate receives it
+				activeSubscription.produce(capture.get());
+			} else {
+				// non-enqueued envelope (e.g. heartbeat): restore the consumed credit immediately
+				// so the server can keep pushing captures despite the periodic heartbeat traffic
+				observer.request(1);
+			}
+		}
+	}
+
+	/**
+	 * Restores one inbound flow-control credit with the server.
+	 *
+	 * Called by the owning {@link ClientSubscription} after each capture is delivered
+	 * to the delegate. Guarded against post-close calls so a slow consumer that finishes
+	 * draining the queue after the stream has been torn down cannot resurrect the channel.
+	 */
+	void requestOneMore() {
+		if (this.serverObserver != null && !this.closed.get() && !this.serverSideClosed.get()) {
+			this.serverObserver.request(1);
 		}
 	}
 
@@ -230,12 +351,50 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 			} else {
 				log.error("Error occurred in the client change capture publisher.", throwable);
 			}
+			// the publisher always attaches the subscription before the stream initializer runs,
+			// so by the time `onError` fires the subscription is guaranteed non-null
+			final ClientSubscription<C, REQ, RES> activeSubscription = Objects.requireNonNull(
+				this.subscription,
+				"Subscription must be attached before `onError` is invoked."
+			);
 			// we notify the subscriber about the error
 			try {
-				this.subscription.getExecutorService().execute(() -> this.delegate.onError(rootCause));
+				activeSubscription.getExecutorService().execute(() -> this.delegate.onError(rootCause));
 			} finally {
 				// this handles cleanup and calling #close on this instance
-				this.subscription.cancel();
+				activeSubscription.cancel();
+			}
+		}
+	}
+
+	/**
+	 * Reports a client-internal failure (typically a queue overflow because the
+	 * delegate cannot keep up) and tears the subscription down.
+	 *
+	 * Unlike {@link #onError} this method does **not** flip `serverSideClosed`
+	 * — the server still believes the stream is open, so the follow-up
+	 * {@link #close} must invoke `serverObserver.cancel(...)` to release the
+	 * gRPC stream. Conflating server-originated and client-originated failures
+	 * would short-circuit the close path and leave the server pushing into a
+	 * dead client.
+	 *
+	 * @param cause exception describing the client-internal failure
+	 */
+	void notifyClientFailureAndClose(@Nonnull Throwable cause) {
+		if (!this.closed.get()) {
+			log.error("Client-side change capture subscription failed.", cause);
+			// invoked from `ClientSubscription.consume`, which can only exist once the
+			// publisher has attached this subscription, so the field is always non-null
+			final ClientSubscription<C, REQ, RES> activeSubscription = Objects.requireNonNull(
+				this.subscription,
+				"Subscription must be attached before `notifyClientFailureAndClose` is invoked."
+			);
+			try {
+				activeSubscription.getExecutorService().execute(() -> this.delegate.onError(cause));
+			} finally {
+				// triggers `close()` which still sees `serverSideClosed == false` and therefore
+				// propagates the cancellation to the gRPC stream
+				activeSubscription.cancel();
 			}
 		}
 	}
@@ -250,11 +409,17 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	public void onComplete() {
 		this.serverSideClosed.set(true);
 		if (!this.closed.get()) {
+			// gRPC calls `onComplete` only after `beforeStart` returned, by which point
+			// the publisher has already attached the subscription
+			final ClientSubscription<C, REQ, RES> activeSubscription = Objects.requireNonNull(
+				this.subscription,
+				"Subscription must be attached before `onComplete` is invoked."
+			);
 			try {
-				this.subscription.getExecutorService().execute(this.delegate::onComplete);
+				activeSubscription.getExecutorService().execute(this.delegate::onComplete);
 			} finally {
 				// this handles cleanup and calling #close on this instance
-				this.subscription.cancel();
+				activeSubscription.cancel();
 			}
 		}
 	}
@@ -294,13 +459,18 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 		if (this.subscription != null && !this.subscription.isCanceled()) {
 			this.subscription.cancel();
 		} else if (this.closed.compareAndSet(false, true)) {
-			// this will eventually trigger the `onComplete` callback (through `onError` callback) and close this publisher
-			if (!this.serverSideClosed.get()) {
-				this.serverObserver.cancel("Closed manually by the client.", new PublisherClosedByClientException());
+			// `close()` can legitimately fire before `beforeStart` (user-initiated abort during
+			// stream setup), so the observer and the subscription may both still be null here.
+			// snapshot the @Nullable fields and guard each dereference explicitly
+			final ClientCallStreamObserver<REQ> observer = this.serverObserver;
+			if (observer != null && !this.serverSideClosed.get()) {
+				// this will eventually trigger the `onComplete` callback (through `onError` callback) and close this publisher
+				observer.cancel("Closed manually by the client.", new PublisherClosedByClientException());
 			}
 			// if the delegate is closeable, close it quietly
-			if (this.delegate instanceof AutoCloseable closeable) {
-				this.subscription.getExecutorService().execute(() -> IOUtils.closeQuietly(closeable::close));
+			final ClientSubscription<C, REQ, RES> activeSubscription = this.subscription;
+			if (activeSubscription != null && this.delegate instanceof AutoCloseable closeable) {
+				activeSubscription.getExecutorService().execute(() -> IOUtils.closeQuietly(closeable::close));
 			}
 		}
 	}

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCatalogCaptureProcessor.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCatalogCaptureProcessor.java
@@ -23,7 +23,6 @@
 
 package io.evitadb.driver.cdc;
 
-
 import io.evitadb.api.requestResponse.cdc.ChangeCatalogCapture;
 import io.evitadb.externalApi.grpc.generated.GrpcCaptureResponseType;
 import io.evitadb.externalApi.grpc.generated.GrpcRegisterChangeCatalogCaptureRequest;
@@ -48,6 +47,9 @@ import static io.evitadb.externalApi.grpc.requestResponse.cdc.ChangeCaptureConve
 public class ClientChangeCatalogCaptureProcessor extends
 	ClientChangeCapturePublisher<ChangeCatalogCapture, GrpcRegisterChangeCatalogCaptureRequest, GrpcRegisterChangeCatalogCaptureResponse> {
 
+	/**
+	 * @see ClientChangeCapturePublisher#ClientChangeCapturePublisher(int, Duration, ExecutorService, Consumer, Consumer)
+	 */
 	public ClientChangeCatalogCaptureProcessor(
 		int queueSize,
 		@Nonnull Duration streamingTimeout,
@@ -61,7 +63,8 @@ public class ClientChangeCatalogCaptureProcessor extends
 	@Nonnull
 	@Override
 	protected Optional<HeartBeat> deserializeAcknowledgementResponse(GrpcRegisterChangeCatalogCaptureResponse itemResponse) {
-		if (itemResponse.getResponseType() == GrpcCaptureResponseType.ACKNOWLEDGEMENT || itemResponse.getResponseType() == GrpcCaptureResponseType.HEARTBEAT) {
+		if (itemResponse.getResponseType() == GrpcCaptureResponseType.ACKNOWLEDGEMENT
+			|| itemResponse.getResponseType() == GrpcCaptureResponseType.HEARTBEAT) {
 			return Optional.of(toHeartBeat(itemResponse.getUuid(), itemResponse.getHeartBeat()));
 		} else {
 			return Optional.empty();

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeSystemCaptureProcessor.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeSystemCaptureProcessor.java
@@ -47,6 +47,9 @@ import static io.evitadb.externalApi.grpc.requestResponse.cdc.ChangeCaptureConve
 public class ClientChangeSystemCaptureProcessor extends
 	ClientChangeCapturePublisher<ChangeSystemCapture, GrpcRegisterSystemChangeCaptureRequest, GrpcRegisterSystemChangeCaptureResponse> {
 
+	/**
+	 * @see ClientChangeCapturePublisher#ClientChangeCapturePublisher(int, Duration, ExecutorService, Consumer, Consumer)
+	 */
 	public ClientChangeSystemCaptureProcessor(
 		int queueSize,
 		@Nonnull Duration streamingTimeout,
@@ -60,7 +63,8 @@ public class ClientChangeSystemCaptureProcessor extends
 	@Nonnull
 	@Override
 	protected Optional<HeartBeat> deserializeAcknowledgementResponse(GrpcRegisterSystemChangeCaptureResponse itemResponse) {
-		if (itemResponse.getResponseType() == GrpcCaptureResponseType.ACKNOWLEDGEMENT || itemResponse.getResponseType() == GrpcCaptureResponseType.HEARTBEAT) {
+		if (itemResponse.getResponseType() == GrpcCaptureResponseType.ACKNOWLEDGEMENT
+			|| itemResponse.getResponseType() == GrpcCaptureResponseType.HEARTBEAT) {
 			return Optional.of(toHeartBeat(itemResponse.getUuid(), itemResponse.getHeartBeat()));
 		} else {
 			return Optional.empty();

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/cdc/ClientChangeCapturePublisherTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/cdc/ClientChangeCapturePublisherTest.java
@@ -57,7 +57,6 @@ import static io.evitadb.test.TestTags.DRIVER;
 import static io.evitadb.test.TestTags.GRPC;
 import static io.evitadb.test.TestTags.STREAM;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -109,9 +108,9 @@ class ClientChangeCapturePublisherTest implements TestConstants {
 			harness.deliverAck();
 
 			// a server-pushed heartbeat is not enqueued for the delegate
-			// — credit must be restored eagerly
-			harness.deliverHeartbeat(2);
-			verify(harness.observer, atLeastOnce()).request(1);
+			// — credit must be restored eagerly; index 1 follows ACK index 0 so the
+			// "Missed heartbeat" warn log stays quiet
+			harness.deliverHeartbeat(1);
 			// heartbeat top-up request(1) → exactly 1 single-credit call
 			verify(harness.observer, times(1)).request(1);
 		}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/cdc/ClientChangeCapturePublisherTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/cdc/ClientChangeCapturePublisherTest.java
@@ -1,0 +1,445 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.driver.cdc;
+
+import io.evitadb.api.requestResponse.cdc.ChangeSystemCapture;
+import io.evitadb.api.requestResponse.cdc.Operation;
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.externalApi.grpc.requestResponse.cdc.HeartBeat;
+import io.evitadb.test.TestConstants;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.nio.BufferOverflowException;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static io.evitadb.test.TestTags.CDC;
+import static io.evitadb.test.TestTags.DRIVER;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.STREAM;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verifies the client-side CDC backpressure contract of {@link ClientChangeCapturePublisher}:
+ *
+ * - inbound flow control is taken over manually before the stream starts,
+ * - the flow window is primed to the queue capacity after the acknowledgement message,
+ * - one gRPC credit is restored per delivered capture and per server-side heartbeat,
+ * - if the queue still overflows (defensive path), the subscription dies with
+ *   `BufferOverflowException` instead of parking the calling thread.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("ClientChangeCapturePublisher backpressure and flow control")
+@Tag(DRIVER)
+@Tag(GRPC)
+@Tag(CDC)
+@Tag(STREAM)
+class ClientChangeCapturePublisherTest implements TestConstants {
+	private static final int QUEUE_SIZE = 4;
+	private static final UUID SUBSCRIPTION_UUID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+	private static final OffsetDateTime FIXED_TS =
+		OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+
+	@Nested
+	@DisplayName("Flow control")
+	class FlowControl {
+
+		@Test
+		@DisplayName("Disables auto inbound flow control and primes the window after ACK")
+		void shouldDisableAutoFlowControlAndPrimeWindowWhenAckReceived() {
+			final TestHarness harness = new TestHarness();
+			harness.start();
+
+			verify(harness.observer, times(1)).disableAutoRequestWithInitial(1);
+
+			// deliver the acknowledgement message — must prime the flow window to queue capacity
+			harness.deliverAck();
+			verify(harness.observer, times(1)).request(QUEUE_SIZE);
+		}
+
+		@Test
+		@DisplayName("Restores a single credit when a server heartbeat arrives")
+		void shouldRestoreCreditWhenServerHeartbeatArrives() {
+			final TestHarness harness = new TestHarness();
+			harness.start();
+			harness.deliverAck();
+
+			// a server-pushed heartbeat is not enqueued for the delegate
+			// — credit must be restored eagerly
+			harness.deliverHeartbeat(2);
+			verify(harness.observer, atLeastOnce()).request(1);
+			// heartbeat top-up request(1) → exactly 1 single-credit call
+			verify(harness.observer, times(1)).request(1);
+		}
+
+		@Test
+		@DisplayName("Restores one credit per item delivered to the delegate")
+		void shouldRestoreOneCreditWhenItemDeliveredToDelegate() {
+			final TestHarness harness = new TestHarness(Long.MAX_VALUE);
+			harness.start();
+			harness.deliverAck();
+
+			final int delivered = 3;
+			for (int i = 0; i < delivered; i++) {
+				harness.deliverCapture(i);
+			}
+
+			// one request(1) per item the delegate received
+			verify(harness.observer, times(delivered)).request(1);
+			// flow window primed once
+			verify(harness.observer, times(1)).request(QUEUE_SIZE);
+		}
+
+		@Test
+		@DisplayName("Fails the subscriber with BufferOverflowException when the queue overflows")
+		void shouldFailSubscriberWithBufferOverflowExceptionWhenQueueOverflows() {
+			// delegate doesn't request anything → items sit in the queue and
+			// overflow on the (QUEUE_SIZE + 1)th
+			final TestHarness harness = new TestHarness(0L);
+			harness.start();
+			harness.deliverAck();
+
+			for (int i = 0; i < QUEUE_SIZE + 1; i++) {
+				harness.deliverCapture(i);
+			}
+
+			// the safety-net must surface as `onError(BufferOverflowException)` on the delegate
+			assertNotNull(
+				harness.delegate.lastError.get(),
+				"delegate must be terminated on overflow"
+			);
+			assertInstanceOf(
+				BufferOverflowException.class,
+				harness.delegate.lastError.get(),
+				"overflow must report `BufferOverflowException`"
+			);
+			// no items must have been pushed to the delegate (it never requested any)
+			assertTrue(
+				harness.delegate.received.isEmpty(),
+				"no items should leak to a zero-demand delegate"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Edge cases")
+	class EdgeCases {
+
+		@Test
+		@DisplayName("Cancels the gRPC stream when the client-side subscription fails")
+		void shouldCancelGrpcStreamWhenSubscriptionFailsClientSide() {
+			final TestHarness harness = new TestHarness(0L);
+			harness.start();
+			harness.deliverAck();
+
+			for (int i = 0; i < QUEUE_SIZE + 1; i++) {
+				harness.deliverCapture(i);
+			}
+
+			// overflow must terminate the delegate AND propagate cancellation to the gRPC
+			// stream so the server stops pushing into a dead client
+			assertInstanceOf(
+				BufferOverflowException.class,
+				harness.delegate.lastError.get(),
+				"delegate must be terminated by the overflow"
+			);
+			verify(harness.observer, times(1)).cancel(
+				org.mockito.ArgumentMatchers.anyString(),
+				org.mockito.ArgumentMatchers.any()
+			);
+		}
+
+		@Test
+		@DisplayName("Handles ACK arriving before onSubscribe completes without NPE")
+		void shouldHandleAckArrivingBeforeOnSubscribeCompletes() {
+			// reproduce the race: deliver the ACK from INSIDE the stream initializer,
+			// i.e. before `subscribe()` reaches `onSubscribe(subscription)`. The subscriber
+			// must already have its subscription field wired so `onNext` does not NPE.
+			final TestHarness harness = new TestHarness(0L, true);
+			harness.start();
+
+			// the ACK was consumed during init — the subscription must have been assigned
+			// its server-side id and the flow window must have been primed
+			verify(harness.observer, times(1)).disableAutoRequestWithInitial(1);
+			verify(harness.observer, times(1)).request(QUEUE_SIZE);
+			// no error must have surfaced to the delegate
+			assertNull(
+				harness.delegate.lastError.get(),
+				"delegate must not see an error from the ACK-before-onSubscribe race"
+			);
+		}
+
+		@Test
+		@DisplayName("Throws a descriptive error when the first message is not an acknowledgement")
+		void shouldThrowDescriptiveErrorWhenFirstMessageIsNotAcknowledgement() {
+			final TestHarness harness = new TestHarness(0L);
+			harness.start();
+
+			// first inbound is a capture, not the ACK — the publisher must reject the protocol
+			// violation with a descriptive error instead of letting an NPE leak through
+			final GenericEvitaInternalError thrown = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> harness.deliverCapture(0)
+			);
+			assertEquals(
+				"Expected ACKNOWLEDGEMENT as first message but got something else.",
+				thrown.getPrivateMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("Terminates the consume scheduler after a cancelled overflow")
+		void shouldTerminateConsumeSchedulerAfterCancelledOverflow() {
+			// After an overflow the walking-dead exception is permanently set and stays
+			// non-null for the lifetime of the subscription. The post-flag re-check
+			// inside consume() must NOT loop on that condition once the subscription
+			// has already been cancelled — otherwise the executor would be hammered
+			// with no-op tasks forever (or, with a synchronous executor, stack-overflow
+			// the calling thread). Verify the scheduler terminates by simply observing
+			// that the overflow path returns cleanly and the delegate sees exactly one
+			// `onError` notification.
+			final TestHarness harness = new TestHarness(0L);
+			harness.start();
+			harness.deliverAck();
+
+			// overflow the queue — this transitively triggers consume() → notify → cancel
+			for (int i = 0; i < QUEUE_SIZE + 1; i++) {
+				harness.deliverCapture(i);
+			}
+
+			// the delegate must have been terminated exactly once with the overflow error
+			assertInstanceOf(
+				BufferOverflowException.class,
+				harness.delegate.lastError.get(),
+				"delegate must receive the overflow error"
+			);
+			// any subsequent `deliverCapture` after cancellation must not resurrect the
+			// scheduler — the subscription is dead and consume() must short-circuit
+			harness.deliverCapture(99);
+			assertInstanceOf(
+				BufferOverflowException.class,
+				harness.delegate.lastError.get(),
+				"the delegate's error must remain the original overflow exception"
+			);
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Test fixtures
+	// ---------------------------------------------------------------------------------------------
+
+	/**
+	 * Synchronous executor — runs every submitted task on the calling thread so the test
+	 * can assert against observable state without awaiting an async dispatcher.
+	 */
+	private static final class SynchronousExecutorService extends AbstractExecutorService {
+		private volatile boolean shutdown;
+
+		@Override
+		public void shutdown() {
+			this.shutdown = true;
+		}
+
+		@Nonnull
+		@Override
+		public List<Runnable> shutdownNow() {
+			this.shutdown = true;
+			return Collections.emptyList();
+		}
+
+		@Override
+		public boolean isShutdown() {
+			return this.shutdown;
+		}
+
+		@Override
+		public boolean isTerminated() {
+			return this.shutdown;
+		}
+
+		@Override
+		public boolean awaitTermination(long timeout, @Nonnull TimeUnit unit) {
+			return true;
+		}
+
+		@Override
+		public void execute(@Nonnull Runnable command) {
+			command.run();
+		}
+	}
+
+	/**
+	 * Recording delegate subscriber — captures `onSubscribe`/`onNext`/`onError`/`onComplete`
+	 * invocations and requests a fixed number of items at subscription time.
+	 */
+	private static final class RecordingSubscriber implements Flow.Subscriber<ChangeSystemCapture> {
+		private final long initialRequest;
+		final List<ChangeSystemCapture> received = new ArrayList<>();
+		final AtomicReference<Throwable> lastError = new AtomicReference<>();
+
+		RecordingSubscriber(long initialRequest) {
+			this.initialRequest = initialRequest;
+		}
+
+		@Override
+		public void onSubscribe(Flow.Subscription subscription) {
+			if (this.initialRequest > 0) {
+				subscription.request(this.initialRequest);
+			}
+		}
+
+		@Override
+		public void onNext(ChangeSystemCapture item) {
+			this.received.add(item);
+		}
+
+		@Override
+		public void onError(Throwable throwable) {
+			this.lastError.set(throwable);
+		}
+
+		@Override
+		public void onComplete() {
+		}
+	}
+
+	/**
+	 * Concrete publisher over `ChangeSystemCapture` captures with an `Object` request/response
+	 * envelope so the test can drive heartbeats and captures by passing distinct java types.
+	 */
+	private static final class SystemCapturePublisher
+		extends ClientChangeCapturePublisher<ChangeSystemCapture, Object, Object> {
+
+		SystemCapturePublisher(
+			int queueSize,
+			@Nonnull ExecutorService executor,
+			@Nonnull Consumer<ClientResponseObserver<Object, Object>> streamInitializer
+		) {
+			super(queueSize, Duration.ofSeconds(60), executor, streamInitializer, p -> {});
+		}
+
+		@Nonnull
+		@Override
+		protected Optional<HeartBeat> deserializeAcknowledgementResponse(Object itemResponse) {
+			return itemResponse instanceof HeartBeat hb ? Optional.of(hb) : Optional.empty();
+		}
+
+		@Nonnull
+		@Override
+		protected Optional<ChangeSystemCapture> deserializeCaptureResponse(Object itemResponse) {
+			return itemResponse instanceof ChangeSystemCapture cap ? Optional.of(cap) : Optional.empty();
+		}
+	}
+
+	/**
+	 * Wires the publisher, a mock gRPC observer and a recording delegate together so each
+	 * test reads cleanly. `start()` performs `subscribe`, which synchronously triggers
+	 * the supplied stream initializer.
+	 */
+	private static final class TestHarness {
+		final ClientCallStreamObserver<Object> observer;
+		final RecordingSubscriber delegate;
+		private final SystemCapturePublisher publisher;
+		private final AtomicReference<ClientResponseObserver<Object, Object>> subscriberRef =
+			new AtomicReference<>();
+
+		TestHarness() {
+			this(0L);
+		}
+
+		TestHarness(long delegateInitialRequest) {
+			this(delegateInitialRequest, false);
+		}
+
+		/**
+		 * Builds a harness that optionally simulates the server ACK landing on the
+		 * stream-initialization thread (i.e. before `subscribe()` returns control to
+		 * `onSubscribe`). This exercises the race where `onNext` would dereference a
+		 * still-null subscription field if the subscriber were not wired early.
+		 */
+		@SuppressWarnings("unchecked")
+		TestHarness(long delegateInitialRequest, boolean deliverAckDuringInit) {
+			this.observer = (ClientCallStreamObserver<Object>) mock(ClientCallStreamObserver.class);
+			this.delegate = new RecordingSubscriber(delegateInitialRequest);
+			this.publisher = new SystemCapturePublisher(
+				QUEUE_SIZE,
+				new SynchronousExecutorService(),
+				subscriber -> {
+					this.subscriberRef.set(subscriber);
+					subscriber.beforeStart(this.observer);
+					if (deliverAckDuringInit) {
+						// fire the ACK from the initializer itself — must NOT NPE
+						subscriber.onNext(buildHeartbeat(0));
+					}
+				}
+			);
+		}
+
+		void start() {
+			this.publisher.subscribe(this.delegate);
+		}
+
+		void deliverAck() {
+			// first message: ACKNOWLEDGEMENT — its presence sets the subscription id
+			this.subscriberRef.get().onNext(buildHeartbeat(0));
+		}
+
+		void deliverHeartbeat(long index) {
+			this.subscriberRef.get().onNext(buildHeartbeat(index));
+		}
+
+		void deliverCapture(int payload) {
+			this.subscriberRef.get().onNext(
+				new ChangeSystemCapture(payload, payload, FIXED_TS, Operation.UPSERT, null)
+			);
+		}
+
+		private static HeartBeat buildHeartbeat(long index) {
+			return new HeartBeat(SUBSCRIPTION_UUID, index, FIXED_TS, 0L, 5000L);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Subscriber takes over inbound gRPC flow control (`disableAutoRequestWithInitial(1)`) and primes a credit window equal to the queue capacity after the ACK; one credit is restored per delivered capture and per server heartbeat. HTTP/2 flow control is now the actual backpressure mechanism, so the per-subscriber `ArrayBlockingQueue` cannot fill under normal operation and the event-loop thread is never parked on `put`.
- `ClientSubscription.produce` switched from blocking `put` to non-blocking `offer`; overflow surfaces as `BufferOverflowException` via a walking-dead path that tears down the gRPC stream through a new `notifyClientFailureAndClose` helper (distinct from server-originated `onError`, which would otherwise leak the stream).
- Closed three latent races: ACK-before-`onSubscribe` (subscription is attached before the stream initializer); `consume()` lost-wakeup (re-check after `currentlyConsuming` reset, guarded by `!cancelled`); protocol-violation NPE on a missing ACK heartbeat (descriptive `GenericEvitaInternalError`).
- Defensive `Objects.requireNonNull` captures of the `@Nullable` fields in `onNext`/`onError`/`onComplete`/`notifyClientFailureAndClose`/`close` document the protocol invariants and silence static-analysis warnings; `close()` also gained a true null-guard so a pre-`beforeStart` close no longer NPEs.

Closes #1196

## Test plan

- [x] `ClientChangeCapturePublisherTest.FlowControl#shouldDisableAutoFlowControlAndPrimeWindowWhenAckReceived`
- [x] `ClientChangeCapturePublisherTest.FlowControl#shouldRestoreCreditWhenServerHeartbeatArrives`
- [x] `ClientChangeCapturePublisherTest.FlowControl#shouldRestoreOneCreditWhenItemDeliveredToDelegate`
- [x] `ClientChangeCapturePublisherTest.FlowControl#shouldFailSubscriberWithBufferOverflowExceptionWhenQueueOverflows`
- [x] `ClientChangeCapturePublisherTest.EdgeCases#shouldCancelGrpcStreamWhenSubscriptionFailsClientSide`
- [x] `ClientChangeCapturePublisherTest.EdgeCases#shouldHandleAckArrivingBeforeOnSubscribeCompletes`
- [x] `ClientChangeCapturePublisherTest.EdgeCases#shouldThrowDescriptiveErrorWhenFirstMessageIsNotAcknowledgement`
- [x] `ClientChangeCapturePublisherTest.EdgeCases#shouldTerminateConsumeSchedulerAfterCancelledOverflow`
- [x] `rtk mvn -pl evita_external_api/evita_external_api_grpc/client compile javadoc:javadoc` — BUILD SUCCESS, no warnings in `cdc/`

## Notes for reviewers

- `evita_test/evita_functional_tests` Surefire is blocked on `dev` by an unrelated `WebSocketWriter` API drift from commit `04a3c3ea8` (REST/GraphQL test files calling a removed `ctx.writer()`). The 8 tests in this PR were verified via direct `javac` + `junit-platform-console-standalone`. Worth a separate cleanup PR.
- The publisher's `subscribe(...)` wiring order is now load-bearing: attach subscription → register → run stream initializer → notify delegate. Comments inline.
- `consume()` re-check guard `!cancelled.get()` is required to prevent infinite reschedule on the synchronous executor used in tests.