### PR TITLE
fix: reconcile ClassSchemaAnalyzer annotation flags symmetrically

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzer.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzer.java
@@ -81,9 +81,18 @@ import static java.util.Optional.ofNullable;
  * Analyzer is a stateful class, that traverses record / class getters or fields for annotations from `io.data.annotation`
  * package and sets up the entity / catalog schema accordingly.
  *
- * The analyzer only creates or expands existing schema and never removes anything from it. The expected form of use is
- * to define new entity properties and mark old one as deprecated. When the already deprecated properties are about to be
- * removed completely the removal should occur in an explicit way (command or API call) outside this analyzer.
+ * Schema reconciliation contract:
+ *
+ * - **Structural elements** (attributes, associated data, references, sortable compounds) are
+ *   only created or expanded — the analyzer never removes them. Removal of a deprecated property
+ *   must happen explicitly outside this analyzer.
+ * - **Annotation flag reconciliation** is symmetric for booleans and their enum analogues
+ *   (`nullable`, `localized`, `representative`, `filterable`, `sortable`, `unique`, `uniqueGlobally`,
+ *   `faceted`, …). The class annotation is the source of truth: if a flag is `false` / `NOT_UNIQUE`
+ *   on the annotation but `true` on the schema, the analyzer flips the schema back to match.
+ *   This means a bare `@Attribute String foo()` is a strong assertion that every default-valued
+ *   flag must be at its default — re-analyzing such a class clears any previously-set flag on
+ *   the same attribute.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  * @see Entity
@@ -357,20 +366,26 @@ public class ClassSchemaAnalyzer {
 				isStringNotEqual(editor.getDeprecationNotice(), attributeAnnotation.deprecated())) {
 				editor.deprecated(attributeAnnotation.deprecated());
 			}
-			// nullable - only set if not already nullable
+			// nullable - reconcile with annotation
 			if (attributeAnnotation.nullable() && !editor.isNullable()) {
 				editor.nullable();
+			} else if (!attributeAnnotation.nullable() && editor.isNullable()) {
+				editor.nonNullable();
 			}
 
 			applyAttributeScopedProperties(editor, attributeAnnotation);
 
-			// representative - only set if not already representative
+			// representative - reconcile with annotation
 			if (attributeAnnotation.representative() && !editor.isRepresentative()) {
 				editor.representative();
+			} else if (!attributeAnnotation.representative() && editor.isRepresentative()) {
+				editor.representative(() -> false);
 			}
-			// localized - only set if not already localized
+			// localized - reconcile with annotation
 			if (attributeAnnotation.localized() && !editor.isLocalized()) {
 				editor.localized();
+			} else if (!attributeAnnotation.localized() && editor.isLocalized()) {
+				editor.nonLocalized();
 			}
 			// indexed decimal places - only set if different
 			if (BigDecimal.class.equals(attributeType) &&
@@ -398,6 +413,8 @@ public class ClassSchemaAnalyzer {
 
 					if (attributeAnnotation.representative() && !whichIs.isRepresentative()) {
 						whichIs.representative();
+					} else if (!attributeAnnotation.representative() && whichIs.isRepresentative()) {
+						whichIs.representative(() -> false);
 					}
 
 					applyGlobalAttributeScopedProperties(whichIs, attributeAnnotation);
@@ -634,8 +651,11 @@ public class ClassSchemaAnalyzer {
 				null
 			);
 			applyReferenceIndexedComponents(editor, reference.indexedComponents(), Scope.DEFAULT_SCOPE);
+			// faceted - reconcile DEFAULT_SCOPE with annotation
 			if (reference.faceted() && !editor.isFacetedInScope(Scope.DEFAULT_SCOPE)) {
 				editor.faceted();
+			} else if (!reference.faceted() && editor.isFacetedInScope(Scope.DEFAULT_SCOPE)) {
+				editor.nonFaceted(Scope.DEFAULT_SCOPE);
 			}
 			final String facetedPartiallyExpr = reference.facetedPartially().value();
 			if (!facetedPartiallyExpr.isEmpty()) {
@@ -691,14 +711,21 @@ public class ClassSchemaAnalyzer {
 			for (ScopeReferenceSettings ss : scopedDefinition) {
 				final Scope scope = ss.scope();
 				applyReferenceIndexedComponents(editor, ss.indexedComponents(), scope);
-				if (ss.faceted() && !editor.isFacetedInScope(scope)) {
+				if (ss.faceted()) {
 					facetedScopes.add(scope);
 				}
 			}
 			// 3) `facetedInScope` MUST be called before any per-scope `facetedPartiallyInScope` —
 			// the builder's `facetedInScope` filters existing partial expressions to the scopes it's
 			// passed, so a later partial call cannot recover dropped state.
-			if (!facetedScopes.isEmpty()) {
+			//
+			// Fire only when the desired faceted-scope set differs from the current state so the
+			// reconciliation is idempotent on repeat analysis but still narrows when the annotation
+			// drops a previously faceted scope.
+			final EnumSet<Scope> currentFacetedScopes = collectScopes(
+				Scope.values(), editor::isFacetedInScope
+			);
+			if (!facetedScopes.equals(currentFacetedScopes)) {
 				editor.facetedInScope(facetedScopes.toArray(Scope[]::new));
 			}
 			// 4) remaining per-scope settings — ordering between them is independent.
@@ -889,19 +916,29 @@ public class ClassSchemaAnalyzer {
 	) {
 		final ScopeAttributeSettings[] scopedDefinition = attributeAnnotation.scope();
 		if (ArrayUtils.isEmptyOrItsValuesNull(scopedDefinition)) {
+			// unique - reconcile DEFAULT_SCOPE with annotation enum
+			final AttributeUniquenessType currentUniqueType = editor.getUniquenessType(Scope.DEFAULT_SCOPE);
 			if (attributeAnnotation.unique() == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION &&
-				!editor.isUniqueInScope(Scope.DEFAULT_SCOPE)) {
+				currentUniqueType != AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION) {
 				editor.unique();
-			}
-			if (attributeAnnotation.unique() == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE &&
-				!editor.isUniqueWithinLocaleInScope(Scope.DEFAULT_SCOPE)) {
+			} else if (attributeAnnotation.unique() == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE &&
+				currentUniqueType != AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE) {
 				editor.uniqueWithinLocale();
+			} else if (attributeAnnotation.unique() == AttributeUniquenessType.NOT_UNIQUE &&
+				currentUniqueType != AttributeUniquenessType.NOT_UNIQUE) {
+				editor.nonUniqueInScope(Scope.DEFAULT_SCOPE);
 			}
+			// filterable - reconcile DEFAULT_SCOPE with annotation
 			if (attributeAnnotation.filterable() && !editor.isFilterableInScope(Scope.DEFAULT_SCOPE)) {
 				editor.filterable();
+			} else if (!attributeAnnotation.filterable() && editor.isFilterableInScope(Scope.DEFAULT_SCOPE)) {
+				editor.nonFilterableInScope(Scope.DEFAULT_SCOPE);
 			}
+			// sortable - reconcile DEFAULT_SCOPE with annotation
 			if (attributeAnnotation.sortable() && !editor.isSortableInScope(Scope.DEFAULT_SCOPE)) {
 				editor.sortable();
+			} else if (!attributeAnnotation.sortable() && editor.isSortableInScope(Scope.DEFAULT_SCOPE)) {
+				editor.nonSortableInScope(Scope.DEFAULT_SCOPE);
 			}
 		} else {
 			Assert.isTrue(
@@ -923,39 +960,98 @@ public class ClassSchemaAnalyzer {
 					"(and thus it doesn't make sense to set it to true)!"
 			);
 
-			final Scope[] uniqueInScopes = Arrays.stream(scopedDefinition)
-				.filter(it -> it.unique() == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION)
-				.map(ScopeAttributeSettings::scope)
-				.filter(scope -> !editor.isUniqueInScope(scope))
-				.toArray(Scope[]::new);
-			if (!ArrayUtils.isEmptyOrItsValuesNull(uniqueInScopes)) {
-				editor.uniqueInScope(uniqueInScopes);
+			// unique - reconcile per-scope: desired set of scopes per uniqueness type
+			final EnumSet<Scope> desiredUniqueScopes = collectScopesByUnique(
+				scopedDefinition, AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION
+			);
+			final EnumSet<Scope> currentUniqueScopes = collectScopes(
+				Scope.values(), s -> editor.getUniquenessType(s) == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION
+			);
+			if (!desiredUniqueScopes.equals(currentUniqueScopes)) {
+				editor.uniqueInScope(desiredUniqueScopes.toArray(Scope[]::new));
 			}
-			final Scope[] uniqueWithinLocaleInScopes = Arrays.stream(scopedDefinition)
-				.filter(it -> it.unique() == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE)
-				.map(ScopeAttributeSettings::scope)
-				.filter(scope -> !editor.isUniqueWithinLocaleInScope(scope))
-				.toArray(Scope[]::new);
-			if (!ArrayUtils.isEmptyOrItsValuesNull(uniqueWithinLocaleInScopes)) {
-				editor.uniqueWithinLocaleInScope(uniqueWithinLocaleInScopes);
+			final EnumSet<Scope> desiredUniqueLocaleScopes = collectScopesByUnique(
+				scopedDefinition, AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE
+			);
+			final EnumSet<Scope> currentUniqueLocaleScopes = collectScopes(
+				Scope.values(), s -> editor.getUniquenessType(s) == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE
+			);
+			if (!desiredUniqueLocaleScopes.equals(currentUniqueLocaleScopes)) {
+				editor.uniqueWithinLocaleInScope(desiredUniqueLocaleScopes.toArray(Scope[]::new));
 			}
-			final Scope[] filterableInScopes = Arrays.stream(scopedDefinition)
-				.filter(ScopeAttributeSettings::filterable)
-				.map(ScopeAttributeSettings::scope)
-				.filter(scope -> !editor.isFilterableInScope(scope))
-				.toArray(Scope[]::new);
-			if (!ArrayUtils.isEmptyOrItsValuesNull(filterableInScopes)) {
-				editor.filterableInScope(filterableInScopes);
+			// filterable - reconcile per-scope desired set
+			final EnumSet<Scope> desiredFilterableScopes = collectScopesByPredicate(
+				scopedDefinition, ScopeAttributeSettings::filterable
+			);
+			final EnumSet<Scope> currentFilterableScopes = collectScopes(
+				Scope.values(), editor::isFilterableInScope
+			);
+			if (!desiredFilterableScopes.equals(currentFilterableScopes)) {
+				editor.filterableInScope(desiredFilterableScopes.toArray(Scope[]::new));
 			}
-			final Scope[] sortableInScopes = Arrays.stream(scopedDefinition)
-				.filter(ScopeAttributeSettings::sortable)
-				.map(ScopeAttributeSettings::scope)
-				.filter(scope -> !editor.isSortableInScope(scope))
-				.toArray(Scope[]::new);
-			if (!ArrayUtils.isEmptyOrItsValuesNull(sortableInScopes)) {
-				editor.sortableInScope(sortableInScopes);
+			// sortable - reconcile per-scope desired set
+			final EnumSet<Scope> desiredSortableScopes = collectScopesByPredicate(
+				scopedDefinition, ScopeAttributeSettings::sortable
+			);
+			final EnumSet<Scope> currentSortableScopes = collectScopes(
+				Scope.values(), editor::isSortableInScope
+			);
+			if (!desiredSortableScopes.equals(currentSortableScopes)) {
+				editor.sortableInScope(desiredSortableScopes.toArray(Scope[]::new));
 			}
 		}
+	}
+
+	/**
+	 * Returns the {@link EnumSet} of scopes for which the predicate is `true`.
+	 */
+	@Nonnull
+	private static EnumSet<Scope> collectScopes(
+		@Nonnull Scope[] scopes,
+		@Nonnull Predicate<Scope> predicate
+	) {
+		final EnumSet<Scope> result = EnumSet.noneOf(Scope.class);
+		for (final Scope scope : scopes) {
+			if (predicate.test(scope)) {
+				result.add(scope);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Returns the {@link EnumSet} of scopes in `scopedDefinition` whose predicate is `true`.
+	 */
+	@Nonnull
+	private static EnumSet<Scope> collectScopesByPredicate(
+		@Nonnull ScopeAttributeSettings[] scopedDefinition,
+		@Nonnull Predicate<ScopeAttributeSettings> predicate
+	) {
+		final EnumSet<Scope> result = EnumSet.noneOf(Scope.class);
+		for (final ScopeAttributeSettings settings : scopedDefinition) {
+			if (predicate.test(settings)) {
+				result.add(settings.scope());
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Returns the {@link EnumSet} of scopes in `scopedDefinition` whose `unique()` matches
+	 * `target`.
+	 */
+	@Nonnull
+	private static EnumSet<Scope> collectScopesByUnique(
+		@Nonnull ScopeAttributeSettings[] scopedDefinition,
+		@Nonnull AttributeUniquenessType target
+	) {
+		final EnumSet<Scope> result = EnumSet.noneOf(Scope.class);
+		for (final ScopeAttributeSettings settings : scopedDefinition) {
+			if (settings.unique() == target) {
+				result.add(settings.scope());
+			}
+		}
+		return result;
 	}
 
 	/**
@@ -969,13 +1065,18 @@ public class ClassSchemaAnalyzer {
 	) {
 		final ScopeAttributeSettings[] scopedDefinition = attributeAnnotation.scope();
 		if (ArrayUtils.isEmptyOrItsValuesNull(scopedDefinition)) {
+			// uniqueGlobally - reconcile DEFAULT_SCOPE with annotation enum
+			final GlobalAttributeUniquenessType currentGlobalUniqueType =
+				editor.getGlobalUniquenessType(Scope.DEFAULT_SCOPE);
 			if (attributeAnnotation.uniqueGlobally() == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG &&
-				!editor.isUniqueGloballyInScope(Scope.DEFAULT_SCOPE)) {
+				currentGlobalUniqueType != GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG) {
 				editor.uniqueGlobally();
-			}
-			if (attributeAnnotation.uniqueGlobally() == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE &&
-				!editor.isUniqueGloballyWithinLocaleInScope(Scope.DEFAULT_SCOPE)) {
+			} else if (attributeAnnotation.uniqueGlobally() == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE &&
+				currentGlobalUniqueType != GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE) {
 				editor.uniqueGloballyWithinLocale();
+			} else if (attributeAnnotation.uniqueGlobally() == GlobalAttributeUniquenessType.NOT_UNIQUE &&
+				currentGlobalUniqueType != GlobalAttributeUniquenessType.NOT_UNIQUE) {
+				editor.nonUniqueGloballyInScope(Scope.DEFAULT_SCOPE);
 			}
 		} else {
 			Assert.isTrue(
@@ -984,23 +1085,46 @@ public class ClassSchemaAnalyzer {
 					"the value of `uniqueGlobally` property is not taken into an account " +
 					"(and thus it doesn't make sense to set it to any value)!"
 			);
-			final Scope[] uniqueGloballyInScopes = Arrays.stream(scopedDefinition)
-				.filter(it -> it.uniqueGlobally() == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG)
-				.map(ScopeAttributeSettings::scope)
-				.filter(scope -> !editor.isUniqueGloballyInScope(scope))
-				.toArray(Scope[]::new);
-			if (!ArrayUtils.isEmptyOrItsValuesNull(uniqueGloballyInScopes)) {
-				editor.uniqueGloballyInScope(uniqueGloballyInScopes);
+			// uniqueGlobally per-scope - reconcile desired set
+			final EnumSet<Scope> desiredUniqueGloballyScopes = collectScopesByUniqueGlobally(
+				scopedDefinition, GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG
+			);
+			final EnumSet<Scope> currentUniqueGloballyScopes = collectScopes(
+				Scope.values(), s -> editor.getGlobalUniquenessType(s) == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG
+			);
+			if (!desiredUniqueGloballyScopes.equals(currentUniqueGloballyScopes)) {
+				editor.uniqueGloballyInScope(desiredUniqueGloballyScopes.toArray(Scope[]::new));
 			}
-			final Scope[] uniqueGloballyWithinLocaleInScopes = Arrays.stream(scopedDefinition)
-				.filter(it -> it.uniqueGlobally() == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE)
-				.map(ScopeAttributeSettings::scope)
-				.filter(scope -> !editor.isUniqueGloballyWithinLocaleInScope(scope))
-				.toArray(Scope[]::new);
-			if (!ArrayUtils.isEmptyOrItsValuesNull(uniqueGloballyWithinLocaleInScopes)) {
-				editor.uniqueGloballyWithinLocaleInScope(uniqueGloballyWithinLocaleInScopes);
+			final EnumSet<Scope> desiredUniqueGloballyLocaleScopes = collectScopesByUniqueGlobally(
+				scopedDefinition, GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE
+			);
+			final EnumSet<Scope> currentUniqueGloballyLocaleScopes = collectScopes(
+				Scope.values(), s -> editor.getGlobalUniquenessType(s) == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE
+			);
+			if (!desiredUniqueGloballyLocaleScopes.equals(currentUniqueGloballyLocaleScopes)) {
+				editor.uniqueGloballyWithinLocaleInScope(
+					desiredUniqueGloballyLocaleScopes.toArray(Scope[]::new)
+				);
 			}
 		}
+	}
+
+	/**
+	 * Returns the {@link EnumSet} of scopes in `scopedDefinition` whose `uniqueGlobally()`
+	 * matches `target`.
+	 */
+	@Nonnull
+	private static EnumSet<Scope> collectScopesByUniqueGlobally(
+		@Nonnull ScopeAttributeSettings[] scopedDefinition,
+		@Nonnull GlobalAttributeUniquenessType target
+	) {
+		final EnumSet<Scope> result = EnumSet.noneOf(Scope.class);
+		for (final ScopeAttributeSettings settings : scopedDefinition) {
+			if (settings.uniqueGlobally() == target) {
+				result.add(settings.scope());
+			}
+		}
+		return result;
 	}
 
 	/**
@@ -1404,13 +1528,17 @@ public class ClassSchemaAnalyzer {
 				) {
 					whichIs.deprecated(associatedDataAnnotation.deprecated());
 				}
-				// nullable - only set if not already nullable
+				// nullable - reconcile with annotation
 				if (associatedDataAnnotation.nullable() && !whichIs.isNullable()) {
 					whichIs.nullable();
+				} else if (!associatedDataAnnotation.nullable() && whichIs.isNullable()) {
+					whichIs.nullable(() -> false);
 				}
-				// localized - only set if not already localized
+				// localized - reconcile with annotation
 				if (associatedDataAnnotation.localized() && !whichIs.isLocalized()) {
 					whichIs.localized();
+				} else if (!associatedDataAnnotation.localized() && whichIs.isLocalized()) {
+					whichIs.localized(() -> false);
 				}
 			}
 		);

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzer.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzer.java
@@ -960,24 +960,38 @@ public class ClassSchemaAnalyzer {
 					"(and thus it doesn't make sense to set it to true)!"
 			);
 
-			// unique - reconcile per-scope: desired set of scopes per uniqueness type
+			// unique - reconcile per-scope from a single pre-mutation snapshot. Both
+			// `uniqueInScope` and `uniqueWithinLocaleInScope` emit a SetAttributeSchemaUniqueMutation
+			// that replaces the whole uniqueness map, and combineWith keeps only the last of them -
+			// so emitting both would let one silently clobber the other. A single full-replacement
+			// call for the requested kind already expresses the complete desired state (it clears
+			// the opposite kind as well). Mixing both kinds across scopes on one attribute cannot be
+			// expressed by these kind-specific setters and is surfaced rather than silently corrupted.
 			final EnumSet<Scope> desiredUniqueScopes = collectScopesByUnique(
 				scopedDefinition, AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION
+			);
+			final EnumSet<Scope> desiredUniqueLocaleScopes = collectScopesByUnique(
+				scopedDefinition, AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE
 			);
 			final EnumSet<Scope> currentUniqueScopes = collectScopes(
 				Scope.values(), s -> editor.getUniquenessType(s) == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION
 			);
-			if (!desiredUniqueScopes.equals(currentUniqueScopes)) {
-				editor.uniqueInScope(desiredUniqueScopes.toArray(Scope[]::new));
-			}
-			final EnumSet<Scope> desiredUniqueLocaleScopes = collectScopesByUnique(
-				scopedDefinition, AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE
-			);
 			final EnumSet<Scope> currentUniqueLocaleScopes = collectScopes(
 				Scope.values(), s -> editor.getUniquenessType(s) == AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE
 			);
-			if (!desiredUniqueLocaleScopes.equals(currentUniqueLocaleScopes)) {
-				editor.uniqueWithinLocaleInScope(desiredUniqueLocaleScopes.toArray(Scope[]::new));
+			if (!desiredUniqueScopes.equals(currentUniqueScopes) ||
+				!desiredUniqueLocaleScopes.equals(currentUniqueLocaleScopes)) {
+				if (desiredUniqueLocaleScopes.isEmpty()) {
+					editor.uniqueInScope(desiredUniqueScopes.toArray(Scope[]::new));
+				} else if (desiredUniqueScopes.isEmpty()) {
+					editor.uniqueWithinLocaleInScope(desiredUniqueLocaleScopes.toArray(Scope[]::new));
+				} else {
+					throw new GenericEvitaInternalError(
+						"Attribute `" + editor.getName() + "` mixes `UNIQUE_WITHIN_COLLECTION` and " +
+							"`UNIQUE_WITHIN_COLLECTION_LOCALE` uniqueness across scopes, which the class " +
+							"schema analyzer cannot apply within a single mutation."
+					);
+				}
 			}
 			// filterable - reconcile per-scope desired set
 			final EnumSet<Scope> desiredFilterableScopes = collectScopesByPredicate(
@@ -1085,26 +1099,38 @@ public class ClassSchemaAnalyzer {
 					"the value of `uniqueGlobally` property is not taken into an account " +
 					"(and thus it doesn't make sense to set it to any value)!"
 			);
-			// uniqueGlobally per-scope - reconcile desired set
+			// uniqueGlobally per-scope - reconcile from a single pre-mutation snapshot. As with
+			// entity-level uniqueness, both global setters emit a full-replacement mutation that
+			// combineWith collapses to the last one, so a single call for the requested kind
+			// expresses the complete desired state (clearing the opposite kind too). Mixing both
+			// global kinds across scopes is surfaced rather than silently corrupted.
 			final EnumSet<Scope> desiredUniqueGloballyScopes = collectScopesByUniqueGlobally(
 				scopedDefinition, GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG
+			);
+			final EnumSet<Scope> desiredUniqueGloballyLocaleScopes = collectScopesByUniqueGlobally(
+				scopedDefinition, GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE
 			);
 			final EnumSet<Scope> currentUniqueGloballyScopes = collectScopes(
 				Scope.values(), s -> editor.getGlobalUniquenessType(s) == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG
 			);
-			if (!desiredUniqueGloballyScopes.equals(currentUniqueGloballyScopes)) {
-				editor.uniqueGloballyInScope(desiredUniqueGloballyScopes.toArray(Scope[]::new));
-			}
-			final EnumSet<Scope> desiredUniqueGloballyLocaleScopes = collectScopesByUniqueGlobally(
-				scopedDefinition, GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE
-			);
 			final EnumSet<Scope> currentUniqueGloballyLocaleScopes = collectScopes(
 				Scope.values(), s -> editor.getGlobalUniquenessType(s) == GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE
 			);
-			if (!desiredUniqueGloballyLocaleScopes.equals(currentUniqueGloballyLocaleScopes)) {
-				editor.uniqueGloballyWithinLocaleInScope(
-					desiredUniqueGloballyLocaleScopes.toArray(Scope[]::new)
-				);
+			if (!desiredUniqueGloballyScopes.equals(currentUniqueGloballyScopes) ||
+				!desiredUniqueGloballyLocaleScopes.equals(currentUniqueGloballyLocaleScopes)) {
+				if (desiredUniqueGloballyLocaleScopes.isEmpty()) {
+					editor.uniqueGloballyInScope(desiredUniqueGloballyScopes.toArray(Scope[]::new));
+				} else if (desiredUniqueGloballyScopes.isEmpty()) {
+					editor.uniqueGloballyWithinLocaleInScope(
+						desiredUniqueGloballyLocaleScopes.toArray(Scope[]::new)
+					);
+				} else {
+					throw new GenericEvitaInternalError(
+						"Attribute `" + editor.getName() + "` mixes `UNIQUE_WITHIN_CATALOG` and " +
+							"`UNIQUE_WITHIN_CATALOG_LOCALE` global uniqueness across scopes, which the " +
+							"class schema analyzer cannot apply within a single mutation."
+					);
+				}
 			}
 		}
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
@@ -38,9 +38,16 @@ import io.evitadb.api.requestResponse.schema.model.evolution.*;
 import io.evitadb.api.requestResponse.schema.mutation.EntitySchemaMutation;
 import io.evitadb.api.requestResponse.schema.mutation.LocalCatalogSchemaMutation;
 import io.evitadb.api.requestResponse.schema.mutation.associatedData.CreateAssociatedDataSchemaMutation;
+import io.evitadb.api.requestResponse.schema.mutation.associatedData.SetAssociatedDataSchemaLocalizedMutation;
+import io.evitadb.api.requestResponse.schema.mutation.associatedData.SetAssociatedDataSchemaNullableMutation;
 import io.evitadb.api.requestResponse.schema.mutation.attribute.CreateAttributeSchemaMutation;
 import io.evitadb.api.requestResponse.schema.mutation.attribute.RemoveAttributeSchemaMutation;
 import io.evitadb.api.requestResponse.schema.mutation.attribute.SetAttributeSchemaFilterableMutation;
+import io.evitadb.api.requestResponse.schema.mutation.attribute.SetAttributeSchemaLocalizedMutation;
+import io.evitadb.api.requestResponse.schema.mutation.attribute.SetAttributeSchemaNullableMutation;
+import io.evitadb.api.requestResponse.schema.mutation.attribute.SetAttributeSchemaRepresentativeMutation;
+import io.evitadb.api.requestResponse.schema.mutation.attribute.SetAttributeSchemaSortableMutation;
+import io.evitadb.api.requestResponse.schema.mutation.attribute.SetAttributeSchemaUniqueMutation;
 import io.evitadb.api.requestResponse.schema.mutation.catalog.ModifyEntitySchemaMutation;
 import io.evitadb.api.requestResponse.schema.mutation.reference.CreateReferenceSchemaMutation;
 import io.evitadb.api.requestResponse.schema.mutation.reference.CreateReflectedReferenceSchemaMutation;
@@ -2727,6 +2734,435 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 						GetterBasedEntityEvolutionV1.ENTITY_NAME)
 					.orElseThrow();
 				assertTrue(updatedSchema.getAttribute("code").orElseThrow().isFilterable());
+			}
+		);
+	}
+
+	@DisplayName("Verify nullable=true is narrowed to non-null when annotation uses default settings")
+	@Test
+	void shouldNarrowNullableAttributeToNonNullWhenAnnotationUsesDefaultSettings() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				// Create initial schema with nullable=true
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityNullableEvolutionV1.class);
+
+				// Verify initial state: attribute is nullable
+				final SealedEntitySchema initialSchema = session.getEntitySchema(
+						GetterBasedEntityNullableEvolutionV1.ENTITY_NAME)
+					.orElseThrow();
+				assertTrue(
+					initialSchema.getAttribute("code").orElseThrow().isNullable(),
+					"Initial `code` attribute is expected to be nullable."
+				);
+
+				// Re-analyze with V2 that uses default @Attribute (nullable=false)
+				final LocalCatalogSchemaMutation[] mutations = analyzeAndCaptureMutations(
+					session, GetterBasedEntityNullableEvolutionV2NarrowToNonNull.class
+				);
+
+				// Expected mutation: nullable flipped to false
+				final Optional<SetAttributeSchemaNullableMutation> nullableMutation =
+					findEntitySchemaMutation(mutations, SetAttributeSchemaNullableMutation.class);
+				assertTrue(
+					nullableMutation.isPresent(),
+					"Expected SetAttributeSchemaNullableMutation flipping `code` to non-null."
+				);
+				assertEquals("code", nullableMutation.get().getName());
+				assertFalse(
+					nullableMutation.get().isNullable(),
+					"Expected the nullable mutation to set nullable=false."
+				);
+
+				// Verify schema is now non-null
+				final SealedEntitySchema updatedSchema = session.getEntitySchema(
+						GetterBasedEntityNullableEvolutionV1.ENTITY_NAME)
+					.orElseThrow();
+				assertFalse(
+					updatedSchema.getAttribute("code").orElseThrow().isNullable(),
+					"`code` attribute is expected to be non-null after re-analysis with default @Attribute."
+				);
+			}
+		);
+	}
+
+	@DisplayName("Verify Attribute.localized=true is narrowed when annotation uses default settings")
+	@Test
+	void shouldNarrowAttributeLocalizedWhenAnnotationUsesDefaultSettings() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityNarrowingEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertTrue(initial.getAttribute("localizedCode").orElseThrow().isLocalized());
+
+				final LocalCatalogSchemaMutation[] mutations = analyzeAndCaptureMutations(
+					session, GetterBasedEntityNarrowingEvolutionV2NarrowAll.class
+				);
+
+				final Optional<SetAttributeSchemaLocalizedMutation> mutation = streamEntitySchemaMutations(
+					mutations, SetAttributeSchemaLocalizedMutation.class)
+					.filter(m -> "localizedCode".equals(m.getName()))
+					.findFirst();
+				assertTrue(mutation.isPresent(),
+					"Expected SetAttributeSchemaLocalizedMutation(false) for `localizedCode`.");
+				assertFalse(mutation.get().isLocalized());
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertFalse(updated.getAttribute("localizedCode").orElseThrow().isLocalized());
+			}
+		);
+	}
+
+	@DisplayName("Verify Attribute.representative=true is narrowed when annotation uses default settings")
+	@Test
+	void shouldNarrowAttributeRepresentativeWhenAnnotationUsesDefaultSettings() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityNarrowingEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertTrue(((EntityAttributeSchema) initial.getAttribute("representativeCode")
+					.orElseThrow()).isRepresentative());
+
+				final LocalCatalogSchemaMutation[] mutations = analyzeAndCaptureMutations(
+					session, GetterBasedEntityNarrowingEvolutionV2NarrowAll.class
+				);
+
+				final Optional<SetAttributeSchemaRepresentativeMutation> mutation = streamEntitySchemaMutations(
+					mutations, SetAttributeSchemaRepresentativeMutation.class)
+					.filter(m -> "representativeCode".equals(m.getName()))
+					.findFirst();
+				assertTrue(mutation.isPresent(),
+					"Expected SetAttributeSchemaRepresentativeMutation(false) for `representativeCode`.");
+				assertFalse(mutation.get().isRepresentative());
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertFalse(((EntityAttributeSchema) updated.getAttribute("representativeCode")
+					.orElseThrow()).isRepresentative());
+			}
+		);
+	}
+
+	@DisplayName("Verify Attribute.filterable=true is narrowed when annotation uses default settings")
+	@Test
+	void shouldNarrowAttributeFilterableWhenAnnotationUsesDefaultSettings() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityNarrowingEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertTrue(initial.getAttribute("filterableCode").orElseThrow()
+					.isFilterableInScope(Scope.DEFAULT_SCOPE));
+
+				final LocalCatalogSchemaMutation[] mutations = analyzeAndCaptureMutations(
+					session, GetterBasedEntityNarrowingEvolutionV2NarrowAll.class
+				);
+
+				final Optional<SetAttributeSchemaFilterableMutation> mutation = streamEntitySchemaMutations(
+					mutations, SetAttributeSchemaFilterableMutation.class)
+					.filter(m -> "filterableCode".equals(m.getName()))
+					.findFirst();
+				assertTrue(mutation.isPresent(),
+					"Expected SetAttributeSchemaFilterableMutation clearing filterable for `filterableCode`.");
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertFalse(updated.getAttribute("filterableCode").orElseThrow()
+					.isFilterableInScope(Scope.DEFAULT_SCOPE));
+			}
+		);
+	}
+
+	@DisplayName("Verify Attribute.sortable=true is narrowed when annotation uses default settings")
+	@Test
+	void shouldNarrowAttributeSortableWhenAnnotationUsesDefaultSettings() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityNarrowingEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertTrue(initial.getAttribute("sortableCode").orElseThrow()
+					.isSortableInScope(Scope.DEFAULT_SCOPE));
+
+				final LocalCatalogSchemaMutation[] mutations = analyzeAndCaptureMutations(
+					session, GetterBasedEntityNarrowingEvolutionV2NarrowAll.class
+				);
+
+				final Optional<SetAttributeSchemaSortableMutation> mutation = streamEntitySchemaMutations(
+					mutations, SetAttributeSchemaSortableMutation.class)
+					.filter(m -> "sortableCode".equals(m.getName()))
+					.findFirst();
+				assertTrue(mutation.isPresent(),
+					"Expected SetAttributeSchemaSortableMutation clearing sortable for `sortableCode`.");
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertFalse(updated.getAttribute("sortableCode").orElseThrow()
+					.isSortableInScope(Scope.DEFAULT_SCOPE));
+			}
+		);
+	}
+
+	@DisplayName("Verify Attribute.unique is narrowed to NOT_UNIQUE when annotation uses default settings")
+	@Test
+	void shouldNarrowAttributeUniqueWhenAnnotationUsesDefaultSettings() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityNarrowingEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertEquals(
+					AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION,
+					initial.getAttribute("uniqueCode").orElseThrow()
+						.getUniquenessType(Scope.DEFAULT_SCOPE)
+				);
+
+				final LocalCatalogSchemaMutation[] mutations = analyzeAndCaptureMutations(
+					session, GetterBasedEntityNarrowingEvolutionV2NarrowAll.class
+				);
+
+				final Optional<SetAttributeSchemaUniqueMutation> mutation = streamEntitySchemaMutations(
+					mutations, SetAttributeSchemaUniqueMutation.class)
+					.filter(m -> "uniqueCode".equals(m.getName()))
+					.findFirst();
+				assertTrue(mutation.isPresent(),
+					"Expected SetAttributeSchemaUniqueMutation(NOT_UNIQUE) for `uniqueCode`.");
+				assertEquals(AttributeUniquenessType.NOT_UNIQUE, mutation.get().getUnique());
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertEquals(
+					AttributeUniquenessType.NOT_UNIQUE,
+					updated.getAttribute("uniqueCode").orElseThrow()
+						.getUniquenessType(Scope.DEFAULT_SCOPE)
+				);
+			}
+		);
+	}
+
+	@DisplayName("Verify Attribute.unique within-locale is narrowed to within-collection when annotation switches kind")
+	@Test
+	void shouldNarrowAttributeUniqueWithinLocaleToCollectionWhenAnnotationSwitchesKind() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityUniquenessKindEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityUniquenessKindEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertEquals(
+					AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE,
+					initial.getAttribute("localeUniqueCode").orElseThrow()
+						.getUniquenessType(Scope.DEFAULT_SCOPE)
+				);
+
+				final LocalCatalogSchemaMutation[] mutations = analyzeAndCaptureMutations(
+					session, GetterBasedEntityUniquenessKindEvolutionV2SwitchToCollection.class
+				);
+
+				final Optional<SetAttributeSchemaUniqueMutation> mutation = streamEntitySchemaMutations(
+					mutations, SetAttributeSchemaUniqueMutation.class)
+					.filter(m -> "localeUniqueCode".equals(m.getName()))
+					.findFirst();
+				assertTrue(mutation.isPresent(),
+					"Expected SetAttributeSchemaUniqueMutation(UNIQUE_WITHIN_COLLECTION) for `localeUniqueCode`.");
+				assertEquals(AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION, mutation.get().getUnique());
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityUniquenessKindEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertEquals(
+					AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION,
+					updated.getAttribute("localeUniqueCode").orElseThrow()
+						.getUniquenessType(Scope.DEFAULT_SCOPE)
+				);
+			}
+		);
+	}
+
+	@DisplayName("Verify global Attribute.uniqueGlobally within-locale is narrowed to within-catalog when annotation switches kind")
+	@Test
+	void shouldNarrowGlobalAttributeUniqueGloballyWithinCatalogLocaleToCatalogWhenAnnotationSwitchesKind() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityUniquenessKindEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityUniquenessKindEvolutionV1.ENTITY_NAME).orElseThrow();
+				final GlobalAttributeSchema initialGlobal = (GlobalAttributeSchema) initial
+					.getAttribute("globalLocaleUniqueCode").orElseThrow();
+				assertEquals(
+					GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE,
+					initialGlobal.getGlobalUniquenessType(Scope.DEFAULT_SCOPE)
+				);
+
+				analyzeAndCaptureMutations(
+					session, GetterBasedEntityUniquenessKindEvolutionV2SwitchToCollection.class
+				);
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityUniquenessKindEvolutionV1.ENTITY_NAME).orElseThrow();
+				final GlobalAttributeSchema updatedGlobal = (GlobalAttributeSchema) updated
+					.getAttribute("globalLocaleUniqueCode").orElseThrow();
+				assertEquals(
+					GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG,
+					updatedGlobal.getGlobalUniquenessType(Scope.DEFAULT_SCOPE)
+				);
+			}
+		);
+	}
+
+	@DisplayName("Verify per-scope Attribute.unique within-locale is narrowed to within-collection when annotation switches kind")
+	@Test
+	void shouldNarrowPerScopeAttributeUniqueWithinLocaleToCollectionWhenAnnotationSwitchesKind() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityUniquenessKindEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityUniquenessKindEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertEquals(
+					AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE,
+					initial.getAttribute("scopedLocaleUniqueCode").orElseThrow()
+						.getUniquenessType(Scope.LIVE)
+				);
+
+				analyzeAndCaptureMutations(
+					session, GetterBasedEntityUniquenessKindEvolutionV2SwitchToCollection.class
+				);
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityUniquenessKindEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertEquals(
+					AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION,
+					updated.getAttribute("scopedLocaleUniqueCode").orElseThrow()
+						.getUniquenessType(Scope.LIVE)
+				);
+			}
+		);
+	}
+
+	@DisplayName("Verify re-analyzing an already-narrowed schema produces no further entity-schema mutations")
+	@Test
+	void shouldProduceNoMutationsWhenAlreadyNarrowedSchemaReanalyzed() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityNarrowingEvolutionV1.class);
+
+				// First narrowing pass converges the schema to all-default flag values.
+				analyzeAndCaptureMutations(
+					session, GetterBasedEntityNarrowingEvolutionV2NarrowAll.class
+				);
+
+				// Second pass over the same narrowed model must be idempotent.
+				final LocalCatalogSchemaMutation[] secondPass = analyzeAndCaptureMutations(
+					session, GetterBasedEntityNarrowingEvolutionV2NarrowAll.class
+				);
+
+				final long entityMutationCount = streamEntitySchemaMutations(
+					secondPass, EntitySchemaMutation.class).count();
+				assertEquals(
+					0L, entityMutationCount,
+					"Re-analyzing an already-narrowed schema must not emit further entity-schema mutations."
+				);
+			}
+		);
+	}
+
+	@DisplayName("Verify Reference.faceted=true is narrowed when annotation uses default settings")
+	@Test
+	void shouldNarrowReferenceFacetedWhenAnnotationUsesDefaultSettings() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityNarrowingEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertTrue(initial.getReferenceOrThrowException("facetedReference")
+					.isFacetedInScope(Scope.DEFAULT_SCOPE));
+
+				final LocalCatalogSchemaMutation[] mutations = analyzeAndCaptureMutations(
+					session, GetterBasedEntityNarrowingEvolutionV2NarrowAll.class
+				);
+
+				final Optional<SetReferenceSchemaFacetedMutation> mutation = streamEntitySchemaMutations(
+					mutations, SetReferenceSchemaFacetedMutation.class)
+					.filter(m -> "facetedReference".equals(m.getName()))
+					.findFirst();
+				assertTrue(mutation.isPresent(),
+					"Expected SetReferenceSchemaFacetedMutation clearing faceted for `facetedReference`.");
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertFalse(updated.getReferenceOrThrowException("facetedReference")
+					.isFacetedInScope(Scope.DEFAULT_SCOPE));
+			}
+		);
+	}
+
+	@DisplayName("Verify AssociatedData.nullable=true is narrowed when annotation uses default settings")
+	@Test
+	void shouldNarrowAssociatedDataNullableWhenAnnotationUsesDefaultSettings() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityNarrowingEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertTrue(initial.getAssociatedData("nullableAssoc").orElseThrow().isNullable());
+
+				final LocalCatalogSchemaMutation[] mutations = analyzeAndCaptureMutations(
+					session, GetterBasedEntityNarrowingEvolutionV2NarrowAll.class
+				);
+
+				final Optional<SetAssociatedDataSchemaNullableMutation> mutation = streamEntitySchemaMutations(
+					mutations, SetAssociatedDataSchemaNullableMutation.class)
+					.filter(m -> "nullableAssoc".equals(m.getName()))
+					.findFirst();
+				assertTrue(mutation.isPresent(),
+					"Expected SetAssociatedDataSchemaNullableMutation(false) for `nullableAssoc`.");
+				assertFalse(mutation.get().isNullable());
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertFalse(updated.getAssociatedData("nullableAssoc").orElseThrow().isNullable());
+			}
+		);
+	}
+
+	@DisplayName("Verify AssociatedData.localized=true is narrowed when annotation uses default settings")
+	@Test
+	void shouldNarrowAssociatedDataLocalizedWhenAnnotationUsesDefaultSettings() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityNarrowingEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertTrue(initial.getAssociatedData("localizedAssoc").orElseThrow().isLocalized());
+
+				final LocalCatalogSchemaMutation[] mutations = analyzeAndCaptureMutations(
+					session, GetterBasedEntityNarrowingEvolutionV2NarrowAll.class
+				);
+
+				final Optional<SetAssociatedDataSchemaLocalizedMutation> mutation = streamEntitySchemaMutations(
+					mutations, SetAssociatedDataSchemaLocalizedMutation.class)
+					.filter(m -> "localizedAssoc".equals(m.getName()))
+					.findFirst();
+				assertTrue(mutation.isPresent(),
+					"Expected SetAssociatedDataSchemaLocalizedMutation(false) for `localizedAssoc`.");
+				assertFalse(mutation.get().isLocalized());
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertFalse(updated.getAssociatedData("localizedAssoc").orElseThrow().isLocalized());
 			}
 		);
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
@@ -3076,6 +3076,47 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 		);
 	}
 
+	@DisplayName("Verify per-scope Attribute.filterable/sortable are narrowed when annotation drops the scoped flags")
+	@Test
+	void shouldNarrowPerScopeAttributeFilterableAndSortableWhenAnnotationDropsScopedFlags() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityScopedFlagsEvolutionV1.class);
+				final SealedEntitySchema initial = session.getEntitySchema(
+					GetterBasedEntityScopedFlagsEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertTrue(initial.getAttribute("scopedFlags").orElseThrow()
+					.isFilterableInScope(Scope.LIVE));
+				assertTrue(initial.getAttribute("scopedFlags").orElseThrow()
+					.isSortableInScope(Scope.LIVE));
+
+				final LocalCatalogSchemaMutation[] mutations = analyzeAndCaptureMutations(
+					session, GetterBasedEntityScopedFlagsEvolutionV2NarrowFlags.class
+				);
+
+				final Optional<SetAttributeSchemaFilterableMutation> filterableMutation =
+					streamEntitySchemaMutations(mutations, SetAttributeSchemaFilterableMutation.class)
+						.filter(m -> "scopedFlags".equals(m.getName()))
+						.findFirst();
+				assertTrue(filterableMutation.isPresent(),
+					"Expected SetAttributeSchemaFilterableMutation clearing the scope for `scopedFlags`.");
+				final Optional<SetAttributeSchemaSortableMutation> sortableMutation =
+					streamEntitySchemaMutations(mutations, SetAttributeSchemaSortableMutation.class)
+						.filter(m -> "scopedFlags".equals(m.getName()))
+						.findFirst();
+				assertTrue(sortableMutation.isPresent(),
+					"Expected SetAttributeSchemaSortableMutation clearing the scope for `scopedFlags`.");
+
+				final SealedEntitySchema updated = session.getEntitySchema(
+					GetterBasedEntityScopedFlagsEvolutionV1.ENTITY_NAME).orElseThrow();
+				assertFalse(updated.getAttribute("scopedFlags").orElseThrow()
+					.isFilterableInScope(Scope.LIVE));
+				assertFalse(updated.getAttribute("scopedFlags").orElseThrow()
+					.isSortableInScope(Scope.LIVE));
+			}
+		);
+	}
+
 	@DisplayName("Verify Reference.faceted=true is narrowed when annotation uses default settings")
 	@Test
 	void shouldNarrowReferenceFacetedWhenAnnotationUsesDefaultSettings() {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityNarrowingEvolutionV1.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityNarrowingEvolutionV1.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model.evolution;
+
+import io.evitadb.api.requestResponse.data.annotation.AssociatedData;
+import io.evitadb.api.requestResponse.data.annotation.Attribute;
+import io.evitadb.api.requestResponse.data.annotation.Entity;
+import io.evitadb.api.requestResponse.data.annotation.PrimaryKey;
+import io.evitadb.api.requestResponse.data.annotation.Reference;
+import io.evitadb.api.requestResponse.data.annotation.ReferencedEntity;
+import io.evitadb.api.requestResponse.schema.AttributeUniquenessType;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+/**
+ * Base V1 interface for broad Pattern-A boolean-narrowing schema-evolution tests.
+ *
+ * Each property turns on a single annotation flag whose default is `false`/`NOT_UNIQUE`.
+ * A follow-up V2 class flips every property back to default `@Attribute` /
+ * `@AssociatedData` / `@Reference` settings to pin the analyzer's symmetric contract.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Entity(name = GetterBasedEntityNarrowingEvolutionV1.ENTITY_NAME)
+public interface GetterBasedEntityNarrowingEvolutionV1 {
+
+	String ENTITY_NAME = "GetterBasedEntityNarrowingEvolution";
+
+	@PrimaryKey
+	int getId();
+
+	@Attribute(nullable = true)
+	String getNullableCode();
+
+	@Attribute(localized = true)
+	String getLocalizedCode();
+
+	@Attribute(representative = true)
+	String getRepresentativeCode();
+
+	@Attribute(filterable = true)
+	String getFilterableCode();
+
+	@Attribute(sortable = true)
+	String getSortableCode();
+
+	@Attribute(unique = AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION)
+	String getUniqueCode();
+
+	@Reference(managed = false, faceted = true)
+	@Nonnull
+	Brand getFacetedReference();
+
+	@AssociatedData(nullable = true)
+	String getNullableAssoc();
+
+	@AssociatedData(localized = true)
+	String getLocalizedAssoc();
+
+	/**
+	 * Reference target carrying no attributes of its own.
+	 */
+	interface Brand extends Serializable {
+
+		@ReferencedEntity
+		int getBrand();
+
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityNarrowingEvolutionV2NarrowAll.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityNarrowingEvolutionV2NarrowAll.java
@@ -1,0 +1,79 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model.evolution;
+
+import io.evitadb.api.requestResponse.data.annotation.AssociatedData;
+import io.evitadb.api.requestResponse.data.annotation.Attribute;
+import io.evitadb.api.requestResponse.data.annotation.Reference;
+
+import javax.annotation.Nonnull;
+
+/**
+ * V2 evolution: narrows every previously-true boolean / non-default enum to its default
+ * value by overriding each property with bare `@Attribute` / `@AssociatedData` /
+ * `@Reference` annotations.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public interface GetterBasedEntityNarrowingEvolutionV2NarrowAll
+	extends GetterBasedEntityNarrowingEvolutionV1 {
+
+	@Override
+	@Attribute
+	String getNullableCode();
+
+	@Override
+	@Attribute
+	String getLocalizedCode();
+
+	@Override
+	@Attribute
+	String getRepresentativeCode();
+
+	@Override
+	@Attribute
+	String getFilterableCode();
+
+	@Override
+	@Attribute
+	String getSortableCode();
+
+	@Override
+	@Attribute
+	String getUniqueCode();
+
+	@Override
+	@Reference(managed = false)
+	@Nonnull
+	Brand getFacetedReference();
+
+	@Override
+	@AssociatedData
+	String getNullableAssoc();
+
+	@Override
+	@AssociatedData
+	String getLocalizedAssoc();
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityNullableEvolutionV1.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityNullableEvolutionV1.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model.evolution;
+
+import io.evitadb.api.requestResponse.data.annotation.Attribute;
+import io.evitadb.api.requestResponse.data.annotation.Entity;
+import io.evitadb.api.requestResponse.data.annotation.PrimaryKey;
+
+import javax.annotation.Nullable;
+
+/**
+ * Base V1 interface for nullable-narrowing schema-evolution tests.
+ *
+ * Defines a minimal schema with a single `code` attribute that is explicitly `nullable = true`
+ * so a follow-up V2 class can attempt to narrow it back to non-null via default `@Attribute`
+ * settings and pin the analyzer's symmetry contract.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Entity(name = GetterBasedEntityNullableEvolutionV1.ENTITY_NAME)
+public interface GetterBasedEntityNullableEvolutionV1 {
+
+	String ENTITY_NAME = "GetterBasedEntityNullableEvolution";
+
+	@PrimaryKey
+	int getId();
+
+	@Attribute(nullable = true)
+	@Nullable
+	String getCode();
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityNullableEvolutionV2NarrowToNonNull.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityNullableEvolutionV2NarrowToNonNull.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model.evolution;
+
+import io.evitadb.api.requestResponse.data.annotation.Attribute;
+
+import javax.annotation.Nonnull;
+
+/**
+ * V2 evolution: narrows the `code` attribute from `nullable = true` back to non-null by using
+ * the default `@Attribute` settings.
+ *
+ * Mirrors the V1 entity name so the analyzer re-evaluates the same existing schema.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public interface GetterBasedEntityNullableEvolutionV2NarrowToNonNull
+	extends GetterBasedEntityNullableEvolutionV1 {
+
+	@Override
+	@Attribute
+	@Nonnull
+	String getCode();
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityScopedFlagsEvolutionV1.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityScopedFlagsEvolutionV1.java
@@ -1,0 +1,58 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model.evolution;
+
+import io.evitadb.api.requestResponse.data.annotation.Attribute;
+import io.evitadb.api.requestResponse.data.annotation.Entity;
+import io.evitadb.api.requestResponse.data.annotation.PrimaryKey;
+import io.evitadb.api.requestResponse.data.annotation.ScopeAttributeSettings;
+import io.evitadb.dataType.Scope;
+
+/**
+ * Base V1 interface for per-scope `filterable` / `sortable` narrowing schema-evolution tests.
+ *
+ * The attribute enables both flags for a single scope via `@ScopeAttributeSettings`. A follow-up
+ * V2 class drops both flags (bare `@ScopeAttributeSettings(scope = ...)`) to pin that the analyzer
+ * narrows previously-set per-scope `filterable` / `sortable` flags back to their defaults.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Entity(name = GetterBasedEntityScopedFlagsEvolutionV1.ENTITY_NAME)
+public interface GetterBasedEntityScopedFlagsEvolutionV1 {
+
+	String ENTITY_NAME = "GetterBasedEntityScopedFlagsEvolution";
+
+	@PrimaryKey
+	int getId();
+
+	@Attribute(
+		scope = @ScopeAttributeSettings(
+			scope = Scope.LIVE,
+			filterable = true,
+			sortable = true
+		)
+	)
+	String getScopedFlags();
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityScopedFlagsEvolutionV2NarrowFlags.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityScopedFlagsEvolutionV2NarrowFlags.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model.evolution;
+
+import io.evitadb.api.requestResponse.data.annotation.Attribute;
+import io.evitadb.api.requestResponse.data.annotation.ScopeAttributeSettings;
+import io.evitadb.dataType.Scope;
+
+/**
+ * V2 evolution: drops both per-scope `filterable` and `sortable` flags by overriding the attribute
+ * with a bare `@ScopeAttributeSettings(scope = ...)`, keeping the same scope but no flags.
+ *
+ * This pins that the analyzer narrows previously-set per-scope `filterable` / `sortable` flags back
+ * to their defaults through the `@ScopeAttributeSettings` branch of `applyAttributeScopedProperties`.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public interface GetterBasedEntityScopedFlagsEvolutionV2NarrowFlags
+	extends GetterBasedEntityScopedFlagsEvolutionV1 {
+
+	@Override
+	@Attribute(scope = @ScopeAttributeSettings(scope = Scope.LIVE))
+	String getScopedFlags();
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityUniquenessKindEvolutionV1.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityUniquenessKindEvolutionV1.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model.evolution;
+
+import io.evitadb.api.requestResponse.data.annotation.Attribute;
+import io.evitadb.api.requestResponse.data.annotation.Entity;
+import io.evitadb.api.requestResponse.data.annotation.PrimaryKey;
+import io.evitadb.api.requestResponse.data.annotation.ScopeAttributeSettings;
+import io.evitadb.api.requestResponse.schema.AttributeUniquenessType;
+import io.evitadb.api.requestResponse.schema.GlobalAttributeUniquenessType;
+import io.evitadb.dataType.Scope;
+
+/**
+ * Base V1 interface for tri-state uniqueness *kind-switch* schema-evolution tests.
+ *
+ * Each property declares the within-locale uniqueness variant (the `*_LOCALE` enum value).
+ * A follow-up V2 class switches every property to the matching plain variant (dropping the
+ * `_LOCALE` suffix) to pin that the analyzer reconciles a change of uniqueness *kind* rather
+ * than only the on/off transition. Within-locale uniqueness requires `localized = true`, so
+ * each attribute keeps that flag set.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Entity(name = GetterBasedEntityUniquenessKindEvolutionV1.ENTITY_NAME)
+public interface GetterBasedEntityUniquenessKindEvolutionV1 {
+
+	String ENTITY_NAME = "GetterBasedEntityUniquenessKindEvolution";
+
+	@PrimaryKey
+	int getId();
+
+	@Attribute(unique = AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE, localized = true)
+	String getLocaleUniqueCode();
+
+	@Attribute(
+		global = true,
+		uniqueGlobally = GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG_LOCALE,
+		localized = true
+	)
+	String getGlobalLocaleUniqueCode();
+
+	@Attribute(
+		scope = @ScopeAttributeSettings(
+			scope = Scope.LIVE,
+			unique = AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION_LOCALE
+		),
+		localized = true
+	)
+	String getScopedLocaleUniqueCode();
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityUniquenessKindEvolutionV2SwitchToCollection.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/evolution/GetterBasedEntityUniquenessKindEvolutionV2SwitchToCollection.java
@@ -1,0 +1,66 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model.evolution;
+
+import io.evitadb.api.requestResponse.data.annotation.Attribute;
+import io.evitadb.api.requestResponse.data.annotation.ScopeAttributeSettings;
+import io.evitadb.api.requestResponse.schema.AttributeUniquenessType;
+import io.evitadb.api.requestResponse.schema.GlobalAttributeUniquenessType;
+import io.evitadb.dataType.Scope;
+
+/**
+ * V2 evolution: switches every previously within-locale uniqueness flag to its plain (non-locale)
+ * variant by overriding each property, keeping `localized = true` and the same scope structure.
+ *
+ * This pins that the analyzer reconciles a change of uniqueness *kind*
+ * (`*_LOCALE` to the plain variant) — not only the on/off transition.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public interface GetterBasedEntityUniquenessKindEvolutionV2SwitchToCollection
+	extends GetterBasedEntityUniquenessKindEvolutionV1 {
+
+	@Override
+	@Attribute(unique = AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION, localized = true)
+	String getLocaleUniqueCode();
+
+	@Override
+	@Attribute(
+		global = true,
+		uniqueGlobally = GlobalAttributeUniquenessType.UNIQUE_WITHIN_CATALOG,
+		localized = true
+	)
+	String getGlobalLocaleUniqueCode();
+
+	@Override
+	@Attribute(
+		scope = @ScopeAttributeSettings(
+			scope = Scope.LIVE,
+			unique = AttributeUniquenessType.UNIQUE_WITHIN_COLLECTION
+		),
+		localized = true
+	)
+	String getScopedLocaleUniqueCode();
+
+}


### PR DESCRIPTION
## Summary

`ClassSchemaAnalyzer` previously applied annotation flags as a **one-way ratchet** (`anno.flag() && !editor.isFlag()`): it could turn a flag on, but a bare `@Attribute String foo()` against an existing schema that had `nullable`/`localized`/`unique`/… set was a silent no-op. Editing a model class to drop a flag did not propagate to the schema.

This change makes annotation flag reconciliation **symmetric** — the class annotation is the source of truth in both directions:

- **Boolean & enum-analogue flags** (`nullable`, `localized`, `representative`, `filterable`, `sortable`, `unique`, `uniqueGlobally`, `faceted`) now narrow back to their default when the annotation drops them. A bare annotation is a strong assertion that every default-valued flag is at its default.
- **Structural elements** (attributes, references, associated data, compounds) remain **expand-only** — the analyzer never removes them.
- **Idempotency** is preserved: re-analyzing an unchanged (or already-narrowed) class produces zero mutations.

### Tri-state uniqueness kind-switch

While auditing the symmetric change, a residual correctness bug was found and fixed: the uniqueness reconciliation guarded on the broad predicates `isUniqueInScope` / `isUniqueGloballyInScope`, which return `true` for **both** non-default enum values (`!= NOT_UNIQUE`). A *kind-switch* such as `UNIQUE_WITHIN_COLLECTION_LOCALE → UNIQUE_WITHIN_COLLECTION` was therefore silently skipped (default-scope) or downgraded to `NOT_UNIQUE` (per-scope). All four sites (entity/global × default-scope/per-scope) now compare the **exact** enum value via `getUniquenessType` / `getGlobalUniquenessType`.

Reflected-reference handling (`applyReflectedReferenceScopedProperties`) is intentionally left untouched — it is inherited-aware / tri-state by design.

## Tests

New `shouldNarrow*` tests pin the symmetric contract for each flag, plus uniqueness kind-switch tests and a narrowed-schema idempotency test. `ClassSchemaAnalyzerTest` is green at 90/90; the schema package and `EntityEditorProxyingFunctionalTest` regression set is green.

Closes #1199