### PR TITLE
Guard CDC ring-buffer cleanup against empty subscriber map

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/cdc/ChangeCatalogCaptureSharedPublisher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cdc/ChangeCatalogCaptureSharedPublisher.java
@@ -564,17 +564,20 @@ public class ChangeCatalogCaptureSharedPublisher implements Flow.Publisher<Chang
 		if (this.lastCaptures != null) {
 			// clear unused data from the ring buffer / statistics
 			final long lowestAvailableCatalogVersion = this.lastCaptures.getEffectiveStartCatalogVersion();
-			if (!this.versionSubscribersCount.isEmpty()) {
-				Long lowestUsedCatalogVersion = this.versionSubscribersCount.firstKey();
+			// firstEntry() returns null on an empty map atomically, unlike firstKey() which throws
+			// NoSuchElementException - this must be re-read on each loop iteration because removing the
+			// last remaining entry empties the map
+			Entry<Long, Integer> lowestUsedEntry = this.versionSubscribersCount.firstEntry();
+			if (lowestUsedEntry != null) {
 				// if the lowest available catalog version is lower than the lowest used catalog version
-				if (lowestUsedCatalogVersion != null && lowestAvailableCatalogVersion < lowestUsedCatalogVersion) {
+				if (lowestAvailableCatalogVersion < lowestUsedEntry.getKey()) {
 					// it means that we keep unnecessary data in the ring buffer and we may strip it
 					this.lastCaptures.clearAllUntil(lowestAvailableCatalogVersion);
 				} else {
 					// otherwise we may clear the statistics
-					while (lowestUsedCatalogVersion != null && lowestUsedCatalogVersion < lowestAvailableCatalogVersion) {
-						this.versionSubscribersCount.remove(lowestUsedCatalogVersion);
-						lowestUsedCatalogVersion = this.versionSubscribersCount.firstKey();
+					while (lowestUsedEntry != null && lowestUsedEntry.getKey() < lowestAvailableCatalogVersion) {
+						this.versionSubscribersCount.remove(lowestUsedEntry.getKey());
+						lowestUsedEntry = this.versionSubscribersCount.firstEntry();
 					}
 				}
 			}

--- a/evita_engine/src/main/java/io/evitadb/core/cdc/ChangeSystemCaptureSharedPublisher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cdc/ChangeSystemCaptureSharedPublisher.java
@@ -683,17 +683,20 @@ public class ChangeSystemCaptureSharedPublisher implements Flow.Publisher<Change
 	private void clearUnusedDataInRingBuffer() {
 		// clear unused data from the ring buffer / statistics
 		final long lowestAvailableCatalogVersion = this.lastCaptures.getEffectiveStartCatalogVersion();
-		if (!this.versionSubscribersCount.isEmpty()) {
-			Long lowestUsedCatalogVersion = this.versionSubscribersCount.firstKey();
+		// firstEntry() returns null on an empty map atomically, unlike firstKey() which throws
+		// NoSuchElementException - this must be re-read on each loop iteration because removing the
+		// last remaining entry empties the map
+		Entry<Long, Integer> lowestUsedEntry = this.versionSubscribersCount.firstEntry();
+		if (lowestUsedEntry != null) {
 			// if the lowest available catalog version is lower than the lowest used catalog version
-			if (lowestUsedCatalogVersion != null && lowestAvailableCatalogVersion < lowestUsedCatalogVersion) {
+			if (lowestAvailableCatalogVersion < lowestUsedEntry.getKey()) {
 				// it means that we keep unnecessary data in the ring buffer and we may strip it
 				this.lastCaptures.clearAllUntil(lowestAvailableCatalogVersion);
 			} else {
 				// otherwise we may clear the statistics
-				while (lowestUsedCatalogVersion != null && lowestUsedCatalogVersion < lowestAvailableCatalogVersion) {
-					this.versionSubscribersCount.remove(lowestUsedCatalogVersion);
-					lowestUsedCatalogVersion = this.versionSubscribersCount.firstKey();
+				while (lowestUsedEntry != null && lowestUsedEntry.getKey() < lowestAvailableCatalogVersion) {
+					this.versionSubscribersCount.remove(lowestUsedEntry.getKey());
+					lowestUsedEntry = this.versionSubscribersCount.firstEntry();
 				}
 			}
 		}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/cdc/CatalogChangeObserverTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/cdc/CatalogChangeObserverTest.java
@@ -52,10 +52,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static io.evitadb.test.utils.ReflectionUtils.getFieldValue;
 import static io.evitadb.test.utils.ReflectionUtils.getNonnullFieldValue;
 import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.CDC;
@@ -707,6 +709,89 @@ class CatalogChangeObserverTest implements EvitaTestSupport {
 
 		// Verify all publishers are removed
 		assertEquals(finalSize - 1, uniquePublishers.size(), "All publishers should be removed after cleaning");
+	}
+
+	/**
+	 * Regression test for issue #1201: the periodic publisher cleanup must not crash when the
+	 * subscriber-version map drains to empty inside `clearUnusedDataInRingBuffer`.
+	 *
+	 * Reproduces the exact production state observed in the crash: an initialised ring buffer plus a
+	 * `versionSubscribersCount` whose only tracked version is strictly below the buffer's effective
+	 * start version. The cleanup loop removes that stale entry, emptying the map; the old code then
+	 * called {@link java.util.concurrent.ConcurrentSkipListMap#firstKey()} on the now-empty map and
+	 * threw {@link java.util.NoSuchElementException}. The fix re-reads `firstEntry()`, which returns
+	 * `null` on an empty map, so the loop terminates cleanly.
+	 *
+	 * @param evita       the Evita database instance with the test dataset already loaded
+	 * @param brandSchema the brand schema created during test setup
+	 */
+	@UseDataSet(value = CDC_TRANSACTIONS, destroyAfterTest = true)
+	@Test
+	@DisplayName("clean ring buffer without crashing when subscriber-version map drains to empty")
+	void shouldCleanRingBufferWhenVersionSubscribersCountDrainsToEmpty(@Nonnull Evita evita, @Nonnull SealedEntitySchema brandSchema) {
+		final Catalog catalog = (Catalog) evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final CatalogChangeObserver tested = (CatalogChangeObserver) catalog.getTransactionManager().getChangeObserver();
+		tested.notifyCatalogPresentInLiveView(catalog);
+
+		final ChangeCatalogCaptureRequest request = ChangeCatalogCaptureRequest.builder()
+			.sinceVersion(catalog.getVersion() + 1)
+			.content(ChangeCaptureContent.BODY)
+			.criteria(
+				ChangeCatalogCaptureCriteria.builder()
+					.dataArea(builder -> builder.containerType(ContainerType.ENTITY).operation(Operation.UPSERT))
+					.build()
+			)
+			.build();
+
+		try (final ChangeCapturePublisher<ChangeCatalogCapture> publisher = tested.registerObserver(request)) {
+			final MockCatalogChangeSubscriber subscriber = new MockCatalogChangeSubscriber();
+			publisher.subscribe(subscriber);
+
+			// drive one transactional mutation so the ring buffer (lastCaptures) gets initialised
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					this.dataGenerator.generateEntities(brandSchema, this.noEntityPicker, SEED)
+						.skip(20)
+						.limit(1)
+						.forEach(session::upsertEntity);
+				}
+			);
+
+			// locate the shared publisher backing this subscription (the only active one with an
+			// initialised ring buffer)
+			final Map<ChangeCatalogCriteriaBundle, ChangeCatalogCaptureSharedPublisher> uniquePublishers =
+				getNonnullFieldValue(tested, "uniquePublishers");
+			ChangeCatalogCaptureSharedPublisher sharedPublisher = null;
+			ChangeCaptureRingBuffer<ChangeCatalogCapture> ringBuffer = null;
+			for (final ChangeCatalogCaptureSharedPublisher candidate : uniquePublishers.values()) {
+				if (candidate.isClosed()) {
+					continue;
+				}
+				final ChangeCaptureRingBuffer<ChangeCatalogCapture> candidateBuffer = getFieldValue(candidate, "lastCaptures");
+				if (candidateBuffer != null) {
+					sharedPublisher = candidate;
+					ringBuffer = candidateBuffer;
+					break;
+				}
+			}
+			assertNotNull(sharedPublisher, "Expected an active shared publisher with an initialised ring buffer");
+
+			// craft the production state: the only tracked version sits strictly below the ring
+			// buffer's effective start version, so cleanup removes it and empties the map
+			final ConcurrentSkipListMap<Long, Integer> versionSubscribersCount =
+				getNonnullFieldValue(sharedPublisher, "versionSubscribersCount");
+			versionSubscribersCount.clear();
+			versionSubscribersCount.put(ringBuffer.getEffectiveStartCatalogVersion() - 1, 1);
+
+			// previously threw NoSuchElementException from firstKey() once the loop emptied the map
+			final ChangeCatalogCaptureSharedPublisher publisherUnderTest = sharedPublisher;
+			assertDoesNotThrow(publisherUnderTest::checkSubscribersLeft);
+			assertTrue(
+				versionSubscribersCount.isEmpty(),
+				"Stale sub-threshold version entry should have been drained"
+			);
+		}
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/cdc/SystemChangeObserverTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/cdc/SystemChangeObserverTest.java
@@ -63,8 +63,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -480,6 +482,61 @@ class SystemChangeObserverTest implements EvitaTestSupport {
 		assertFalse(subscriber1.isCompleted(), "Subscriber 1 should not be completed yet");
 		assertFalse(subscriber2.isCompleted(), "Subscriber 2 should not be completed yet");
 		assertFalse(subscriber3.isCompleted(), "Subscriber 3 should not be completed yet");
+	}
+
+	/**
+	 * Regression test for issue #1201: the periodic subscriber cleanup must not crash when the
+	 * subscriber-version map drains to empty inside `clearUnusedDataInRingBuffer`.
+	 *
+	 * Mirrors the catalog-level regression for the system publisher. Reproduces the exact production
+	 * state: an initialised ring buffer plus a `versionSubscribersCount` whose only tracked version is
+	 * strictly below the buffer's effective start version. The cleanup loop removes that stale entry,
+	 * emptying the map; the old code then called
+	 * {@link java.util.concurrent.ConcurrentSkipListMap#firstKey()} on the now-empty map and threw
+	 * {@link java.util.NoSuchElementException}. The fix re-reads `firstEntry()`, which returns `null`
+	 * on an empty map, so the loop terminates cleanly.
+	 *
+	 * @param evita the Evita database instance with the test dataset already loaded
+	 */
+	@UseDataSet(value = SYSTEM_CDC_TRANSACTIONS, destroyAfterTest = true)
+	@Test
+	@DisplayName("clean ring buffer without crashing when subscriber-version map drains to empty")
+	void shouldCleanRingBufferWhenVersionSubscribersCountDrainsToEmpty(@Nonnull Evita evita) {
+		final SystemChangeObserver tested = evita.getChangeObserver();
+		final ChangeSystemCaptureSharedPublisher sharedPublisher = getNonnullFieldValue(tested, "sharedPublisher");
+
+		final long currentVersion = evita.getEngineState().version();
+		final ChangeSystemCaptureRequest request = new ChangeSystemCaptureRequest(
+			currentVersion + 1, 0, null, ChangeCaptureContent.BODY
+		);
+
+		try (
+			final ChangeCapturePublisher<ChangeSystemCapture> publisher = evita.registerSystemChangeCapture(request)
+		) {
+			final MockSystemChangeSubscriber subscriber = new MockSystemChangeSubscriber();
+			publisher.subscribe(subscriber);
+
+			// drive an engine mutation so the ring buffer (lastCaptures) is initialised
+			final String catalog = TEST_CATALOG + "_drain";
+			evita.defineCatalog(catalog);
+			evita.updateCatalog(catalog, EvitaSessionContract::goLiveAndClose);
+
+			// craft the production state: the only tracked version sits strictly below the ring
+			// buffer's effective start version, so cleanup removes it and empties the map
+			final ChangeCaptureRingBuffer<ChangeSystemCapture> ringBuffer =
+				getNonnullFieldValue(sharedPublisher, "lastCaptures");
+			final ConcurrentSkipListMap<Long, Integer> versionSubscribersCount =
+				getNonnullFieldValue(sharedPublisher, "versionSubscribersCount");
+			versionSubscribersCount.clear();
+			versionSubscribersCount.put(ringBuffer.getEffectiveStartCatalogVersion() - 1, 1);
+
+			// previously threw NoSuchElementException from firstKey() once the loop emptied the map
+			assertDoesNotThrow(sharedPublisher::checkSubscribersLeft);
+			assertTrue(
+				versionSubscribersCount.isEmpty(),
+				"Stale sub-threshold version entry should have been drained"
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Closes #1201

Fixes a `NoSuchElementException` thrown from the periodic CDC cleanup task (`CatalogChangeObserver.cleanInactivePublishers`), observed in production.

## Root cause
`ConcurrentSkipListMap.firstKey()` **throws `NoSuchElementException` on an empty map** — it never returns `null`. `clearUnusedDataInRingBuffer` re-read `firstKey()` after removing the last remaining entry, so emptying the `versionSubscribersCount` map crashed the cleanup cycle. The leading `!isEmpty()` check only guarded the *first* read; the `!= null` guards reveal the author's mistaken assumption that `firstKey()` returns `null` on empty.

## Fix
Switch to `firstEntry()`, which atomically returns `null` on an empty map (matching the intent of the existing `!= null` guards), and re-read it on each loop iteration. Applied to both `ChangeCatalogCaptureSharedPublisher` and the identical pattern in `ChangeSystemCaptureSharedPublisher`. Also removes a latent non-atomic `isEmpty()` → `firstKey()` race on the concurrent map.
