### PR TITLE
fix: honor configured maxThreadCount for request pool parallelism

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/executor/ObservableThreadExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/ObservableThreadExecutor.java
@@ -118,9 +118,11 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 	/**
 	 * Creates a new executor configured according to the supplied options.
 	 *
-	 * In production mode a {@link ForkJoinPool} is created in async mode (LIFO work-stealing) with parallelism
-	 * capped at `min(options.minThreadCount(), availableProcessors)`. Worker threads are daemon threads named
-	 * `Evita-{@code name}-N` with the configured priority.
+	 * In production mode a {@link ForkJoinPool} is created in async mode (LIFO work-stealing). Its parallelism
+	 * level is resolved by {@link #resolveParallelism(String, ThreadPoolOptions)} from the configured
+	 * {@link ThreadPoolOptions#maxThreadCount()} — deliberately decoupled from {@code availableProcessors()},
+	 * because pool tasks frequently block on I/O and lock contention rather than computing (see that method for
+	 * the rationale). Worker threads are daemon threads named `Evita-{@code name}-N` with the configured priority.
 	 *
 	 * @param name                   logical name of this executor, used in thread names, log messages, and JFR events
 	 * @param options                pool sizing and priority settings; see {@link ThreadPoolOptions}
@@ -133,7 +135,6 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 		@Nonnull ThreadPoolOptions options,
 		boolean immediateExecutorService
 	) {
-		final int processorsCount = Runtime.getRuntime().availableProcessors();
 		this.rejectedExecutionHandler = new EvitaRejectingExecutorHandler(name, this.rejectedTaskCount::increment);
 		this.queueLimit = options.queueSize();
 		this.executorService = immediateExecutorService ?
@@ -141,7 +142,7 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 			new ImmediateExecutorService() :
 			// in standard environment we use a ForkJoinPool that allows to run tasks asynchronously
 			new ForkJoinPool(
-				Math.min(options.minThreadCount(), processorsCount),
+				resolveParallelism(name, options),
 				pool -> new EvitaWorkerThread(pool, name, options.threadPriority()),
 				LoggingUncaughtExceptionHandler.INSTANCE,
 				true,
@@ -161,6 +162,36 @@ public class ObservableThreadExecutor implements ObservableExecutorServiceWithCa
 				60,
 				TimeUnit.SECONDS
 			);
+	}
+
+	/**
+	 * Resolves the {@link ForkJoinPool} parallelism level for a pool of the given logical {@code name}.
+	 *
+	 * The parallelism level is the effective concurrency cap for tasks that block on plain I/O (network,
+	 * gRPC/HTTP (de)serialization) or lock contention — such blocking does **not** spawn ForkJoinPool
+	 * compensation threads (only {@link java.util.concurrent.ForkJoinPool.ManagedBlocker} and `join()` do),
+	 * so the configured {@code corePoolSize}/{@code maximumPoolSize} alone never raise concurrency above this
+	 * value for that kind of work. Historically this was clamped to
+	 * `min(minThreadCount, availableProcessors())`, which silently throttled the pool to a single in-flight
+	 * task inside cgroup-limited containers where `availableProcessors()` reports ≈1 — overflowing the bounded
+	 * queue and rejecting requests while the configured {@code maxThreadCount} stayed inert.
+	 *
+	 * The level therefore defaults to the operator-configured {@link ThreadPoolOptions#maxThreadCount()} (the
+	 * explicit concurrency ceiling) rather than the live CPU count. It can be overridden per pool via the
+	 * `-Devita.poolParallelism.{@code <name>}` system property (clamped to `[1, maxThreadCount]`) as an
+	 * operational escape hatch.
+	 *
+	 * @param name    logical pool name (matches the `-Devita.poolParallelism.<name>` override key)
+	 * @param options pool sizing options supplying the {@link ThreadPoolOptions#maxThreadCount()} ceiling
+	 * @return the parallelism level to use, always at least {@code 1}
+	 */
+	private static int resolveParallelism(@Nonnull String name, @Nonnull ThreadPoolOptions options) {
+		final String override = System.getProperty("evita.poolParallelism." + name);
+		if (override != null && !override.isBlank()) {
+			final int requested = Integer.parseInt(override.trim());
+			return Math.max(1, Math.min(requested, options.maxThreadCount()));
+		}
+		return Math.max(1, options.maxThreadCount());
 	}
 
 	@Override

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/ObservableThreadExecutorParallelismTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/ObservableThreadExecutorParallelismTest.java
@@ -1,0 +1,181 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.executor;
+
+import io.evitadb.api.configuration.ThreadPoolOptions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for {@link ObservableThreadExecutor} parallelism resolution (issue #1204).
+ *
+ * The production {@link java.util.concurrent.ForkJoinPool} parallelism used to be clamped to
+ * `min(minThreadCount, availableProcessors())`. Because tasks blocking on plain I/O (network,
+ * gRPC/HTTP (de)serialization) or lock contention do **not** spawn ForkJoinPool compensation threads, that
+ * parallelism level is the effective concurrency cap for such work — so inside cgroup-limited containers
+ * where `availableProcessors()` reports ≈1 the pool was throttled to a single in-flight task and the
+ * configured `maxThreadCount` became inert, overflowing the bounded queue and rejecting requests.
+ *
+ * The fix decouples parallelism from the live CPU count and honors the configured
+ * {@link ThreadPoolOptions#maxThreadCount()} (overridable via the `-Devita.poolParallelism.&lt;name&gt;`
+ * system property). These tests pin that contract: the pool must run **more** concurrent (I/O-blocking)
+ * tasks than there are CPUs — on the buggy clamped code the peak concurrency could never exceed
+ * `availableProcessors()`.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+class ObservableThreadExecutorParallelismTest {
+
+	private static final int AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors();
+
+	@Test
+	void shouldRunMoreConcurrentBlockingTasksThanCpuCountHonoringMaxThreadCount() throws Exception {
+		// configured concurrency ceiling deliberately above the CPU count — on the buggy (clamped) code the
+		// pool would never run more than AVAILABLE_PROCESSORS tasks at once, regardless of this setting
+		final int maxThreadCount = AVAILABLE_PROCESSORS + 8;
+		final ObservableThreadExecutor executor = new ObservableThreadExecutor(
+			"test-parallelism",
+			// (minThreadCount, maxThreadCount, threadPriority, queueSize)
+			new ThreadPoolOptions(1, maxThreadCount, Thread.NORM_PRIORITY, 10_000),
+			false
+		);
+		try {
+			final int peak = measurePeakConcurrency(executor, maxThreadCount, maxThreadCount);
+			assertTrue(
+				peak > AVAILABLE_PROCESSORS,
+				"Pool must run more concurrent blocking tasks (" + peak + ") than CPUs (" +
+					AVAILABLE_PROCESSORS + ") — parallelism must not be clamped to the CPU count"
+			);
+			assertEquals(
+				maxThreadCount, peak,
+				"Pool should run up to the configured maxThreadCount tasks concurrently"
+			);
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	void shouldHonorPoolParallelismSystemPropertyOverride() throws Exception {
+		final int maxThreadCount = AVAILABLE_PROCESSORS + 8;
+		// override deliberately BETWEEN the CPU count and maxThreadCount: proves the override is actually
+		// applied (peak != maxThreadCount) while still decoupling concurrency from the CPU count (peak > CPUs)
+		final int override = AVAILABLE_PROCESSORS + 4;
+		final String poolName = "test-parallelism-override";
+		final String propertyKey = "evita.poolParallelism." + poolName;
+		System.setProperty(propertyKey, Integer.toString(override));
+		try {
+			final ObservableThreadExecutor executor = new ObservableThreadExecutor(
+				poolName,
+				new ThreadPoolOptions(1, maxThreadCount, Thread.NORM_PRIORITY, 10_000),
+				false
+			);
+			try {
+				// submit more tasks than the override allows; only `override` of them may run concurrently
+				final int peak = measurePeakConcurrency(executor, maxThreadCount, override);
+				assertTrue(
+					peak > AVAILABLE_PROCESSORS,
+					"Override must still raise concurrency above the CPU count; was " + peak
+				);
+				assertEquals(
+					override, peak,
+					"System-property override should cap concurrency at the requested parallelism level"
+				);
+			} finally {
+				executor.shutdownNow();
+			}
+		} finally {
+			System.clearProperty(propertyKey);
+		}
+	}
+
+	/**
+	 * Submits {@code tasksToSubmit} tasks that each block until released, waits until {@code expectedConcurrent}
+	 * of them are simultaneously running, records the peak observed concurrency, then releases all tasks and
+	 * drains them so the pool is idle before the caller shuts it down.
+	 *
+	 * Because every started task stays in the running set until it is released, the moment
+	 * {@code expectedConcurrent} tasks have signalled start is exactly the moment that many run concurrently —
+	 * giving a deterministic peak with no sampling race.
+	 *
+	 * @param executor           the executor under test
+	 * @param tasksToSubmit      total number of blocking tasks to submit
+	 * @param expectedConcurrent number of concurrently-running tasks to wait for before measuring the peak
+	 * @return the peak number of tasks observed running concurrently
+	 */
+	private static int measurePeakConcurrency(
+		ObservableThreadExecutor executor,
+		int tasksToSubmit,
+		int expectedConcurrent
+	) throws InterruptedException {
+		final AtomicInteger concurrent = new AtomicInteger();
+		final AtomicInteger peak = new AtomicInteger();
+		final CountDownLatch reachedExpected = new CountDownLatch(expectedConcurrent);
+		final CountDownLatch release = new CountDownLatch(1);
+		final List<CancellableRunnable> tasks = new ArrayList<>(tasksToSubmit);
+
+		for (int i = 0; i < tasksToSubmit; i++) {
+			final CancellableRunnable task = executor.createTask("blocking-" + i, () -> {
+				final int running = concurrent.incrementAndGet();
+				peak.accumulateAndGet(running, Math::max);
+				reachedExpected.countDown();
+				try {
+					release.await(10, TimeUnit.SECONDS);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				} finally {
+					concurrent.decrementAndGet();
+				}
+			});
+			executor.execute(task);
+			tasks.add(task);
+		}
+
+		final boolean reached = reachedExpected.await(10, TimeUnit.SECONDS);
+		final int observedPeak = peak.get();
+		release.countDown();
+		// drain so the pool is idle before shutdown
+		for (CancellableRunnable task : tasks) {
+			try {
+				task.completionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+			} catch (Exception e) {
+				// ignore — only the peak concurrency matters for these assertions
+			}
+		}
+		assertTrue(
+			reached,
+			"Expected " + expectedConcurrent + " tasks to run concurrently within the timeout, " +
+				"but the pool never reached that level"
+		);
+		return observedPeak;
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/cdc/ClientChangeCapturePublisherTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/cdc/ClientChangeCapturePublisherTest.java
@@ -32,7 +32,6 @@ import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
@@ -52,10 +51,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static io.evitadb.test.TestTags.CDC;
-import static io.evitadb.test.TestTags.DRIVER;
-import static io.evitadb.test.TestTags.GRPC;
-import static io.evitadb.test.TestTags.STREAM;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -73,10 +68,6 @@ import static org.mockito.Mockito.verify;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 @DisplayName("ClientChangeCapturePublisher backpressure and flow control")
-@Tag(DRIVER)
-@Tag(GRPC)
-@Tag(CDC)
-@Tag(STREAM)
 class ClientChangeCapturePublisherTest implements TestConstants {
 	private static final int QUEUE_SIZE = 4;
 	private static final UUID SUBSCRIPTION_UUID = UUID.fromString("11111111-1111-1111-1111-111111111111");


### PR DESCRIPTION
## Problem

Under concurrent load the `request` thread pool intermittently rejects tasks with `RejectedExecutionException` — surfaced as GraphQL `GraphQLInternalError` and gRPC `RejectedExecutionException`, both carrying *"Evita executor queue full. Please add more threads to the `request` pool."* — **even though `maxThreadCount=64` is configured and the runtime thread gauge (`io_evitadb_system_request_fork_join_pool_statistics_running`) never rises above ≈1.**

## Root cause

`ObservableThreadExecutor` built its `ForkJoinPool` with parallelism clamped to `min(minThreadCount, availableProcessors())`. A `ForkJoinPool`'s **parallelism** is the effective concurrency cap for tasks that block on plain I/O (network, gRPC/HTTP (de)serialization) or lock contention — such blocking does **not** spawn compensation threads (only `ManagedBlocker`/`join()` does), so `corePoolSize`/`maximumPoolSize` never raise concurrency above the parallelism level for that work. In a cgroup-limited container `availableProcessors()` reports ≈1, so parallelism collapsed to **1** and the configured `maxThreadCount=64` was **inert**. The bounded-queue rejection is independent of thread count, so the queue overflowed and rejected while only ~1 task ran.

## Evidence

Driving the **real gRPC path** (`EvitaSessionService` dispatches every query to `getRequestExecutor()` at the RPC boundary) against a 100k-product catalog, pinned to 4 CPUs, 200 concurrent clients, varying pool parallelism:

| parallelism | rejection ratio | real work admitted |
|---|---|---|
| 1 (container-like) | **98.0 %** | 4 954 |
| 4 (= CPU cores) | 88.5 % | 16 288 |
| 16 | 81.7 % | 12 939 |
| 64 (= configured max) | **0.6 %** | 42 175 |

On the **same 4 cores**, raising parallelism 4→64 multiplied real admitted throughput by 2.6× and collapsed rejections from 88% to 0.6% — proving the request workload spends substantial time **blocked**, not computing, so sizing concurrency to CPU count is the wrong policy. (Note: nominal ops/s is *highest* at the worst setting because rejected calls fast-fail — throughput dashboards look healthy while users get errors; rejection count is the only honest signal.)

## Fix

`ObservableThreadExecutor` now resolves parallelism via `resolveParallelism(name, options)`, defaulting to the operator-configured `maxThreadCount()` (the explicit concurrency ceiling) **decoupled from the live CPU count**, with a `-Devita.poolParallelism.<name>` system-property override (clamped to `[1, maxThreadCount]`) as an operational escape hatch.

`ObservableThreadExecutorParallelismTest` is added as a deterministic regression guard: it asserts the pool runs **more** concurrent (I/O-blocking) tasks than there are CPUs, up to `maxThreadCount` — an assertion that *fails* on the old clamped code — and that the system-property override is honored.

## Note: incidental release-branch build fix (separate commit)

The first commit (`test: drop dev-only TestTags reference from backported CDC test`) is unrelated to the parallelism fix. `ClientChangeCapturePublisherTest` was backported to `release_2026-1` via #1196/#1198 with `@Tag` annotations importing `io.evitadb.test.TestTags`, a dev-only test-tagging class that was **not** backported. The dangling import aborted the javac annotation-processing round (disabling Lombok), which broke the entire `evita_functional_tests` test-compile on `release_2026-1`. `release_2026-1` has no tag taxonomy, so the tags are removed to restore the build (required for this PR's test to run).

Closes #1204
