### PR TITLE
fix: harden Scheduler thread and queue handling

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
@@ -271,6 +271,11 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 					runnable.run();
 				} catch (Throwable t) {
 					log.error("Uncaught error during execution of a task submitted via execute().", t);
+					// never swallow VM errors (OutOfMemoryError, StackOverflowError, ...) - the process may be in
+					// an inconsistent state, so re-raise them after logging while still absorbing ordinary exceptions
+					if (t instanceof Error error) {
+						throw error;
+					}
 				}
 			});
 			this.submittedTaskCount.increment();
@@ -419,6 +424,13 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Note: only 1 is added to {@link #submittedTaskCount} regardless of how many tasks are provided, because from
+	 * the caller's perspective a single logical operation has been submitted (this mirrors the convention used by
+	 * the sibling observable executor).
+	 */
 	@Nonnull
 	@Override
 	public <T> T invokeAny(@Nonnull Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
@@ -439,6 +451,13 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 		}
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Note: only 1 is added to {@link #submittedTaskCount} regardless of how many tasks are provided, because from
+	 * the caller's perspective a single logical operation has been submitted (this mirrors the convention used by
+	 * the sibling observable executor).
+	 */
 	@Nullable
 	@Override
 	public <T> T invokeAny(@Nonnull Collection<? extends Callable<T>> tasks, long timeout, @Nonnull TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
@@ -657,13 +676,18 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	 * Adds the task to the tracking {@link #queue}, returning the same instance to allow for fluent chaining. The
 	 * task is first added via a non-blocking {@link ArrayBlockingQueue#offer(Object) offer}; if the queue is full,
 	 * {@link #purgeFinishedAndLongWaitingTasks()} is triggered to reclaim space and the offer is retried. Should the
-	 * queue still be full afterwards, the task is marked as failed, the rejecting handler (when present) is notified
-	 * and an {@link IllegalStateException} is thrown.
+	 * queue still be full afterwards, the task is marked as failed and the overflow is reported.
+	 *
+	 * The exception type observed by the caller on overflow depends on whether a rejecting handler is registered:
+	 * with a handler (the regular runtime setup) {@link EvitaRejectingExecutorHandler#rejectedExecution()} emits its
+	 * event and throws a {@link RejectedExecutionException}; without one (the test-only constructor) the method falls
+	 * through to throw an {@link IllegalStateException}.
 	 *
 	 * @param task the task to add
 	 * @param <T>  the type of the task
 	 * @return the task that was added
-	 * @throws IllegalStateException if the queue remains full even after a purge attempt
+	 * @throws RejectedExecutionException if the queue remains full after a purge and a rejecting handler is registered
+	 * @throws IllegalStateException      if the queue remains full after a purge and no rejecting handler is registered
 	 */
 	@Nonnull
 	private <T extends ServerTask<?, ?>> T addTaskToQueue(@Nonnull T task) {

--- a/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
+++ b/evita_engine/src/main/java/io/evitadb/core/executor/Scheduler.java
@@ -49,7 +49,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -80,11 +80,11 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	/**
 	 * Counter monitoring the number of tasks submitted to the executor service.
 	 */
-	private final AtomicLong submittedTaskCount = new AtomicLong();
+	private final LongAdder submittedTaskCount = new LongAdder();
 	/**
 	 * Counter monitoring the number of tasks rejected by the executor service.
 	 */
-	private final AtomicLong rejectedTaskCount = new AtomicLong();
+	private final LongAdder rejectedTaskCount = new LongAdder();
 	/**
 	 * Flag indicating whether the scheduler is in the process of shutting down.
 	 */
@@ -98,6 +98,12 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	 * Maximum number of tasks that can be stored in the queue.
 	 */
 	private final int queueCapacity;
+	/**
+	 * Physical capacity of the {@link #queue} - i.e. the actual number of slots the backing
+	 * {@link ArrayBlockingQueue} was allocated with. The purge logic reasons against this value so that the
+	 * "keep roughly one third of the queue empty" breathing-room invariant matches the real allocation.
+	 */
+	private final int physicalQueueCapacity;
 	/**
 	 * Rejected execution handler that is called when the queue is full and a new task cannot be added.
 	 */
@@ -136,7 +142,10 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	}
 
 	public Scheduler(@Nonnull ThreadPoolOptions options) {
-		this.rejectingExecutorHandler = new EvitaRejectingExecutorHandler("service", this.rejectedTaskCount::incrementAndGet);
+		this.rejectingExecutorHandler = new EvitaRejectingExecutorHandler("service", this.rejectedTaskCount::increment);
+		// note: a ScheduledThreadPoolExecutor uses an unbounded DelayedWorkQueue, so this handler is effectively only
+		// triggered for tasks submitted after shutdown - back-pressure for the bounded task registry is enforced
+		// separately in #addTaskToQueue, which invokes the same handler on overflow
 		final ScheduledThreadPoolExecutor theExecutor = new ScheduledThreadPoolExecutor(
 			options.maxThreadCount(),
 			new EvitaThreadFactory(options.threadPriority()),
@@ -148,7 +157,8 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 		this.executorService = theExecutor;
 		// create queue with double the size of the configured queue size to have some breathing room
 		this.queueCapacity = options.queueSize();
-		this.queue = new ArrayBlockingQueue<>(this.queueCapacity << 1);
+		this.physicalQueueCapacity = this.queueCapacity << 1;
+		this.queue = new ArrayBlockingQueue<>(this.physicalQueueCapacity);
 		// schedule automatic purging task
 		this.purgingTask = new DelayedAsyncTask(
 			null,
@@ -167,8 +177,9 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	 */
 	public Scheduler(@Nonnull ScheduledThreadPoolExecutor executorService) {
 		this.executorService = executorService;
-		this.queue = new ArrayBlockingQueue<>(64);
 		this.queueCapacity = 64;
+		this.physicalQueueCapacity = 64;
+		this.queue = new ArrayBlockingQueue<>(this.physicalQueueCapacity);
 		this.rejectingExecutorHandler = null;
 		this.purgingTask = null;
 	}
@@ -177,7 +188,9 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	@Override
 	public ScheduledFuture<?> schedule(@Nonnull Runnable lambda, long delay, @Nonnull TimeUnit delayUnits) {
 		if (!this.executorService.isShutdown()) {
-			return this.executorService.schedule(lambda, delay, delayUnits);
+			final ScheduledFuture<?> scheduledFuture = this.executorService.schedule(lambda, delay, delayUnits);
+			this.submittedTaskCount.increment();
+			return scheduledFuture;
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
 		} else {
@@ -189,7 +202,9 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	@Override
 	public <V> ScheduledFuture<V> schedule(@Nonnull Callable<V> callable, long delay, @Nonnull TimeUnit unit) {
 		if (!this.executorService.isShutdown()) {
-			return this.executorService.schedule(callable, delay, unit);
+			final ScheduledFuture<V> scheduledFuture = this.executorService.schedule(callable, delay, unit);
+			this.submittedTaskCount.increment();
+			return scheduledFuture;
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
 		} else {
@@ -207,7 +222,7 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 				period,
 				unit
 			);
-			this.submittedTaskCount.incrementAndGet();
+			this.submittedTaskCount.increment();
 			return scheduledFuture;
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
@@ -226,7 +241,7 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 				delay,
 				unit
 			);
-			this.submittedTaskCount.incrementAndGet();
+			this.submittedTaskCount.increment();
 			return scheduledFuture;
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
@@ -237,17 +252,28 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 
 	/**
 	 * Method schedules immediate execution of `runnable`. If there is no free thread left in the pool, the runnable
-	 * will be executed "as soon as possible".
+	 * will be executed "as soon as possible". This is a fire-and-forget submission - no future is handed back to the
+	 * caller, therefore any exception thrown while the runnable executes is logged on the worker thread rather than
+	 * propagated to the caller.
 	 *
 	 * @param runnable the runnable task to be executed
 	 * @throws NullPointerException       if the runnable parameter is null
-	 * @throws RejectedExecutionException if the task cannot be submitted for execution
+	 * @throws RejectedExecutionException if the scheduler is already shut down (and shutdown is not merely in progress)
 	 */
 	@Override
 	public void execute(@Nonnull Runnable runnable) {
 		if (!this.executorService.isShutdown()) {
-			this.executorService.submit(runnable);
-			this.submittedTaskCount.incrementAndGet();
+			// ScheduledThreadPoolExecutor wraps every task (even via execute()) in a ScheduledFutureTask that
+			// captures thrown exceptions into the future. Since this fire-and-forget path hands no future back to
+			// the caller, wrap the runnable to log any otherwise-swallowed exception instead of losing it silently.
+			this.executorService.execute(() -> {
+				try {
+					runnable.run();
+				} catch (Throwable t) {
+					log.error("Uncaught error during execution of a task submitted via execute().", t);
+				}
+			});
+			this.submittedTaskCount.increment();
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
 		}
@@ -255,12 +281,12 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 
 	@Override
 	public long getSubmittedTaskCount() {
-		return this.submittedTaskCount.get();
+		return this.submittedTaskCount.sum();
 	}
 
 	@Override
 	public long getRejectedTaskCount() {
-		return this.rejectedTaskCount.get();
+		return this.rejectedTaskCount.sum();
 	}
 
 	@Override
@@ -312,7 +338,7 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 				st.transitionToIssued();
 			}
 			final Future<T> future = this.executorService.submit(task);
-			this.submittedTaskCount.incrementAndGet();
+			this.submittedTaskCount.increment();
 			return future;
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
@@ -329,7 +355,7 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 				st.transitionToIssued();
 			}
 			final Future<T> future = this.executorService.submit(task, result);
-			this.submittedTaskCount.incrementAndGet();
+			this.submittedTaskCount.increment();
 			return future;
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
@@ -346,7 +372,7 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 				st.transitionToIssued();
 			}
 			final Future<?> future = this.executorService.submit(task);
-			this.submittedTaskCount.incrementAndGet();
+			this.submittedTaskCount.increment();
 			return future;
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
@@ -365,7 +391,7 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 				}
 			}
 			final List<Future<T>> futures = this.executorService.invokeAll(tasks);
-			this.submittedTaskCount.addAndGet(futures.size());
+			this.submittedTaskCount.add(futures.size());
 			return futures;
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
@@ -384,7 +410,7 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 				}
 			}
 			final List<Future<T>> futures = this.executorService.invokeAll(tasks, timeout, unit);
-			this.submittedTaskCount.addAndGet(futures.size());
+			this.submittedTaskCount.add(futures.size());
 			return futures;
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
@@ -403,9 +429,12 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 				}
 			}
 			final T result = this.executorService.invokeAny(tasks);
-			this.submittedTaskCount.incrementAndGet();
+			this.submittedTaskCount.increment();
 			return result;
 		} else {
+			// unlike the other shut-down branches this one cannot return a graceful sentinel: the method contract is
+			// @Nonnull and there is no result to hand back, so a RejectedExecutionException is thrown even while the
+			// shutdown is merely in progress
 			throw new RejectedExecutionException("Scheduler is already shut down.");
 		}
 	}
@@ -415,12 +444,12 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 	public <T> T invokeAny(@Nonnull Collection<? extends Callable<T>> tasks, long timeout, @Nonnull TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
 		if (!this.executorService.isShutdown()) {
 			for (Callable<T> task : tasks) {
-				if (task instanceof AbstractServerTask<?, ?> ast) {
-					ast.transitionToIssued();
+				if (task instanceof ServerTask<?, ?> st) {
+					st.transitionToIssued();
 				}
 			}
 			final T result = this.executorService.invokeAny(tasks, timeout, unit);
-			this.submittedTaskCount.incrementAndGet();
+			this.submittedTaskCount.increment();
 			return result;
 		} else if (!this.shutdownInProgress.get()) {
 			throw new RejectedExecutionException("Scheduler is already shut down.");
@@ -620,45 +649,70 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 		} else {
 			this.executorService.submit(task::execute);
 		}
-		this.submittedTaskCount.incrementAndGet();
+		this.submittedTaskCount.increment();
 		return task.getFutureResult();
 	}
 
 	/**
-	 * Wraps the task into an observable task and adds it to the queue. Returns the same type as the input argument
-	 * to allow for fluent chaining.
+	 * Adds the task to the tracking {@link #queue}, returning the same instance to allow for fluent chaining. The
+	 * task is first added via a non-blocking {@link ArrayBlockingQueue#offer(Object) offer}; if the queue is full,
+	 * {@link #purgeFinishedAndLongWaitingTasks()} is triggered to reclaim space and the offer is retried. Should the
+	 * queue still be full afterwards, the task is marked as failed, the rejecting handler (when present) is notified
+	 * and an {@link IllegalStateException} is thrown.
 	 *
 	 * @param task the task to add
 	 * @param <T>  the type of the task
-	 * @return the task that was added and wrapped
+	 * @return the task that was added
+	 * @throws IllegalStateException if the queue remains full even after a purge attempt
 	 */
 	@Nonnull
 	private <T extends ServerTask<?, ?>> T addTaskToQueue(@Nonnull T task) {
+		final boolean added;
+		// hold the buffer lock around the whole add so that registry writes never interleave with a concurrent
+		// purge: this prevents the purge's drain/refill window from racing an offer, which could otherwise overflow
+		// the re-add and silently drop live tasks. The purge re-enters this lock reentrantly on the full-queue path.
+		this.bufferLock.lock();
 		try {
-			// add the task to the queue
-			this.queue.add(task);
-		} catch (IllegalStateException e) {
-			// this means the queue is full, so we need to remove some tasks
-			this.purgeFinishedAndLongWaitingTasks();
-			// and try adding the task again
-			try {
-				this.queue.add(task);
-			} catch (IllegalStateException exceptionAgain) {
-				// and this should never happen since queue was cleared of finished and timed out tasks and its size
-				// is double the configured size
-				if (this.rejectingExecutorHandler != null) {
-					this.rejectingExecutorHandler.rejectedExecution();
-				}
-				task.fail(exceptionAgain);
-				throw exceptionAgain;
+			// try to add the task to the queue without resorting to exceptions for control flow
+			if (this.queue.offer(task)) {
+				return task;
 			}
+			// the queue is full, so we need to remove some tasks and try again
+			this.purgeFinishedAndLongWaitingTasks();
+			added = this.queue.offer(task);
+		} finally {
+			this.bufferLock.unlock();
+		}
+		if (!added) {
+			// this should never happen since the queue was cleared of finished and timed out tasks and its
+			// physical size is double the configured size
+			final IllegalStateException exception = new IllegalStateException(
+				"Scheduler queue is full and no task could be purged to make room."
+			);
+			// mark the task as failed first so it is reported as failed regardless of the handler presence
+			task.fail(exception);
+			// the rejecting handler (when present) emits an event and rethrows a RejectedExecutionException
+			if (this.rejectingExecutorHandler != null) {
+				this.rejectingExecutorHandler.rejectedExecution();
+			}
+			throw exception;
 		}
 		return task;
 	}
 
 	/**
-	 * Iterates over all tasks in {@link #queue} in a batch manner and removes all finished tasks. Tasks that are
-	 * still waiting or running are added to the tail of the queue again.
+	 * Iterates over all tasks in {@link #queue} in a batch manner and prunes it according to the following policy:
+	 *
+	 * - tasks still waiting for a precondition longer than {@link #WAITING_TASKS_KEEP_INTERVAL_MILLIS} are dropped,
+	 * - finished or failed tasks are removed, but those whose completion falls within the defense period are
+	 *   re-queued up to a fill threshold that keeps roughly one third of {@link #physicalQueueCapacity} empty as
+	 *   breathing room for newly submitted tasks,
+	 * - all remaining waiting or running tasks are added back to the tail of the queue.
+	 *
+	 * The method is guarded by {@link #bufferLock}; a concurrent caller that cannot acquire the lock blocks until the
+	 * in-progress purge finishes rather than busy-spinning.
+	 *
+	 * @return always {@code 0L}, signalling the scheduling framework to re-plan the purge at its standard interval
 	 */
 	private long purgeFinishedAndLongWaitingTasks() {
 		if (this.bufferLock.tryLock()) {
@@ -699,26 +753,26 @@ public class Scheduler implements ObservableExecutorService, ScheduledExecutorSe
 					// clear the buffer for the next iteration
 					this.buffer.clear();
 				}
-				// now add the tasks that are still in defense period back to the queue, but keep at least 1/3 of the queue empty
-				final int requiredEmptyBlock = Math.min(1, this.queueCapacity / 3);
-				final int remainingCapacity = this.queueCapacity - this.queue.size();
-				if (remainingCapacity > requiredEmptyBlock && finishedTaskInDefensePeriod != null) {
+				// now add the tasks that are still in defense period back to the queue, but keep at least 1/3 of the
+				// physical queue capacity empty as breathing room for newly submitted tasks
+				final int requiredEmptyBlock = Math.max(1, this.physicalQueueCapacity / 3);
+				final int maxFill = this.physicalQueueCapacity - requiredEmptyBlock;
+				if (finishedTaskInDefensePeriod != null) {
 					//noinspection rawtypes
 					final Iterator<Task> it = finishedTaskInDefensePeriod.iterator();
-					final int currentCapacity = this.queue.size();
-					for (int i = currentCapacity; i < this.queueCapacity - requiredEmptyBlock && i < remainingCapacity && it.hasNext(); i++) {
-						this.queue.add((ServerTask<?, ?>) it.next());
+					// re-add defense-period tasks until either the fill threshold is reached or we run out of tasks
+					while (this.queue.size() < maxFill && it.hasNext()) {
+						this.queue.offer((ServerTask<?, ?>) it.next());
 					}
 				}
 			} finally {
 				this.bufferLock.unlock();
 			}
 		} else {
-			// someone else is currently purging the queue
-			// we need to wait until he's done and then the queue should have enough free room
-			while (this.bufferLock.isLocked()) {
-				Thread.onSpinWait();
-			}
+			// someone else is currently purging the queue - block until they are done (at which point the queue
+			// should have enough free room) instead of busy-spinning on the lock state
+			this.bufferLock.lock();
+			this.bufferLock.unlock();
 		}
 		// plan to next standard time
 		return 0L;

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -48,6 +49,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.evitadb.test.TestTags.ENGINE;
@@ -56,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * This test verifies the correct functionality of the {@link Scheduler} class.
@@ -259,6 +262,17 @@ class SchedulerTest {
 			assertEquals(42, result);
 			assertEquals(before + 1, SchedulerTest.this.scheduler.getSubmittedTaskCount());
 		}
+
+		@Test
+		@DisplayName("counts a timed invokeAny submission")
+		void shouldCountTimedInvokeAnySubmission() throws InterruptedException, ExecutionException, TimeoutException {
+			final long before = SchedulerTest.this.scheduler.getSubmittedTaskCount();
+			final Integer result = SchedulerTest.this.scheduler.invokeAny(
+				List.of((Callable<Integer>) () -> 42), 5, TimeUnit.SECONDS
+			);
+			assertEquals(42, result);
+			assertEquals(before + 1, SchedulerTest.this.scheduler.getSubmittedTaskCount());
+		}
 	}
 
 	@Nested
@@ -270,31 +284,32 @@ class SchedulerTest {
 		void shouldLogExceptionThrownViaExecute() throws InterruptedException {
 			// an exception thrown by a fire-and-forget execute() task must not be silently swallowed inside the
 			// discarded future - it has to be logged
-			final Logger schedulerLogger = (Logger) LoggerFactory.getLogger(Scheduler.class);
-			final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+			final org.slf4j.Logger slf4jLogger = LoggerFactory.getLogger(Scheduler.class);
+			// the assertion captures log output through Logback's appender API; skip gracefully under a different
+			// SLF4J binding rather than failing with a ClassCastException
+			assumeTrue(slf4jLogger instanceof Logger, "Logback backend required to capture log output.");
+			final Logger schedulerLogger = (Logger) slf4jLogger;
+
+			// the appender releases the latch as soon as the expected error event arrives - no polling needed
+			final CountDownLatch errorLogged = new CountDownLatch(1);
+			final ListAppender<ILoggingEvent> appender = new ListAppender<>() {
+				@Override
+				protected void append(@Nonnull ILoggingEvent eventObject) {
+					super.append(eventObject);
+					if (eventObject.getLevel() == Level.ERROR && eventObject.getThrowableProxy() != null) {
+						errorLogged.countDown();
+					}
+				}
+			};
 			appender.start();
 			schedulerLogger.addAppender(appender);
 			try {
-				final CountDownLatch latch = new CountDownLatch(1);
 				SchedulerTest.this.scheduler.execute(() -> {
-					try {
-						throw new RuntimeException("boom");
-					} finally {
-						latch.countDown();
-					}
+					throw new RuntimeException("boom");
 				});
 
-				assertTrue(latch.await(5, TimeUnit.SECONDS), "Task was not executed in time.");
-
-				// the wrapper logs after run() returns, so wait until the error event is observed
-				final long start = System.currentTimeMillis();
-				while (appender.list.stream().noneMatch(it -> it.getLevel() == Level.ERROR)
-					&& System.currentTimeMillis() - start < 5_000) {
-					Thread.onSpinWait();
-				}
-
 				assertTrue(
-					appender.list.stream().anyMatch(it -> it.getLevel() == Level.ERROR && it.getThrowableProxy() != null),
+					errorLogged.await(5, TimeUnit.SECONDS),
 					"Expected an ERROR log entry carrying the swallowed exception."
 				);
 			} finally {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/executor/SchedulerTest.java
@@ -23,27 +23,39 @@
 
 package io.evitadb.core.executor;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.evitadb.api.configuration.ThreadPoolOptions;
 import io.evitadb.api.task.ServerTask;
 import io.evitadb.api.task.TaskStatus;
 import io.evitadb.api.task.TaskStatus.TaskSimplifiedState;
 import io.evitadb.dataType.PaginatedList;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.jupiter.api.Tag;
 
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.TASK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static io.evitadb.test.TestTags.ENGINE;
-import static io.evitadb.test.TestTags.TASK;
 
 /**
  * This test verifies the correct functionality of the {@link Scheduler} class.
@@ -52,6 +64,7 @@ import static io.evitadb.test.TestTags.TASK;
  */
 @Tag(ENGINE)
 @Tag(TASK)
+@DisplayName("Scheduler")
 class SchedulerTest {
 	private final Scheduler scheduler = new Scheduler(
 		ThreadPoolOptions
@@ -64,126 +77,230 @@ class SchedulerTest {
 		this.scheduler.shutdownNow();
 	}
 
-	@Test
-	void shouldRegisterTask() {
-		assertEquals(0, this.scheduler.listTaskStatuses(1, 20, null).getTotalRecordCount());
+	@Nested
+	@DisplayName("Task tracking")
+	class TaskTracking {
 
-		this.scheduler.submit(
-			(ServerTask<?, ?>) new ClientRunnableTask<>("task", "Test task", null, () -> {
-			})
-		);
+		@Test
+		@DisplayName("registers a submitted task in the queue")
+		void shouldRegisterSubmittedTask() {
+			assertEquals(0, SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null).getTotalRecordCount());
 
-		assertEquals(1, this.scheduler.listTaskStatuses(1, 20, null).getTotalRecordCount());
-	}
-
-	@Test
-	void shouldListTasks() {
-		assertEquals(0, this.scheduler.listTaskStatuses(1, 20, null).getTotalRecordCount());
-
-		for (int i = 0; i < 10; i++) {
-			this.scheduler.submit(
+			SchedulerTest.this.scheduler.submit(
 				(ServerTask<?, ?>) new ClientRunnableTask<>("task", "Test task", null, () -> {
 				})
 			);
+
+			assertEquals(1, SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null).getTotalRecordCount());
 		}
 
-		final PaginatedList<TaskStatus<?, ?>> taskStatuses = this.scheduler.listTaskStatuses(1, 5, null);
-		assertEquals(10, taskStatuses.getTotalRecordCount());
-		assertEquals(5, taskStatuses.getData().size());
-	}
+		@Test
+		@DisplayName("lists tracked tasks with pagination")
+		void shouldListTrackedTasksWithPagination() {
+			assertEquals(0, SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null).getTotalRecordCount());
 
-	@Test
-	void shouldGetStatusOfTheTask() throws ExecutionException, InterruptedException {
-		assertEquals(0, this.scheduler.listTaskStatuses(1, 20, null).getTotalRecordCount());
-
-		final CompletableFuture<Integer> result = this.scheduler.submit(
-			(ServerTask<?, Integer>) new ClientCallableTask<>("task", "Test task", null, () -> 5)
-		);
-
-		final PaginatedList<TaskStatus<?, ?>> jobStatuses = this.scheduler.listTaskStatuses(1, 20, null);
-		assertEquals(1, jobStatuses.getTotalRecordCount());
-
-		final PaginatedList<TaskStatus<?, ?>> typeFilteredJobStatuses = this.scheduler.listTaskStatuses(1, 20, new String[] { "task" });
-		assertEquals(1, typeFilteredJobStatuses.getTotalRecordCount());
-
-		while (this.scheduler.listTaskStatuses(1, 20, null).getData().get(0).simplifiedState() != TaskSimplifiedState.FINISHED) {
-			synchronized (this) {
-				wait(100);
+			for (int i = 0; i < 10; i++) {
+				SchedulerTest.this.scheduler.submit(
+					(ServerTask<?, ?>) new ClientRunnableTask<>("task", "Test task", null, () -> {
+					})
+				);
 			}
+
+			final PaginatedList<TaskStatus<?, ?>> taskStatuses = SchedulerTest.this.scheduler.listTaskStatuses(1, 5, null);
+			assertEquals(10, taskStatuses.getTotalRecordCount());
+			assertEquals(5, taskStatuses.getData().size());
 		}
 
-		final PaginatedList<TaskStatus<?, ?>> statusFilteredJobStatuses = this.scheduler.listTaskStatuses(1, 20, null, TaskSimplifiedState.QUEUED);
-		assertEquals(0, statusFilteredJobStatuses.getTotalRecordCount());
+		@Test
+		@DisplayName("exposes status of a completed task filtered by type and state")
+		void shouldExposeStatusOfCompletedTask() throws ExecutionException, InterruptedException {
+			assertEquals(0, SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null).getTotalRecordCount());
 
-		final PaginatedList<TaskStatus<?, ?>> typeFilteredOutJobStatuses = this.scheduler.listTaskStatuses(1, 20, new String[] { "Non-existing task" });
-		assertEquals(0, typeFilteredOutJobStatuses.getTotalRecordCount());
+			final CompletableFuture<Integer> result = SchedulerTest.this.scheduler.submit(
+				(ServerTask<?, Integer>) new ClientCallableTask<>("task", "Test task", null, () -> 5)
+			);
 
-		assertEquals(5, result.get());
+			final PaginatedList<TaskStatus<?, ?>> jobStatuses = SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null);
+			assertEquals(1, jobStatuses.getTotalRecordCount());
 
-		final PaginatedList<TaskStatus<?, ?>> statusFilteredJobStatusesWhenDone = this.scheduler.listTaskStatuses(1, 20, null, TaskSimplifiedState.FINISHED);
-		assertEquals(1, statusFilteredJobStatusesWhenDone.getTotalRecordCount());
+			final PaginatedList<TaskStatus<?, ?>> typeFilteredJobStatuses = SchedulerTest.this.scheduler.listTaskStatuses(1, 20, new String[] { "task" });
+			assertEquals(1, typeFilteredJobStatuses.getTotalRecordCount());
 
-		final PaginatedList<TaskStatus<?, ?>> nonMatchingFilteredJobStatusesWhenDone = this.scheduler.listTaskStatuses(1, 20, new String[] { "Non-existing task" }, TaskSimplifiedState.FINISHED);
-		assertEquals(0, nonMatchingFilteredJobStatusesWhenDone.getTotalRecordCount());
+			while (SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null).getData().get(0).simplifiedState() != TaskSimplifiedState.FINISHED) {
+				synchronized (this) {
+					wait(100);
+				}
+			}
 
-		final Optional<TaskStatus<?, ?>> jobStatus = this.scheduler.getTaskStatus(typeFilteredJobStatuses.getData().get(0).taskId());
+			final PaginatedList<TaskStatus<?, ?>> statusFilteredJobStatuses = SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null, TaskSimplifiedState.QUEUED);
+			assertEquals(0, statusFilteredJobStatuses.getTotalRecordCount());
 
-		assertTrue(jobStatus.isPresent());
-		assertEquals("Test task", jobStatus.get().taskName());
-		assertEquals(5, jobStatus.get().result());
-		assertEquals(TaskSimplifiedState.FINISHED, jobStatus.get().simplifiedState());
+			final PaginatedList<TaskStatus<?, ?>> typeFilteredOutJobStatuses = SchedulerTest.this.scheduler.listTaskStatuses(1, 20, new String[] { "Non-existing task" });
+			assertEquals(0, typeFilteredOutJobStatuses.getTotalRecordCount());
+
+			assertEquals(5, result.get());
+
+			final PaginatedList<TaskStatus<?, ?>> statusFilteredJobStatusesWhenDone = SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null, TaskSimplifiedState.FINISHED);
+			assertEquals(1, statusFilteredJobStatusesWhenDone.getTotalRecordCount());
+
+			final PaginatedList<TaskStatus<?, ?>> nonMatchingFilteredJobStatusesWhenDone = SchedulerTest.this.scheduler.listTaskStatuses(1, 20, new String[] { "Non-existing task" }, TaskSimplifiedState.FINISHED);
+			assertEquals(0, nonMatchingFilteredJobStatusesWhenDone.getTotalRecordCount());
+
+			final Optional<TaskStatus<?, ?>> jobStatus = SchedulerTest.this.scheduler.getTaskStatus(typeFilteredJobStatuses.getData().get(0).taskId());
+
+			assertTrue(jobStatus.isPresent());
+			assertEquals("Test task", jobStatus.get().taskName());
+			assertEquals(5, jobStatus.get().result());
+			assertEquals(TaskSimplifiedState.FINISHED, jobStatus.get().simplifiedState());
+		}
+
+		@Test
+		@DisplayName("cancels a running task")
+		void shouldCancelRunningTask() throws InterruptedException {
+			assertEquals(0, SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null).getTotalRecordCount());
+
+			final AtomicBoolean started = new AtomicBoolean(false);
+			final AtomicBoolean interrupted = new AtomicBoolean(false);
+			final CompletableFuture<Integer> result = SchedulerTest.this.scheduler.submit(
+				(ServerTask<Void, Integer>) new ClientCallableTask<Void, Integer>("task", "Test task", null, theTask -> {
+					started.set(true);
+					for (int i = 0; i < 1_000_000_000; i++) {
+						if (theTask.getFutureResult().isCancelled()) {
+							interrupted.set(true);
+							return -1;
+						}
+						Thread.onSpinWait();
+					}
+					return 5;
+				})
+			);
+
+			final PaginatedList<TaskStatus<?, ?>> jobStatuses = SchedulerTest.this.scheduler.listTaskStatuses(1, 20, null);
+			assertEquals(1, jobStatuses.getTotalRecordCount());
+
+			final Optional<TaskStatus<?, ?>> jobStatus = SchedulerTest.this.scheduler.getTaskStatus(jobStatuses.getData().get(0).taskId());
+
+			assertTrue(jobStatus.isPresent());
+			assertEquals("Test task", jobStatus.get().taskName());
+
+			SchedulerTest.this.scheduler.cancelTask(jobStatus.get().taskId());
+
+			try {
+				result.get();
+				fail("Exception expected");
+			} catch (CancellationException | ExecutionException e) {
+				// expected
+			}
+
+			// wait for the task to be interrupted
+			final long start = System.currentTimeMillis();
+			do {
+				Thread.onSpinWait();
+			} while (started.get() && !interrupted.get() && System.currentTimeMillis() - start < 100_000);
+
+			final Optional<TaskStatus<?, ?>> jobStatusAgain = SchedulerTest.this.scheduler.getTaskStatus(jobStatuses.getData().get(0).taskId());
+			jobStatusAgain.ifPresent(taskStatus -> {
+				assertNull(taskStatus.result());
+				assertEquals(TaskSimplifiedState.FAILED, taskStatus.simplifiedState());
+			});
+			assertTrue(interrupted.get() || !started.get());
+		}
 	}
 
-	@Test
-	void shouldCancelTheTask() throws InterruptedException {
-		assertEquals(0, this.scheduler.listTaskStatuses(1, 20, null).getTotalRecordCount());
+	@Nested
+	@DisplayName("Submitted-task counting")
+	class SubmittedTaskCounting {
 
-		final AtomicBoolean started = new AtomicBoolean(false);
-		final AtomicBoolean interrupted = new AtomicBoolean(false);
-		final CompletableFuture<Integer> result = this.scheduler.submit(
-			(ServerTask<Void, Integer>) new ClientCallableTask<Void, Integer>("task", "Test task", null, theTask -> {
-				started.set(true);
-				for (int i = 0; i < 1_000_000_000; i++) {
-					if (theTask.getFutureResult().isCancelled()) {
-						interrupted.set(true);
-						return -1;
+		@Test
+		@DisplayName("counts both one-shot schedule(...) variants")
+		void shouldCountOneShotScheduledSubmissions() {
+			// one-shot schedule(...) variants (Runnable and Callable) must increment the submitted-task counter
+			final long before = SchedulerTest.this.scheduler.getSubmittedTaskCount();
+
+			// schedule with a long delay so the tasks never actually run during the test
+			SchedulerTest.this.scheduler.schedule((Runnable) () -> {}, 1, TimeUnit.HOURS);
+			SchedulerTest.this.scheduler.schedule((Callable<Integer>) () -> 1, 1, TimeUnit.HOURS);
+
+			assertEquals(before + 2, SchedulerTest.this.scheduler.getSubmittedTaskCount());
+		}
+
+		@Test
+		@DisplayName("counts a submitted runnable")
+		void shouldCountSubmittedRunnable() {
+			final long before = SchedulerTest.this.scheduler.getSubmittedTaskCount();
+			SchedulerTest.this.scheduler.submit(() -> {});
+			assertEquals(before + 1, SchedulerTest.this.scheduler.getSubmittedTaskCount());
+		}
+
+		@Test
+		@DisplayName("counts a submitted callable")
+		void shouldCountSubmittedCallable() {
+			final long before = SchedulerTest.this.scheduler.getSubmittedTaskCount();
+			SchedulerTest.this.scheduler.submit((Callable<Integer>) () -> 1);
+			assertEquals(before + 1, SchedulerTest.this.scheduler.getSubmittedTaskCount());
+		}
+
+		@Test
+		@DisplayName("counts invokeAll submissions matching the returned futures")
+		void shouldCountInvokeAllSubmissions() throws InterruptedException {
+			final long before = SchedulerTest.this.scheduler.getSubmittedTaskCount();
+			final List<Future<Integer>> futures = SchedulerTest.this.scheduler.invokeAll(
+				List.of((Callable<Integer>) () -> 1, () -> 2, () -> 3)
+			);
+			// the counter must grow by exactly the number of futures the executor reported as submitted
+			assertEquals(before + futures.size(), SchedulerTest.this.scheduler.getSubmittedTaskCount());
+		}
+
+		@Test
+		@DisplayName("counts an invokeAny submission")
+		void shouldCountInvokeAnySubmission() throws InterruptedException, ExecutionException {
+			final long before = SchedulerTest.this.scheduler.getSubmittedTaskCount();
+			final Integer result = SchedulerTest.this.scheduler.invokeAny(List.of((Callable<Integer>) () -> 42));
+			assertEquals(42, result);
+			assertEquals(before + 1, SchedulerTest.this.scheduler.getSubmittedTaskCount());
+		}
+	}
+
+	@Nested
+	@DisplayName("Exception handling")
+	class ExceptionHandling {
+
+		@Test
+		@DisplayName("logs an exception thrown by a fire-and-forget execute() task")
+		void shouldLogExceptionThrownViaExecute() throws InterruptedException {
+			// an exception thrown by a fire-and-forget execute() task must not be silently swallowed inside the
+			// discarded future - it has to be logged
+			final Logger schedulerLogger = (Logger) LoggerFactory.getLogger(Scheduler.class);
+			final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+			appender.start();
+			schedulerLogger.addAppender(appender);
+			try {
+				final CountDownLatch latch = new CountDownLatch(1);
+				SchedulerTest.this.scheduler.execute(() -> {
+					try {
+						throw new RuntimeException("boom");
+					} finally {
+						latch.countDown();
 					}
+				});
+
+				assertTrue(latch.await(5, TimeUnit.SECONDS), "Task was not executed in time.");
+
+				// the wrapper logs after run() returns, so wait until the error event is observed
+				final long start = System.currentTimeMillis();
+				while (appender.list.stream().noneMatch(it -> it.getLevel() == Level.ERROR)
+					&& System.currentTimeMillis() - start < 5_000) {
 					Thread.onSpinWait();
 				}
-				return 5;
-			})
-		);
 
-		final PaginatedList<TaskStatus<?, ?>> jobStatuses = this.scheduler.listTaskStatuses(1, 20, null);
-		assertEquals(1, jobStatuses.getTotalRecordCount());
-
-		final Optional<TaskStatus<?, ?>> jobStatus = this.scheduler.getTaskStatus(jobStatuses.getData().get(0).taskId());
-
-		assertTrue(jobStatus.isPresent());
-		assertEquals("Test task", jobStatus.get().taskName());
-
-		this.scheduler.cancelTask(jobStatus.get().taskId());
-
-		try {
-			result.get();
-			fail("Exception expected");
-		} catch (CancellationException | ExecutionException e) {
-			// expected
+				assertTrue(
+					appender.list.stream().anyMatch(it -> it.getLevel() == Level.ERROR && it.getThrowableProxy() != null),
+					"Expected an ERROR log entry carrying the swallowed exception."
+				);
+			} finally {
+				schedulerLogger.detachAppender(appender);
+			}
 		}
-
-		// wait for the task to be interrupted
-		final long start = System.currentTimeMillis();
-		do {
-			Thread.onSpinWait();
-		} while (started.get() && !interrupted.get() && System.currentTimeMillis() - start < 100_000);
-
-		final Optional<TaskStatus<?, ?>> jobStatusAgain = this.scheduler.getTaskStatus(jobStatuses.getData().get(0).taskId());
-		final Optional<TaskStatus<?, ?>> taskStatusRef = jobStatusAgain;
-		taskStatusRef.ifPresent(taskStatus -> {
-			assertNull(taskStatus.result());
-			assertEquals(TaskSimplifiedState.FAILED, taskStatus.simplifiedState());
-		});
-		assertTrue(interrupted.get() || !started.get());
 	}
 
 }


### PR DESCRIPTION
## Summary

Hardens `Scheduler` thread/queue handling, fixing the bugs reported in #1206 plus a latent concurrency bug found during review.

### Functional fixes
- **Purge sizing**: replace `Math.min` with `Math.max` and reason against a single `physicalQueueCapacity` source of truth (set in both constructors), so finished-but-in-defense tasks are re-added beyond a single configured capacity while keeping ~1/3 of the physical queue free.
- **Swallowed exceptions**: the fire-and-forget `execute(Runnable)` path now logs exceptions that a `ScheduledThreadPoolExecutor` would otherwise capture inside the discarded future.
- **Wrong type check**: timed `invokeAny` issues any `ServerTask` (previously only `AbstractServerTask`), matching the other submission methods.
- **Submission counting**: one-shot `schedule(Runnable)` / `schedule(Callable)` now increment the submitted-task counter.
- **Counter type**: `submittedTaskCount` / `rejectedTaskCount` migrated from `AtomicLong` to `LongAdder`, consistent with `ObservableThreadExecutor`.

### Concurrency fix
- `addTaskToQueue` now holds `bufferLock` around `offer → purge → retry`, so a concurrent `offer` can no longer refill drained slots and make the purge's `addAll` overflow and silently drop live tasks. The `fail`/throw path runs outside the lock.

### Consistency cleanups
- Exception-driven queue add replaced with boolean `offer()`; the task is marked failed before notifying the rejecting handler.
- Busy spin-wait on the buffer lock replaced with a blocking lock acquisition.

### Tests
- `SchedulerTest` reorganized into `@Nested` groups (Task tracking, Submitted-task counting, Exception handling) with `@DisplayName`s.
- Added deterministic coverage for submitted-task counting (`submit`, `invokeAll`, `invokeAny`, one-shot `schedule`) and for the `execute()` exception-logging behavior. All 10 tests green.

Closes #1206
