### PR TITLE
fix: WAL-rotation purge reads an already-deleted .catalog file under heavy compaction

### DIFF
--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -1050,7 +1050,7 @@ public class DefaultCatalogPersistenceService
 			scheduler,
 			this.catalogStoragePath,
 			this.storageSettings.timeTravelEnabled(),
-			this::fetchDataFilesInfo
+			this::fetchOldestRetainedDataFilesInfo
 		);
 		final CatalogBootstrap initialCatalogBootstrap = new CatalogBootstrap(
 			0, 0, Instant.now().atZone(ZoneId.systemDefault()).toOffsetDateTime(), null
@@ -1228,7 +1228,7 @@ public class DefaultCatalogPersistenceService
 			scheduler,
 			this.catalogStoragePath,
 			this.storageSettings.timeTravelEnabled(),
-			this::fetchDataFilesInfo
+			this::fetchOldestRetainedDataFilesInfo
 		);
 		final String verifiedCatalogName = verifyDirectory(this.catalogStoragePath, false);
 		// TOBEDONE #538 - introduced with #650 and could be removed later when no version prior to 2025.2 is used
@@ -1365,7 +1365,7 @@ public class DefaultCatalogPersistenceService
 			this.scheduler,
 			this.catalogStoragePath,
 			this.storageSettings.timeTravelEnabled(),
-			this::fetchDataFilesInfo
+			this::fetchOldestRetainedDataFilesInfo
 		);
 		final String verifiedCatalogName = verifyDirectory(this.catalogStoragePath, false);
 		// TOBEDONE #538 - introduced with #650 and could be removed later when no version prior to 2025.2 is used
@@ -3715,33 +3715,20 @@ public class DefaultCatalogPersistenceService
 	}
 
 	/**
-	 * This method finds bootstrap record for the given catalog version and returns its record along with the appropriate
-	 * catalog header.
+	 * Returns the bootstrap record and catalog header of the oldest catalog version still retained on disk (the first
+	 * record in the bootstrap file). This is the basis for the WAL-rotation purge driven by
+	 * {@link ObsoleteFileMaintainer}: the catalog data file referenced by this bootstrap is the lowest index that is
+	 * kept, so deleting everything strictly below it never removes a file that a retained bootstrap record still
+	 * references, and - because that file is by definition not eligible for deletion - the header read itself can never
+	 * target an already purged file. This mirrors the time-travel branch of {@link #purgeAllObsoleteFiles()}.
 	 *
-	 * @param catalogVersion the catalog version
-	 * @return the catalog header and the bootstrap record
+	 * @return the data files info of the oldest retained catalog version, or {@code null} when no bootstrap is available
 	 */
 	@Nullable
-	private DataFilesBulkInfo fetchDataFilesInfo(long catalogVersion) {
-		try (
-			final Stream<CatalogBootstrap> catalogBootstrapRecordStream = getCatalogBootstrapRecordStream(
-				this.catalogName, this.bootstrapStorageSettings
-			)
-		) {
-			final AtomicReference<CatalogBootstrap> lastExaminedBootstrap = new AtomicReference<>();
-			return catalogBootstrapRecordStream
-				.peek(lastExaminedBootstrap::set)
-				.filter(it -> it.catalogVersion() == catalogVersion)
-				.map(it -> new DataFilesBulkInfo(it, fetchCatalogHeader(it)))
-				.findFirst()
-				.orElseGet(() -> {
-					// when particular catalog version is not found
-					final CatalogBootstrap catalogBootstrap = lastExaminedBootstrap.get();
-					// we return the first bootstrap record that is greater than the requested catalog version
-					return catalogBootstrap.catalogVersion() > catalogVersion ?
-						new DataFilesBulkInfo(catalogBootstrap, fetchCatalogHeader(catalogBootstrap)) : null;
-				});
-		}
+	private DataFilesBulkInfo fetchOldestRetainedDataFilesInfo() {
+		return getFirstCatalogBootstrap(this.catalogName, this.bootstrapStorageSettings)
+			.map(it -> new DataFilesBulkInfo(it, fetchCatalogHeader(it)))
+			.orElse(null);
 	}
 
 	/**

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/ObsoleteFileMaintainer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/ObsoleteFileMaintainer.java
@@ -49,7 +49,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongConsumer;
-import java.util.function.LongFunction;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService.CATALOG_FILE_SUFFIX;
@@ -100,9 +101,17 @@ public class ObsoleteFileMaintainer implements CatalogConsumersListener, Closeab
 	 */
 	private final AtomicLong lastKnownMinimalActiveVersion = new AtomicLong(0L);
 	/**
-	 * The supplier of the catalog header for the specified catalog version.
+	 * The minimal catalog version that is still referenced by an active reader (open session) or writer. This floor is
+	 * tracked even when time travel is enabled (where it does not gate the {@link #purgeTask}) so that the WAL-rotation
+	 * purge can be clamped by it and never delete a catalog data file that an active reader still needs.
 	 */
-	private final LongFunction<DataFilesBulkInfo> dataFilesInfoFetcher;
+	private final AtomicLong activeReaderFloor = new AtomicLong(0L);
+	/**
+	 * The supplier of the catalog header and bootstrap record for the oldest catalog version that is still retained on
+	 * disk (the first record in the bootstrap file). The catalog data file referenced by this bootstrap is, by
+	 * definition, the lowest index that is kept and therefore is guaranteed not to have been purged.
+	 */
+	private final Supplier<DataFilesBulkInfo> oldestDataFilesInfoSupplier;
 	/**
 	 * Flag indicating whether the maintainer has been closed.
 	 */
@@ -113,11 +122,11 @@ public class ObsoleteFileMaintainer implements CatalogConsumersListener, Closeab
 		@Nonnull Scheduler scheduler,
 		@Nonnull Path catalogStoragePath,
 		boolean timeTravelEnabled,
-		@Nonnull LongFunction<DataFilesBulkInfo> dataFilesInfoFetcher
+		@Nonnull Supplier<DataFilesBulkInfo> oldestDataFilesInfoSupplier
 	) {
 		this.catalogStoragePath = catalogStoragePath;
 		this.timeTravelEnabled = timeTravelEnabled;
-		this.dataFilesInfoFetcher = dataFilesInfoFetcher;
+		this.oldestDataFilesInfoSupplier = oldestDataFilesInfoSupplier;
 		// purge task is not present when time travel is enabled
 		// in this situation the files are removed in the synchronous manner when the WAL history is purged
 		this.purgeTask = new DelayedAsyncTask(
@@ -160,9 +169,11 @@ public class ObsoleteFileMaintainer implements CatalogConsumersListener, Closeab
 	}
 
 	/**
-	 * Updates the catalog version that is no longer used by any active session and plans the purge task for
-	 * asynchronous file removal. This method does nothing when time travel is enabled, because the files are removed
-	 * when WAL files are removed and this logic is executed in {@link ObsoleteWalPurgeCallback} callback.
+	 * Updates the catalog version that is no longer used by any active session. On every call it records the
+	 * active-reader floor (the minimal still-active catalog version, monotonically increasing), which is later used
+	 * to clamp the WAL-rotation purge so that files still needed by an active reader are never deleted. Only the
+	 * immediate, synchronous file purge is suppressed when time travel is enabled - in that mode purging is driven
+	 * later by the {@link ObsoleteWalPurgeCallback} callback when WAL files are removed.
 	 *
 	 * @param lastKnownMinimalActiveVersionRead the minimal catalog version that is still being read from
 	 * @param lastKnownMinimalActiveVersionWritten the minimal catalog version that is still being written on top of
@@ -173,12 +184,20 @@ public class ObsoleteFileMaintainer implements CatalogConsumersListener, Closeab
 		long lastKnownMinimalActiveVersionWritten
 	) {
 		assertNotClosed();
+		final long lastKnownMinimalActiveVersion = Math.min(
+			lastKnownMinimalActiveVersionRead,
+			lastKnownMinimalActiveVersionWritten
+		);
+		// always record the active-reader floor (monotonically increasing) - even with time travel enabled it is used
+		// to clamp the WAL-rotation purge so that files still needed by an active reader are never deleted
+		if (lastKnownMinimalActiveVersion > 0L) {
+			this.activeReaderFloor.accumulateAndGet(
+				lastKnownMinimalActiveVersion,
+				Math::max
+			);
+		}
 		// immediate file purging on catalog version exchange is not used when time travel is enabled
 		if (!this.timeTravelEnabled) {
-			final long lastKnownMinimalActiveVersion = Math.min(
-				lastKnownMinimalActiveVersionRead,
-				lastKnownMinimalActiveVersionWritten
-			);
 			if (lastKnownMinimalActiveVersion > 0L && this.firstCatalogVersion.get() < lastKnownMinimalActiveVersion) {
 				this.lastKnownMinimalActiveVersion.accumulateAndGet(
 					lastKnownMinimalActiveVersion,
@@ -187,6 +206,17 @@ public class ObsoleteFileMaintainer implements CatalogConsumersListener, Closeab
 				this.purgeTask.schedule();
 			}
 		}
+	}
+
+	/**
+	 * Returns the minimal catalog version that is still referenced by an active reader or writer, or {@code 0} when no
+	 * active version has been observed yet. The WAL-rotation purge is clamped by this floor so that a catalog data file
+	 * holding records for a version with active readers is never deleted.
+	 *
+	 * @return the active-reader floor (minimal active catalog version), or {@code 0} when unknown
+	 */
+	public long getActiveReaderFloor() {
+		return this.activeReaderFloor.get();
 	}
 
 	/**
@@ -202,7 +232,8 @@ public class ObsoleteFileMaintainer implements CatalogConsumersListener, Closeab
 			return new ObsoleteWalPurgeCallback(
 				this.catalogStoragePath,
 				this::purgeMaintainedFilesOlderThan,
-				this.dataFilesInfoFetcher
+				this.oldestDataFilesInfoSupplier,
+				this::getActiveReaderFloor
 			);
 		} else {
 			return WalPurgeCallback.NO_OP;
@@ -342,15 +373,38 @@ public class ObsoleteFileMaintainer implements CatalogConsumersListener, Closeab
 		 */
 		private final LongConsumer maintainedFilePurgeCallback;
 		/**
-		 * The supplier of the catalog header for the specified catalog version or the first larger available
-		 * catalog version.
+		 * The supplier of the catalog header and bootstrap record of the oldest catalog version still retained on disk.
+		 * The catalog data file it references is the lowest kept index and is therefore guaranteed to be present, which
+		 * makes the header read resilient against concurrently purged files.
 		 */
-		private final LongFunction<DataFilesBulkInfo> dataFilesInfoFetcher;
+		private final Supplier<DataFilesBulkInfo> oldestDataFilesInfoSupplier;
+		/**
+		 * Supplier of the active-reader floor - the minimal catalog version that still has active readers. The purge is
+		 * clamped by this floor so that files needed by an active reader are never deleted.
+		 */
+		private final LongSupplier activeReaderFloorSupplier;
 		/**
 		 * The last catalog version that was observed. This variable is used to ignore calls with lower catalog version
 		 * than were already processed.
 		 */
 		private long lastObservedCatalogVersion = -1L;
+
+		/**
+		 * Clamps the requested keep-version down to the active-reader floor (when the floor is greater than {@code 0})
+		 * so the time-travel purge never deletes catalog data still needed by an active reader. This narrows the
+		 * inherited identity default, which would otherwise keep exactly the requested version.
+		 *
+		 * @param requestedFirstVersionToBeKept the first catalog version the WAL purge intends to keep
+		 * @return the requested version, lowered to the active-reader floor when a floor is set
+		 */
+		@Override
+		public long effectivePurgeVersion(long requestedFirstVersionToBeKept) {
+			final long readerFloor = this.activeReaderFloorSupplier.getAsLong();
+			// never purge beyond the minimal version that still has active readers (time-travel invariant)
+			return readerFloor > 0L ?
+				Math.min(requestedFirstVersionToBeKept, readerFloor) :
+				requestedFirstVersionToBeKept;
+		}
 
 		@Override
 		public void purgeFilesUpTo(long firstActiveCatalogVersion) {
@@ -358,8 +412,10 @@ public class ObsoleteFileMaintainer implements CatalogConsumersListener, Closeab
 				this.lastObservedCatalogVersion = firstActiveCatalogVersion;
 				// first purge all maintained files
 				this.maintainedFilePurgeCallback.accept(firstActiveCatalogVersion);
-				// then purge all obsolete files in the folders
-				ofNullable(this.dataFilesInfoFetcher.apply(firstActiveCatalogVersion))
+				// then purge all obsolete files in the folders - the threshold is derived from the oldest bootstrap
+				// record still retained on disk (whose data file is guaranteed to exist), not from an exact-version
+				// lookup that may reference an already purged file
+				ofNullable(this.oldestDataFilesInfoSupplier.get())
 					.ifPresent(
 						activeFiles -> {
 							final int firstUsedCatalogDataFileIndex = activeFiles.bootstrapRecord().catalogFileIndex();

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
@@ -442,7 +442,7 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 		@Nonnull Path walFilePath,
 		@Nonnull WalKind walKind
 	) throws IOException {
-		final byte[] buffer = new byte[8192];
+		@SuppressWarnings("CheckForOutOfMemoryOnLargeArrayAllocation") final byte[] buffer = new byte[8192];
 		int transactionSize = 0;
 		int previousTransactionSize = 0;
 		long previousOffset = 0;
@@ -2075,6 +2075,18 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 		WalPurgeCallback NO_OP = __ -> {
 			// do nothing
 		};
+
+		/**
+		 * Clamps the requested first-version-to-be-kept so that neither the bootstrap-record trimming nor the catalog
+		 * data file purge ever removes data still needed by an active reader. The default implementation performs no
+		 * clamping; implementations that track active readers narrow the version down to the active-reader floor.
+		 *
+		 * @param requestedFirstVersionToBeKept the first catalog version that WAL retention would keep
+		 * @return the first catalog version that may actually be kept once active readers are taken into account
+		 */
+		default long effectivePurgeVersion(long requestedFirstVersionToBeKept) {
+			return requestedFirstVersionToBeKept;
+		}
 
 		/**
 		 * Purges the files up to the given active files.

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/CatalogWriteAheadLog.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/CatalogWriteAheadLog.java
@@ -292,11 +292,14 @@ public class CatalogWriteAheadLog extends AbstractMutationLog<CatalogBoundMutati
 
 	@Override
 	protected void updateFirstVersionKept(long firstVersionToBeKept) {
+		// clamp the version by the active-reader floor so that neither the bootstrap-record trimming nor the catalog
+		// data file purge ever removes data still needed by an active reader (time-travel invariant)
+		final long effectiveVersionToBeKept = this.onWalPurgeCallback.effectivePurgeVersion(firstVersionToBeKept);
 		// first trim the bootstrap record file
-		this.bootstrapFileTrimmer.accept(firstVersionToBeKept);
+		this.bootstrapFileTrimmer.accept(effectiveVersionToBeKept);
 		// call the listener to remove the obsolete files
-		if (firstVersionToBeKept > -1) {
-			this.onWalPurgeCallback.purgeFilesUpTo(firstVersionToBeKept);
+		if (effectiveVersionToBeKept > -1) {
+			this.onWalPurgeCallback.purgeFilesUpTo(effectiveVersionToBeKept);
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/ObsoleteFileMaintainerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/ObsoleteFileMaintainerTest.java
@@ -1,0 +1,185 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.catalog;
+
+import io.evitadb.core.executor.Scheduler;
+import io.evitadb.store.catalog.ObsoleteFileMaintainer.DataFilesBulkInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.annotation.Nonnull;
+import java.nio.file.Path;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.function.Supplier;
+
+import static io.evitadb.test.TestTags.STORAGE;
+import static io.evitadb.test.TestTags.WAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies the active-reader floor tracking exposed by {@link ObsoleteFileMaintainer} through its public API.
+ *
+ * The active-reader floor is the minimal catalog version that is still referenced by an active reader (open
+ * session) or writer. It is recorded monotonically by {@link ObsoleteFileMaintainer#catalogConsumersLeft(long, long)}
+ * and read back via {@link ObsoleteFileMaintainer#getActiveReaderFloor()}. The floor is tracked regardless of
+ * whether time travel is enabled, because the WAL-rotation purge is clamped by it so that a catalog data file
+ * still needed by an active reader is never deleted.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+@DisplayName("Obsolete file maintainer active-reader floor tracking")
+@Tag(STORAGE)
+@Tag(WAL)
+class ObsoleteFileMaintainerTest {
+
+	/**
+	 * Catalog name used for the maintainer under test; the value is irrelevant to floor tracking.
+	 */
+	private static final String CATALOG_NAME = "testCatalog";
+
+	/**
+	 * No-op supplier of oldest data file info; the floor logic never consults it.
+	 */
+	private static final Supplier<DataFilesBulkInfo> NO_OP_SUPPLIER = () -> null;
+
+	/**
+	 * Executor backing the scheduler; shut down after each test.
+	 */
+	private ScheduledThreadPoolExecutor executor;
+
+	/**
+	 * Scheduler handed to the maintainer; the floor logic never schedules work in these tests.
+	 */
+	private Scheduler scheduler;
+
+	@TempDir
+	private Path catalogStoragePath;
+
+	@BeforeEach
+	void setUp() {
+		this.executor = new ScheduledThreadPoolExecutor(1);
+		this.scheduler = new Scheduler(this.executor);
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.executor.shutdownNow();
+	}
+
+	@Test
+	@DisplayName("Floor is zero before any consumers-left notification")
+	void shouldReportZeroFloorBeforeAnyConsumersLeftCall() {
+		try (ObsoleteFileMaintainer maintainer = newMaintainer(false)) {
+			assertEquals(0L, maintainer.getActiveReaderFloor());
+		}
+	}
+
+	@Test
+	@DisplayName("Single notification records the minimum of read and written versions")
+	void shouldRecordMinimumOfReadAndWrittenVersions() {
+		try (ObsoleteFileMaintainer maintainer = newMaintainer(false)) {
+			maintainer.catalogConsumersLeft(5L, 3L);
+
+			assertEquals(3L, maintainer.getActiveReaderFloor());
+		}
+	}
+
+	@Test
+	@DisplayName("Floor accumulates monotonically and never decreases")
+	void shouldAccumulateFloorMonotonically() {
+		try (ObsoleteFileMaintainer maintainer = newMaintainer(false)) {
+			maintainer.catalogConsumersLeft(5L, 5L);
+			assertEquals(5L, maintainer.getActiveReaderFloor());
+
+			// a lower minimum must not lower the floor
+			maintainer.catalogConsumersLeft(2L, 2L);
+			assertEquals(5L, maintainer.getActiveReaderFloor());
+
+			// a higher minimum raises the floor
+			maintainer.catalogConsumersLeft(9L, 7L);
+			assertEquals(7L, maintainer.getActiveReaderFloor());
+		}
+	}
+
+	@Test
+	@DisplayName("Notification whose minimum is zero or negative leaves the floor unchanged")
+	void shouldIgnoreNonPositiveMinimum() {
+		try (ObsoleteFileMaintainer maintainer = newMaintainer(false)) {
+			maintainer.catalogConsumersLeft(4L, 4L);
+			assertEquals(4L, maintainer.getActiveReaderFloor());
+
+			// minimum is zero -> guarded out
+			maintainer.catalogConsumersLeft(8L, 0L);
+			assertEquals(4L, maintainer.getActiveReaderFloor());
+
+			// minimum is negative -> guarded out
+			maintainer.catalogConsumersLeft(-1L, 8L);
+			assertEquals(4L, maintainer.getActiveReaderFloor());
+		}
+	}
+
+	@ParameterizedTest(name = "timeTravelEnabled={0}")
+	@ValueSource(booleans = {true, false})
+	@DisplayName("Floor accumulation is identical regardless of time-travel mode")
+	void shouldAccumulateFloorIdenticallyInBothTimeTravelModes(boolean timeTravelEnabled) {
+		try (ObsoleteFileMaintainer maintainer = newMaintainer(timeTravelEnabled)) {
+			assertEquals(0L, maintainer.getActiveReaderFloor());
+
+			maintainer.catalogConsumersLeft(6L, 4L);
+			assertEquals(4L, maintainer.getActiveReaderFloor());
+
+			// lower minimum does not lower the floor in either mode
+			maintainer.catalogConsumersLeft(3L, 3L);
+			assertEquals(4L, maintainer.getActiveReaderFloor());
+
+			// higher minimum raises the floor in either mode
+			maintainer.catalogConsumersLeft(10L, 8L);
+			assertEquals(8L, maintainer.getActiveReaderFloor());
+		}
+	}
+
+	/**
+	 * Builds an {@link ObsoleteFileMaintainer} bound to the per-test scheduler and temporary storage path.
+	 *
+	 * @param timeTravelEnabled whether the maintainer should operate in time-travel mode
+	 * @return a freshly constructed maintainer that the caller is responsible for closing
+	 */
+	@Nonnull
+	private ObsoleteFileMaintainer newMaintainer(boolean timeTravelEnabled) {
+		return new ObsoleteFileMaintainer(
+			CATALOG_NAME,
+			this.scheduler,
+			this.catalogStoragePath,
+			timeTravelEnabled,
+			NO_OP_SUPPLIER
+		);
+	}
+
+}


### PR DESCRIPTION
Closes #1203

## Problem
Under intense transactional activity with aggressive compaction and time travel enabled, the WAL-rotation purge read the `.catalog` header at an **exact** catalog version (`fetchDataFilesInfo(v)`). That file could already have been deleted, so the read threw `FileNotFoundException` (wrapped as `UnexpectedIOException`). Because the purge ran on the commit path, the exception failed the in-flight transaction. The catalog-file purge was also decoupled from active readers.

## Fix
- **Robust threshold:** derive the keep-threshold from the **oldest retained bootstrap** record (`fetchOldestRetainedDataFilesInfo`, file position 0), mirroring the already-correct time-travel branch of `purgeAllObsoleteFiles`. That file is the lowest retained index and is never deleted below, so the header read can no longer target a purged file, and catalog-file retention stays aligned with bootstrap-record retention.
- **Active-reader floor:** `ObsoleteFileMaintainer` now tracks the minimal active catalog version in **both** time-travel and non-time-travel modes (`activeReaderFloor`), exposed via `getActiveReaderFloor()`. A new `WalPurgeCallback.effectivePurgeVersion` (identity default, overridden to clamp by the floor) makes `CatalogWriteAheadLog.updateFirstVersionKept` clamp **both** bootstrap trimming and catalog-file deletion by `min(firstVersionToBeKept, readerFloor)` — so a file still needed by an open session is never removed.

## Verification
- Reproduction soak `LongRunningEvitaTransactionalFunctionalTest#shouldCorrectlyRotateAllFiles`: 1×1 min + 3×2 min parallel high-churn runs (distinct seeds, ~86 compactions each), all clean of `FileNotFoundException`.
- Regression: `CatalogWriteAheadLogTest`, `CatalogWriteAheadLogIntegrationTest`, `DefaultCatalogPersistenceServiceTest`, `EvitaTransactionalFunctionalTest` green.
- New `ObsoleteFileMaintainerTest` (6 tests) covers the floor tracking.