### PR TITLE
Fix memory leak retaining old catalog snapshots (#1220)

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -289,9 +289,14 @@ public final class Catalog
 	@Getter private final TrafficRecordingEngine trafficRecordingEngine;
 	/**
 	 * Contains reference to the archived catalog index that allows fast lookups for entities across all types.
+	 *
+	 * The archived index is initialized lazily on the first archived-scope access (see
+	 * {@link #getCatalogIndex(Scope)}). It is held in an {@link AtomicReference} so that the lazy
+	 * transition is safe against concurrent read queries - the reference stays {@code null} until the
+	 * first archived-scope query, which preserves the "null means no archived data" semantics relied
+	 * upon by the copy and persistence paths.
 	 */
-	@Nullable
-	private CatalogIndex archiveCatalogIndex;
+	private final AtomicReference<CatalogIndex> archiveCatalogIndex = new AtomicReference<>();
 	/**
 	 * Last persisted schema version of the catalog.
 	 */
@@ -564,7 +569,6 @@ public final class Catalog
 		);
 		this.catalogIndex = new CatalogIndex(Scope.LIVE);
 		this.catalogIndex.attachToCatalog(null, this);
-		this.archiveCatalogIndex = null;
 		this.proxyFactory = proxyFactory;
 		this.newCatalogVersionConsumer = newCatalogVersionConsumer;
 		this.lastPersistedSchemaVersion = internalCatalogSchema.version();
@@ -649,11 +653,12 @@ public final class Catalog
 		this.catalogIndex = this.persistenceService.readCatalogIndex(this, Scope.LIVE)
 			.orElseGet(() -> new CatalogIndex(Scope.LIVE));
 		this.catalogIndex.attachToCatalog(null, this);
-		this.archiveCatalogIndex = this.persistenceService.readCatalogIndex(this, Scope.ARCHIVED)
+		final CatalogIndex loadedArchiveCatalogIndex = this.persistenceService.readCatalogIndex(this, Scope.ARCHIVED)
 			.filter(it -> !it.isEmpty())
 			.orElse(null);
-		if (this.archiveCatalogIndex != null) {
-			this.archiveCatalogIndex.attachToCatalog(null, this);
+		if (loadedArchiveCatalogIndex != null) {
+			loadedArchiveCatalogIndex.attachToCatalog(null, this);
+			this.archiveCatalogIndex.set(loadedArchiveCatalogIndex);
 		}
 		this.cacheSupervisor = cacheSupervisor;
 		this.trafficRecordingEngine = new TrafficRecordingEngine(
@@ -722,7 +727,7 @@ public final class Catalog
 		this.versionId = new TransactionalReference<>(catalogVersion);
 		this.state = catalogState;
 		this.catalogIndex = catalogIndex;
-		this.archiveCatalogIndex = archiveCatalogIndex;
+		this.archiveCatalogIndex.set(archiveCatalogIndex);
 		this.persistenceService = persistenceService;
 		this.cacheSupervisor = previousCatalogVersion.cacheSupervisor;
 		this.trafficRecordingEngine = previousCatalogVersion.trafficRecordingEngine;
@@ -735,8 +740,8 @@ public final class Catalog
 		this.transactionManager = previousCatalogVersion.transactionManager;
 
 		this.catalogIndex.attachToCatalog(null, this);
-		if (this.archiveCatalogIndex != null) {
-			this.archiveCatalogIndex.attachToCatalog(null, this);
+		if (archiveCatalogIndex != null) {
+			archiveCatalogIndex.attachToCatalog(null, this);
 		}
 		final StoragePartPersistenceService<StorageDescriptor> storagePartPersistenceService =
 			persistenceService.getStoragePartPersistenceService(catalogVersion);
@@ -1054,9 +1059,9 @@ public final class Catalog
 					catalogVersionAfterRename,
 					catalogState,
 					this.catalogIndex.createCopyForNewCatalogAttachment(catalogState),
-					this.archiveCatalogIndex == null ?
+					this.archiveCatalogIndex.get() == null ?
 						null :
-						this.archiveCatalogIndex.createCopyForNewCatalogAttachment(catalogState),
+						this.archiveCatalogIndex.get().createCopyForNewCatalogAttachment(catalogState),
 					newCollections,
 					newIoService,
 					this,
@@ -1106,9 +1111,9 @@ public final class Catalog
 				1L,
 				CatalogState.ALIVE,
 				this.catalogIndex.createCopyForNewCatalogAttachment(CatalogState.ALIVE),
-				this.archiveCatalogIndex == null ?
+				this.archiveCatalogIndex.get() == null ?
 					null :
-					this.archiveCatalogIndex.createCopyForNewCatalogAttachment(CatalogState.ALIVE),
+					this.archiveCatalogIndex.get().createCopyForNewCatalogAttachment(CatalogState.ALIVE),
 				newCollections,
 				this.persistenceService,
 				this,
@@ -1363,7 +1368,7 @@ public final class Catalog
 	 */
 	@Nonnull
 	public Optional<CatalogIndex> getCatalogIndexIfExits(@Nonnull Scope scope) {
-		return scope == Scope.ARCHIVED ? ofNullable(this.archiveCatalogIndex) : of(this.catalogIndex);
+		return scope == Scope.ARCHIVED ? ofNullable(this.archiveCatalogIndex.get()) : of(this.catalogIndex);
 	}
 
 	/**
@@ -1372,11 +1377,19 @@ public final class Catalog
 	@Nonnull
 	public CatalogIndex getCatalogIndex(@Nonnull Scope scope) {
 		if (scope == Scope.ARCHIVED) {
-			if (this.archiveCatalogIndex == null) {
-				this.archiveCatalogIndex = new CatalogIndex(Scope.ARCHIVED);
-				this.archiveCatalogIndex.attachToCatalog(null, this);
+			// The archived index is lazily initialized on first archived-scope access. Guard the
+			// transition against concurrent read queries: create and attach the candidate before
+			// publishing it, then CAS it in. A candidate that loses the race is discarded (and GC'd)
+			// having been attached exactly once - so attachToCatalog is never invoked twice on the
+			// same instance, which would otherwise trip its "already attached" premise check
+			CatalogIndex existing = this.archiveCatalogIndex.get();
+			if (existing == null) {
+				final CatalogIndex candidate = new CatalogIndex(Scope.ARCHIVED);
+				candidate.attachToCatalog(null, this);
+				existing = this.archiveCatalogIndex.compareAndSet(null, candidate) ?
+					candidate : this.archiveCatalogIndex.get();
 			}
-			return this.archiveCatalogIndex;
+			return existing;
 		} else {
 			return this.catalogIndex;
 		}
@@ -1447,8 +1460,9 @@ public final class Catalog
 		this.schema.removeLayer(transactionalLayer);
 		this.entityCollections.removeLayer(transactionalLayer);
 		this.catalogIndex.removeLayer(transactionalLayer);
-		if (this.archiveCatalogIndex != null) {
-			this.archiveCatalogIndex.removeLayer(transactionalLayer);
+		final CatalogIndex theArchiveCatalogIndex = this.archiveCatalogIndex.get();
+		if (theArchiveCatalogIndex != null) {
+			theArchiveCatalogIndex.removeLayer(transactionalLayer);
 		}
 		this.entityCollectionsByPrimaryKey.removeLayer(transactionalLayer);
 		this.entitySchemaIndex.removeLayer(transactionalLayer);
@@ -1521,9 +1535,10 @@ public final class Catalog
 			this.entityCollections);
 		final CatalogIndex possiblyUpdatedCatalogIndex = transactionalLayer.getStateCopyWithCommittedChanges(
 			this.catalogIndex);
-		final CatalogIndex possiblyUpdatedArchiveCatalogIndex = this.archiveCatalogIndex == null ?
+		final CatalogIndex theArchiveCatalogIndex = this.archiveCatalogIndex.get();
+		final CatalogIndex possiblyUpdatedArchiveCatalogIndex = theArchiveCatalogIndex == null ?
 			null :
-			of(transactionalLayer.getStateCopyWithCommittedChanges(this.archiveCatalogIndex))
+			of(transactionalLayer.getStateCopyWithCommittedChanges(theArchiveCatalogIndex))
 				.filter(it -> !it.isEmpty())
 				.orElse(null);
 		transactionalLayer.removeTransactionalMemoryLayerIfExists(this.entityCollectionsByPrimaryKey);
@@ -1550,7 +1565,7 @@ public final class Catalog
 			);
 		} else {
 			if (possiblyUpdatedCatalogIndex != this.catalogIndex ||
-				possiblyUpdatedArchiveCatalogIndex != this.archiveCatalogIndex ||
+				possiblyUpdatedArchiveCatalogIndex != theArchiveCatalogIndex ||
 				possiblyUpdatedCollections
 					.entrySet()
 					.stream()
@@ -2358,7 +2373,7 @@ public final class Catalog
 		@Override
 		public CatalogIndex getIndexIfExists(@Nonnull CatalogIndexKey catalogIndexKey) {
 			return catalogIndexKey.scope() == Scope.ARCHIVED ?
-				Catalog.this.archiveCatalogIndex : Catalog.this.catalogIndex;
+				Catalog.this.archiveCatalogIndex.get() : Catalog.this.catalogIndex;
 		}
 
 		@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/core/cdc/CatalogChangeObserver.java
+++ b/evita_engine/src/main/java/io/evitadb/core/cdc/CatalogChangeObserver.java
@@ -169,6 +169,11 @@ public class CatalogChangeObserver implements ChangeCatalogObserverContract {
 			theCatalog != null,
 			"Catalog must be attached to the observer before registering a new publisher!"
 		);
+		// capture only the catalog name (a String) for logging purposes - capturing the whole
+		// `theCatalog` instance in the lambdas below (especially the long-lived `onClose` callback
+		// stored in the shared publisher) would pin the entire catalog snapshot in memory for the
+		// whole lifetime of the publisher, leaking old catalog versions (see issue #557)
+		final String catalogName = theCatalog.getName();
 
 		// Provide isolated publisher wrapping the shared one to the outside world.
 		// This way we can reuse predicate and caching logic for all subscribers with the same criteria.
@@ -180,7 +185,7 @@ public class CatalogChangeObserver implements ChangeCatalogObserverContract {
 				cb -> {
 					log.info(
 						"Creating new shared CDC publisher for catalog '{}' and criteria: {}",
-						theCatalog.getName(), cb
+						catalogName, cb
 					);
 					return new ChangeCatalogCaptureSharedPublisher(
 						this.currentCatalog.get(),
@@ -192,7 +197,7 @@ public class CatalogChangeObserver implements ChangeCatalogObserverContract {
 						publisher -> {
 							log.info(
 								"Closing shared CDC publisher for catalog '{}' and criteria: {}",
-								theCatalog.getName(), cb
+								catalogName, cb
 							);
 							this.uniquePublishers.remove(publisher);
 						}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/EmptyFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/base/EmptyFormula.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.core.query.algebra.base;
 
+import io.evitadb.core.query.QueryExecutionContext;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.index.bitmap.Bitmap;
@@ -42,6 +43,19 @@ public class EmptyFormula extends AbstractFormula {
 
 	private EmptyFormula() {
 		this.initFields();
+	}
+
+	/**
+	 * {@link #INSTANCE} is a shared, application-wide singleton. {@link AbstractFormula#initialize}
+	 * stores the per-query {@link QueryExecutionContext} in a field - doing so on this shared instance
+	 * would pin that query's execution context (and the whole {@link io.evitadb.core.catalog.Catalog}
+	 * snapshot reachable from it) in a static field for the entire JVM lifetime, leaking catalog
+	 * versions. This formula never reads the execution context ({@link #computeInternal()} returns
+	 * {@link EmptyBitmap#INSTANCE}), so initialization is intentionally a no-op.
+	 */
+	@Override
+	public void initialize(@Nonnull QueryExecutionContext executionContext) {
+		// intentionally empty - see JavaDoc
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/infra/SkipFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/infra/SkipFormula.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.core.query.algebra.infra;
 
+import io.evitadb.core.query.QueryExecutionContext;
 import io.evitadb.core.query.algebra.AbstractFormula;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.index.bitmap.Bitmap;
@@ -45,6 +46,19 @@ public class SkipFormula extends AbstractFormula {
 
 	private SkipFormula() {
 		this.initFields();
+	}
+
+	/**
+	 * {@link #INSTANCE} is a shared, application-wide singleton. {@link AbstractFormula#initialize}
+	 * stores the per-query {@link QueryExecutionContext} in a field - doing so on this shared instance
+	 * would pin that query's execution context (and the whole {@link io.evitadb.core.catalog.Catalog}
+	 * snapshot reachable from it) in a static field for the entire JVM lifetime, leaking catalog
+	 * versions. This formula is never actually computed ({@link #computeInternal()} throws), so
+	 * initialization is intentionally a no-op.
+	 */
+	@Override
+	public void initialize(@Nonnull QueryExecutionContext executionContext) {
+		// intentionally empty - see JavaDoc
 	}
 
 	@Nonnull


### PR DESCRIPTION
## Summary

Production OOM on `deco-eshop/prod/evita` retained 124 `Catalog` MVCC snapshots (~6.6 GB)
instead of the expected handful. Eclipse MAT analysis traced the retained snapshots to a
set of GC-root anchors that pinned old snapshots in memory. This PR removes those anchors.

## Fixes

1. **CDC `onClose` lambda captured the whole snapshot** — `CatalogChangeObserver.registerObserver`
   captured the `Catalog` in the shared publisher's `onClose` callback only to log its name,
   pinning one old snapshot per publisher. It now captures the catalog name (`String`).
2. **Shared formula singletons retained query state** — `EmptyFormula.INSTANCE` and
   `SkipFormula.INSTANCE` inherited `AbstractFormula#initialize`, which stores the per-query
   `QueryExecutionContext` (and the `Catalog` reachable from it) in a field on a process-wide
   singleton. `initialize()` is now overridden as a no-op in both.
3. **Race in `Catalog.getCatalogIndex(Scope.ARCHIVED)`** — the archived index was lazily
   created and attached without synchronization and dereferenced the field rather than the
   freshly created local, double-attaching under concurrent archived-scope queries (the
   `"Catalog was already attached to this index!"` errors). The archived index is now held in
   an `AtomicReference` and published via `compareAndSet`, preserving the "null means no
   archived data" semantics.

## Investigation note

The originally suspected "shared entity-index to stale catalog cascade" was ruled out: the
commit path deep-copies and re-attaches every collection and price index on every version
bump, resetting all catalog references (`initCallback`, price `superIndex`, `collection.catalog`).
The remaining many-snapshot retention observed during the incident correlates with
transaction-pipeline backpressure (cf. #1196 and the request-pool clamp) and is tracked
separately.

Closes #1220
Related: #557