### PR TITLE
fix: route per-group PK injection through every nested ReferenceHaving

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
@@ -1749,18 +1749,27 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 	}
 
 	/**
-	 * Rewrites every {@link ReferenceHaving} whose reference name matches `referenceName` anywhere in
-	 * `filterBy` by passing it through {@link #injectPkScope}. The traversal is full-tree (handles
-	 * `Or`, `And`, `Not`, and any other container the constraint model defines), so the rewrite is
-	 * applied to every match regardless of nesting depth — not just to top-level direct children of
-	 * the {@link FilterBy}.
+	 * Rewrites every owner-scope {@link ReferenceHaving} whose reference name matches `referenceName`
+	 * anywhere in `filterBy` by passing it through {@link #injectPkScope}. The traversal is full-tree
+	 * (handles `Or`, `And`, `Not`, and any other container the constraint model defines), so the
+	 * rewrite reaches every owner-scope match regardless of nesting depth — not just top-level direct
+	 * children of the {@link FilterBy}.
+	 *
+	 * The translator can emit nested `referenceHaving(otherRef, ...)` inside an enclosing
+	 * `entityHaving(...)` / `groupHaving(...)` (paths `REFERENCED_ENTITY_REFERENCE_ATTRIBUTE` and
+	 * `GROUP_ENTITY_REFERENCE_ATTRIBUTE`). Those inner clauses live in a *different* entity scope
+	 * (the referenced entity, not the owner), so their PK constraints must NOT be merged with the
+	 * owner-scope mutation's PK. The guard `!visitor.isWithin(EntityHaving.class)
+	 * && !visitor.isWithin(GroupHaving.class)` skips such inner clauses even when they happen to
+	 * carry the same `referenceName` as the owner-scope reference (e.g. self-referencing schemas).
 	 *
 	 * @param filterBy       the filter to rewrite
 	 * @param referenceName  the reference whose `ReferenceHaving` instances receive the PK scope
 	 * @param pkConstraint   the PK constraint to merge into each matching `ReferenceHaving`
 	 * @param isGroupScope   `true` for {@link GroupHaving}-scoped injection, `false` for
 	 *                       {@link EntityHaving}-scoped injection
-	 * @return the rewritten filter; structurally identical when no `ReferenceHaving` matched
+	 * @return the rewritten filter; structurally identical when no owner-scope `ReferenceHaving`
+	 *         matched
 	 */
 	@Nonnull
 	private static FilterBy rewriteMatchingReferenceHavings(
@@ -1773,6 +1782,8 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 			filterBy,
 			(visitor, constraint) -> constraint instanceof final ReferenceHaving rh
 				&& rh.getReferenceName().equals(referenceName)
+				&& !visitor.isWithin(EntityHaving.class)
+				&& !visitor.isWithin(GroupHaving.class)
 				? injectPkScope(rh, referenceName, pkConstraint, isGroupScope)
 				: constraint
 		);

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
@@ -30,6 +30,7 @@ import io.evitadb.api.query.filter.EntityPrimaryKeyInSet;
 import io.evitadb.api.query.filter.FilterBy;
 import io.evitadb.api.query.filter.GroupHaving;
 import io.evitadb.api.query.filter.ReferenceHaving;
+import io.evitadb.api.query.visitor.ConstraintCloneVisitor;
 import io.evitadb.api.query.visitor.FinderVisitor;
 import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
 import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
@@ -430,10 +431,10 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 			(depType == DependencyType.REFERENCED_ENTITY_ATTRIBUTE
 				|| depType == DependencyType.REFERENCED_ENTITY_REFERENCE_ATTRIBUTE)
 				&& affected.groups().stream().anyMatch(g -> g.groupPK() != null)
-				&& FinderVisitor.findConstraint(
+				&& !FinderVisitor.findConstraints(
 					trigger.getFilterByConstraint(),
 					GroupHaving.class::isInstance
-				) != null;
+				).isEmpty();
 
 		if (needsPerGroupEvaluation) {
 			return evaluateConditionPerGroup(trigger, mutation, target, affected);
@@ -526,21 +527,13 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		if (groupPK == null) {
 			return parameterize(triggerFilterBy, referenceName, mutatedEntityPK, dependencyType);
 		}
-		// inject group PK scope into the ORIGINAL filter first (before entity PK injection),
-		// so that injectPkScope can find the GroupHaving at the top of ReferenceHaving's children
+		// Inject group PK scope into the ORIGINAL filter first (before entity PK injection); the
+		// recursive rewrite reaches every matching ReferenceHaving regardless of nesting (Or/And/Not),
+		// and injectPkScope merges the PK into every GroupHaving sibling in each match.
 		final EntityPrimaryKeyInSet groupPkConstraint = new EntityPrimaryKeyInSet(groupPK);
-		final FilterConstraint[] topChildren = triggerFilterBy.getChildren();
-		final FilterConstraint[] newTopChildren = new FilterConstraint[topChildren.length];
-		for (int i = 0; i < topChildren.length; i++) {
-			if (topChildren[i] instanceof ReferenceHaving rh
-				&& rh.getReferenceName().equals(referenceName)
-			) {
-				newTopChildren[i] = injectPkScope(rh, referenceName, groupPkConstraint, true);
-			} else {
-				newTopChildren[i] = topChildren[i];
-			}
-		}
-		final FilterBy groupScoped = new FilterBy(newTopChildren);
+		final FilterBy groupScoped = rewriteMatchingReferenceHavings(
+			triggerFilterBy, referenceName, groupPkConstraint, true
+		);
 		// then apply the standard entity PK scoping
 		return parameterize(groupScoped, referenceName, mutatedEntityPK, dependencyType);
 	}
@@ -1752,25 +1745,47 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		final EntityPrimaryKeyInSet pkConstraint = new EntityPrimaryKeyInSet(mutatedEntityPK);
 		final boolean isGroupScope = dependencyType == DependencyType.GROUP_ENTITY_ATTRIBUTE
 			|| dependencyType == DependencyType.GROUP_ENTITY_REFERENCE_ATTRIBUTE;
-		// Walk the top-level children and inject the PK-scope into the matching referenceHaving clause.
-		final FilterConstraint[] topChildren = triggerFilterBy.getChildren();
-		final FilterConstraint[] newTopChildren = new FilterConstraint[topChildren.length];
-		for (int i = 0; i < topChildren.length; i++) {
-			if (topChildren[i] instanceof ReferenceHaving rh
-				&& rh.getReferenceName().equals(referenceName)) {
-				newTopChildren[i] = injectPkScope(rh, referenceName, pkConstraint, isGroupScope);
-			} else {
-				newTopChildren[i] = topChildren[i];
-			}
-		}
-		return new FilterBy(newTopChildren);
+		return rewriteMatchingReferenceHavings(triggerFilterBy, referenceName, pkConstraint, isGroupScope);
 	}
 
 	/**
-	 * Injects the given PK constraint into the matching {@link ReferenceHaving} clause. If the clause already
-	 * contains an {@link EntityHaving} (or {@link GroupHaving} for group-scoped dependencies), the PK constraint
-	 * is merged into that existing scope container so that only a single scope shift is used. Otherwise, a new
-	 * scope container wrapping the PK constraint is appended as an additional And-sibling.
+	 * Rewrites every {@link ReferenceHaving} whose reference name matches `referenceName` anywhere in
+	 * `filterBy` by passing it through {@link #injectPkScope}. The traversal is full-tree (handles
+	 * `Or`, `And`, `Not`, and any other container the constraint model defines), so the rewrite is
+	 * applied to every match regardless of nesting depth — not just to top-level direct children of
+	 * the {@link FilterBy}.
+	 *
+	 * @param filterBy       the filter to rewrite
+	 * @param referenceName  the reference whose `ReferenceHaving` instances receive the PK scope
+	 * @param pkConstraint   the PK constraint to merge into each matching `ReferenceHaving`
+	 * @param isGroupScope   `true` for {@link GroupHaving}-scoped injection, `false` for
+	 *                       {@link EntityHaving}-scoped injection
+	 * @return the rewritten filter; structurally identical when no `ReferenceHaving` matched
+	 */
+	@Nonnull
+	private static FilterBy rewriteMatchingReferenceHavings(
+		@Nonnull FilterBy filterBy,
+		@Nonnull String referenceName,
+		@Nonnull EntityPrimaryKeyInSet pkConstraint,
+		boolean isGroupScope
+	) {
+		return (FilterBy) ConstraintCloneVisitor.clone(
+			filterBy,
+			(visitor, constraint) -> constraint instanceof final ReferenceHaving rh
+				&& rh.getReferenceName().equals(referenceName)
+				? injectPkScope(rh, referenceName, pkConstraint, isGroupScope)
+				: constraint
+		);
+	}
+
+	/**
+	 * Injects the given PK constraint into the matching {@link ReferenceHaving} clause. Every existing
+	 * {@link GroupHaving} (or {@link EntityHaving} for entity-scoped dependencies) child receives the
+	 * PK constraint merged into its body, so a {@link ReferenceHaving} carrying multiple sibling
+	 * scope containers (produced by the expression translator when the same reference declares more
+	 * than one `groupEntity?.…` / `entity?.…` predicate) is correctly constrained on every branch.
+	 * When no scope container is present, a new one wrapping the PK constraint is appended as an
+	 * And-sibling.
 	 *
 	 * @param rh            the original referenceHaving clause
 	 * @param referenceName the reference name for the new ReferenceHaving
@@ -1787,38 +1802,33 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		boolean isGroupScope
 	) {
 		final FilterConstraint[] rhChildren = rh.getChildren();
-		// Find an existing EntityHaving or GroupHaving to merge the PK constraint into.
-		int scopeIndex = -1;
+		final FilterConstraint[] updatedChildren = new FilterConstraint[rhChildren.length];
+		boolean scopeContainerFound = false;
 		for (int j = 0; j < rhChildren.length; j++) {
-			if (isGroupScope ? rhChildren[j] instanceof GroupHaving : rhChildren[j] instanceof EntityHaving) {
-				scopeIndex = j;
-				break;
+			final FilterConstraint child = rhChildren[j];
+			if (isGroupScope && child instanceof final GroupHaving existing) {
+				updatedChildren[j] = new GroupHaving(new And(existing.getChild(), pkConstraint));
+				scopeContainerFound = true;
+			} else if (!isGroupScope && child instanceof final EntityHaving existing) {
+				updatedChildren[j] = new EntityHaving(new And(existing.getChild(), pkConstraint));
+				scopeContainerFound = true;
+			} else {
+				updatedChildren[j] = child;
 			}
 		}
-		if (scopeIndex >= 0) {
-			// Merge PK constraint into the existing scope container to avoid multiple scope shifts.
-			final FilterConstraint[] updatedChildren = new FilterConstraint[rhChildren.length];
-			System.arraycopy(rhChildren, 0, updatedChildren, 0, rhChildren.length);
-			if (isGroupScope) {
-				final GroupHaving existing = (GroupHaving) rhChildren[scopeIndex];
-				updatedChildren[scopeIndex] = new GroupHaving(new And(existing.getChild(), pkConstraint));
-			} else {
-				final EntityHaving existing = (EntityHaving) rhChildren[scopeIndex];
-				updatedChildren[scopeIndex] = new EntityHaving(new And(existing.getChild(), pkConstraint));
-			}
+		if (scopeContainerFound) {
 			return updatedChildren.length == 1
 				? new ReferenceHaving(referenceName, updatedChildren[0])
 				: new ReferenceHaving(referenceName, new And(updatedChildren));
-		} else {
-			// No existing scope container — wrap PK in a new one and add as an And-sibling.
-			final FilterConstraint pkScope = isGroupScope
-				? new GroupHaving(pkConstraint)
-				: new EntityHaving(pkConstraint);
-			final FilterConstraint[] andChildren = new FilterConstraint[rhChildren.length + 1];
-			System.arraycopy(rhChildren, 0, andChildren, 0, rhChildren.length);
-			andChildren[rhChildren.length] = pkScope;
-			return new ReferenceHaving(referenceName, new And(andChildren));
 		}
+		// No existing scope container — wrap PK in a new one and add as an And-sibling.
+		final FilterConstraint pkScope = isGroupScope
+			? new GroupHaving(pkConstraint)
+			: new EntityHaving(pkConstraint);
+		final FilterConstraint[] andChildren = new FilterConstraint[rhChildren.length + 1];
+		System.arraycopy(rhChildren, 0, andChildren, 0, rhChildren.length);
+		andChildren[rhChildren.length] = pkScope;
+		return new ReferenceHaving(referenceName, new And(andChildren));
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/ReevaluateExpressionExecutorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/ReevaluateExpressionExecutorTest.java
@@ -1017,6 +1017,90 @@ class ReevaluateExpressionExecutorTest {
 				);
 			}
 		}
+
+		/**
+		 * Review safeguard (Copilot, PR #1235): the recursive PK-scope rewrite must only target
+		 * **owner-scope** `ReferenceHaving` clauses. The expression translator emits nested
+		 * `referenceHaving(otherRef, …)` inside an enclosing `entityHaving(…)` for
+		 * `REFERENCED_ENTITY_REFERENCE_ATTRIBUTE` paths (and inside `groupHaving(…)` for
+		 * `GROUP_ENTITY_REFERENCE_ATTRIBUTE`). Those inner clauses live in a *different* entity
+		 * scope — the referenced entity's own references — and their PK constraints must not be
+		 * merged with the owner-scope mutation's PK. When the inner reference happens to share
+		 * the same name as the mutation's owner reference (e.g. self-referencing schemas), the
+		 * rewrite must skip the inner clause.
+		 *
+		 * Without the `isWithin(EntityHaving.class)` guard, the inner `ReferenceHaving`'s body
+		 * would be silently augmented with `entityPrimaryKeyInSet(...)` of the owner-entity PK,
+		 * matching a wrong scope.
+		 */
+		@Test
+		@DisplayName("PK injection skips nested ReferenceHaving inside EntityHaving even on name match")
+		void shouldSkipNestedReferenceHavingUnderEntityHavingEvenOnNameMatch() {
+			final String outerReference = "otherReferenceWithDifferentName";
+			final FilterBy triggerFilter = new FilterBy(
+				new ReferenceHaving(
+					outerReference,
+					new EntityHaving(
+						new ReferenceHaving(
+							REFERENCE_NAME,
+							new AttributeEquals("attr", "X")
+						)
+					)
+				)
+			);
+
+			final StubFacetTrigger facetTrigger = new StubFacetTrigger(
+				REFERENCE_NAME, triggerFilter, DependencyType.REFERENCED_ENTITY_ATTRIBUTE
+			);
+
+			// groupPK is non-null so the resolution-index mock fixtures fire, but the trigger
+			// filter has no GroupHaving — so `needsPerGroupEvaluation` is still false and the
+			// global path runs (which is where the recursive rewrite traverses arbitrary nesting).
+			final AffectedReferenceGroup group = new AffectedReferenceGroup(
+				3, 1, new BaseBitmap(100)
+			);
+			final AffectedEntityResolution affected = new AffectedEntityResolution(List.of(group));
+
+			final TestTarget testTarget = createTestTarget(affected, ReferenceIndexType.FOR_FILTERING);
+			final IndexMutationTarget target = testTarget.target();
+			final ReevaluateExpressionMutation mutation = ReevaluateExpressionMutation.withoutOldValues(
+				REFERENCE_NAME, 3, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE
+			);
+
+			when(target.evaluateFilter(any(FilterBy.class), eq(Scope.LIVE)))
+				.thenReturn(new BaseBitmap());
+			when(target.getFacetTrigger(REFERENCE_NAME, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE))
+				.thenReturn(facetTrigger);
+			when(target.getHistogramTriggers(REFERENCE_NAME, Scope.LIVE))
+				.thenReturn(Collections.emptyList());
+
+			ReevaluateExpressionExecutorTest.this.executor.execute(mutation, target);
+
+			final ArgumentCaptor<FilterBy> filterCaptor = ArgumentCaptor.forClass(FilterBy.class);
+			verify(target).evaluateFilter(filterCaptor.capture(), eq(Scope.LIVE));
+
+			// Find the inner ReferenceHaving (the one for REFERENCE_NAME, nested inside EntityHaving).
+			// Its children must remain exactly the original attributeEquals — no entityPrimaryKeyInSet
+			// sibling appended by an over-eager rewrite.
+			final List<ReferenceHaving> matches = FinderVisitor.findConstraints(
+				filterCaptor.getValue(),
+				c -> c instanceof final ReferenceHaving rh && REFERENCE_NAME.equals(rh.getReferenceName())
+			);
+			assertEquals(
+				1, matches.size(),
+				"Exactly one ReferenceHaving for REFERENCE_NAME (the inner, cross-scope one) must exist"
+			);
+			final ReferenceHaving inner = matches.get(0);
+			final FilterConstraint[] innerChildren = inner.getChildren();
+			assertEquals(
+				1, innerChildren.length,
+				"Inner ReferenceHaving must remain with its single original child — not PK-injected"
+			);
+			assertTrue(
+				innerChildren[0] instanceof AttributeEquals,
+				"Inner ReferenceHaving's only child must remain the original AttributeEquals"
+			);
+		}
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/ReevaluateExpressionExecutorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/ReevaluateExpressionExecutorTest.java
@@ -30,7 +30,9 @@ import io.evitadb.api.query.filter.EntityHaving;
 import io.evitadb.api.query.filter.EntityPrimaryKeyInSet;
 import io.evitadb.api.query.filter.FilterBy;
 import io.evitadb.api.query.filter.GroupHaving;
+import io.evitadb.api.query.filter.Or;
 import io.evitadb.api.query.filter.ReferenceHaving;
+import io.evitadb.api.query.visitor.FinderVisitor;
 import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
 import io.evitadb.api.requestResponse.data.structure.RepresentativeReferenceKey;
 import io.evitadb.api.requestResponse.schema.Cardinality;
@@ -805,6 +807,215 @@ class ReevaluateExpressionExecutorTest {
 			// Product 100 faceted, product 200 not
 			assertFacetPresent(testTarget.globalIndex(), REFERENCE_NAME, 1, 3, 100);
 			assertFacetAbsent(testTarget.globalIndex(), REFERENCE_NAME, 3, 200);
+		}
+
+		/**
+		 * Reproduces production `INVALID_ARGUMENT` failure (issue #1233): catalog `senesi`,
+		 * `ParameterValue` upsert blowing up with `A total of 2 constraints were found in a query,
+		 * but expected is only one!`.
+		 *
+		 * `ReevaluateExpressionExecutor.evaluateCondition` decides whether per-group evaluation is
+		 * required by calling `FinderVisitor.findConstraint(filter, GroupHaving.class::isInstance)`.
+		 * The singular variant throws `MoreThanSingleResultException` when more than one match is
+		 * found in the constraint tree — but the caller only wants an existence check.
+		 *
+		 * `ExpressionToQueryTranslator` wraps each sibling `$reference.groupEntity?.…` predicate in
+		 * its own `groupHaving(...)`. When a reference declares two such predicates (e.g.
+		 * `bucketedPartially` and `assignedWhen` both probing group attributes), the resulting
+		 * `FilterBy` contains two `GroupHaving` siblings and the existence check incorrectly throws.
+		 */
+		@Test
+		@DisplayName("evaluateCondition must not throw when filter has multiple GroupHaving siblings")
+		void shouldNotThrowWhenFilterHasMultipleGroupHavingConstraints() {
+			// Simulates ExpressionToQueryTranslator output: two GroupHaving siblings inside the same
+			// ReferenceHaving — exactly the production shape that triggered the INVALID_ARGUMENT.
+			final FilterBy triggerFilter = new FilterBy(
+				new ReferenceHaving(
+					REFERENCE_NAME,
+					new GroupHaving(
+						new AttributeEquals("inputWidgetType", "INTERVAL")
+					),
+					new GroupHaving(
+						new AttributeEquals("bucketedPartially", true)
+					)
+				)
+			);
+
+			final StubFacetTrigger facetTrigger = new StubFacetTrigger(
+				REFERENCE_NAME, triggerFilter, DependencyType.REFERENCED_ENTITY_ATTRIBUTE
+			);
+
+			final AffectedReferenceGroup group = new AffectedReferenceGroup(
+				3, 1, new BaseBitmap(100)
+			);
+			final AffectedEntityResolution affected = new AffectedEntityResolution(List.of(group));
+
+			final TestTarget testTarget = createTestTarget(affected, ReferenceIndexType.FOR_FILTERING);
+			final IndexMutationTarget target = testTarget.target();
+			final ReevaluateExpressionMutation mutation = ReevaluateExpressionMutation.withoutOldValues(
+				REFERENCE_NAME, 3, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE
+			);
+
+			// Pre-stub evaluateFilter so the per-group code path (reachable once the fix lands)
+			// has a deterministic empty result and does not NPE on a missing stub.
+			when(target.evaluateFilter(any(FilterBy.class), eq(Scope.LIVE)))
+				.thenReturn(new BaseBitmap());
+			when(target.getFacetTrigger(REFERENCE_NAME, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE))
+				.thenReturn(facetTrigger);
+			when(target.getHistogramTriggers(REFERENCE_NAME, Scope.LIVE))
+				.thenReturn(Collections.emptyList());
+
+			// Before the fix this call propagates `MoreThanSingleResultException` with message
+			// "A total of `2` constraints were found in a query, but expected is only one!"
+			assertDoesNotThrow(() ->
+				ReevaluateExpressionExecutorTest.this.executor.execute(mutation, target)
+			);
+		}
+
+		/**
+		 * Companion regression for issue #1233: once the existence check stops throwing on multiple
+		 * sibling `GroupHaving` constraints, the per-group evaluation must still produce a
+		 * **correctly scoped** filter — i.e. the group PK must be injected into **every** sibling
+		 * `GroupHaving`, not just the first one. Otherwise the unscoped sibling would match across
+		 * all groups, producing the same cross-reference false positive that
+		 * `shouldPreventCrossReferenceFalsePositive` proves the per-group path must prevent.
+		 */
+		@Test
+		@DisplayName("per-group evaluation injects group PK into every sibling GroupHaving")
+		void shouldInjectGroupPkIntoEverySiblingGroupHaving() {
+			final FilterBy triggerFilter = new FilterBy(
+				new ReferenceHaving(
+					REFERENCE_NAME,
+					new GroupHaving(
+						new AttributeEquals("inputWidgetType", "INTERVAL")
+					),
+					new GroupHaving(
+						new AttributeEquals("bucketedPartially", true)
+					)
+				)
+			);
+
+			final StubFacetTrigger facetTrigger = new StubFacetTrigger(
+				REFERENCE_NAME, triggerFilter, DependencyType.REFERENCED_ENTITY_ATTRIBUTE
+			);
+
+			final AffectedReferenceGroup group = new AffectedReferenceGroup(
+				3, 1, new BaseBitmap(100)
+			);
+			final AffectedEntityResolution affected = new AffectedEntityResolution(List.of(group));
+
+			final TestTarget testTarget = createTestTarget(affected, ReferenceIndexType.FOR_FILTERING);
+			final IndexMutationTarget target = testTarget.target();
+			final ReevaluateExpressionMutation mutation = ReevaluateExpressionMutation.withoutOldValues(
+				REFERENCE_NAME, 3, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE
+			);
+
+			when(target.evaluateFilter(any(FilterBy.class), eq(Scope.LIVE)))
+				.thenReturn(new BaseBitmap());
+			when(target.getFacetTrigger(REFERENCE_NAME, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE))
+				.thenReturn(facetTrigger);
+			when(target.getHistogramTriggers(REFERENCE_NAME, Scope.LIVE))
+				.thenReturn(Collections.emptyList());
+
+			// Act
+			ReevaluateExpressionExecutorTest.this.executor.execute(mutation, target);
+
+			// Capture the parameterized filter sent to evaluateFilter.
+			final ArgumentCaptor<FilterBy> filterCaptor = ArgumentCaptor.forClass(FilterBy.class);
+			verify(target).evaluateFilter(filterCaptor.capture(), eq(Scope.LIVE));
+
+			// Both sibling GroupHaving constraints must contain entityPrimaryKeyInSet(groupPK=1).
+			final List<GroupHaving> groupHavings = FinderVisitor.findConstraints(
+				filterCaptor.getValue(), GroupHaving.class::isInstance
+			);
+			assertEquals(
+				2, groupHavings.size(),
+				"Parameterized filter should preserve both sibling GroupHaving constraints"
+			);
+			for (final GroupHaving groupHaving : groupHavings) {
+				assertTrue(
+					containsPKInSet(groupHaving.getChildren(), 1),
+					"GroupHaving must contain entityPrimaryKeyInSet(1) after per-group injection"
+				);
+			}
+		}
+
+		/**
+		 * Pre-existing limitation surfaced while fixing issue #1233: `parameterize` /
+		 * `parameterizeWithGroupScope` previously walked only the top-level direct children of
+		 * `FilterBy`. When the trigger filter wrapped its `ReferenceHaving` instances in an
+		 * `Or` (e.g. expression `attrA == X || attrB == Y` on the same reference), neither inner
+		 * `ReferenceHaving` was reached and PK scope injection was silently skipped — producing
+		 * cross-reference false positives identical to the in-group sibling case.
+		 *
+		 * The fix routes PK injection through `ConstraintCloneVisitor`, which recurses through
+		 * any container (`Or`, `And`, `Not`, ...) so every matching `ReferenceHaving` is rewritten
+		 * regardless of nesting depth.
+		 */
+		@Test
+		@DisplayName("per-group evaluation injects group PK into every Or-branch ReferenceHaving")
+		void shouldInjectGroupPkIntoEveryOrBranchReferenceHaving() {
+			final FilterBy triggerFilter = new FilterBy(
+				new Or(
+					new ReferenceHaving(
+						REFERENCE_NAME,
+						new GroupHaving(
+							new AttributeEquals("inputWidgetType", "INTERVAL")
+						)
+					),
+					new ReferenceHaving(
+						REFERENCE_NAME,
+						new GroupHaving(
+							new AttributeEquals("bucketedPartially", true)
+						)
+					)
+				)
+			);
+
+			final StubFacetTrigger facetTrigger = new StubFacetTrigger(
+				REFERENCE_NAME, triggerFilter, DependencyType.REFERENCED_ENTITY_ATTRIBUTE
+			);
+
+			final AffectedReferenceGroup group = new AffectedReferenceGroup(
+				3, 1, new BaseBitmap(100)
+			);
+			final AffectedEntityResolution affected = new AffectedEntityResolution(List.of(group));
+
+			final TestTarget testTarget = createTestTarget(affected, ReferenceIndexType.FOR_FILTERING);
+			final IndexMutationTarget target = testTarget.target();
+			final ReevaluateExpressionMutation mutation = ReevaluateExpressionMutation.withoutOldValues(
+				REFERENCE_NAME, 3, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE
+			);
+
+			when(target.evaluateFilter(any(FilterBy.class), eq(Scope.LIVE)))
+				.thenReturn(new BaseBitmap());
+			when(target.getFacetTrigger(REFERENCE_NAME, DependencyType.REFERENCED_ENTITY_ATTRIBUTE, Scope.LIVE))
+				.thenReturn(facetTrigger);
+			when(target.getHistogramTriggers(REFERENCE_NAME, Scope.LIVE))
+				.thenReturn(Collections.emptyList());
+
+			// Act
+			ReevaluateExpressionExecutorTest.this.executor.execute(mutation, target);
+
+			// Capture the parameterized filter sent to evaluateFilter.
+			final ArgumentCaptor<FilterBy> filterCaptor = ArgumentCaptor.forClass(FilterBy.class);
+			verify(target).evaluateFilter(filterCaptor.capture(), eq(Scope.LIVE));
+
+			// Both ReferenceHavings nested under the Or must have been rewritten so their inner
+			// GroupHaving contains the group PK (=1). Before the fix, neither was touched.
+			final List<GroupHaving> groupHavings = FinderVisitor.findConstraints(
+				filterCaptor.getValue(), GroupHaving.class::isInstance
+			);
+			assertEquals(
+				2, groupHavings.size(),
+				"Parameterized filter should preserve both Or-branch GroupHaving constraints"
+			);
+			for (final GroupHaving groupHaving : groupHavings) {
+				assertTrue(
+					containsPKInSet(groupHaving.getChildren(), 1),
+					"GroupHaving must contain entityPrimaryKeyInSet(1) after per-group injection"
+				);
+			}
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/ReevaluateExpressionExecutorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/ReevaluateExpressionExecutorTest.java
@@ -1019,15 +1019,14 @@ class ReevaluateExpressionExecutorTest {
 		}
 
 		/**
-		 * Review safeguard (Copilot, PR #1235): the recursive PK-scope rewrite must only target
-		 * **owner-scope** `ReferenceHaving` clauses. The expression translator emits nested
-		 * `referenceHaving(otherRef, …)` inside an enclosing `entityHaving(…)` for
-		 * `REFERENCED_ENTITY_REFERENCE_ATTRIBUTE` paths (and inside `groupHaving(…)` for
-		 * `GROUP_ENTITY_REFERENCE_ATTRIBUTE`). Those inner clauses live in a *different* entity
-		 * scope — the referenced entity's own references — and their PK constraints must not be
-		 * merged with the owner-scope mutation's PK. When the inner reference happens to share
-		 * the same name as the mutation's owner reference (e.g. self-referencing schemas), the
-		 * rewrite must skip the inner clause.
+		 * The recursive PK-scope rewrite must only target **owner-scope** `ReferenceHaving` clauses.
+		 * The expression translator emits nested `referenceHaving(otherRef, …)` inside an enclosing
+		 * `entityHaving(…)` for `REFERENCED_ENTITY_REFERENCE_ATTRIBUTE` paths (and inside
+		 * `groupHaving(…)` for `GROUP_ENTITY_REFERENCE_ATTRIBUTE`). Those inner clauses live in a
+		 * *different* entity scope — the referenced entity's own references — and their PK
+		 * constraints must not be merged with the owner-scope mutation's PK. When the inner
+		 * reference happens to share the same name as the mutation's owner reference (e.g.
+		 * self-referencing schemas), the rewrite must skip the inner clause.
 		 *
 		 * Without the `isWithin(EntityHaving.class)` guard, the inner `ReferenceHaving`'s body
 		 * would be silently augmented with `entityPrimaryKeyInSet(...)` of the owner-entity PK,


### PR DESCRIPTION
## Summary

Closes #1233.

Cross-entity re-evaluation in `ReevaluateExpressionExecutor` failed two ways when a reference declared more than one `groupEntity?.…` predicate or wrapped multiple `ReferenceHaving` constraints under an `Or`:

- The presence check used singular `FinderVisitor.findConstraint(...)` for `GroupHaving`. With two siblings present (e.g. `bucketedPartially` + `assignedWhen`), the singular variant throws `MoreThanSingleResultException` and production `ParameterValue` upserts crashed with `INVALID_ARGUMENT: A total of 2 constraints were found in a query, but expected is only one!`.
- Once the presence check passed, `injectPkScope` only mutated the first matching `GroupHaving`/`EntityHaving`, and `parameterize` / `parameterizeWithGroupScope` only walked the FilterBy's top-level direct children. Any sibling scope container or any `ReferenceHaving` nested inside `Or`/`And`/`Not` was left unscoped — silently producing the cross-reference false positive the per-group path is meant to prevent.

## Changes

- `evaluateCondition` now uses the plural `FinderVisitor.findConstraints(...).isEmpty()` existence check.
- `injectPkScope` iterates every sibling scope container, not just the first.
- `parameterize` and `parameterizeWithGroupScope` delegate to a new `rewriteMatchingReferenceHavings` helper that routes the walk through `ConstraintCloneVisitor`, recursing through every container the constraint model defines.
- Three new regression tests in `ReevaluateExpressionExecutorTest`:
  - the original `MoreThanSingleResultException` reproducer
  - a sibling-`GroupHaving` PK-injection assertion
  - an `Or`-branch PK-injection assertion

## Test plan

- [x] `mvn test -pl evita_test/evita_functional_tests -Dtest=ReevaluateExpressionExecutorTest` — 25/0/0/0
- [x] `mvn test -pl evita_test/evita_functional_tests -Dtest=ConditionalFacetIndexingTest` — 88/0/0/0
- [x] `mvn test -pl evita_test/evita_functional_tests -Dtest=ConditionalBucketIndexingTest` — 93/0/0/0