### PR TITLE
fix: apply indexedDecimalPlaces for BigDecimalNumberRange attributes

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzer.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzer.java
@@ -37,6 +37,7 @@ import io.evitadb.api.requestResponse.schema.ReflectedReferenceSchemaEditor.Refl
 import io.evitadb.api.requestResponse.schema.SortableAttributeCompoundSchemaContract.AttributeElement;
 import io.evitadb.api.requestResponse.schema.mutation.LocalCatalogSchemaMutation;
 import io.evitadb.api.query.expression.ExpressionFactory;
+import io.evitadb.dataType.BigDecimalNumberRange;
 import io.evitadb.dataType.ComplexDataObject;
 import io.evitadb.dataType.EvitaDataTypes;
 import io.evitadb.dataType.Scope;
@@ -387,8 +388,10 @@ public class ClassSchemaAnalyzer {
 			} else if (!attributeAnnotation.localized() && editor.isLocalized()) {
 				editor.nonLocalized();
 			}
-			// indexed decimal places - only set if different
-			if (BigDecimal.class.equals(attributeType) &&
+			// indexed decimal places - applies to BigDecimal and BigDecimalNumberRange (incl. array variants),
+			// whose values are scaled to comparable longs using this decimal-places count for filtering/sorting
+			final Class<?> indexedBaseType = attributeType.isArray() ? attributeType.getComponentType() : attributeType;
+			if ((BigDecimal.class.equals(indexedBaseType) || BigDecimalNumberRange.class.equals(indexedBaseType)) &&
 				editor.getIndexedDecimalPlaces() != attributeAnnotation.indexedDecimalPlaces()) {
 				editor.indexDecimalPlaces(attributeAnnotation.indexedDecimalPlaces());
 			}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
@@ -58,6 +58,7 @@ import io.evitadb.api.requestResponse.schema.mutation.reference.ScopedHistogramI
 import io.evitadb.api.requestResponse.schema.mutation.reference.SetReferenceSchemaFacetedMutation;
 import io.evitadb.api.requestResponse.schema.mutation.sortableAttributeCompound.CreateSortableAttributeCompoundSchemaMutation;
 import io.evitadb.core.Evita;
+import io.evitadb.dataType.BigDecimalNumberRange;
 import io.evitadb.dataType.ComplexDataObject;
 import io.evitadb.dataType.Scope;
 import io.evitadb.test.EvitaTestSupport;
@@ -85,6 +86,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static io.evitadb.test.TestTags.ATTRIBUTE;
 import static io.evitadb.test.TestTags.CONTRACT;
 import static io.evitadb.test.TestTags.HISTOGRAM;
 import static io.evitadb.test.TestTags.REFERENCE;
@@ -4342,6 +4344,34 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 				assertNotNull(
 					bucketedPartially[0].expression(),
 					"bucketedPartially expression must not be null"
+				);
+			}
+		);
+	}
+
+	@DisplayName("indexedDecimalPlaces is propagated for a BigDecimalNumberRange attribute")
+	@Tag(ATTRIBUTE)
+	@Test
+	void shouldApplyIndexedDecimalPlacesForBigDecimalNumberRangeAttribute() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityWithBigDecimalNumberRangeAttribute.class);
+
+				final AttributeSchemaContract priceRangeAttr = session
+					.getEntitySchema("BigDecimalRangeEntity")
+					.orElseThrow()
+					.getAttribute("priceRange")
+					.orElseThrow();
+
+				assertSame(
+					BigDecimalNumberRange.class, priceRangeAttr.getType(),
+					"Attribute `priceRange` must be of type BigDecimalNumberRange"
+				);
+				assertEquals(
+					2, priceRangeAttr.getIndexedDecimalPlaces(),
+					"indexedDecimalPlaces must be 2 for BigDecimalNumberRange attribute; " +
+						"was dropped to 0 due to missing type check"
 				);
 			}
 		);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/ClassSchemaAnalyzerTest.java
@@ -4377,6 +4377,34 @@ class ClassSchemaAnalyzerTest implements EvitaTestSupport {
 		);
 	}
 
+	@DisplayName("indexedDecimalPlaces is propagated for a BigDecimal array attribute")
+	@Tag(ATTRIBUTE)
+	@Test
+	void shouldApplyIndexedDecimalPlacesForBigDecimalArrayAttribute() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchemaFromModelClass(GetterBasedEntityWithBigDecimalNumberRangeAttribute.class);
+
+				final AttributeSchemaContract pricesAttr = session
+					.getEntitySchema("BigDecimalRangeEntity")
+					.orElseThrow()
+					.getAttribute("prices")
+					.orElseThrow();
+
+				assertSame(
+					BigDecimal[].class, pricesAttr.getType(),
+					"Attribute `prices` must be of type BigDecimal[]"
+				);
+				assertEquals(
+					3, pricesAttr.getIndexedDecimalPlaces(),
+					"indexedDecimalPlaces must be 3 for BigDecimal[] attribute; " +
+						"the array component type must be unwrapped before the type check"
+				);
+			}
+		);
+	}
+
 	@DisplayName("Reflected reference faceted tri-state is propagated into mutations")
 	@Nested
 	class ReflectedReferenceFacetedTriState {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithBigDecimalNumberRangeAttribute.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithBigDecimalNumberRangeAttribute.java
@@ -29,12 +29,14 @@ import io.evitadb.api.requestResponse.data.annotation.PrimaryKey;
 import io.evitadb.dataType.BigDecimalNumberRange;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 
 /**
  * Minimal entity model used to verify that {@code indexedDecimalPlaces} declared on a
- * {@link BigDecimalNumberRange} attribute is correctly propagated to the schema mutation.
+ * {@link BigDecimalNumberRange} attribute — and on a {@link BigDecimal} array attribute —
+ * is correctly propagated to the schema.
  *
- * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 @Entity(name = "BigDecimalRangeEntity")
 public interface GetterBasedEntityWithBigDecimalNumberRangeAttribute {
@@ -49,5 +51,13 @@ public interface GetterBasedEntityWithBigDecimalNumberRangeAttribute {
 	@Attribute(indexedDecimalPlaces = 2, filterable = true, nullable = true)
 	@Nullable
 	BigDecimalNumberRange getPriceRange();
+
+	/**
+	 * An array attribute over BigDecimal values. The {@code indexedDecimalPlaces = 3} exercises the
+	 * array-component-type branch of the schema analyzer's decimal-places propagation.
+	 */
+	@Attribute(indexedDecimalPlaces = 3, filterable = true, nullable = true)
+	@Nullable
+	BigDecimal[] getPrices();
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithBigDecimalNumberRangeAttribute.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/schema/model/GetterBasedEntityWithBigDecimalNumberRangeAttribute.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.schema.model;
+
+import io.evitadb.api.requestResponse.data.annotation.Attribute;
+import io.evitadb.api.requestResponse.data.annotation.Entity;
+import io.evitadb.api.requestResponse.data.annotation.PrimaryKey;
+import io.evitadb.dataType.BigDecimalNumberRange;
+
+import javax.annotation.Nullable;
+
+/**
+ * Minimal entity model used to verify that {@code indexedDecimalPlaces} declared on a
+ * {@link BigDecimalNumberRange} attribute is correctly propagated to the schema mutation.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ */
+@Entity(name = "BigDecimalRangeEntity")
+public interface GetterBasedEntityWithBigDecimalNumberRangeAttribute {
+
+	@PrimaryKey
+	int getId();
+
+	/**
+	 * A range attribute over BigDecimal values. The {@code indexedDecimalPlaces = 2} instructs
+	 * evitaDB to encode range bounds to comparable longs at two decimal places of precision.
+	 */
+	@Attribute(indexedDecimalPlaces = 2, filterable = true, nullable = true)
+	@Nullable
+	BigDecimalNumberRange getPriceRange();
+
+}


### PR DESCRIPTION
Closes #1236

## Problem
`ClassSchemaAnalyzer.defineAttribute` propagated the `@Attribute(indexedDecimalPlaces = N)` value to the schema only when the attribute type was **exactly** `BigDecimal`. For `BigDecimalNumberRange` attributes — and array variants of either `BigDecimal` or `BigDecimalNumberRange` — the annotation was silently dropped, leaving `indexedDecimalPlaces = 0`.

Because `BigDecimalNumberRange` encodes its bounds into comparable longs using exactly this scale (`BigDecimalNumberRange.toComparableLong(BigDecimal, int)`), range bounds with fractional digits lost precision in the index, producing incorrect `inRange` / `between` results. The misconfiguration was silent — no exception, no warning.

## Fix
The type guard now unwraps the array component type and matches both `BigDecimal` and `BigDecimalNumberRange`, applying `indexedDecimalPlaces` identically for all of them.

## Test
Added regression test `shouldApplyIndexedDecimalPlacesForBigDecimalNumberRangeAttribute` (with a minimal `BigDecimalNumberRange` model entity) asserting the effective schema reports the declared scale. The assertion targets the effective schema rather than `CreateAttributeSchemaMutation`, since `indexDecimalPlaces` rides a separate `ModifyAttributeSchemaTypeMutation`. Verified RED before the fix (`expected: <2> but was: <0>`) and GREEN after; the full `ClassSchemaAnalyzerTest` suite (92 tests) passes.
