### PR TITLE
Fix BigDecimalNumberRange value scale not normalized to indexedDecimalPlaces

### DIFF
--- a/evita_common/src/main/java/io/evitadb/dataType/BigDecimalNumberRange.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/BigDecimalNumberRange.java
@@ -73,7 +73,11 @@ public final class BigDecimalNumberRange extends NumberRange<BigDecimal> {
 	 * @param retainedDecimalPlaces defines how many fractional places will be kept for comparison
 	 */
 	@Nonnull
-	public static BigDecimalNumberRange between(@Nonnull BigDecimal from, @Nonnull BigDecimal to, int retainedDecimalPlaces) {
+	public static BigDecimalNumberRange between(
+		@Nonnull BigDecimal from,
+		@Nonnull BigDecimal to,
+		int retainedDecimalPlaces
+	) {
 		return new BigDecimalNumberRange(from, to, retainedDecimalPlaces);
 	}
 
@@ -123,19 +127,9 @@ public final class BigDecimalNumberRange extends NumberRange<BigDecimal> {
 	 */
 	@Nonnull
 	public static BigDecimalNumberRange fromString(@Nonnull String string) throws DataTypeParseException {
-		Assert.isTrue(
-			string.startsWith(OPEN_CHAR) && string.endsWith(CLOSE_CHAR),
-			() -> new DataTypeParseException("NumberRange must start with " + OPEN_CHAR + " and end with " + CLOSE_CHAR + "!")
-		);
-		final int delimiter = string.indexOf(INTERVAL_JOIN, 1);
-		Assert.isTrue(
-			delimiter > -1,
-			() -> new DataTypeParseException("NumberRange must contain " + INTERVAL_JOIN + " to separate from and to values!")
-		);
-		final BigDecimal from = delimiter == 1 ? null : parseBigDecimal(string.substring(1, delimiter));
-		final BigDecimal to = delimiter == string.length() - 2 ? null : parseBigDecimal(string.substring(delimiter + 1, string.length() - 1));
-		return Range.materializeOpenEndedRange(
-			from, to, BigDecimalNumberRange::to, BigDecimalNumberRange::from, BigDecimalNumberRange::between
+		return Range.parseRange(
+			string, BigDecimalNumberRange::parseBigDecimal,
+			BigDecimalNumberRange::to, BigDecimalNumberRange::from, BigDecimalNumberRange::between
 		);
 	}
 
@@ -146,7 +140,11 @@ public final class BigDecimalNumberRange extends NumberRange<BigDecimal> {
 	 * Do not use this method from in the client code!
 	 */
 	@Nonnull
-	public static BigDecimalNumberRange _internalBuild(@Nullable BigDecimal from, @Nullable BigDecimal to, @Nullable Integer retainedDecimalPlaces, long fromToCompare, long toToCompare) {
+	public static BigDecimalNumberRange _internalBuild(
+		@Nullable BigDecimal from, @Nullable BigDecimal to,
+		@Nullable Integer retainedDecimalPlaces,
+		long fromToCompare, long toToCompare
+	) {
 		return new BigDecimalNumberRange(from, to, retainedDecimalPlaces, fromToCompare, toToCompare);
 	}
 
@@ -160,12 +158,19 @@ public final class BigDecimalNumberRange extends NumberRange<BigDecimal> {
 	 * @return A new BigDecimalNumberRange representing the union (convex hull) of rangeA and rangeB.
 	 */
 	@Nonnull
-	public static BigDecimalNumberRange union(@Nonnull BigDecimalNumberRange rangeA, @Nonnull BigDecimalNumberRange rangeB) {
+	public static BigDecimalNumberRange union(
+		@Nonnull BigDecimalNumberRange rangeA,
+		@Nonnull BigDecimalNumberRange rangeB
+	) {
 		if (rangeA == INFINITE || rangeB == INFINITE) {
 			return INFINITE;
 		} else {
-			final BigDecimal from = rangeA.from == null ? null : (rangeB.from == null ? null : rangeA.from.min(rangeB.from));
-			final BigDecimal to = rangeA.to == null ? null : (rangeB.to == null ? null : rangeA.to.max(rangeB.to));
+			final BigDecimal from = rangeA.from == null
+				? null
+				: (rangeB.from == null ? null : rangeA.from.min(rangeB.from));
+			final BigDecimal to = rangeA.to == null
+				? null
+				: (rangeB.to == null ? null : rangeA.to.max(rangeB.to));
 			final boolean leftLesserThanRight = from != null && to != null && from.compareTo(to) > 0;
 			final BigDecimal recalculatedFrom = leftLesserThanRight ? to : from;
 			final BigDecimal recalculatedTo = leftLesserThanRight ? from : to;
@@ -176,8 +181,12 @@ public final class BigDecimalNumberRange extends NumberRange<BigDecimal> {
 					recalculatedFrom,
 					recalculatedTo,
 					Math.max(
-						rangeA.retainedDecimalPlaces == null ? resolveDefaultRetainedDecimalPlaces(rangeA.from, rangeA.to) : rangeA.retainedDecimalPlaces,
-						rangeB.retainedDecimalPlaces == null ? resolveDefaultRetainedDecimalPlaces(rangeB.from, rangeB.to) : rangeB.retainedDecimalPlaces
+						rangeA.retainedDecimalPlaces == null
+							? resolveDefaultRetainedDecimalPlaces(rangeA.from, rangeA.to)
+							: rangeA.retainedDecimalPlaces,
+						rangeB.retainedDecimalPlaces == null
+							? resolveDefaultRetainedDecimalPlaces(rangeB.from, rangeB.to)
+							: rangeB.retainedDecimalPlaces
 					)
 				);
 			}
@@ -193,18 +202,29 @@ public final class BigDecimalNumberRange extends NumberRange<BigDecimal> {
 	 * @return A new BigDecimalNumberRange representing the intersection of rangeA and rangeB.
 	 */
 	@Nonnull
-	public static BigDecimalNumberRange intersect(@Nonnull BigDecimalNumberRange rangeA, @Nonnull BigDecimalNumberRange rangeB) {
+	public static BigDecimalNumberRange intersect(
+		@Nonnull BigDecimalNumberRange rangeA,
+		@Nonnull BigDecimalNumberRange rangeB
+	) {
 		if (rangeA == INFINITE && rangeB == INFINITE) {
 			return INFINITE;
 		} else {
-			final BigDecimal from = rangeA.from == null ? rangeB.from : (rangeB.from == null ? rangeA.from : rangeA.from.max(rangeB.from));
-			final BigDecimal to = rangeA.to == null ? rangeB.to : (rangeB.to == null ? rangeA.to : rangeA.to.min(rangeB.to));
+			final BigDecimal from = rangeA.from == null
+				? rangeB.from
+				: (rangeB.from == null ? rangeA.from : rangeA.from.max(rangeB.from));
+			final BigDecimal to = rangeA.to == null
+				? rangeB.to
+				: (rangeB.to == null ? rangeA.to : rangeA.to.min(rangeB.to));
 			if (rangeA.overlaps(rangeB) && (from != null || to != null)) {
 				return new BigDecimalNumberRange(
 					from, to,
 					Math.max(
-						rangeA.retainedDecimalPlaces == null ? resolveDefaultRetainedDecimalPlaces(rangeA.from, rangeA.to) : rangeA.retainedDecimalPlaces,
-						rangeB.retainedDecimalPlaces == null ? resolveDefaultRetainedDecimalPlaces(rangeB.from, rangeB.to) : rangeB.retainedDecimalPlaces
+						rangeA.retainedDecimalPlaces == null
+							? resolveDefaultRetainedDecimalPlaces(rangeA.from, rangeA.to)
+							: rangeA.retainedDecimalPlaces,
+						rangeB.retainedDecimalPlaces == null
+							? resolveDefaultRetainedDecimalPlaces(rangeB.from, rangeB.to)
+							: rangeB.retainedDecimalPlaces
 					)
 				);
 			} else {
@@ -212,13 +232,6 @@ public final class BigDecimalNumberRange extends NumberRange<BigDecimal> {
 				return INFINITE;
 			}
 		}
-	}
-
-	@Override
-	public boolean isWithin(@Nonnull BigDecimal valueToCheck) {
-		Assert.notNull(valueToCheck, "Cannot resolve within range with NULL value!");
-		final long valueToCompare = toComparableLong(valueToCheck, ofNullable(this.retainedDecimalPlaces).orElse(0), 0L);
-		return this.fromToCompare <= valueToCompare && valueToCompare <= this.toToCompare;
 	}
 
 	@Nonnull
@@ -230,11 +243,30 @@ public final class BigDecimalNumberRange extends NumberRange<BigDecimal> {
 		}
 	}
 
+	/**
+	 * If no explicit retained places were passed from client, places are resolved from actual numbers.
+	 */
+	private static int resolveDefaultRetainedDecimalPlaces(@Nullable BigDecimal from, @Nullable BigDecimal to) {
+		if (from == null && to == null) {
+			return 0;
+		}
+		if (from == null) {
+			return to.scale();
+		} else if (to == null) {
+			return from.scale();
+		} else {
+			return Math.max(from.scale(), to.scale());
+		}
+	}
+
 	private BigDecimalNumberRange() {
 		super(null, null, 0, Long.MIN_VALUE, Long.MAX_VALUE);
 	}
 
-	private BigDecimalNumberRange(@Nullable BigDecimal from, @Nullable BigDecimal to, @Nullable Integer retainedDecimalPlaces, long fromToCompare, long toToCompare) {
+	private BigDecimalNumberRange(
+		@Nullable BigDecimal from, @Nullable BigDecimal to, @Nullable Integer retainedDecimalPlaces, long fromToCompare,
+		long toToCompare
+	) {
 		super(from, to, retainedDecimalPlaces, fromToCompare, toToCompare);
 	}
 
@@ -256,6 +288,13 @@ public final class BigDecimalNumberRange extends NumberRange<BigDecimal> {
 		);
 		assertEitherBoundaryNotNull(from, to);
 		assertFromLesserThanTo(from, to);
+	}
+
+	@Override
+	public boolean isWithin(@Nonnull BigDecimal valueToCheck) {
+		Assert.notNull(valueToCheck, "Cannot resolve within range with NULL value!");
+		final long valueToCompare = toComparableLong(valueToCheck, getEffectiveRetainedDecimalPlaces(), 0L);
+		return this.fromToCompare <= valueToCompare && valueToCompare <= this.toToCompare;
 	}
 
 	@Nonnull
@@ -288,29 +327,28 @@ public final class BigDecimalNumberRange extends NumberRange<BigDecimal> {
 		}
 	}
 
+	/**
+	 * Returns the scale at which the comparable-long bounds ({@link #fromToCompare} /
+	 * {@link #toToCompare}) of this range are encoded, so probe values can be encoded at the very
+	 * same scale. When an explicit `retainedDecimalPlaces` was supplied it is returned verbatim;
+	 * otherwise the value falls back to the resolved default derived from the bounds' own scales
+	 * (the same scale the constructor used to compute the stored bounds) rather than to `0`.
+	 *
+	 * @return the scale at which both the stored bounds and any probe value must be encoded
+	 */
+	public int getEffectiveRetainedDecimalPlaces() {
+		return this.retainedDecimalPlaces != null
+			? this.retainedDecimalPlaces
+			: resolveDefaultRetainedDecimalPlaces(this.from, this.to);
+	}
+
 	@Override
 	protected long toComparableLong(@Nullable BigDecimal valueToCheck, long defaultValue) {
-		return toComparableLong(valueToCheck, ofNullable(this.retainedDecimalPlaces).orElse(0), defaultValue);
+		return toComparableLong(valueToCheck, getEffectiveRetainedDecimalPlaces(), defaultValue);
 	}
 
 	@Override
 	protected Class<BigDecimal> getSupportedType() {
 		return BigDecimal.class;
-	}
-
-	/**
-	 * If no explicit retained places were passed from client, places are resolved from actual numbers.
-	 */
-	private static int resolveDefaultRetainedDecimalPlaces(@Nullable BigDecimal from, @Nullable BigDecimal to) {
-		if (from == null && to == null) {
-			return 0;
-		}
-		if (from == null) {
-			return to.scale();
-		} else if (to == null) {
-			return from.scale();
-		} else {
-			return Math.max(from.scale(), to.scale());
-		}
 	}
 }

--- a/evita_common/src/main/java/io/evitadb/dataType/ByteNumberRange.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/ByteNumberRange.java
@@ -24,7 +24,6 @@
 package io.evitadb.dataType;
 
 import io.evitadb.dataType.exception.DataTypeParseException;
-import io.evitadb.utils.Assert;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -70,19 +69,9 @@ public final class ByteNumberRange extends NumberRange<Byte> {
 	 */
 	@Nonnull
 	public static ByteNumberRange fromString(@Nonnull String string) throws DataTypeParseException {
-		Assert.isTrue(
-			string.startsWith(OPEN_CHAR) && string.endsWith(CLOSE_CHAR),
-			() -> new DataTypeParseException("NumberRange must start with " + OPEN_CHAR + " and end with " + CLOSE_CHAR + "!")
-		);
-		final int delimiter = string.indexOf(INTERVAL_JOIN, 1);
-		Assert.isTrue(
-			delimiter > -1,
-			() -> new DataTypeParseException("NumberRange must contain " + INTERVAL_JOIN + " to separate from and to values!")
-		);
-		final Byte from = delimiter == 1 ? null : parseByte(string.substring(1, delimiter));
-		final Byte to = delimiter == string.length() - 2 ? null : parseByte(string.substring(delimiter + 1, string.length() - 1));
-		return Range.materializeOpenEndedRange(
-			from, to, ByteNumberRange::to, ByteNumberRange::from, ByteNumberRange::between
+		return Range.parseRange(
+			string, ByteNumberRange::parseByte,
+			ByteNumberRange::to, ByteNumberRange::from, ByteNumberRange::between
 		);
 	}
 

--- a/evita_common/src/main/java/io/evitadb/dataType/DateTimeRange.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/DateTimeRange.java
@@ -86,19 +86,9 @@ public final class DateTimeRange implements Range<OffsetDateTime>, Serializable,
 	 */
 	@Nonnull
 	public static DateTimeRange fromString(@Nonnull String string) throws DataTypeParseException {
-		Assert.isTrue(
-			string.startsWith(OPEN_CHAR) && string.endsWith(CLOSE_CHAR),
-			() -> new DataTypeParseException("DateTimeRange must start with " + OPEN_CHAR + " and end with " + CLOSE_CHAR + "!")
-		);
-		final int delimiter = string.indexOf(INTERVAL_JOIN, 1);
-		Assert.isTrue(
-			delimiter > -1,
-			() -> new DataTypeParseException("DateTimeRange must contain " + INTERVAL_JOIN + " to separate since and until dates!")
-		);
-		final OffsetDateTime since = delimiter == 1 ? null : parseDateTime(string.substring(1, delimiter));
-		final OffsetDateTime until = delimiter == string.length() - 2 ? null : parseDateTime(string.substring(delimiter + 1, string.length() - 1));
-		return Range.materializeOpenEndedRange(
-			since, until, DateTimeRange::until, DateTimeRange::since, DateTimeRange::between
+		return Range.parseRange(
+			string, DateTimeRange::parseDateTime,
+			DateTimeRange::until, DateTimeRange::since, DateTimeRange::between
 		);
 	}
 

--- a/evita_common/src/main/java/io/evitadb/dataType/IntegerNumberRange.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/IntegerNumberRange.java
@@ -24,7 +24,6 @@
 package io.evitadb.dataType;
 
 import io.evitadb.dataType.exception.DataTypeParseException;
-import io.evitadb.utils.Assert;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -70,19 +69,9 @@ public final class IntegerNumberRange extends NumberRange<Integer> {
 	 */
 	@Nonnull
 	public static IntegerNumberRange fromString(@Nonnull String string) throws DataTypeParseException {
-		Assert.isTrue(
-			string.startsWith(OPEN_CHAR) && string.endsWith(CLOSE_CHAR),
-			() -> new DataTypeParseException("NumberRange must start with " + OPEN_CHAR + " and end with " + CLOSE_CHAR + "!")
-		);
-		final int delimiter = string.indexOf(INTERVAL_JOIN, 1);
-		Assert.isTrue(
-			delimiter > -1,
-			() -> new DataTypeParseException("NumberRange must contain " + INTERVAL_JOIN + " to separate from and to values!")
-		);
-		final Integer from = delimiter == 1 ? null : parseInt(string.substring(1, delimiter));
-		final Integer to = delimiter == string.length() - 2 ? null : parseInt(string.substring(delimiter + 1, string.length() - 1));
-		return Range.materializeOpenEndedRange(
-			from, to, IntegerNumberRange::to, IntegerNumberRange::from, IntegerNumberRange::between
+		return Range.parseRange(
+			string, IntegerNumberRange::parseInt,
+			IntegerNumberRange::to, IntegerNumberRange::from, IntegerNumberRange::between
 		);
 	}
 

--- a/evita_common/src/main/java/io/evitadb/dataType/LongNumberRange.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/LongNumberRange.java
@@ -24,7 +24,6 @@
 package io.evitadb.dataType;
 
 import io.evitadb.dataType.exception.DataTypeParseException;
-import io.evitadb.utils.Assert;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -70,19 +69,9 @@ public final class LongNumberRange extends NumberRange<Long> {
 	 */
 	@Nonnull
 	public static LongNumberRange fromString(@Nonnull String string) throws DataTypeParseException {
-		Assert.isTrue(
-			string.startsWith(OPEN_CHAR) && string.endsWith(CLOSE_CHAR),
-			() -> new DataTypeParseException("NumberRange must start with " + OPEN_CHAR + " and end with " + CLOSE_CHAR + "!")
-		);
-		final int delimiter = string.indexOf(INTERVAL_JOIN, 1);
-		Assert.isTrue(
-			delimiter > -1,
-			() -> new DataTypeParseException("NumberRange must contain " + INTERVAL_JOIN + " to separate from and to values!")
-		);
-		final Long from = delimiter == 1 ? null : parseLong(string.substring(1, delimiter));
-		final Long to = delimiter == string.length() - 2 ? null : parseLong(string.substring(delimiter + 1, string.length() - 1));
-		return Range.materializeOpenEndedRange(
-			from, to, LongNumberRange::to, LongNumberRange::from, LongNumberRange::between
+		return Range.parseRange(
+			string, LongNumberRange::parseLong,
+			LongNumberRange::to, LongNumberRange::from, LongNumberRange::between
 		);
 	}
 

--- a/evita_common/src/main/java/io/evitadb/dataType/Range.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/Range.java
@@ -137,6 +137,49 @@ public sealed interface Range<T> extends Serializable permits DateTimeRange, Num
 	}
 
 	/**
+	 * Parses a range serialized in the canonical `[from,to]` form (as produced by the range `toString()` methods)
+	 * into a concrete range instance. The textual structure is identical for every range type, so the boundary
+	 * delimiting and open-ended detection are handled here; only the parsing of an individual boundary value and
+	 * the target range factories differ per type and are supplied by the caller.
+	 *
+	 * An empty boundary (e.g. `[,to]` or `[from,]`) is treated as an open end and passed as `null` to
+	 * {@link #materializeOpenEndedRange(Object, Object, Function, Function, BiFunction)}.
+	 *
+	 * @param string          the serialized range, must be wrapped in {@link #OPEN_CHAR} / {@link #CLOSE_CHAR} and
+	 *                        contain a single {@link #INTERVAL_JOIN} boundary separator
+	 * @param boundParser     parses a single boundary substring into a boundary value
+	 * @param toOnlyFactory   builds a range open on the lower end (only the upper boundary is known)
+	 * @param fromOnlyFactory builds a range open on the upper end (only the lower boundary is known)
+	 * @param betweenFactory  builds a range bounded on both ends
+	 * @param <T>             the boundary value type
+	 * @param <R>             the concrete range type
+	 * @return the parsed range instance
+	 * @throws DataTypeParseException if the string is not wrapped correctly or lacks the boundary separator
+	 */
+	@Nonnull
+	static <T, R> R parseRange(
+		@Nonnull String string,
+		@Nonnull Function<String, T> boundParser,
+		@Nonnull Function<T, R> toOnlyFactory,
+		@Nonnull Function<T, R> fromOnlyFactory,
+		@Nonnull BiFunction<T, T, R> betweenFactory
+	) {
+		Assert.isTrue(
+			string.startsWith(OPEN_CHAR) && string.endsWith(CLOSE_CHAR),
+			() -> new DataTypeParseException("Range must start with " + OPEN_CHAR + " and end with " + CLOSE_CHAR + "!")
+		);
+		final int delimiter = string.indexOf(INTERVAL_JOIN, 1);
+		Assert.isTrue(
+			delimiter > -1,
+			() -> new DataTypeParseException("Range must contain " + INTERVAL_JOIN + " to separate its boundaries!")
+		);
+		final T from = delimiter == 1 ? null : boundParser.apply(string.substring(1, delimiter));
+		final T to = delimiter == string.length() - 2 ?
+			null : boundParser.apply(string.substring(delimiter + 1, string.length() - 1));
+		return materializeOpenEndedRange(from, to, toOnlyFactory, fromOnlyFactory, betweenFactory);
+	}
+
+	/**
 	 * Lower bound of the range (inclusive). This value is used for range comparisons.
 	 */
 	long getFrom();

--- a/evita_common/src/main/java/io/evitadb/dataType/Range.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/Range.java
@@ -154,7 +154,8 @@ public sealed interface Range<T> extends Serializable permits DateTimeRange, Num
 	 * @param <T>             the boundary value type
 	 * @param <R>             the concrete range type
 	 * @return the parsed range instance
-	 * @throws DataTypeParseException if the string is not wrapped correctly or lacks the boundary separator
+	 * @throws DataTypeParseException if the string is not wrapped correctly, or does not contain exactly one
+	 *                               boundary separator
 	 */
 	@Nonnull
 	static <T, R> R parseRange(
@@ -173,9 +174,14 @@ public sealed interface Range<T> extends Serializable permits DateTimeRange, Num
 			delimiter > -1,
 			() -> new DataTypeParseException("Range must contain " + INTERVAL_JOIN + " to separate its boundaries!")
 		);
+		Assert.isTrue(
+			string.indexOf(INTERVAL_JOIN, delimiter + 1) == -1,
+			() -> new DataTypeParseException("Range must contain only a single " + INTERVAL_JOIN + " to separate its boundaries!")
+		);
 		final T from = delimiter == 1 ? null : boundParser.apply(string.substring(1, delimiter));
-		final T to = delimiter == string.length() - 2 ?
-			null : boundParser.apply(string.substring(delimiter + 1, string.length() - 1));
+		final T to = delimiter == string.length() - 2
+			? null
+			: boundParser.apply(string.substring(delimiter + 1, string.length() - 1));
 		return materializeOpenEndedRange(from, to, toOnlyFactory, fromOnlyFactory, betweenFactory);
 	}
 

--- a/evita_common/src/main/java/io/evitadb/dataType/ShortNumberRange.java
+++ b/evita_common/src/main/java/io/evitadb/dataType/ShortNumberRange.java
@@ -24,7 +24,6 @@
 package io.evitadb.dataType;
 
 import io.evitadb.dataType.exception.DataTypeParseException;
-import io.evitadb.utils.Assert;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -81,19 +80,9 @@ public final class ShortNumberRange extends NumberRange<Short> {
 	 */
 	@Nonnull
 	public static ShortNumberRange fromString(@Nonnull String string) throws DataTypeParseException {
-		Assert.isTrue(
-			string.startsWith(OPEN_CHAR) && string.endsWith(CLOSE_CHAR),
-			() -> new DataTypeParseException("NumberRange must start with " + OPEN_CHAR + " and end with " + CLOSE_CHAR + "!")
-		);
-		final int delimiter = string.indexOf(INTERVAL_JOIN, 1);
-		Assert.isTrue(
-			delimiter > -1,
-			() -> new DataTypeParseException("NumberRange must contain " + INTERVAL_JOIN + " to separate from and to values!")
-		);
-		final Short from = delimiter == 1 ? null : parseShort(string.substring(1, delimiter));
-		final Short to = delimiter == string.length() - 2 ? null : parseShort(string.substring(delimiter + 1, string.length() - 1));
-		return Range.materializeOpenEndedRange(
-			from, to, ShortNumberRange::to, ShortNumberRange::from, ShortNumberRange::between
+		return Range.parseRange(
+			string, ShortNumberRange::parseShort,
+			ShortNumberRange::to, ShortNumberRange::from, ShortNumberRange::between
 		);
 	}
 

--- a/evita_common/src/main/java/io/evitadb/utils/NumberUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/NumberUtils.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.utils;
 
+import io.evitadb.dataType.BigDecimalNumberRange;
 import io.evitadb.exception.EvitaInvalidUsageException;
 
 import javax.annotation.Nonnull;
@@ -297,6 +298,85 @@ public class NumberUtils {
 			return normalized;
 		}
 		return value;
+	}
+
+	/**
+	 * Normalizes a value into the canonical form fed to the attribute indexes at the index-write boundary.
+	 *
+	 * This is the precision-aware counterpart of {@link #normalizeIfBigDecimal(Serializable)}: in addition to
+	 * stripping trailing zeros from scalar `BigDecimal` values (so numerically equal values map to the same
+	 * inverted-index key), it re-encodes {@link BigDecimalNumberRange} values to the attribute schema's
+	 * `indexedDecimalPlaces`. A range constructed from `BigDecimal`s whose own scale differs from the schema
+	 * (e.g. via {@link BigDecimalNumberRange#between(BigDecimal, BigDecimal)}) carries comparable longs frozen
+	 * at that intrinsic scale; left unchanged, those longs would not line up with the query bounds (which are
+	 * always encoded at `indexedDecimalPlaces`), so range overlap tests would silently miss. Re-encoding here
+	 * keeps the stored value untouched (store-verbatim) while guaranteeing the range index uses the same scale
+	 * as the query side. Both directions of an index mutation (insert and remove) must run through this method
+	 * so the encoded longs stay symmetric.
+	 *
+	 * Array variants are handled element-wise (preserving `null` elements); all other types are returned
+	 * unchanged. This null-guarding of array elements is the reason this method is kept separate from
+	 * {@link #normalizeIfBigDecimal(Serializable)} rather than folded into it — do not merge the two, the
+	 * differing element handling is a deliberate behavioral distinction.
+	 *
+	 * @param value                the value to normalize for indexing
+	 * @param indexedDecimalPlaces the attribute schema's indexed decimal places — the authoritative scale used
+	 *                             to encode `BigDecimalNumberRange` bounds into comparable longs
+	 * @return the value in its canonical index form
+	 */
+	@Nonnull
+	public static Serializable normalizeForIndexing(@Nonnull Serializable value, int indexedDecimalPlaces) {
+		if (value instanceof BigDecimal bd) {
+			return normalize(bd);
+		} else if (value instanceof BigDecimalNumberRange range) {
+			return normalizeRangeForIndexing(range, indexedDecimalPlaces);
+		} else if (value instanceof BigDecimal[] bdArray) {
+			final BigDecimal[] normalized = new BigDecimal[bdArray.length];
+			for (int i = 0; i < bdArray.length; i++) {
+				normalized[i] = bdArray[i] == null ? null : normalize(bdArray[i]);
+			}
+			return normalized;
+		} else if (value instanceof BigDecimalNumberRange[] rangeArray) {
+			final BigDecimalNumberRange[] normalized = new BigDecimalNumberRange[rangeArray.length];
+			for (int i = 0; i < rangeArray.length; i++) {
+				normalized[i] = rangeArray[i] == null ?
+					null : normalizeRangeForIndexing(rangeArray[i], indexedDecimalPlaces);
+			}
+			return normalized;
+		}
+		return value;
+	}
+
+	/**
+	 * Re-encodes a {@link BigDecimalNumberRange} so its comparable-long bounds use `indexedDecimalPlaces`.
+	 * Returns the original instance when it already carries the requested scale, or when it has no bounds to
+	 * re-scale (fully open / infinite range).
+	 *
+	 * @param range                the range to re-encode
+	 * @param indexedDecimalPlaces the authoritative scale to encode the bounds with
+	 * @return a range whose comparable-long bounds are encoded at `indexedDecimalPlaces`
+	 */
+	@Nonnull
+	private static BigDecimalNumberRange normalizeRangeForIndexing(
+		@Nonnull BigDecimalNumberRange range,
+		int indexedDecimalPlaces
+	) {
+		if (range.getEffectiveRetainedDecimalPlaces() == indexedDecimalPlaces) {
+			// already encoded at the requested scale (explicitly or by natural bound scale) - nothing to do
+			return range;
+		}
+		final BigDecimal from = range.getPreciseFrom();
+		final BigDecimal to = range.getPreciseTo();
+		if (from != null && to != null) {
+			return BigDecimalNumberRange.between(from, to, indexedDecimalPlaces);
+		} else if (from != null) {
+			return BigDecimalNumberRange.from(from, indexedDecimalPlaces);
+		} else if (to != null) {
+			return BigDecimalNumberRange.to(to, indexedDecimalPlaces);
+		} else {
+			// fully open / infinite range - no bounds to encode
+			return range;
+		}
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeInRangeTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeInRangeTranslator.java
@@ -207,7 +207,12 @@ public class AttributeInRangeTranslator extends AbstractAttributeTranslator
 			if (theValue instanceof BigDecimal) {
 				return BigDecimalNumberRange.toComparableLong((BigDecimal) theValue, attributeDefinition.getIndexedDecimalPlaces());
 			} else {
-				return theValue.longValue();
+				// non-BigDecimal numeric arguments must be scaled by indexedDecimalPlaces too, otherwise the
+				// probe (e.g. `90`) is encoded as a raw long while the range index holds scale-encoded bounds
+				// (e.g. `900000` at 4 decimal places) - mirrors AttributeBetweenTranslator's bound encoding
+				return BigDecimalNumberRange.toComparableLong(
+					BigDecimal.valueOf(theValue.longValue()), attributeDefinition.getIndexedDecimalPlaces()
+				);
 			}
 		} else if (DateTimeRange.class.isAssignableFrom(attributeDefinition.getPlainType())) {
 			final OffsetDateTime theMoment = ofNullable(filterConstraint.getTheMoment()).orElseGet(filterByVisitor::getNow);

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/AttributeIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/AttributeIndexMutator.java
@@ -175,11 +175,12 @@ public interface AttributeIndexMutator {
 			attributeKey.attributeName());
 		Assert.notNull(attributeDefinition, "Attribute `" + attributeKey.attributeName() + "` not defined in schema!");
 
-		final Serializable valueToInsert = NumberUtils.normalizeIfBigDecimal(
+		final Serializable valueToInsert = NumberUtils.normalizeForIndexing(
 			Objects.requireNonNull(
 				EvitaDataTypes.toTargetType(
 					attributeValue, attributeDefinition.getType(), attributeDefinition.getIndexedDecimalPlaces())
-			)
+			),
+			attributeDefinition.getIndexedDecimalPlaces()
 		);
 
 		final Scope scope = getIndexedScope(indexForRemoval, indexForUpsert);
@@ -197,7 +198,9 @@ public interface AttributeIndexMutator {
 				final Optional<AttributeValue> existingValue = existingValueSupplier.getAttributeValue(attributeKey);
 				if (existingValue.isPresent()) {
 					final AttributeValue theValue = existingValue.get();
-					final Serializable theValueToRemove = Objects.requireNonNull(theValue.value());
+					final Serializable theValueToRemove = NumberUtils.normalizeForIndexing(
+						Objects.requireNonNull(theValue.value()), attributeDefinition.getIndexedDecimalPlaces()
+					);
 					indexForRemoval.removeUniqueAttribute(
 						referenceSchema, attributeDefinition, allowedLocales, scope, locale, theValueToRemove,
 						epkForRemoval
@@ -205,7 +208,7 @@ public interface AttributeIndexMutator {
 					if (undoActionConsumer != null) {
 						undoActionConsumer.accept(
 							() -> indexForUpsert.insertUniqueAttribute(
-								referenceSchema, attributeDefinition, allowedLocales, scope, locale, theValue.value(),
+								referenceSchema, attributeDefinition, allowedLocales, scope, locale, theValueToRemove,
 								epkForRemoval
 							)
 						);
@@ -213,13 +216,13 @@ public interface AttributeIndexMutator {
 					if (!attributeDefinition.isFilterableInScope(scope)) {
 						// TOBEDONE JNO this should be replaced with RadixTree (for String values)
 						indexForRemoval.removeFilterAttribute(
-							referenceSchema, attributeDefinition, allowedLocales, locale, theValue.value(),
+							referenceSchema, attributeDefinition, allowedLocales, locale, theValueToRemove,
 							epkForRemoval
 						);
 						if (undoActionConsumer != null) {
 							undoActionConsumer.accept(
 								() -> indexForUpsert.insertFilterAttribute(
-									referenceSchema, attributeDefinition, allowedLocales, locale, theValue.value(),
+									referenceSchema, attributeDefinition, allowedLocales, locale, theValueToRemove,
 									epkForRemoval
 								)
 							);
@@ -259,7 +262,9 @@ public interface AttributeIndexMutator {
 				final Optional<AttributeValue> existingValue = existingValueSupplier.getAttributeValue(attributeKey);
 				if (existingValue.isPresent()) {
 					final AttributeValue theValue = existingValue.get();
-					final Serializable theValueToRemove = Objects.requireNonNull(theValue.value());
+					final Serializable theValueToRemove = NumberUtils.normalizeForIndexing(
+						Objects.requireNonNull(theValue.value()), attributeDefinition.getIndexedDecimalPlaces()
+					);
 					indexForRemoval.removeFilterAttribute(
 						referenceSchema, attributeDefinition, allowedLocales, locale, theValueToRemove,
 						epkForRemoval
@@ -267,7 +272,7 @@ public interface AttributeIndexMutator {
 					if (undoActionConsumer != null) {
 						undoActionConsumer.accept(
 							() -> indexForUpsert.insertFilterAttribute(
-								referenceSchema, attributeDefinition, allowedLocales, locale, theValue.value(),
+								referenceSchema, attributeDefinition, allowedLocales, locale, theValueToRemove,
 								epkForRemoval
 							)
 						);
@@ -294,7 +299,9 @@ public interface AttributeIndexMutator {
 					final int epkForRemoval = executor.getPrimaryKeyToIndex(
 						IndexType.ATTRIBUTE_SORT_INDEX, Target.EXISTING
 					);
-					final Serializable theValueToRemove = Objects.requireNonNull(theValue.value());
+					final Serializable theValueToRemove = NumberUtils.normalizeForIndexing(
+						Objects.requireNonNull(theValue.value()), attributeDefinition.getIndexedDecimalPlaces()
+					);
 					indexForRemoval.removeSortAttribute(
 						referenceSchema, attributeDefinition, allowedLocales, locale, theValueToRemove,
 						epkForRemoval
@@ -302,7 +309,7 @@ public interface AttributeIndexMutator {
 					if (undoActionConsumer != null) {
 						undoActionConsumer.accept(
 							() -> indexForUpsert.insertSortAttribute(
-								referenceSchema, attributeDefinition, allowedLocales, locale, theValue.value(),
+								referenceSchema, attributeDefinition, allowedLocales, locale, theValueToRemove,
 								epkForRemoval
 							)
 						);
@@ -334,7 +341,9 @@ public interface AttributeIndexMutator {
 				final Optional<AttributeValue> existingValue = existingValueSupplier.getAttributeValue(attributeKey);
 				if (existingValue.isPresent()) {
 					final AttributeValue theValue = existingValue.get();
-					final Serializable theValueToRemove = Objects.requireNonNull(theValue.value());
+					final Serializable theValueToRemove = NumberUtils.normalizeForIndexing(
+						Objects.requireNonNull(theValue.value()), attributeDefinition.getIndexedDecimalPlaces()
+					);
 					catalogIndex.removeUniqueAttribute(
 						entitySchema, globalAttributeSchema, allowedLocales, locale,
 						theValueToRemove, epkForRemoval
@@ -342,7 +351,7 @@ public interface AttributeIndexMutator {
 					if (undoActionConsumer != null) {
 						undoActionConsumer.accept(
 							() -> catalogIndex.insertUniqueAttribute(
-								entitySchema, globalAttributeSchema, allowedLocales, locale, theValue.value(),
+								entitySchema, globalAttributeSchema, allowedLocales, locale, theValueToRemove,
 								epkForRemoval
 							)
 						);
@@ -446,7 +455,9 @@ public interface AttributeIndexMutator {
 						executor.getPrimaryKeyToIndex(IndexType.ATTRIBUTE_INDEX, Target.EXISTING) + "!"
 				);
 				//noinspection unchecked
-				return (T) existingValue.value();
+				return (T) NumberUtils.normalizeForIndexing(
+					Objects.requireNonNull(existingValue.value()), attributeDefinition.getIndexedDecimalPlaces()
+				);
 			} else {
 				return alreadyKnownOldValue;
 			}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/BigDecimalNumberRangeValueScaleFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/BigDecimalNumberRangeValueScaleFunctionalTest.java
@@ -1,0 +1,834 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.attribute;
+
+import io.evitadb.api.requestResponse.data.EntityReferenceContract;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.core.Evita;
+import io.evitadb.dataType.BigDecimalNumberRange;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nonnull;
+import java.math.BigDecimal;
+import java.util.List;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.attributeBetween;
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
+import static io.evitadb.api.query.QueryConstraints.attributeEquals;
+import static io.evitadb.api.query.QueryConstraints.attributeInRange;
+import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.filterBy;
+import static io.evitadb.api.query.QueryConstraints.referenceContentAllWithAttributes;
+import static io.evitadb.api.query.QueryConstraints.referenceHaving;
+import static io.evitadb.test.TestConstants.TEST_CATALOG;
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.FILTER;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for the indexing of {@link BigDecimalNumberRange} attribute values whose
+ * intrinsic scale differs from the attribute schema's `indexedDecimalPlaces`.
+ *
+ * When a range value is supplied to the engine already typed as {@link BigDecimalNumberRange}
+ * (the normal Java / embedded-client case), it must be re-encoded to the schema's
+ * `indexedDecimalPlaces` before its comparable `from`/`to` longs are written into the range index.
+ * If that re-encoding is skipped, the value keeps the scale derived from the input BigDecimals
+ * (via the 2-arg {@link BigDecimalNumberRange#between(BigDecimal, BigDecimal)} factory), and the
+ * stored longs land in a different order of magnitude than the longs the query side derives from
+ * the schema's `indexedDecimalPlaces`. Overlap tests then never match and the query returns nothing
+ * even though the ranges clearly overlap.
+ *
+ * Every test here deliberately constructs values at scale 5 while the schema uses
+ * `indexedDecimalPlaces = 4`, so the input scale differs from the indexed scale (the trigger).
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("BigDecimalNumberRange attribute value scale must match indexedDecimalPlaces")
+@ExtendWith(EvitaParameterResolver.class)
+@Tag(CONTRACT)
+@Tag(FILTER)
+@Tag(ATTRIBUTE)
+class BigDecimalNumberRangeValueScaleFunctionalTest {
+	private static final int INDEXED_DECIMAL_PLACES = 4;
+	private static final String ATTR_RANGE = "priceRange";
+	private static final String ATTR_RANGE_ARRAY = "priceRanges";
+	private static final String ATTR_SCALAR = "quantity";
+	private static final String ATTR_SCALAR_ARRAY = "quantities";
+
+	/**
+	 * Core reproduction: a single {@link BigDecimalNumberRange} attribute whose value is built from
+	 * scale-5 BigDecimals while the schema indexes 4 decimal places. The query bounds overlap the
+	 * stored range, so the entity must be returned.
+	 */
+	@DisplayName("Single range value built at scale 5 must be found by overlapping attributeBetween")
+	@Test
+	void shouldFindEntityWhenRangeValueScaleDiffersFromIndexedDecimalPlaces(@Nonnull Evita evita) {
+		final String entityType = "rangeSingle";
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(entityType)
+					.withAttribute(
+						ATTR_RANGE, BigDecimalNumberRange.class,
+						whichIs -> whichIs.filterable().indexDecimalPlaces(INDEXED_DECIMAL_PLACES)
+					)
+					.updateVia(session);
+
+				// intrinsic scale 5 (differs from indexedDecimalPlaces = 4) -> triggers the bug
+				session.createNewEntity(entityType, 1)
+					.setAttribute(
+						ATTR_RANGE,
+						BigDecimalNumberRange.between(new BigDecimal("88.10000"), new BigDecimal("118.10000"))
+					)
+					.upsertVia(session);
+			}
+		);
+
+		evita.queryCatalog(TEST_CATALOG, session -> {
+			// [88.1, 118.1] clearly overlaps [88, 100]
+			final List<EntityReferenceContract> result = session.queryListOfEntityReferences(
+				query(
+					collection(entityType),
+					filterBy(attributeBetween(ATTR_RANGE, 88, 100))
+				)
+			);
+			assertEquals(
+				1, result.size(),
+				"Stored range [88.1, 118.1] (built at scale 5) overlaps query bounds [88, 100] but was " +
+					"not found - the range value was not re-encoded to indexedDecimalPlaces=" + INDEXED_DECIMAL_PLACES +
+					", so the indexed longs are at a different scale than the query bounds. Expected 1 record, got " +
+					result.size() + "."
+			);
+			assertEquals(1, result.get(0).getPrimaryKey());
+			return null;
+		});
+	}
+
+	/**
+	 * Negative control: with the same scale-5 value and same schema, query bounds that genuinely do
+	 * not overlap the stored range must return nothing. This proves the positive test above cannot
+	 * pass trivially by "always returning everything".
+	 */
+	@DisplayName("Non-overlapping attributeBetween must return nothing (negative control)")
+	@Test
+	void shouldNotFindEntityWhenRangeDoesNotOverlap(@Nonnull Evita evita) {
+		final String entityType = "rangeSingleNegative";
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(entityType)
+					.withAttribute(
+						ATTR_RANGE, BigDecimalNumberRange.class,
+						whichIs -> whichIs.filterable().indexDecimalPlaces(INDEXED_DECIMAL_PLACES)
+					)
+					.updateVia(session);
+
+				session.createNewEntity(entityType, 1)
+					.setAttribute(
+						ATTR_RANGE,
+						BigDecimalNumberRange.between(new BigDecimal("88.10000"), new BigDecimal("118.10000"))
+					)
+					.upsertVia(session);
+			}
+		);
+
+		evita.queryCatalog(TEST_CATALOG, session -> {
+			// [10, 20] does not overlap [88.1, 118.1]
+			final List<EntityReferenceContract> result = session.queryListOfEntityReferences(
+				query(
+					collection(entityType),
+					filterBy(attributeBetween(ATTR_RANGE, 10, 20))
+				)
+			);
+			assertTrue(
+				result.isEmpty(),
+				"Query bounds [10, 20] do not overlap stored range [88.1, 118.1] yet " + result.size() +
+					" record(s) were returned."
+			);
+			return null;
+		});
+	}
+
+	/**
+	 * Array variant: a {@link BigDecimalNumberRange}[] attribute where one element is built at scale 5.
+	 * A query overlapping that element must return the entity (array matches if any element overlaps).
+	 */
+	@DisplayName("Array range element built at scale 5 must be found by overlapping attributeBetween")
+	@Test
+	void shouldFindEntityWhenArrayRangeElementScaleDiffersFromIndexedDecimalPlaces(@Nonnull Evita evita) {
+		final String entityType = "rangeArray";
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(entityType)
+					.withAttribute(
+						ATTR_RANGE_ARRAY, BigDecimalNumberRange[].class,
+						whichIs -> whichIs.filterable().indexDecimalPlaces(INDEXED_DECIMAL_PLACES)
+					)
+					.updateVia(session);
+
+				final BigDecimalNumberRange[] ranges = new BigDecimalNumberRange[] {
+					// element built at scale 5 (differs from indexedDecimalPlaces = 4)
+					BigDecimalNumberRange.between(new BigDecimal("88.10000"), new BigDecimal("118.10000")),
+					// an unrelated element that must NOT match the query bounds below
+					BigDecimalNumberRange.between(new BigDecimal("500.00000"), new BigDecimal("600.00000"))
+				};
+				session.createNewEntity(entityType, 1)
+					.setAttribute(ATTR_RANGE_ARRAY, ranges)
+					.upsertVia(session);
+			}
+		);
+
+		evita.queryCatalog(TEST_CATALOG, session -> {
+			final List<EntityReferenceContract> result = session.queryListOfEntityReferences(
+				query(
+					collection(entityType),
+					filterBy(attributeBetween(ATTR_RANGE_ARRAY, 88, 100))
+				)
+			);
+			assertEquals(
+				1, result.size(),
+				"Array element [88.1, 118.1] (built at scale 5) overlaps query bounds [88, 100] but the " +
+					"entity was not found - the array range element was not re-encoded to indexedDecimalPlaces=" +
+					INDEXED_DECIMAL_PLACES + ". Expected 1 record, got " + result.size() + "."
+			);
+			assertEquals(1, result.get(0).getPrimaryKey());
+			return null;
+		});
+	}
+
+	/**
+	 * attributeInRange variant: a single numeric value that falls inside the stored scale-5 range
+	 * must locate the entity.
+	 */
+	@DisplayName("attributeInRange must find entity whose range value was built at scale 5")
+	@Test
+	void shouldFindEntityWithAttributeInRangeWhenScaleDiffers(@Nonnull Evita evita) {
+		final String entityType = "rangeInRange";
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(entityType)
+					.withAttribute(
+						ATTR_RANGE, BigDecimalNumberRange.class,
+						whichIs -> whichIs.filterable().indexDecimalPlaces(INDEXED_DECIMAL_PLACES)
+					)
+					.updateVia(session);
+
+				session.createNewEntity(entityType, 1)
+					.setAttribute(
+						ATTR_RANGE,
+						BigDecimalNumberRange.between(new BigDecimal("88.10000"), new BigDecimal("118.10000"))
+					)
+					.upsertVia(session);
+			}
+		);
+
+		evita.queryCatalog(TEST_CATALOG, session -> {
+			// 90 falls within [88.1, 118.1]
+			final List<EntityReferenceContract> result = session.queryListOfEntityReferences(
+				query(
+					collection(entityType),
+					filterBy(attributeInRange(ATTR_RANGE, 90))
+				)
+			);
+			assertEquals(
+				1, result.size(),
+				"Value 90 falls within stored range [88.1, 118.1] (built at scale 5) but the entity was " +
+					"not found via attributeInRange - the range value was not re-encoded to indexedDecimalPlaces=" +
+					INDEXED_DECIMAL_PLACES + ". Expected 1 record, got " + result.size() + "."
+			);
+			assertEquals(1, result.get(0).getPrimaryKey());
+			return null;
+		});
+	}
+
+	/**
+	 * Insert / update / remove symmetry: after the entity is upserted, its range is updated to a
+	 * different (also scale-5) value. The old bounds must no longer match (no stale index entry) and
+	 * the new bounds must match (the new value must be correctly indexed). Finally the entity is
+	 * removed and must not be found by either query.
+	 */
+	@DisplayName("Updating and removing a scale-5 range value must keep the index consistent")
+	@Test
+	void shouldKeepIndexConsistentOnUpdateAndRemove(@Nonnull Evita evita) {
+		final String entityType = "rangeUpdate";
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(entityType)
+					.withAttribute(
+						ATTR_RANGE, BigDecimalNumberRange.class,
+						whichIs -> whichIs.filterable().indexDecimalPlaces(INDEXED_DECIMAL_PLACES)
+					)
+					.updateVia(session);
+
+				session.createNewEntity(entityType, 1)
+					.setAttribute(
+						ATTR_RANGE,
+						BigDecimalNumberRange.between(new BigDecimal("88.10000"), new BigDecimal("118.10000"))
+					)
+					.upsertVia(session);
+			}
+		);
+
+		// update the range to a non-overlapping window (still scale 5)
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.getEntity(entityType, 1, attributeContentAll()).orElseThrow()
+					.openForWrite()
+					.setAttribute(
+						ATTR_RANGE,
+						BigDecimalNumberRange.between(new BigDecimal("200.10000"), new BigDecimal("230.10000"))
+					)
+					.upsertVia(session);
+			}
+		);
+
+		evita.queryCatalog(TEST_CATALOG, session -> {
+			// the OLD window [88, 100] must no longer match (no stale index entry)
+			final List<EntityReferenceContract> staleResult = session.queryListOfEntityReferences(
+				query(
+					collection(entityType),
+					filterBy(attributeBetween(ATTR_RANGE, 88, 100))
+				)
+			);
+			assertTrue(
+				staleResult.isEmpty(),
+				"After updating the range to [200.1, 230.1], the obsolete query [88, 100] still matched " +
+					staleResult.size() + " record(s) - stale index entry leaked."
+			);
+
+			// the NEW window [210, 220] must match the updated value
+			final List<EntityReferenceContract> freshResult = session.queryListOfEntityReferences(
+				query(
+					collection(entityType),
+					filterBy(attributeBetween(ATTR_RANGE, 210, 220))
+				)
+			);
+			assertEquals(
+				1, freshResult.size(),
+				"Updated range [200.1, 230.1] (built at scale 5) overlaps query [210, 220] but was not " +
+					"found - the updated range value was not re-encoded to indexedDecimalPlaces=" +
+					INDEXED_DECIMAL_PLACES + ". Expected 1 record, got " + freshResult.size() + "."
+			);
+			return null;
+		});
+
+		// remove the entity
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.deleteEntity(entityType, 1);
+			}
+		);
+
+		evita.queryCatalog(TEST_CATALOG, session -> {
+			final List<EntityReferenceContract> afterRemoval = session.queryListOfEntityReferences(
+				query(
+					collection(entityType),
+					filterBy(attributeBetween(ATTR_RANGE, 210, 220))
+				)
+			);
+			assertTrue(
+				afterRemoval.isEmpty(),
+				"After removing the entity, query [210, 220] still matched " + afterRemoval.size() +
+					" record(s) - the index was not cleaned up."
+			);
+			return null;
+		});
+	}
+
+	/**
+	 * Scalar {@link BigDecimal} counterpart of the range suite. Scalars are matched through the inverted
+	 * index, which keys values by {@code compareTo} (scale-insensitive), so a value supplied at scale 5
+	 * while the schema indexes 4 decimal places is unaffected by the range bug. These tests mirror the
+	 * range coverage (single / array / equality / update / remove) and must pass both before and after the
+	 * range fix — they document that only range attributes encode to scale-sensitive comparable longs.
+	 */
+	@Nested
+	@DisplayName("Scalar BigDecimal attribute paths (scale-insensitive control)")
+	@Tag(CONTRACT)
+	@Tag(FILTER)
+	@Tag(ATTRIBUTE)
+	class ScalarBigDecimalAttributePaths {
+
+		@DisplayName("Scalar value at scale 5 must be found by overlapping attributeBetween")
+		@Test
+		void shouldFindScalarByOverlappingAttributeBetween(@Nonnull Evita evita) {
+			final String entityType = "scalarSingle";
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(entityType)
+						.withAttribute(
+							ATTR_SCALAR, BigDecimal.class,
+							whichIs -> whichIs.filterable().indexDecimalPlaces(INDEXED_DECIMAL_PLACES)
+						)
+						.updateVia(session);
+
+					// scale 5, differs from indexedDecimalPlaces = 4
+					session.createNewEntity(entityType, 1)
+						.setAttribute(ATTR_SCALAR, new BigDecimal("88.10000"))
+						.upsertVia(session);
+				}
+			);
+
+			evita.queryCatalog(TEST_CATALOG, session -> {
+				final List<EntityReferenceContract> result = session.queryListOfEntityReferences(
+					query(
+						collection(entityType),
+						filterBy(attributeBetween(ATTR_SCALAR, new BigDecimal("88"), new BigDecimal("100")))
+					)
+				);
+				assertEquals(
+					1, result.size(),
+					"Scalar BigDecimal 88.1 (scale 5) within [88, 100] should always be found regardless of " +
+						"indexedDecimalPlaces. Expected 1 record, got " + result.size() + "."
+				);
+				assertEquals(1, result.get(0).getPrimaryKey());
+				return null;
+			});
+		}
+
+		@DisplayName("Non-overlapping attributeBetween on a scalar must return nothing (negative control)")
+		@Test
+		void shouldNotFindScalarByNonOverlappingAttributeBetween(@Nonnull Evita evita) {
+			final String entityType = "scalarSingleNegative";
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(entityType)
+						.withAttribute(
+							ATTR_SCALAR, BigDecimal.class,
+							whichIs -> whichIs.filterable().indexDecimalPlaces(INDEXED_DECIMAL_PLACES)
+						)
+						.updateVia(session);
+
+					session.createNewEntity(entityType, 1)
+						.setAttribute(ATTR_SCALAR, new BigDecimal("88.10000"))
+						.upsertVia(session);
+				}
+			);
+
+			evita.queryCatalog(TEST_CATALOG, session -> {
+				final List<EntityReferenceContract> result = session.queryListOfEntityReferences(
+					query(
+						collection(entityType),
+						filterBy(attributeBetween(ATTR_SCALAR, new BigDecimal("10"), new BigDecimal("20")))
+					)
+				);
+				assertTrue(
+					result.isEmpty(),
+					"Query bounds [10, 20] do not contain scalar 88.1 yet " + result.size() +
+						" record(s) were returned."
+				);
+				return null;
+			});
+		}
+
+		@DisplayName("attributeEquals must match a scalar regardless of the query value scale")
+		@Test
+		void shouldFindScalarByAttributeEqualsRegardlessOfScale(@Nonnull Evita evita) {
+			final String entityType = "scalarEquals";
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(entityType)
+						.withAttribute(
+							ATTR_SCALAR, BigDecimal.class,
+							whichIs -> whichIs.filterable().indexDecimalPlaces(INDEXED_DECIMAL_PLACES)
+						)
+						.updateVia(session);
+
+					// stored at scale 5
+					session.createNewEntity(entityType, 1)
+						.setAttribute(ATTR_SCALAR, new BigDecimal("88.10000"))
+						.upsertVia(session);
+				}
+			);
+
+			evita.queryCatalog(TEST_CATALOG, session -> {
+				// query value at scale 3 - numerically equal, must match (inverted index uses compareTo)
+				final List<EntityReferenceContract> result = session.queryListOfEntityReferences(
+					query(
+						collection(entityType),
+						filterBy(attributeEquals(ATTR_SCALAR, new BigDecimal("88.100")))
+					)
+				);
+				assertEquals(
+					1, result.size(),
+					"Scalar 88.10000 must match attributeEquals(88.100) - scalar equality is scale-insensitive. " +
+						"Expected 1 record, got " + result.size() + "."
+				);
+				assertEquals(1, result.get(0).getPrimaryKey());
+				return null;
+			});
+		}
+
+		@DisplayName("Scalar array element at scale 5 must be found by overlapping attributeBetween")
+		@Test
+		void shouldFindScalarArrayElementRegardlessOfScale(@Nonnull Evita evita) {
+			final String entityType = "scalarArray";
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(entityType)
+						.withAttribute(
+							ATTR_SCALAR_ARRAY, BigDecimal[].class,
+							whichIs -> whichIs.filterable().indexDecimalPlaces(INDEXED_DECIMAL_PLACES)
+						)
+						.updateVia(session);
+
+					session.createNewEntity(entityType, 1)
+						.setAttribute(
+							ATTR_SCALAR_ARRAY,
+							new BigDecimal[]{new BigDecimal("88.10000"), new BigDecimal("500.00000")}
+						)
+						.upsertVia(session);
+				}
+			);
+
+			evita.queryCatalog(TEST_CATALOG, session -> {
+				final List<EntityReferenceContract> result = session.queryListOfEntityReferences(
+					query(
+						collection(entityType),
+						filterBy(attributeBetween(ATTR_SCALAR_ARRAY, new BigDecimal("88"), new BigDecimal("100")))
+					)
+				);
+				assertEquals(
+					1, result.size(),
+					"Array element 88.1 (scale 5) within [88, 100] should always be found regardless of " +
+						"indexedDecimalPlaces. Expected 1 record, got " + result.size() + "."
+				);
+				assertEquals(1, result.get(0).getPrimaryKey());
+				return null;
+			});
+		}
+
+		@DisplayName("Updating and removing a scale-5 scalar value must keep the index consistent")
+		@Test
+		void shouldKeepScalarIndexConsistentOnUpdateAndRemove(@Nonnull Evita evita) {
+			final String entityType = "scalarUpdate";
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(entityType)
+						.withAttribute(
+							ATTR_SCALAR, BigDecimal.class,
+							whichIs -> whichIs.filterable().indexDecimalPlaces(INDEXED_DECIMAL_PLACES)
+						)
+						.updateVia(session);
+
+					session.createNewEntity(entityType, 1)
+						.setAttribute(ATTR_SCALAR, new BigDecimal("88.10000"))
+						.upsertVia(session);
+				}
+			);
+
+			// update the scalar to a different (also scale-5) value
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(entityType, 1, attributeContentAll()).orElseThrow()
+						.openForWrite()
+						.setAttribute(ATTR_SCALAR, new BigDecimal("200.10000"))
+						.upsertVia(session);
+				}
+			);
+
+			evita.queryCatalog(TEST_CATALOG, session -> {
+				// the OLD value must no longer match
+				final List<EntityReferenceContract> staleResult = session.queryListOfEntityReferences(
+					query(
+						collection(entityType),
+						filterBy(attributeBetween(ATTR_SCALAR, new BigDecimal("88"), new BigDecimal("100")))
+					)
+				);
+				assertTrue(
+					staleResult.isEmpty(),
+					"After updating the scalar to 200.1, the obsolete query [88, 100] still matched " +
+						staleResult.size() + " record(s) - stale index entry leaked."
+				);
+
+				// the NEW value must match
+				final List<EntityReferenceContract> freshResult = session.queryListOfEntityReferences(
+					query(
+						collection(entityType),
+						filterBy(attributeBetween(ATTR_SCALAR, new BigDecimal("190"), new BigDecimal("210")))
+					)
+				);
+				assertEquals(
+					1, freshResult.size(),
+					"Updated scalar 200.1 within [190, 210] was not found. Expected 1 record, got " +
+						freshResult.size() + "."
+				);
+				return null;
+			});
+
+			// remove the entity
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.deleteEntity(entityType, 1);
+				}
+			);
+
+			evita.queryCatalog(TEST_CATALOG, session -> {
+				final List<EntityReferenceContract> afterRemoval = session.queryListOfEntityReferences(
+					query(
+						collection(entityType),
+						filterBy(attributeBetween(ATTR_SCALAR, new BigDecimal("190"), new BigDecimal("210")))
+					)
+				);
+				assertTrue(
+					afterRemoval.isEmpty(),
+					"After removing the entity, query [190, 210] still matched " + afterRemoval.size() +
+						" record(s) - the index was not cleaned up."
+				);
+				return null;
+			});
+		}
+	}
+
+	/**
+	 * Reference-attribute insertion paths. Reference attributes are indexed through
+	 * {@code ReferenceIndexMutator}, which delegates to the same {@code AttributeIndexMutator} upsert /
+	 * removal routine as entity attributes. These tests assert the range-value re-encoding holds on that
+	 * route too — for single values, array variants, and across update / remove.
+	 */
+	@Nested
+	@DisplayName("Reference attribute insertion paths")
+	@Tag(CONTRACT)
+	@Tag(FILTER)
+	@Tag(ATTRIBUTE)
+	@Tag(REFERENCE)
+	class ReferenceAttributePaths {
+		private static final String PRODUCT = "product";
+		private static final String BRAND = "brand";
+
+		/**
+		 * Defines a product with an indexed reference to a brand carrying a filterable
+		 * {@link BigDecimalNumberRange} attribute, and creates a single brand to point at.
+		 */
+		private static void defineSchema(
+			@Nonnull Evita evita,
+			@Nonnull Class<? extends java.io.Serializable> rangeAttributeType,
+			@Nonnull String attributeName
+		) {
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.defineEntitySchema(BRAND).updateVia(session);
+					session.defineEntitySchema(PRODUCT)
+						.withReferenceToEntity(
+							BRAND, BRAND, Cardinality.ZERO_OR_MORE,
+							thatIs -> thatIs.indexed().withAttribute(
+								attributeName, rangeAttributeType,
+								whichIs -> whichIs.filterable().indexDecimalPlaces(INDEXED_DECIMAL_PLACES)
+							)
+						)
+						.updateVia(session);
+					session.createNewEntity(BRAND, 100).upsertVia(session);
+				}
+			);
+		}
+
+		@DisplayName("Reference range attribute built at scale 5 must be found via referenceHaving")
+		@Test
+		void shouldFindEntityByReferenceRangeAttributeBuiltAtScale5(@Nonnull Evita evita) {
+			defineSchema(evita, BigDecimalNumberRange.class, ATTR_RANGE);
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(PRODUCT, 1)
+						.setReference(
+							BRAND, 100,
+							whichIs -> whichIs.setAttribute(
+								ATTR_RANGE,
+								BigDecimalNumberRange.between(new BigDecimal("88.10000"), new BigDecimal("118.10000"))
+							)
+						)
+						.upsertVia(session);
+				}
+			);
+
+			evita.queryCatalog(TEST_CATALOG, session -> {
+				final List<EntityReferenceContract> result = session.queryListOfEntityReferences(
+					query(
+						collection(PRODUCT),
+						filterBy(referenceHaving(BRAND, attributeBetween(ATTR_RANGE, 88, 100)))
+					)
+				);
+				assertEquals(
+					1, result.size(),
+					"Reference range [88.1, 118.1] (built at scale 5) overlaps [88, 100] but the owning entity " +
+						"was not found via referenceHaving - the reference range value was not re-encoded to " +
+						"indexedDecimalPlaces=" + INDEXED_DECIMAL_PLACES + ". Expected 1 record, got " + result.size() + "."
+				);
+				assertEquals(1, result.get(0).getPrimaryKey());
+				return null;
+			});
+		}
+
+		@DisplayName("Reference range array element built at scale 5 must be found via referenceHaving")
+		@Test
+		void shouldFindEntityByReferenceRangeArrayElementBuiltAtScale5(@Nonnull Evita evita) {
+			defineSchema(evita, BigDecimalNumberRange[].class, ATTR_RANGE_ARRAY);
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(PRODUCT, 1)
+						.setReference(
+							BRAND, 100,
+							whichIs -> whichIs.setAttribute(
+								ATTR_RANGE_ARRAY,
+								new BigDecimalNumberRange[]{
+									BigDecimalNumberRange.between(new BigDecimal("88.10000"), new BigDecimal("118.10000")),
+									BigDecimalNumberRange.between(new BigDecimal("500.00000"), new BigDecimal("600.00000"))
+								}
+							)
+						)
+						.upsertVia(session);
+				}
+			);
+
+			evita.queryCatalog(TEST_CATALOG, session -> {
+				final List<EntityReferenceContract> result = session.queryListOfEntityReferences(
+					query(
+						collection(PRODUCT),
+						filterBy(referenceHaving(BRAND, attributeBetween(ATTR_RANGE_ARRAY, 88, 100)))
+					)
+				);
+				assertEquals(
+					1, result.size(),
+					"Reference range array element [88.1, 118.1] (built at scale 5) overlaps [88, 100] but the " +
+						"owning entity was not found - the reference range array element was not re-encoded to " +
+						"indexedDecimalPlaces=" + INDEXED_DECIMAL_PLACES + ". Expected 1 record, got " + result.size() + "."
+				);
+				assertEquals(1, result.get(0).getPrimaryKey());
+				return null;
+			});
+		}
+
+		@DisplayName("Updating and removing a scale-5 reference range value must keep the index consistent")
+		@Test
+		void shouldKeepReferenceIndexConsistentOnUpdateAndRemove(@Nonnull Evita evita) {
+			defineSchema(evita, BigDecimalNumberRange.class, ATTR_RANGE);
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(PRODUCT, 1)
+						.setReference(
+							BRAND, 100,
+							whichIs -> whichIs.setAttribute(
+								ATTR_RANGE,
+								BigDecimalNumberRange.between(new BigDecimal("88.10000"), new BigDecimal("118.10000"))
+							)
+						)
+						.upsertVia(session);
+				}
+			);
+
+			// update the reference attribute to a non-overlapping window (still scale 5)
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(PRODUCT, 1, attributeContentAll(), referenceContentAllWithAttributes())
+						.orElseThrow()
+						.openForWrite()
+						.setReference(
+							BRAND, 100,
+							whichIs -> whichIs.setAttribute(
+								ATTR_RANGE,
+								BigDecimalNumberRange.between(new BigDecimal("200.10000"), new BigDecimal("230.10000"))
+							)
+						)
+						.upsertVia(session);
+				}
+			);
+
+			evita.queryCatalog(TEST_CATALOG, session -> {
+				final List<EntityReferenceContract> staleResult = session.queryListOfEntityReferences(
+					query(
+						collection(PRODUCT),
+						filterBy(referenceHaving(BRAND, attributeBetween(ATTR_RANGE, 88, 100)))
+					)
+				);
+				assertTrue(
+					staleResult.isEmpty(),
+					"After updating the reference range to [200.1, 230.1], the obsolete query [88, 100] still " +
+						"matched " + staleResult.size() + " record(s) - stale reference index entry leaked."
+				);
+
+				final List<EntityReferenceContract> freshResult = session.queryListOfEntityReferences(
+					query(
+						collection(PRODUCT),
+						filterBy(referenceHaving(BRAND, attributeBetween(ATTR_RANGE, 210, 220)))
+					)
+				);
+				assertEquals(
+					1, freshResult.size(),
+					"Updated reference range [200.1, 230.1] (scale 5) overlaps [210, 220] but was not found - " +
+						"the updated reference range value was not re-encoded to indexedDecimalPlaces=" +
+						INDEXED_DECIMAL_PLACES + ". Expected 1 record, got " + freshResult.size() + "."
+				);
+				return null;
+			});
+
+			// remove the owning entity
+			evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.deleteEntity(PRODUCT, 1);
+				}
+			);
+
+			evita.queryCatalog(TEST_CATALOG, session -> {
+				final List<EntityReferenceContract> afterRemoval = session.queryListOfEntityReferences(
+					query(
+						collection(PRODUCT),
+						filterBy(referenceHaving(BRAND, attributeBetween(ATTR_RANGE, 210, 220)))
+					)
+				);
+				assertTrue(
+					afterRemoval.isEmpty(),
+					"After removing the entity, query [210, 220] still matched " + afterRemoval.size() +
+						" record(s) - the reference index was not cleaned up."
+				);
+				return null;
+			});
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/BigDecimalNumberRangeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/BigDecimalNumberRangeTest.java
@@ -31,14 +31,16 @@ import java.math.BigDecimal;
 import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.evitadb.test.TestTags.CONTRACT;
 import static io.evitadb.test.TestTags.DATA_TYPE;
 
 /**
  * Test class for the {@link BigDecimalNumberRange} set operations (union, intersection, inverse).
  *
- * @author Jan Novotn\u00fd (novotny@fg.cz), FG Forrest a.s. (c) 2024
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
 @DisplayName("BigDecimalNumberRange set operations")
 @Tag(CONTRACT)
@@ -213,6 +215,79 @@ class BigDecimalNumberRangeTest {
 			final BigDecimalNumberRange range = BigDecimalNumberRange.INFINITE;
 			final BigDecimalNumberRange result = range.inverse(2);
 			assertEquals(BigDecimalNumberRange.INFINITE, result);
+		}
+	}
+
+	@Nested
+	@DisplayName("Within")
+	class WithinTest {
+
+		@Test
+		@DisplayName("Should contain value strictly inside two-arg range with fractional inputs")
+		void shouldContainValueStrictlyInsideTwoArgRangeWithFractionalInputs() {
+			final BigDecimalNumberRange range = BigDecimalNumberRange.between(
+				new BigDecimal("88.10000"), new BigDecimal("118.10000")
+			);
+			assertTrue(range.isWithin(new BigDecimal("90")));
+			assertTrue(range.isWithin((Number) 90));
+		}
+
+		@Test
+		@DisplayName("Should contain both boundaries of two-arg range with fractional inputs")
+		void shouldContainBothBoundariesOfTwoArgRangeWithFractionalInputs() {
+			final BigDecimalNumberRange range = BigDecimalNumberRange.between(
+				new BigDecimal("88.10000"), new BigDecimal("118.10000")
+			);
+			assertTrue(range.isWithin(new BigDecimal("88.1")));
+			assertTrue(range.isWithin(new BigDecimal("118.1")));
+			assertTrue(range.isWithin((Number) new BigDecimal("88.1")));
+			assertTrue(range.isWithin((Number) new BigDecimal("118.1")));
+		}
+
+		@Test
+		@DisplayName("Should not contain values just outside two-arg range with fractional inputs")
+		void shouldNotContainValuesJustOutsideTwoArgRangeWithFractionalInputs() {
+			final BigDecimalNumberRange range = BigDecimalNumberRange.between(
+				new BigDecimal("88.10000"), new BigDecimal("118.10000")
+			);
+			assertFalse(range.isWithin(new BigDecimal("88.09")));
+			assertFalse(range.isWithin(new BigDecimal("118.11")));
+			assertFalse(range.isWithin((Number) new BigDecimal("88.09")));
+			assertFalse(range.isWithin((Number) new BigDecimal("118.11")));
+		}
+
+		@Test
+		@DisplayName("Should evaluate open-ended from-only range with fractional input")
+		void shouldEvaluateOpenEndedFromOnlyRangeWithFractionalInput() {
+			final BigDecimalNumberRange range = BigDecimalNumberRange.from(new BigDecimal("88.10000"));
+			assertTrue(range.isWithin(new BigDecimal("90")));
+			assertTrue(range.isWithin((Number) 90));
+			assertFalse(range.isWithin(new BigDecimal("88.09")));
+			assertFalse(range.isWithin((Number) new BigDecimal("88.09")));
+		}
+
+		@Test
+		@DisplayName("Should evaluate open-ended to-only range with fractional input")
+		void shouldEvaluateOpenEndedToOnlyRangeWithFractionalInput() {
+			final BigDecimalNumberRange range = BigDecimalNumberRange.to(new BigDecimal("118.10000"));
+			assertTrue(range.isWithin(new BigDecimal("90")));
+			assertTrue(range.isWithin((Number) 90));
+			assertFalse(range.isWithin(new BigDecimal("118.11")));
+			assertFalse(range.isWithin((Number) new BigDecimal("118.11")));
+		}
+
+		@Test
+		@DisplayName("Should evaluate explicit-scale three-arg range")
+		void shouldEvaluateExplicitScaleThreeArgRange() {
+			final BigDecimalNumberRange range = BigDecimalNumberRange.between(
+				new BigDecimal("88.10000"), new BigDecimal("118.10000"), 4
+			);
+			assertTrue(range.isWithin(new BigDecimal("90")));
+			assertTrue(range.isWithin((Number) 90));
+			assertTrue(range.isWithin(new BigDecimal("88.1")));
+			assertTrue(range.isWithin(new BigDecimal("118.1")));
+			assertFalse(range.isWithin(new BigDecimal("88.09")));
+			assertFalse(range.isWithin(new BigDecimal("118.11")));
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/DateTimeRangeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/DateTimeRangeTest.java
@@ -236,6 +236,7 @@ class DateTimeRangeTest {
 			assertThrows(DataTypeParseException.class, () -> DateTimeRange.fromString("[a,b]"));
 			assertThrows(DataTypeParseException.class, () -> DateTimeRange.fromString("[2021-01-01T12:22:45,2021-01-05T12:22:45]"));
 			assertThrows(DataTypeParseException.class, () -> DateTimeRange.fromString("[2021-01-01T12:22:45-03:00]"));
+			assertThrows(DataTypeParseException.class, () -> DateTimeRange.fromString("[2021-01-01T12:22:45-03:00,2021-01-02T12:22:45-03:00,2021-01-03T12:22:45-03:00]"));
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/DateTimeRangeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/DateTimeRangeTest.java
@@ -235,6 +235,7 @@ class DateTimeRangeTest {
 			assertThrows(DataTypeParseException.class, () -> DateTimeRange.fromString("[,]"));
 			assertThrows(DataTypeParseException.class, () -> DateTimeRange.fromString("[a,b]"));
 			assertThrows(DataTypeParseException.class, () -> DateTimeRange.fromString("[2021-01-01T12:22:45,2021-01-05T12:22:45]"));
+			assertThrows(DataTypeParseException.class, () -> DateTimeRange.fromString("[2021-01-01T12:22:45-03:00]"));
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/NumberRangeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/NumberRangeTest.java
@@ -551,6 +551,8 @@ class NumberRangeTest {
 			assertThrows(DataTypeParseException.class, () -> BigDecimalNumberRange.fromString("[,]"));
 			assertThrows(DataTypeParseException.class, () -> BigDecimalNumberRange.fromString("[a,b]"));
 			assertThrows(DataTypeParseException.class, () -> BigDecimalNumberRange.fromString("[5]"));
+			// wrapped correctly but contains more than one , separator
+			assertThrows(DataTypeParseException.class, () -> BigDecimalNumberRange.fromString("[1,2,3]"));
 		}
 
 		@Test
@@ -582,6 +584,8 @@ class NumberRangeTest {
 			assertThrows(DataTypeParseException.class, () -> LongNumberRange.fromString("[a,b]"));
 			// wrapped correctly but missing the , boundary separator
 			assertThrows(DataTypeParseException.class, () -> LongNumberRange.fromString("[5]"));
+			// wrapped correctly but contains more than one , separator
+			assertThrows(DataTypeParseException.class, () -> LongNumberRange.fromString("[1,2,3]"));
 		}
 
 		@Test
@@ -613,6 +617,8 @@ class NumberRangeTest {
 			assertThrows(DataTypeParseException.class, () -> IntegerNumberRange.fromString("[a,b]"));
 			// wrapped correctly but missing the , boundary separator
 			assertThrows(DataTypeParseException.class, () -> IntegerNumberRange.fromString("[5]"));
+			// wrapped correctly but contains more than one , separator
+			assertThrows(DataTypeParseException.class, () -> IntegerNumberRange.fromString("[1,2,3]"));
 		}
 
 		@Test
@@ -644,6 +650,8 @@ class NumberRangeTest {
 			assertThrows(DataTypeParseException.class, () -> ShortNumberRange.fromString("[a,b]"));
 			// wrapped correctly but missing the , boundary separator
 			assertThrows(DataTypeParseException.class, () -> ShortNumberRange.fromString("[5]"));
+			// wrapped correctly but contains more than one , separator
+			assertThrows(DataTypeParseException.class, () -> ShortNumberRange.fromString("[1,2,3]"));
 		}
 
 		@Test
@@ -675,6 +683,8 @@ class NumberRangeTest {
 			assertThrows(DataTypeParseException.class, () -> ByteNumberRange.fromString("[a,b]"));
 			// wrapped correctly but missing the , boundary separator
 			assertThrows(DataTypeParseException.class, () -> ByteNumberRange.fromString("[5]"));
+			// wrapped correctly but contains more than one , separator
+			assertThrows(DataTypeParseException.class, () -> ByteNumberRange.fromString("[1,2,3]"));
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/NumberRangeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/dataType/NumberRangeTest.java
@@ -550,6 +550,7 @@ class NumberRangeTest {
 			assertThrows(DataTypeParseException.class, () -> BigDecimalNumberRange.fromString(""));
 			assertThrows(DataTypeParseException.class, () -> BigDecimalNumberRange.fromString("[,]"));
 			assertThrows(DataTypeParseException.class, () -> BigDecimalNumberRange.fromString("[a,b]"));
+			assertThrows(DataTypeParseException.class, () -> BigDecimalNumberRange.fromString("[5]"));
 		}
 
 		@Test
@@ -579,6 +580,8 @@ class NumberRangeTest {
 			assertThrows(DataTypeParseException.class, () -> LongNumberRange.fromString(""));
 			assertThrows(DataTypeParseException.class, () -> LongNumberRange.fromString("[,]"));
 			assertThrows(DataTypeParseException.class, () -> LongNumberRange.fromString("[a,b]"));
+			// wrapped correctly but missing the , boundary separator
+			assertThrows(DataTypeParseException.class, () -> LongNumberRange.fromString("[5]"));
 		}
 
 		@Test
@@ -608,6 +611,8 @@ class NumberRangeTest {
 			assertThrows(DataTypeParseException.class, () -> IntegerNumberRange.fromString(""));
 			assertThrows(DataTypeParseException.class, () -> IntegerNumberRange.fromString("[,]"));
 			assertThrows(DataTypeParseException.class, () -> IntegerNumberRange.fromString("[a,b]"));
+			// wrapped correctly but missing the , boundary separator
+			assertThrows(DataTypeParseException.class, () -> IntegerNumberRange.fromString("[5]"));
 		}
 
 		@Test
@@ -637,6 +642,8 @@ class NumberRangeTest {
 			assertThrows(DataTypeParseException.class, () -> ShortNumberRange.fromString(""));
 			assertThrows(DataTypeParseException.class, () -> ShortNumberRange.fromString("[,]"));
 			assertThrows(DataTypeParseException.class, () -> ShortNumberRange.fromString("[a,b]"));
+			// wrapped correctly but missing the , boundary separator
+			assertThrows(DataTypeParseException.class, () -> ShortNumberRange.fromString("[5]"));
 		}
 
 		@Test
@@ -666,6 +673,8 @@ class NumberRangeTest {
 			assertThrows(DataTypeParseException.class, () -> ByteNumberRange.fromString(""));
 			assertThrows(DataTypeParseException.class, () -> ByteNumberRange.fromString("[,]"));
 			assertThrows(DataTypeParseException.class, () -> ByteNumberRange.fromString("[a,b]"));
+			// wrapped correctly but missing the , boundary separator
+			assertThrows(DataTypeParseException.class, () -> ByteNumberRange.fromString("[5]"));
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/NumberUtilsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/NumberUtilsTest.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.utils;
 
+import io.evitadb.dataType.BigDecimalNumberRange;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -324,6 +326,152 @@ class NumberUtilsTest {
 			final Map<BigDecimal, Integer> map = Map.of(normalized[0], 1);
 			assertEquals(1, map.get(normalized[1]));
 			assertEquals(1, map.get(normalized[2]));
+		}
+	}
+
+	@Nested
+	@DisplayName("normalizeForIndexing tests")
+	class NormalizeForIndexingTests {
+
+		@Test
+		@DisplayName("Should strip trailing zeros for scalar BigDecimal regardless of indexed decimal places")
+		void shouldNormalizeScalarBigDecimal() {
+			assertEquals(new BigDecimal("5E+1"), NumberUtils.normalizeForIndexing(new BigDecimal("50.00"), 4));
+			assertEquals(new BigDecimal("88.1"), NumberUtils.normalizeForIndexing(new BigDecimal("88.10000"), 4));
+		}
+
+		@Test
+		@DisplayName("Should return non-decimal values unchanged")
+		void shouldReturnNonDecimalValuesUnchanged() {
+			final Serializable intValue = 42;
+			assertSame(intValue, NumberUtils.normalizeForIndexing(intValue, 4));
+			final Serializable strValue = "hello";
+			assertSame(strValue, NumberUtils.normalizeForIndexing(strValue, 4));
+		}
+
+		@Test
+		@DisplayName("Should normalize each element in BigDecimal array, preserving nulls")
+		void shouldNormalizeBigDecimalArrayPreservingNulls() {
+			final BigDecimal[] input = new BigDecimal[]{new BigDecimal("10.00"), null, new BigDecimal("30.50")};
+			final BigDecimal[] result = (BigDecimal[]) NumberUtils.normalizeForIndexing(input, 4);
+			assertEquals(new BigDecimal("1E+1"), result[0]);
+			assertNull(result[1]);
+			assertEquals(new BigDecimal("30.5"), result[2]);
+		}
+
+		@Test
+		@DisplayName("Should re-encode a typed range built at a different intrinsic scale to indexedDecimalPlaces")
+		void shouldReEncodeRangeToIndexedDecimalPlaces() {
+			// 2-arg factory derives retainedDecimalPlaces from the inputs' own scale (5) and leaves the
+			// schema-authoritative scale unknown (null) - this is the buggy case that must be re-encoded
+			final BigDecimalNumberRange input = BigDecimalNumberRange.between(
+				new BigDecimal("88.10000"), new BigDecimal("118.10000")
+			);
+			final BigDecimalNumberRange result =
+				(BigDecimalNumberRange) NumberUtils.normalizeForIndexing(input, 4);
+
+			final BigDecimalNumberRange expected = BigDecimalNumberRange.between(
+				new BigDecimal("88.10000"), new BigDecimal("118.10000"), 4
+			);
+			assertEquals(4, result.getRetainedDecimalPlaces());
+			assertEquals(expected.getFrom(), result.getFrom());
+			assertEquals(expected.getTo(), result.getTo());
+			// the comparable longs must equal those the query side produces at the same scale
+			assertEquals(881000L, result.getFrom());
+			assertEquals(1181000L, result.getTo());
+		}
+
+		@Test
+		@DisplayName("Should re-encode a range whose explicit scale differs from indexedDecimalPlaces")
+		void shouldReEncodeRangeWhenExplicitScaleDiffersFromIndexedDecimalPlaces() {
+			// the range carries an explicit retainedDecimalPlaces (2) that differs from the requested
+			// indexedDecimalPlaces (4), so it must be re-encoded to the schema-authoritative scale
+			final BigDecimalNumberRange input = BigDecimalNumberRange.between(
+				new BigDecimal("88.1"), new BigDecimal("118.1"), 2
+			);
+			final BigDecimalNumberRange result =
+				(BigDecimalNumberRange) NumberUtils.normalizeForIndexing(input, 4);
+
+			assertNotSame(input, result);
+			assertEquals(4, result.getRetainedDecimalPlaces());
+			assertEquals(881000L, result.getFrom());
+			assertEquals(1181000L, result.getTo());
+			// the precise bounds must be preserved through the re-encoding
+			assertEquals(0, new BigDecimal("88.1").compareTo(result.getPreciseFrom()));
+			assertEquals(0, new BigDecimal("118.1").compareTo(result.getPreciseTo()));
+		}
+
+		@Test
+		@DisplayName("Should return the same range instance when it already carries the requested scale")
+		void shouldReturnSameInstanceWhenScaleAlreadyMatches() {
+			final BigDecimalNumberRange input = BigDecimalNumberRange.between(
+				new BigDecimal("88.1"), new BigDecimal("118.1"), 4
+			);
+			assertSame(input, NumberUtils.normalizeForIndexing(input, 4));
+		}
+
+		@Test
+		@DisplayName("Should return the same range instance when null-retained natural scale already matches")
+		void shouldReturnSameInstanceWhenNullRetainedNaturalScaleAlreadyMatches() {
+			// 2-arg factory leaves retainedDecimalPlaces null but the bounds' natural scale (2) already
+			// equals indexedDecimalPlaces - the common index path must not allocate a fresh equal range
+			final BigDecimalNumberRange input = BigDecimalNumberRange.between(
+				new BigDecimal("88.10"), new BigDecimal("118.10")
+			);
+			assertSame(input, NumberUtils.normalizeForIndexing(input, 2));
+		}
+
+		@Test
+		@DisplayName("Should re-encode open-ended ranges (from-only and to-only)")
+		void shouldReEncodeOpenEndedRanges() {
+			final BigDecimalNumberRange fromOnly =
+				(BigDecimalNumberRange) NumberUtils.normalizeForIndexing(
+					BigDecimalNumberRange.from(new BigDecimal("88.10000")), 4
+				);
+			assertEquals(4, fromOnly.getRetainedDecimalPlaces());
+			assertEquals(881000L, fromOnly.getFrom());
+
+			final BigDecimalNumberRange toOnly =
+				(BigDecimalNumberRange) NumberUtils.normalizeForIndexing(
+					BigDecimalNumberRange.to(new BigDecimal("118.10000")), 4
+				);
+			assertEquals(4, toOnly.getRetainedDecimalPlaces());
+			assertEquals(1181000L, toOnly.getTo());
+		}
+
+		@Test
+		@DisplayName("Should round to indexedDecimalPlaces = 0")
+		void shouldRoundToZeroIndexedDecimalPlaces() {
+			final BigDecimalNumberRange result =
+				(BigDecimalNumberRange) NumberUtils.normalizeForIndexing(
+					BigDecimalNumberRange.between(new BigDecimal("88.10000"), new BigDecimal("118.90000")), 0
+				);
+			assertEquals(0, result.getRetainedDecimalPlaces());
+			assertEquals(88L, result.getFrom());
+			assertEquals(119L, result.getTo());
+		}
+
+		@Test
+		@DisplayName("Should leave the infinite range untouched")
+		void shouldLeaveInfiniteRangeUntouched() {
+			assertSame(
+				BigDecimalNumberRange.INFINITE,
+				NumberUtils.normalizeForIndexing(BigDecimalNumberRange.INFINITE, 4)
+			);
+		}
+
+		@Test
+		@DisplayName("Should re-encode each element of a range array, preserving nulls")
+		void shouldReEncodeRangeArrayPreservingNulls() {
+			final BigDecimalNumberRange[] input = new BigDecimalNumberRange[]{
+				BigDecimalNumberRange.between(new BigDecimal("88.10000"), new BigDecimal("118.10000")),
+				null
+			};
+			final BigDecimalNumberRange[] result =
+				(BigDecimalNumberRange[]) NumberUtils.normalizeForIndexing(input, 4);
+			assertEquals(4, result[0].getRetainedDecimalPlaces());
+			assertEquals(881000L, result[0].getFrom());
+			assertNull(result[1]);
 		}
 	}
 }


### PR DESCRIPTION
Closes #1238

## Problem
`BigDecimalNumberRange` attribute values supplied already-typed via the 2-arg `between(from, to)` factory (Java / embedded client) were **not** re-encoded to the attribute schema's `indexedDecimalPlaces` at the index-write boundary. The range kept its intrinsic scale (derived from the inputs' own `scale()`) baked into the comparable longs stored in `RangeIndex`, while the query side always encodes at the schema scale. The two never lined up, so `attributeBetween`, `histogramHaving` and `attributeInRange` over range attributes silently returned **zero records**. This is the value-side twin of the schema-side fix #1236.

## Fix
- Normalize at the single `AttributeIndexMutator` chokepoint (insert + all remove sites) via the new `NumberUtils.normalizeForIndexing(Serializable, int)`, keeping the **store-verbatim / normalize-at-index-boundary** philosophy intact (the stored value is untouched; only the indexed comparable longs are re-encoded).
- Fix `BigDecimalNumberRange.isWithin` and the `toComparableLong(BigDecimal, long)` override to use the *effective* retained scale (`getEffectiveRetainedDecimalPlaces()`), matching the scale the 2-arg constructor freezes its bounds at.
- Fix the query-side `AttributeInRangeTranslator` to scale a non-`BigDecimal` integer argument by `indexedDecimalPlaces` (a sibling defect that also returned nothing).
- Refactor the duplicated `fromString` parse/validation logic across the six range types into a shared `Range.parseRange` helper (unified, generic error wording).

## Tests
- New functional `BigDecimalNumberRangeValueScaleFunctionalTest` (range single/array/`attributeInRange`/update-remove/negative control + parallel scalar suite + reference-attribute paths).
- `NumberUtilsTest` coverage for `normalizeForIndexing`, `BigDecimalNumberRangeTest` coverage for `isWithin`, and the centralized no-separator branch of `Range.parseRange` in `NumberRangeTest` / `DateTimeRangeTest`.
- Full touched-test set green (203 tests, 0 failures).