### PR TITLE
fix: @RemoveWhenExists must match referencedId AND @AttributeRef predicate

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
+++ b/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
@@ -357,8 +357,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nonnull SealedEntityProxyState theState
 	) {
 		final String referenceName = referenceSchema.getName();
-		final int referencedId = Objects.requireNonNull(
-			EvitaDataTypes.toTargetType((Serializable) args[referenceIdLocation], int.class));
+		final int referencedId = requireReferencedId(args, referenceIdLocation, referenceName);
 		final Optional<ReferenceContract> reference = theState
 			.entityBuilder()
 		    .getReference(referenceName, referencedId);
@@ -508,8 +507,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nullable ConstantPredicate constantPredicate
 	) {
 		final String referenceName = referenceSchema.getName();
-		final int referencedId = Objects.requireNonNull(
-			EvitaDataTypes.toTargetType((Serializable) args[referenceIdLocation], int.class));
+		final int referencedId = requireReferencedId(args, referenceIdLocation, referenceName);
 		final Predicate<Object> predicate = predicateLocation >= 0 ?
 			(Predicate<Object>) Objects.requireNonNull(args[predicateLocation]) : null;
 		final Predicate<Object> composedPredicate = combinePredicates(predicate, constantPredicate, args);
@@ -826,7 +824,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		final Object referenceProxy = theState.getOrCreateReferencedEntityProxyWithCallback(
 			referenceSchema.getName(),
 			referencedIdIndex >= 0 ?
-				Objects.requireNonNull(EvitaDataTypes.toTargetType((Serializable) args[referencedIdIndex], int.class)) :
+				requireReferencedId(args, referencedIdIndex, referenceSchema.getName()) :
 				null,
 			referencedEntitySchema,
 			expectedType,
@@ -919,9 +917,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 				if (schemaCardinality.allowsDuplicates()) {
 					throw new ReferenceAllowsDuplicatesException(referenceName, theState.getEntitySchema(), Operation.WRITE);
 				} else {
-					final int requestedPrimaryKey = Objects.requireNonNull(
-						EvitaDataTypes.toTargetType((Serializable) args[referencedIdIndex], int.class)
-					);
+					final int requestedPrimaryKey = requireReferencedId(args, referencedIdIndex, referenceName);
 					referencedEntity = references.stream()
 						.filter(it -> it.getReferencedPrimaryKey() == requestedPrimaryKey)
 						.findFirst()
@@ -968,8 +964,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 	) {
 		final String referenceName = referenceSchema.getName();
 		return (entityClassifier, theMethod, args, theState, invokeSuper) -> {
-			final int referencedId = Objects.requireNonNull(
-				EvitaDataTypes.toTargetType((Serializable) args[0], int.class));
+			final int referencedId = requireReferencedId(args, 0, referenceName);
 			final Optional<ReferenceContract> reference = theState
 				.entityBuilder()
 			    .getReference(referenceName, referencedId);
@@ -1050,6 +1045,33 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 	}
 
 	/**
+	 * Reads the referenced primary key at `args[referencedIdIndex]` and converts it to `int`.
+	 * Throws `EvitaInvalidUsageException` carrying the reference name when the argument is `null`
+	 * (e.g. a boxed `Integer` parameter passed as `null`) instead of letting an opaque
+	 * `NullPointerException` bubble up from the value conversion (see #1241).
+	 *
+	 * @param args               the original method arguments
+	 * @param referencedIdIndex  position of the referenced primary key in `args` (must be `>= 0`)
+	 * @param referenceName      the reference schema name (used only in the error message)
+	 * @return the referenced primary key as an `int`
+	 */
+	private static int requireReferencedId(
+		@Nonnull Object[] args,
+		int referencedIdIndex,
+		@Nonnull String referenceName
+	) {
+		final Object rawArg = args[referencedIdIndex];
+		if (rawArg == null) {
+			throw new EvitaInvalidUsageException(
+				"Referenced primary key for reference `" + referenceName + "` must not be null!"
+			);
+		}
+		return Objects.requireNonNull(
+			EvitaDataTypes.toTargetType((Serializable) rawArg, int.class)
+		);
+	}
+
+	/**
 	 * Returns the references of the given name from the builder, optionally narrowed to a single
 	 * referenced primary key read from `args[referencedIdIndex]` when `referencedIdIndex >= 0`.
 	 * Mirrors the id-narrowing performed by the create/update path in
@@ -1070,9 +1092,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		int referencedIdIndex
 	) {
 		if (referencedIdIndex >= 0) {
-			final int referencedId = Objects.requireNonNull(
-				EvitaDataTypes.toTargetType((Serializable) args[referencedIdIndex], int.class)
-			);
+			final int referencedId = requireReferencedId(args, referencedIdIndex, referenceName);
 			return entityBuilder.getReferences(referenceName, referencedId);
 		}
 		return entityBuilder.getReferences(referenceName);
@@ -2157,8 +2177,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nonnull SealedEntityProxyState theState
 	) {
 		final EntityBuilder entityBuilder = theState.entityBuilder();
-		final Serializable referencedPrimaryKey = (Serializable) args[0];
-		final int referenceId = Objects.requireNonNull(EvitaDataTypes.toTargetType(referencedPrimaryKey, int.class));
+		final int referenceId = requireReferencedId(args, 0, referenceName);
 		final Optional<ReferenceContract> reference = entityBuilder.getReference(referenceName, referenceId);
 		if (reference.isPresent()) {
 			final ReferenceKey referenceKey = reference.get().getReferenceKey();
@@ -2185,8 +2204,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		final String referenceName = referenceSchema.getName();
 		return (proxy, theMethod, args, theState, invokeSuper) -> {
 			final EntityBuilder entityBuilder = theState.entityBuilder();
-			final int referencedPrimaryKey = Objects.requireNonNull(
-				EvitaDataTypes.toTargetType((Serializable) args[0], int.class));
+			final int referencedPrimaryKey = requireReferencedId(args, 0, referenceName);
 			final Optional<ReferenceContract> reference = entityBuilder.getReference(
 				referenceName, referencedPrimaryKey
 			);
@@ -2367,8 +2385,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		} else {
 			return (proxy, theMethod, args, theState, invokeSuper) -> {
 				final InternalEntityBuilder entityBuilder = theState.entityBuilder();
-				final int referencedId = Objects.requireNonNull(
-					EvitaDataTypes.toTargetType((Serializable) args[0], int.class));
+				final int referencedId = requireReferencedId(args, 0, referenceSchema.getName());
 				final ReferenceKey referenceKey = entityBuilder.createReference(
 					referenceSchema.getName(), referencedId
 				);
@@ -2660,7 +2677,10 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 				.map(AttributeRef::value)
 				.orElseGet(parameter::getName);
 
-			if (NumberUtils.isIntConvertibleNumber(parameterType)) {
+			// `@AttributeRef` takes precedence over the int-convertible referenced-id classification:
+			// an `@AttributeRef` parameter of an int-convertible type is a representative/filter
+			// attribute predicate, not the referenced primary key (see #1241).
+			if (NumberUtils.isIntConvertibleNumber(parameterType) && attributeRef.isEmpty()) {
 				referencedIdIndex = OptionalInt.of(i);
 			} else if (Consumer.class.isAssignableFrom(parameterType)) {
 				consumerIndex = OptionalInt.of(i);

--- a/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
+++ b/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
@@ -1066,9 +1066,8 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 				"Referenced primary key for reference `" + referenceName + "` must not be null!"
 			);
 		}
-		return Objects.requireNonNull(
-			EvitaDataTypes.toTargetType((Serializable) rawArg, int.class)
-		);
+		// EvitaDataTypes.toTargetType only returns null for null input; rawArg is non-null here.
+		return EvitaDataTypes.toTargetType((Serializable) rawArg, int.class);
 	}
 
 	/**

--- a/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
+++ b/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
@@ -1050,9 +1050,39 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 	}
 
 	/**
+	 * Returns the references of the given name from the builder, optionally narrowed to a single
+	 * referenced primary key read from `args[referencedIdIndex]` when `referencedIdIndex >= 0`.
+	 * Mirrors the id-narrowing performed by the create/update path in
+	 * `getOrCreateReferenceWithPredicateAndId`, so that remove-by-(id + attribute predicate)
+	 * matches on BOTH the id and the predicate instead of the predicate alone.
+	 *
+	 * @param entityBuilder      the entity builder to read references from
+	 * @param referenceName      the reference schema name
+	 * @param args               the original method arguments (used only when referencedIdIndex >= 0)
+	 * @param referencedIdIndex  position of the referenced primary key in `args`, or `-1` if none
+	 * @return references for the given reference name (optionally narrowed by referenced primary key)
+	 */
+	@Nonnull
+	private static Collection<ReferenceContract> getReferencesForRemoval(
+		@Nonnull EntityBuilder entityBuilder,
+		@Nonnull String referenceName,
+		@Nonnull Object[] args,
+		int referencedIdIndex
+	) {
+		if (referencedIdIndex >= 0) {
+			final int referencedId = Objects.requireNonNull(
+				EvitaDataTypes.toTargetType((Serializable) args[referencedIdIndex], int.class)
+			);
+			return entityBuilder.getReferences(referenceName, referencedId);
+		}
+		return entityBuilder.getReferences(referenceName);
+	}
+
+	/**
 	 * Return a method implementation that removes the single reference if exists.
 	 *
 	 * @param referenceSchema the reference schema to use
+	 * @param referencedIdIndex index of the referenced primary key in the method args, or -1 if none
 	 * @return the method implementation
 	 */
 	@Nonnull
@@ -1061,6 +1091,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nonnull ReferenceSchemaContract referenceSchema,
 		@Nonnull ResolvedParameter resolvedParameter,
 		boolean entityRecognizedInReturnType,
+		int referencedIdIndex,
 		int predicateIndex,
 		@Nullable Class<?> predicateType,
 		@Nullable ConstantPredicate constantPredicate
@@ -1071,8 +1102,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 			if (Number.class.isAssignableFrom(returnType)) {
 				return (proxy, theMethod, args, theState, invokeSuper) -> {
 					final EntityBuilder entityBuilder = theState.entityBuilder();
-					final Collection<ReferenceContract> references = entityBuilder.getReferences(
-						referenceName);
+					final Collection<ReferenceContract> references = getReferencesForRemoval(
+						entityBuilder, referenceName, args, referencedIdIndex
+					);
 					//noinspection unchecked
 					final Predicate<Object> predicate = predicateIndex >= 0 ?
 						(Predicate<Object>) Objects.requireNonNull(args[predicateIndex]) :
@@ -1096,6 +1128,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 					referenceSchema,
 					returnType,
 					entityRecognizedInReturnType,
+					referencedIdIndex,
 					predicateIndex,
 					predicateType,
 					constantPredicate
@@ -1104,7 +1137,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		} else if (returnType.equals(void.class)) {
 			return (proxy, theMethod, args, theState, invokeSuper) -> {
 				final EntityBuilder entityBuilder = theState.entityBuilder();
-				final Collection<ReferenceContract> references = entityBuilder.getReferences(referenceName);
+				final Collection<ReferenceContract> references = getReferencesForRemoval(
+					entityBuilder, referenceName, args, referencedIdIndex
+				);
 				//noinspection unchecked
 				final Predicate<Object> predicate = predicateIndex >= 0 ? (Predicate<Object>) Objects.requireNonNull(
 					args[predicateIndex]) : null;
@@ -1123,7 +1158,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		} else if (Boolean.class.isAssignableFrom(returnType)) {
 			return (proxy, theMethod, args, theState, invokeSuper) -> {
 				final EntityBuilder entityBuilder = theState.entityBuilder();
-				final Collection<ReferenceContract> references = entityBuilder.getReferences(referenceName);
+				final Collection<ReferenceContract> references = getReferencesForRemoval(
+					entityBuilder, referenceName, args, referencedIdIndex
+				);
 				//noinspection unchecked
 				final Predicate<Object> predicate = predicateIndex >= 0 ? (Predicate<Object>) Objects.requireNonNull(
 					args[predicateIndex]) : null;
@@ -1145,8 +1182,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 			if (returnType.equals(proxyState.getProxyClass())) {
 				return (proxy, theMethod, args, theState, invokeSuper) -> {
 					final EntityBuilder entityBuilder = theState.entityBuilder();
-					final Collection<ReferenceContract> references = entityBuilder.getReferences(
-						referenceName);
+					final Collection<ReferenceContract> references = getReferencesForRemoval(
+						entityBuilder, referenceName, args, referencedIdIndex
+					);
 					if (references.isEmpty()) {
 						// do nothing
 					} else {
@@ -1170,7 +1208,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 			} else if (Number.class.isAssignableFrom(returnType) || (returnType.isPrimitive() && (int.class.equals(returnType) || long.class.equals(returnType)))) {
 				return (proxy, theMethod, args, theState, invokeSuper) -> {
 					final EntityBuilder entityBuilder = theState.entityBuilder();
-					final Collection<ReferenceContract> references = entityBuilder.getReferences(referenceName);
+					final Collection<ReferenceContract> references = getReferencesForRemoval(
+						entityBuilder, referenceName, args, referencedIdIndex
+					);
 					if (references.isEmpty()) {
 						// do nothing
 						return 0;
@@ -1198,6 +1238,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 					referenceSchema,
 					returnType,
 					entityRecognizedInReturnType,
+					referencedIdIndex,
 					predicateIndex,
 					predicateType,
 					constantPredicate
@@ -1241,6 +1282,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 	 * @param referenceSchema              the reference schema to use
 	 * @param returnType                   the return type
 	 * @param entityRecognizedInReturnType true if the entity annotation is recognized in the return type
+	 * @param referencedIdIndex            index of the referenced PK in method args, or -1 if none
 	 * @return the method implementation
 	 */
 	@Nonnull
@@ -1248,6 +1290,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nonnull ReferenceSchemaContract referenceSchema,
 		@Nonnull Class<?> returnType,
 		boolean entityRecognizedInReturnType,
+		int referencedIdIndex,
 		int predicateIndex,
 		@Nullable Class<?> predicateType,
 		@Nullable ConstantPredicate constantPredicate
@@ -1255,7 +1298,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		return (proxy, theMethod, args, theState, invokeSuper) -> {
 			final EntityBuilder entityBuilder = theState.entityBuilder();
 			final String referenceName = referenceSchema.getName();
-			final Collection<ReferenceContract> references = entityBuilder.getReferences(referenceName);
+			final Collection<ReferenceContract> references = getReferencesForRemoval(
+				entityBuilder, referenceName, args, referencedIdIndex
+			);
 			if (references.isEmpty()) {
 				// do nothing
 				return null;
@@ -1314,6 +1359,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 	 * @param referenceSchema              the reference schema to use
 	 * @param returnType                   the return type
 	 * @param entityRecognizedInReturnType true if the entity annotation is recognized in the return type
+	 * @param referencedIdIndex            index of the referenced PK in method args, or -1 if none
 	 * @return the method implementation
 	 */
 	@Nonnull
@@ -1321,6 +1367,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nonnull ReferenceSchemaContract referenceSchema,
 		@Nonnull Class<?> returnType,
 		boolean entityRecognizedInReturnType,
+		int referencedIdIndex,
 		int predicateIndex,
 		@Nullable Class<?> predicateType,
 		@Nullable ConstantPredicate constantPredicate
@@ -1328,7 +1375,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		return (proxy, theMethod, args, theState, invokeSuper) -> {
 			final EntityBuilder entityBuilder = theState.entityBuilder();
 			final String referenceName = referenceSchema.getName();
-			final Collection<ReferenceContract> references = entityBuilder.getReferences(referenceName);
+			final Collection<ReferenceContract> references = getReferencesForRemoval(
+				entityBuilder, referenceName, args, referencedIdIndex
+			);
 			if (references.isEmpty()) {
 				// do nothing
 				return Collections.emptyList();
@@ -2806,6 +2855,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 							      }),
 							isEntityRecognizedIn(parsedArguments.entityRecognizedIn(), EntityRecognizedIn.RETURN_TYPE),
 							-1,
+							-1,
 							null,
 							null
 						);
@@ -2841,6 +2891,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 										return new ResolvedParameter(method.getReturnType(), methodReturnType);
 									}),
 								isEntityRecognizedIn(parsedArguments.entityRecognizedIn(), EntityRecognizedIn.RETURN_TYPE),
+								parsedArguments.referencedIdIndex().orElse(-1),
 								parsedArguments.predicateIndex().orElse(-1),
 								parsedArguments.predicateType().map(ResolvedParameter::resolvedType).orElse(null),
 								parsedArguments.constantPredicate().orElse(null)
@@ -2901,6 +2952,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 									      return new ResolvedParameter(method.getReturnType(), methodReturnType);
 								      }),
 								isEntityRecognizedIn(parsedArguments.entityRecognizedIn(), EntityRecognizedIn.RETURN_TYPE),
+								parsedArguments.referencedIdIndex().orElse(-1),
 								parsedArguments.predicateIndex().orElse(-1),
 								parsedArguments.predicateType().map(ResolvedParameter::resolvedType).orElse(null),
 								parsedArguments.constantPredicate().orElse(null)

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
@@ -666,6 +666,17 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 
 		final int referenceCountAfterRemoving = editor2.entityBuilder().getReferences().size();
 		assertEquals(referenceCountAfterAdding - 1, referenceCountAfterRemoving);
+
+		// the surviving ref for the targeted related entity must be the CATEGORY_SIMILAR one
+		// (callers always remove the "accessory"-typed one)
+		final List<ReferenceContract> survivingForRelated = editor2.entityBuilder()
+			.getReferences(Entities.PRODUCT, related.getPrimaryKey());
+		assertEquals(1, survivingForRelated.size(),
+			"Exactly one reference must remain for the targeted related entity after the removal");
+		assertEquals(CATEGORY_SIMILAR,
+			survivingForRelated.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class),
+			"The 'accessory' reference must have been removed and the CATEGORY_SIMILAR one must survive");
+
 		editor2.upsertVia(evitaSession);
 
 		final SealedEntity after = evitaSession.getEntity(
@@ -674,6 +685,12 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 			entityFetchAllContent()
 		).orElseThrow();
 		assertEquals(referenceCountAfterRemoving, after.getReferences().size());
+
+		final List<ReferenceContract> survivingPersistedForRelated = after.getReferences(
+			Entities.PRODUCT, related.getPrimaryKey());
+		assertEquals(1, survivingPersistedForRelated.size());
+		assertEquals(CATEGORY_SIMILAR,
+			survivingPersistedForRelated.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class));
 	}
 
 	/**
@@ -3710,6 +3727,260 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 		));
 	}
 
+	@DisplayName("Should not remove unrelated reference when remove targets id of different ref")
+	@Order(47)
+	@Test
+	@UseDataSet(HUNDRED_PRODUCTS)
+	void shouldNotRemoveWrongReferenceWhenIdAndAttributePredicateProvided(
+		EvitaSessionContract evitaSession,
+		List<SealedEntity> originalProducts
+	) {
+		// Regression: see #1239 — @RemoveWhenExists(int + @AttributeRef) must match BOTH
+		// id AND attribute. Scenario from the bug report:
+		// references of type 'product' on a single main product:
+		//   (refId=A, relationType='similar')
+		//   (refId=B, relationType='different')
+		// then call remove(category='similar', productId=B)
+		//   expected: no-op (no reference matches BOTH id=B AND category='similar')
+		//   actual (bug): removes (A, 'similar') because the attribute predicate matches
+		//                 and the productId argument is silently ignored
+		final SealedEntity mainProduct = originalProducts.get(8);
+		final SealedEntity refA = originalProducts.get(9);
+		final SealedEntity refB = originalProducts.get(10);
+		final int idA = refA.getPrimaryKey();
+		final int idB = refB.getPrimaryKey();
+
+		// --- arrange: persist exactly two related-product references ---
+		final ProductInterfaceEditor setup = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		setup.removeAllRelatedProducts();
+		setup.addOrUpdateRelatedProduct(idA, CATEGORY_SIMILAR, rp -> {
+			rp.setLabel(Locale.ENGLISH, "Similar A");
+			rp.setLabel(CZECH_LOCALE, "Podobné A");
+		});
+		setup.addOrUpdateRelatedProduct(idB, CATEGORY_DIFFERENT, rp -> {
+			rp.setLabel(Locale.ENGLISH, "Different B");
+			rp.setLabel(CZECH_LOCALE, "Jiné B");
+		});
+		setup.upsertVia(evitaSession);
+
+		final SealedEntity persisted = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		assertEquals(2, persisted.getReferences(Entities.PRODUCT).size(),
+			"Precondition: main product must have exactly 2 related-product references");
+		assertEquals(1, persisted.getReferences(Entities.PRODUCT, idA).size());
+		assertEquals(1, persisted.getReferences(Entities.PRODUCT, idB).size());
+
+		// --- act (a): cross-call - attribute of ref A, id of ref B -> MUST be a no-op ---
+		final ProductInterfaceEditor crossEditor = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		crossEditor.removeRelatedProductByCategoryAndId(CATEGORY_SIMILAR, idB);
+
+		final List<ReferenceContract> afterCrossA = crossEditor.entityBuilder()
+			.getReferences(Entities.PRODUCT, idA);
+		final List<ReferenceContract> afterCrossB = crossEditor.entityBuilder()
+			.getReferences(Entities.PRODUCT, idB);
+		assertEquals(1, afterCrossA.size(),
+			"BUG: remove(category=SIMILAR, id=B) wrongly removed ref A whose category matches " +
+				"and whose id is NOT the argument B - the int productId argument must be honoured");
+		assertEquals(1, afterCrossB.size(),
+			"Ref B must remain untouched - its category is 'different', not 'similar'");
+
+		crossEditor.upsertVia(evitaSession);
+		final SealedEntity afterCrossPersisted = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		assertEquals(2, afterCrossPersisted.getReferences(Entities.PRODUCT).size(),
+			"Cross-arg remove must persist as a no-op - both references must still exist after reload");
+
+		// --- act (b): matching-call - attribute of ref A, id of ref A -> MUST remove exactly ref A ---
+		final ProductInterfaceEditor matchEditor = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		matchEditor.removeRelatedProductByCategoryAndId(CATEGORY_SIMILAR, idA);
+
+		final List<ReferenceContract> afterMatchA = matchEditor.entityBuilder()
+			.getReferences(Entities.PRODUCT, idA);
+		final List<ReferenceContract> afterMatchB = matchEditor.entityBuilder()
+			.getReferences(Entities.PRODUCT, idB);
+		assertEquals(0, afterMatchA.size(), "Ref A (matching both id and category) must be removed");
+		assertEquals(1, afterMatchB.size(), "Ref B must remain untouched");
+
+		matchEditor.upsertVia(evitaSession);
+		final SealedEntity afterMatchPersisted = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		assertEquals(1, afterMatchPersisted.getReferences(Entities.PRODUCT).size(),
+			"Exactly one reference (B) must remain after the matching-arg remove");
+		assertEquals(idB, afterMatchPersisted.getReferences(Entities.PRODUCT).iterator().next()
+			.getReferencedPrimaryKey());
+	}
+
+	@DisplayName("Should remove only the matching duplicate on id+representative-attribute remove")
+	@Order(47)
+	@Test
+	@UseDataSet(HUNDRED_PRODUCTS)
+	void shouldRemoveCorrectDuplicateWhenIdAndAttributePredicateProvided(
+		EvitaSessionContract evitaSession,
+		List<SealedEntity> originalProducts
+	) {
+		// Regression: see #1239 — @RemoveWhenExists(int + @AttributeRef) must match BOTH
+		// id AND attribute. Variant locking down the allowDuplicates + representative-attribute path:
+		// two references to the SAME referenced id distinguished by the representative attribute:
+		//   (refId=X, relationType='similar')
+		//   (refId=X, relationType='different')
+		// remove(category='similar', id=X) MUST remove only the 'similar' duplicate.
+		final SealedEntity mainProduct = originalProducts.get(11);
+		final SealedEntity related = originalProducts.get(12);
+		final int idX = related.getPrimaryKey();
+
+		final ProductInterfaceEditor setup = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		setup.removeAllRelatedProducts();
+		setup.addOrUpdateRelatedProduct(idX, CATEGORY_SIMILAR, rp -> {
+			rp.setLabel(Locale.ENGLISH, "Similar X");
+			rp.setLabel(CZECH_LOCALE, "Podobné X");
+		});
+		setup.addOrUpdateRelatedProduct(idX, CATEGORY_DIFFERENT, rp -> {
+			rp.setLabel(Locale.ENGLISH, "Different X");
+			rp.setLabel(CZECH_LOCALE, "Jiné X");
+		});
+		setup.upsertVia(evitaSession);
+
+		final SealedEntity persisted = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		assertEquals(2, persisted.getReferences(Entities.PRODUCT, idX).size(),
+			"Precondition: two duplicates of the same referenced id must exist");
+
+		// --- act: remove only the 'similar' duplicate ---
+		final ProductInterfaceEditor editor = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		editor.removeRelatedProductByCategoryAndId(CATEGORY_SIMILAR, idX);
+
+		final List<ReferenceContract> remaining = editor.entityBuilder()
+			.getReferences(Entities.PRODUCT, idX);
+		assertEquals(1, remaining.size(),
+			"After remove(category=SIMILAR, id=X) exactly one duplicate (the 'different' one) must remain");
+		assertEquals(CATEGORY_DIFFERENT,
+			remaining.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class),
+			"The surviving duplicate must be the 'different' one - id+category remove must NOT touch it");
+
+		editor.upsertVia(evitaSession);
+		final SealedEntity afterReload = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		final List<ReferenceContract> reloaded = afterReload.getReferences(Entities.PRODUCT, idX);
+		assertEquals(1, reloaded.size(),
+			"After persist+reload only one duplicate must remain");
+		assertEquals(CATEGORY_DIFFERENT,
+			reloaded.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class));
+	}
+
+	@DisplayName("Should update existing reference on repeat addOrUpdate, not duplicate it")
+	@Order(47)
+	@Test
+	@UseDataSet(HUNDRED_PRODUCTS)
+	void shouldUpdateExistingDuplicatedReferenceOnRepeatAddOrUpdate(
+		EvitaSessionContract evitaSession,
+		List<SealedEntity> originalProducts
+	) {
+		// Symmetry lockdown for #1239 — the create/update path already worked;
+		// this guards against regressing it.
+		// Lockdown for the create/update symmetric path: when a reference for (relatedPk, attribute)
+		// is already persisted, a second addOrUpdate call must FIND it and update its attributes
+		// rather than recreate (this path already worked - the test prevents regression).
+		final SealedEntity mainProduct = originalProducts.get(4);
+		final SealedEntity relatedProduct = originalProducts.get(5);
+		final int relatedPk = relatedProduct.getPrimaryKey();
+		final String relationType = CATEGORY_SIMILAR;
+
+		// Phase 1: clear any pre-existing related products and persist a single one
+		final ProductInterfaceEditor firstEditor = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		firstEditor.removeAllRelatedProducts();
+		firstEditor.addOrUpdateRelatedProduct(
+			relatedPk,
+			relationType,
+			rp -> {
+				rp.setLabel(Locale.ENGLISH, "Initial");
+				rp.setLabel(CZECH_LOCALE, "Počáteční");
+			}
+		);
+		firstEditor.upsertVia(evitaSession);
+
+		// Phase 2: reload (so the reference is part of the BASE references) and call addOrUpdate again
+		final ProductInterfaceEditor secondEditor = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		secondEditor.addOrUpdateRelatedProduct(
+			relatedPk,
+			relationType,
+			rp -> rp.setLabel(Locale.ENGLISH, "Updated")
+		);
+
+		final List<ReferenceContract> afterUpdate = secondEditor.entityBuilder()
+			.getReferences(Entities.PRODUCT, relatedPk);
+		assertEquals(1, afterUpdate.size(),
+			"addOrUpdate must FIND the existing persisted reference and update it - not create a duplicate");
+		assertEquals(
+			"Updated",
+			afterUpdate.get(0).getAttribute(ATTRIBUTE_PRODUCT_LABEL, Locale.ENGLISH, String.class),
+			"The new English label must be applied to the existing reference");
+		assertEquals(
+			"Počáteční",
+			afterUpdate.get(0).getAttribute(ATTRIBUTE_PRODUCT_LABEL, CZECH_LOCALE, String.class),
+			"Czech label from phase 1 must be preserved - if it is null, " +
+				"the reference was recreated rather than updated");
+
+		// Persist and verify after reload
+		secondEditor.upsertVia(evitaSession);
+		final SealedEntity reloaded = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		final List<ReferenceContract> reloadedRefs = reloaded.getReferences(Entities.PRODUCT, relatedPk);
+		assertEquals(1, reloadedRefs.size(),
+			"After persistence there must still be exactly one reference for (refId, relationType)");
+		assertEquals(
+			"Updated",
+			reloadedRefs.get(0).getAttribute(ATTRIBUTE_PRODUCT_LABEL, Locale.ENGLISH, String.class));
+		assertEquals(
+			"Počáteční",
+			reloadedRefs.get(0).getAttribute(ATTRIBUTE_PRODUCT_LABEL, CZECH_LOCALE, String.class));
+	}
+
 	@DisplayName("Should update duplicated reference when predicate matches")
 	@Order(47)
 	@Test
@@ -3765,11 +4036,12 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 		EvitaSessionContract evitaSession,
 		List<SealedEntity> originalProducts
 	) {
+		final int relatedPk = originalProducts.get(6).getPrimaryKey();
 		shouldRemoveRelatedProductInternal(
 			evitaSession,
 			originalProducts,
 			5, 6,
-			editor -> editor.removeRelatedProduct(6, "accessory")
+			editor -> editor.removeRelatedProduct(relatedPk, "accessory")
 		);
 	}
 
@@ -3781,11 +4053,13 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 		EvitaSessionContract evitaSession,
 		List<SealedEntity> originalProducts
 	) {
+		final int relatedPk = originalProducts.get(8).getPrimaryKey();
 		shouldRemoveRelatedProductInternal(
 			evitaSession,
 			originalProducts,
 			7, 8,
-			editor -> editor.removeRelatedProduct(6, ref -> "accessory".equals(ref.getRelationType()))
+			editor -> editor.removeRelatedProduct(
+				relatedPk, ref -> "accessory".equals(ref.getRelationType()))
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
@@ -29,6 +29,7 @@ import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.exception.MandatoryAttributesNotProvidedException;
 import io.evitadb.api.exception.ReferenceCardinalityViolatedException;
 import io.evitadb.api.proxy.mock.*;
+import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
@@ -3900,6 +3901,96 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 			"After persist+reload only one duplicate must remain");
 		assertEquals(CATEGORY_DIFFERENT,
 			reloaded.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class));
+	}
+
+	@DisplayName("Should treat @AttributeRef int-convertible parameter as attribute predicate, not referenced id")
+	@Order(47)
+	@Test
+	@UseDataSet(HUNDRED_PRODUCTS)
+	void shouldClassifyAttributeRefLongAsAttributePredicateNotReferencedId(
+		EvitaSessionContract evitaSession,
+		List<SealedEntity> originalProducts
+	) {
+		// Regression: see #1241 (finding A). With the bug, an @AttributeRef parameter of an
+		// int-convertible type was classified as `referencedIdIndex`, so the remove call would
+		// look up `getReferences("CATEGORY", priorityValue)` (treating the attribute value as a
+		// primary key) and remove the wrong reference (or nothing).
+		final SealedEntity mainProduct = originalProducts.get(13);
+		final int mainPk = mainProduct.getPrimaryKey();
+		final int categoryAPk = originalProducts.get(14).getPrimaryKey();
+		final int categoryBPk = originalProducts.get(15).getPrimaryKey();
+		final long priorityToRemove = 1_000_001L;
+		final long priorityToKeep = 1_000_002L;
+
+		// arrange: clear any pre-existing category refs, then add two with distinct priorities
+		final ProductInterfaceEditor setup = evitaSession.getEntity(
+			ProductInterfaceEditor.class, mainPk, entityFetchAllContent()
+		).orElseThrow();
+		setup.removeAllProductCategoriesAndReturnTheirIds();
+		setup.addProductCategory(categoryAPk, pc -> pc
+			.setOrderInCategory(priorityToRemove)
+			.setShadow(false)
+			.setLabel(CZECH_LOCALE, "A")
+			.setLabel(Locale.ENGLISH, "A"));
+		setup.addProductCategory(categoryBPk, pc -> pc
+			.setOrderInCategory(priorityToKeep)
+			.setShadow(false)
+			.setLabel(CZECH_LOCALE, "B")
+			.setLabel(Locale.ENGLISH, "B"));
+		setup.upsertVia(evitaSession);
+
+		// act: remove by the priority attribute predicate; with bug -> no-op (no category PK
+		// equals 1_000_001), so both refs survive and the test catches the regression.
+		final ProductInterfaceEditor editor = evitaSession.getEntity(
+			ProductInterfaceEditor.class, mainPk, entityFetchAllContent()
+		).orElseThrow();
+		editor.removeProductCategoryByPriority(priorityToRemove);
+
+		// in-builder
+		final List<ReferenceContract> remainingInBuilder = editor.entityBuilder()
+			.getReferences(Entities.CATEGORY)
+			.stream().toList();
+		assertEquals(1, remainingInBuilder.size(),
+			"Exactly one category reference must remain - the matching-priority one was removed");
+		assertEquals(categoryBPk, remainingInBuilder.get(0).getReferencedPrimaryKey(),
+			"The surviving reference must point to category B (priorityToKeep)");
+
+		// persisted
+		editor.upsertVia(evitaSession);
+		final SealedEntity reloaded = evitaSession.getEntity(
+			Entities.PRODUCT, mainPk, entityFetchAllContent()
+		).orElseThrow();
+		final List<ReferenceContract> remainingPersisted = reloaded.getReferences(Entities.CATEGORY)
+			.stream().toList();
+		assertEquals(1, remainingPersisted.size());
+		assertEquals(categoryBPk, remainingPersisted.get(0).getReferencedPrimaryKey());
+	}
+
+	@DisplayName("Should throw EvitaInvalidUsageException naming the reference when null Integer id is passed")
+	@Order(47)
+	@Test
+	@UseDataSet(HUNDRED_PRODUCTS)
+	void shouldThrowTypedExceptionOnNullReferencedIdArg(
+		EvitaSessionContract evitaSession,
+		List<SealedEntity> originalProducts
+	) {
+		// Regression: see #1241 (finding B). A null boxed-Integer argument used to surface as
+		// an opaque NullPointerException with no context. The classifier now throws a typed
+		// EvitaInvalidUsageException whose message names the reference schema.
+		final SealedEntity mainProduct = originalProducts.get(16);
+		final ProductInterfaceEditor editor = evitaSession.getEntity(
+			ProductInterfaceEditor.class, mainProduct.getPrimaryKey(), entityFetchAllContent()
+		).orElseThrow();
+
+		final EvitaInvalidUsageException thrown = assertThrows(
+			EvitaInvalidUsageException.class,
+			() -> editor.removeRelatedProductByBoxedId(null),
+			"Null Integer referenced primary key must raise a typed EvitaInvalidUsageException"
+		);
+		assertTrue(
+			thrown.getMessage() != null && thrown.getMessage().contains(Entities.PRODUCT),
+			"Exception message must name the reference schema; was: " + thrown.getMessage()
+		);
 	}
 
 	@DisplayName("Should update existing reference on repeat addOrUpdate, not duplicate it")

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
@@ -29,7 +29,6 @@ import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.exception.MandatoryAttributesNotProvidedException;
 import io.evitadb.api.exception.ReferenceCardinalityViolatedException;
 import io.evitadb.api.proxy.mock.*;
-import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
@@ -3903,7 +3902,7 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 			reloaded.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class));
 	}
 
-	@DisplayName("Should treat @AttributeRef int-convertible parameter as attribute predicate, not referenced id")
+	@DisplayName("Should treat @AttributeRef parameter as attribute predicate, not referenced id")
 	@Order(47)
 	@Test
 	@UseDataSet(HUNDRED_PRODUCTS)
@@ -3966,7 +3965,7 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 		assertEquals(categoryBPk, remainingPersisted.get(0).getReferencedPrimaryKey());
 	}
 
-	@DisplayName("Should throw EvitaInvalidUsageException naming the reference when null Integer id is passed")
+	@DisplayName("Should throw EvitaInvalidUsageException naming reference on null id")
 	@Order(47)
 	@Test
 	@UseDataSet(HUNDRED_PRODUCTS)
@@ -3987,8 +3986,9 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 			() -> editor.removeRelatedProductByBoxedId(null),
 			"Null Integer referenced primary key must raise a typed EvitaInvalidUsageException"
 		);
+		assertNotNull(thrown.getMessage(), "Exception must carry a non-null message");
 		assertTrue(
-			thrown.getMessage() != null && thrown.getMessage().contains(Entities.PRODUCT),
+			thrown.getMessage().contains(Entities.PRODUCT),
 			"Exception message must name the reference schema; was: " + thrown.getMessage()
 		);
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
@@ -43,6 +43,7 @@ import io.evitadb.test.generator.DataGenerator.Labels;
 import io.evitadb.test.generator.DataGenerator.ReferencedFileSet;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Currency;
@@ -158,7 +159,7 @@ public interface ProductInterfaceEditor extends ProductInterface, WithEntityBuil
 	 */
 	@ReferenceRef(Entities.PRODUCT)
 	@RemoveWhenExists
-	void removeRelatedProductByBoxedId(@javax.annotation.Nullable Integer productId);
+	void removeRelatedProductByBoxedId(@Nullable Integer productId);
 
 	@ReferenceRef(Entities.CATEGORY)
 	@RemoveWhenExists

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
@@ -186,6 +186,19 @@ public interface ProductInterfaceEditor extends ProductInterface, WithEntityBuil
 		@AttributeRef(ATTRIBUTE_RELATION_TYPE) String category
 	);
 
+	/**
+	 * Reproduces the production bug shape — `void` return, attribute-first then id —
+	 * matching `WithPublishedMediaEditor.removeMediaById(@AttributeRef gallery, int mediaId)`.
+	 * Expected semantics: remove the reference with id == productId AND attribute == category;
+	 * no-op if no such reference exists.
+	 */
+	@ReferenceRef(Entities.PRODUCT)
+	@RemoveWhenExists
+	void removeRelatedProductByCategoryAndId(
+		@AttributeRef(ATTRIBUTE_RELATION_TYPE) String category,
+		int productId
+	);
+
 	@ReferenceRef(Entities.PRODUCT)
 	@RemoveWhenExists
 	RelatedProductInterface removeRelatedProduct(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
@@ -141,6 +141,25 @@ public interface ProductInterfaceEditor extends ProductInterface, WithEntityBuil
 	@RemoveWhenExists
 	ProductInterfaceEditor removeProductCategoryById(int categoryId);
 
+	/**
+	 * Single-argument `@AttributeRef` of an int-convertible type. The argument is an attribute
+	 * predicate (filter by `ATTRIBUTE_CATEGORY_PRIORITY`), NOT the referenced primary key — see
+	 * #1241. With the bug, the classifier wrongly treated this as `referencedIdIndex` and tried
+	 * to remove the reference to category PK == priority.
+	 */
+	@ReferenceRef(Entities.CATEGORY)
+	@RemoveWhenExists
+	void removeProductCategoryByPriority(@AttributeRef(DataGenerator.ATTRIBUTE_CATEGORY_PRIORITY) Long priority);
+
+	/**
+	 * Boxed `Integer` referenced primary key — exists so a `null` argument can be passed at
+	 * runtime to verify the classifier raises a typed `EvitaInvalidUsageException` with the
+	 * reference name (instead of an opaque NPE — see #1241).
+	 */
+	@ReferenceRef(Entities.PRODUCT)
+	@RemoveWhenExists
+	void removeRelatedProductByBoxedId(@javax.annotation.Nullable Integer productId);
+
 	@ReferenceRef(Entities.CATEGORY)
 	@RemoveWhenExists
 	List<Integer> removeAllProductCategoriesAndReturnTheirIds();


### PR DESCRIPTION
## Summary

This PR fixes two related proxy-dispatch bugs surfaced while investigating churn on re-publish of media references in EdeeShop.

### Bug #1239 — `@RemoveWhenExists(int + @AttributeRef)` ignored the referenced id

- `@RemoveWhenExists` proxy methods declaring both an `int` referenced primary key and a `@AttributeRef` parameter silently dropped the `int` at dispatch and removed every reference whose attribute matched the predicate alone — e.g. `removeMediaById("gallery-x", 1110)` removed the reference to entity `1109` because its `gallery` attribute matched. On a re-publish loop this produced a `RemoveReferenceMutation` + `InsertReferenceMutation` pair for unchanged references, drifting the duplicate discriminator (`2 → 6 → …`) on every cycle.
- Thread `referencedIdIndex` through `removeReference`, `removeReferenceAndReturnItsProxy`, `removeReferencesAndReturnTheirProxies` via a new `getReferencesForRemoval` helper that narrows by referenced primary key before applying the composed predicate — mirroring the symmetric create/update path in `getOrCreateReferenceWithPredicateAndId`.

### Bug #1241 — classifier ordering and null-arg messaging (added in second commit)

Two pre-existing classifier concerns surfaced during this PR's Phase 1 bug-hunt. Originally filed as a follow-up; now resolved here:

- **A.** `getParsedArguments` classified any `int`-convertible parameter as `referencedIdIndex` *before* checking `@AttributeRef`. An `@AttributeRef int x` parameter was therefore misclassified as the referenced PK and — combined with the `getReferencesForRemoval` narrowing — would have looked up `entityBuilder.getReferences(refName, attributeValue)` and removed the wrong reference. Fixed by guarding the int-classification branch with `attributeRef.isEmpty()`.
- **B.** Nine sites in the classifier shared `Objects.requireNonNull(EvitaDataTypes.toTargetType((Serializable) args[i], int.class))`. A `null` boxed `Integer` argument therefore surfaced as an opaque `NullPointerException` with no context. Extracted a `requireReferencedId(args, idx, refName)` helper that throws `EvitaInvalidUsageException` naming the reference and applied it across all 9 sites.

Closes #1239
Closes #1241

## Test plan

- [x] **#1239** `shouldNotRemoveWrongReferenceWhenIdAndAttributePredicateProvided` — cross-arg `(attrOfA, idOfB)` no-op; matching `(attrOfA, idOfA)` removes only A
- [x] **#1239** `shouldRemoveCorrectDuplicateWhenIdAndAttributePredicateProvided` — `allowDuplicates` + representative attr variant
- [x] **#1239** `shouldUpdateExistingDuplicatedReferenceOnRepeatAddOrUpdate` — symmetry lockdown for the create/update path
- [x] **#1239** Strengthened `shouldRemoveRelatedProductInternal` to assert *which* reference survived
- [x] **#1239** Fixed two pre-existing tests that passed a literal id (latently broken — only "worked" under the bug): `shouldRemoveRelatedProductWhenFilterMatches`, `shouldRemoveRelatedProductWhenPredicateMatches`
- [x] **#1241-A** `shouldClassifyAttributeRefLongAsAttributePredicateNotReferencedId` — `@AttributeRef Long` parameter must be a ConstantPredicate, not the referenced PK
- [x] **#1241-B** `shouldThrowTypedExceptionOnNullReferencedIdArg` — null boxed-`Integer` arg raises `EvitaInvalidUsageException` whose message names the reference schema
- [x] `EntityEditorProxyingFunctionalTest` — 67/67 pass (was 65; +2 new)
- [x] `EntityInterfaceProxyingFunctionalTest` — 71/71 pass
- [x] `IsolatedEntityEditorProxyingFunctionalTest` — 8/8 pass
- [x] Full `io.evitadb.api.proxy.**` package — 389/389 pass (was 387; +2 new)