### PR TITLE
Forward-port #1239+#1241 @RemoveWhenExists id/predicate fixes to dev

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
+++ b/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
@@ -358,8 +358,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nonnull SealedEntityProxyState theState
 	) {
 		final String referenceName = referenceSchema.getName();
-		final int referencedId = Objects.requireNonNull(
-			EvitaDataTypes.toTargetType((Serializable) args[referenceIdLocation], int.class));
+		final int referencedId = requireReferencedId(args, referenceIdLocation, referenceName);
 		final Optional<ReferenceContract> reference = theState
 			.entityBuilder()
 		    .getReference(referenceName, referencedId);
@@ -509,8 +508,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nullable ConstantPredicate constantPredicate
 	) {
 		final String referenceName = referenceSchema.getName();
-		final int referencedId = Objects.requireNonNull(
-			EvitaDataTypes.toTargetType((Serializable) args[referenceIdLocation], int.class));
+		final int referencedId = requireReferencedId(args, referenceIdLocation, referenceName);
 		final Predicate<Object> predicate = predicateLocation >= 0 ?
 			(Predicate<Object>) Objects.requireNonNull(args[predicateLocation]) : null;
 		final Predicate<Object> composedPredicate = combinePredicates(predicate, constantPredicate, args);
@@ -827,7 +825,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		final Object referenceProxy = theState.getOrCreateReferencedEntityProxyWithCallback(
 			referenceSchema.getName(),
 			referencedIdIndex >= 0 ?
-				Objects.requireNonNull(EvitaDataTypes.toTargetType((Serializable) args[referencedIdIndex], int.class)) :
+				requireReferencedId(args, referencedIdIndex, referenceSchema.getName()) :
 				null,
 			referencedEntitySchema,
 			expectedType,
@@ -920,9 +918,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 				if (schemaCardinality.allowsDuplicates()) {
 					throw new ReferenceAllowsDuplicatesException(referenceName, theState.getEntitySchema(), Operation.WRITE);
 				} else {
-					final int requestedPrimaryKey = Objects.requireNonNull(
-						EvitaDataTypes.toTargetType((Serializable) args[referencedIdIndex], int.class)
-					);
+					final int requestedPrimaryKey = requireReferencedId(args, referencedIdIndex, referenceName);
 					referencedEntity = references.stream()
 						.filter(it -> it.getReferencedPrimaryKey() == requestedPrimaryKey)
 						.findFirst()
@@ -969,8 +965,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 	) {
 		final String referenceName = referenceSchema.getName();
 		return (entityClassifier, theMethod, args, theState, invokeSuper) -> {
-			final int referencedId = Objects.requireNonNull(
-				EvitaDataTypes.toTargetType((Serializable) args[0], int.class));
+			final int referencedId = requireReferencedId(args, 0, referenceName);
 			final Optional<ReferenceContract> reference = theState
 				.entityBuilder()
 			    .getReference(referenceName, referencedId);
@@ -1051,6 +1046,33 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 	}
 
 	/**
+	 * Reads the referenced primary key at `args[referencedIdIndex]` and converts it to `int`.
+	 * Throws `EvitaInvalidUsageException` carrying the reference name when the argument is `null`
+	 * (e.g. a boxed `Integer` parameter passed as `null`) instead of letting an opaque
+	 * `NullPointerException` bubble up from the value conversion (see #1241).
+	 *
+	 * @param args               the original method arguments
+	 * @param referencedIdIndex  position of the referenced primary key in `args` (must be `>= 0`)
+	 * @param referenceName      the reference schema name (used only in the error message)
+	 * @return the referenced primary key as an `int`
+	 */
+	private static int requireReferencedId(
+		@Nonnull Object[] args,
+		int referencedIdIndex,
+		@Nonnull String referenceName
+	) {
+		final Object rawArg = args[referencedIdIndex];
+		if (rawArg == null) {
+			throw new EvitaInvalidUsageException(
+				"Referenced primary key for reference `" + referenceName + "` must not be null!"
+			);
+		}
+		return Objects.requireNonNull(
+			EvitaDataTypes.toTargetType((Serializable) rawArg, int.class)
+		);
+	}
+
+	/**
 	 * Returns the references of the given name from the builder, optionally narrowed to a single
 	 * referenced primary key read from `args[referencedIdIndex]` when `referencedIdIndex >= 0`.
 	 * Mirrors the id-narrowing performed by the create/update path in
@@ -1071,9 +1093,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		int referencedIdIndex
 	) {
 		if (referencedIdIndex >= 0) {
-			final int referencedId = Objects.requireNonNull(
-				EvitaDataTypes.toTargetType((Serializable) args[referencedIdIndex], int.class)
-			);
+			final int referencedId = requireReferencedId(args, referencedIdIndex, referenceName);
 			return entityBuilder.getReferences(referenceName, referencedId);
 		}
 		return entityBuilder.getReferences(referenceName);
@@ -2158,8 +2178,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nonnull SealedEntityProxyState theState
 	) {
 		final EntityBuilder entityBuilder = theState.entityBuilder();
-		final Serializable referencedPrimaryKey = (Serializable) args[0];
-		final int referenceId = Objects.requireNonNull(EvitaDataTypes.toTargetType(referencedPrimaryKey, int.class));
+		final int referenceId = requireReferencedId(args, 0, referenceName);
 		final Optional<ReferenceContract> reference = entityBuilder.getReference(referenceName, referenceId);
 		if (reference.isPresent()) {
 			final ReferenceKey referenceKey = reference.get().getReferenceKey();
@@ -2186,8 +2205,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		final String referenceName = referenceSchema.getName();
 		return (proxy, theMethod, args, theState, invokeSuper) -> {
 			final EntityBuilder entityBuilder = theState.entityBuilder();
-			final int referencedPrimaryKey = Objects.requireNonNull(
-				EvitaDataTypes.toTargetType((Serializable) args[0], int.class));
+			final int referencedPrimaryKey = requireReferencedId(args, 0, referenceName);
 			final Optional<ReferenceContract> reference = entityBuilder.getReference(
 				referenceName, referencedPrimaryKey
 			);
@@ -2368,8 +2386,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		} else {
 			return (proxy, theMethod, args, theState, invokeSuper) -> {
 				final InternalEntityBuilder entityBuilder = theState.entityBuilder();
-				final int referencedId = Objects.requireNonNull(
-					EvitaDataTypes.toTargetType((Serializable) args[0], int.class));
+				final int referencedId = requireReferencedId(args, 0, referenceSchema.getName());
 				final ReferenceKey referenceKey = entityBuilder.createReference(
 					referenceSchema.getName(), referencedId
 				);
@@ -2661,7 +2678,10 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 				.map(AttributeRef::value)
 				.orElseGet(parameter::getName);
 
-			if (NumberUtils.isIntConvertibleNumber(parameterType)) {
+			// `@AttributeRef` takes precedence over the int-convertible referenced-id classification:
+			// an `@AttributeRef` parameter of an int-convertible type is a representative/filter
+			// attribute predicate, not the referenced primary key (see #1241).
+			if (NumberUtils.isIntConvertibleNumber(parameterType) && attributeRef.isEmpty()) {
 				referencedIdIndex = OptionalInt.of(i);
 			} else if (Consumer.class.isAssignableFrom(parameterType)) {
 				consumerIndex = OptionalInt.of(i);

--- a/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
+++ b/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
@@ -1051,9 +1051,39 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 	}
 
 	/**
+	 * Returns the references of the given name from the builder, optionally narrowed to a single
+	 * referenced primary key read from `args[referencedIdIndex]` when `referencedIdIndex >= 0`.
+	 * Mirrors the id-narrowing performed by the create/update path in
+	 * `getOrCreateReferenceWithPredicateAndId`, so that remove-by-(id + attribute predicate)
+	 * matches on BOTH the id and the predicate instead of the predicate alone.
+	 *
+	 * @param entityBuilder      the entity builder to read references from
+	 * @param referenceName      the reference schema name
+	 * @param args               the original method arguments (used only when referencedIdIndex >= 0)
+	 * @param referencedIdIndex  position of the referenced primary key in `args`, or `-1` if none
+	 * @return references for the given reference name (optionally narrowed by referenced primary key)
+	 */
+	@Nonnull
+	private static Collection<ReferenceContract> getReferencesForRemoval(
+		@Nonnull EntityBuilder entityBuilder,
+		@Nonnull String referenceName,
+		@Nonnull Object[] args,
+		int referencedIdIndex
+	) {
+		if (referencedIdIndex >= 0) {
+			final int referencedId = Objects.requireNonNull(
+				EvitaDataTypes.toTargetType((Serializable) args[referencedIdIndex], int.class)
+			);
+			return entityBuilder.getReferences(referenceName, referencedId);
+		}
+		return entityBuilder.getReferences(referenceName);
+	}
+
+	/**
 	 * Return a method implementation that removes the single reference if exists.
 	 *
 	 * @param referenceSchema the reference schema to use
+	 * @param referencedIdIndex index of the referenced primary key in the method args, or -1 if none
 	 * @return the method implementation
 	 */
 	@Nonnull
@@ -1062,6 +1092,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nonnull ReferenceSchemaContract referenceSchema,
 		@Nonnull ResolvedParameter resolvedParameter,
 		boolean entityRecognizedInReturnType,
+		int referencedIdIndex,
 		int predicateIndex,
 		@Nullable Class<?> predicateType,
 		@Nullable ConstantPredicate constantPredicate
@@ -1072,8 +1103,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 			if (Number.class.isAssignableFrom(returnType)) {
 				return (proxy, theMethod, args, theState, invokeSuper) -> {
 					final EntityBuilder entityBuilder = theState.entityBuilder();
-					final Collection<ReferenceContract> references = entityBuilder.getReferences(
-						referenceName);
+					final Collection<ReferenceContract> references = getReferencesForRemoval(
+						entityBuilder, referenceName, args, referencedIdIndex
+					);
 					//noinspection unchecked
 					final Predicate<Object> predicate = predicateIndex >= 0 ?
 						(Predicate<Object>) Objects.requireNonNull(args[predicateIndex]) :
@@ -1097,6 +1129,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 					referenceSchema,
 					returnType,
 					entityRecognizedInReturnType,
+					referencedIdIndex,
 					predicateIndex,
 					predicateType,
 					constantPredicate
@@ -1105,7 +1138,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		} else if (returnType.equals(void.class)) {
 			return (proxy, theMethod, args, theState, invokeSuper) -> {
 				final EntityBuilder entityBuilder = theState.entityBuilder();
-				final Collection<ReferenceContract> references = entityBuilder.getReferences(referenceName);
+				final Collection<ReferenceContract> references = getReferencesForRemoval(
+					entityBuilder, referenceName, args, referencedIdIndex
+				);
 				//noinspection unchecked
 				final Predicate<Object> predicate = predicateIndex >= 0 ? (Predicate<Object>) Objects.requireNonNull(
 					args[predicateIndex]) : null;
@@ -1124,7 +1159,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		} else if (Boolean.class.isAssignableFrom(returnType)) {
 			return (proxy, theMethod, args, theState, invokeSuper) -> {
 				final EntityBuilder entityBuilder = theState.entityBuilder();
-				final Collection<ReferenceContract> references = entityBuilder.getReferences(referenceName);
+				final Collection<ReferenceContract> references = getReferencesForRemoval(
+					entityBuilder, referenceName, args, referencedIdIndex
+				);
 				//noinspection unchecked
 				final Predicate<Object> predicate = predicateIndex >= 0 ? (Predicate<Object>) Objects.requireNonNull(
 					args[predicateIndex]) : null;
@@ -1146,8 +1183,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 			if (returnType.equals(proxyState.getProxyClass())) {
 				return (proxy, theMethod, args, theState, invokeSuper) -> {
 					final EntityBuilder entityBuilder = theState.entityBuilder();
-					final Collection<ReferenceContract> references = entityBuilder.getReferences(
-						referenceName);
+					final Collection<ReferenceContract> references = getReferencesForRemoval(
+						entityBuilder, referenceName, args, referencedIdIndex
+					);
 					if (references.isEmpty()) {
 						// do nothing
 					} else {
@@ -1171,7 +1209,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 			} else if (Number.class.isAssignableFrom(returnType) || (returnType.isPrimitive() && (int.class.equals(returnType) || long.class.equals(returnType)))) {
 				return (proxy, theMethod, args, theState, invokeSuper) -> {
 					final EntityBuilder entityBuilder = theState.entityBuilder();
-					final Collection<ReferenceContract> references = entityBuilder.getReferences(referenceName);
+					final Collection<ReferenceContract> references = getReferencesForRemoval(
+						entityBuilder, referenceName, args, referencedIdIndex
+					);
 					if (references.isEmpty()) {
 						// do nothing
 						return 0;
@@ -1199,6 +1239,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 					referenceSchema,
 					returnType,
 					entityRecognizedInReturnType,
+					referencedIdIndex,
 					predicateIndex,
 					predicateType,
 					constantPredicate
@@ -1242,6 +1283,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 	 * @param referenceSchema              the reference schema to use
 	 * @param returnType                   the return type
 	 * @param entityRecognizedInReturnType true if the entity annotation is recognized in the return type
+	 * @param referencedIdIndex            index of the referenced PK in method args, or -1 if none
 	 * @return the method implementation
 	 */
 	@Nonnull
@@ -1249,6 +1291,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nonnull ReferenceSchemaContract referenceSchema,
 		@Nonnull Class<?> returnType,
 		boolean entityRecognizedInReturnType,
+		int referencedIdIndex,
 		int predicateIndex,
 		@Nullable Class<?> predicateType,
 		@Nullable ConstantPredicate constantPredicate
@@ -1256,7 +1299,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		return (proxy, theMethod, args, theState, invokeSuper) -> {
 			final EntityBuilder entityBuilder = theState.entityBuilder();
 			final String referenceName = referenceSchema.getName();
-			final Collection<ReferenceContract> references = entityBuilder.getReferences(referenceName);
+			final Collection<ReferenceContract> references = getReferencesForRemoval(
+				entityBuilder, referenceName, args, referencedIdIndex
+			);
 			if (references.isEmpty()) {
 				// do nothing
 				return null;
@@ -1315,6 +1360,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 	 * @param referenceSchema              the reference schema to use
 	 * @param returnType                   the return type
 	 * @param entityRecognizedInReturnType true if the entity annotation is recognized in the return type
+	 * @param referencedIdIndex            index of the referenced PK in method args, or -1 if none
 	 * @return the method implementation
 	 */
 	@Nonnull
@@ -1322,6 +1368,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		@Nonnull ReferenceSchemaContract referenceSchema,
 		@Nonnull Class<?> returnType,
 		boolean entityRecognizedInReturnType,
+		int referencedIdIndex,
 		int predicateIndex,
 		@Nullable Class<?> predicateType,
 		@Nullable ConstantPredicate constantPredicate
@@ -1329,7 +1376,9 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 		return (proxy, theMethod, args, theState, invokeSuper) -> {
 			final EntityBuilder entityBuilder = theState.entityBuilder();
 			final String referenceName = referenceSchema.getName();
-			final Collection<ReferenceContract> references = entityBuilder.getReferences(referenceName);
+			final Collection<ReferenceContract> references = getReferencesForRemoval(
+				entityBuilder, referenceName, args, referencedIdIndex
+			);
 			if (references.isEmpty()) {
 				// do nothing
 				return Collections.emptyList();
@@ -2807,6 +2856,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 							      }),
 							isEntityRecognizedIn(parsedArguments.entityRecognizedIn(), EntityRecognizedIn.RETURN_TYPE),
 							-1,
+							-1,
 							null,
 							null
 						);
@@ -2842,6 +2892,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 										return new ResolvedParameter(method.getReturnType(), methodReturnType);
 									}),
 								isEntityRecognizedIn(parsedArguments.entityRecognizedIn(), EntityRecognizedIn.RETURN_TYPE),
+								parsedArguments.referencedIdIndex().orElse(-1),
 								parsedArguments.predicateIndex().orElse(-1),
 								parsedArguments.predicateType().map(ResolvedParameter::resolvedType).orElse(null),
 								parsedArguments.constantPredicate().orElse(null)
@@ -2902,6 +2953,7 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 									      return new ResolvedParameter(method.getReturnType(), methodReturnType);
 								      }),
 								isEntityRecognizedIn(parsedArguments.entityRecognizedIn(), EntityRecognizedIn.RETURN_TYPE),
+								parsedArguments.referencedIdIndex().orElse(-1),
 								parsedArguments.predicateIndex().orElse(-1),
 								parsedArguments.predicateType().map(ResolvedParameter::resolvedType).orElse(null),
 								parsedArguments.constantPredicate().orElse(null)

--- a/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
+++ b/evita_api/src/main/java/io/evitadb/api/proxy/impl/entityBuilder/SetReferenceMethodClassifier.java
@@ -1067,9 +1067,8 @@ public class SetReferenceMethodClassifier extends DirectMethodClassification<Obj
 				"Referenced primary key for reference `" + referenceName + "` must not be null!"
 			);
 		}
-		return Objects.requireNonNull(
-			EvitaDataTypes.toTargetType((Serializable) rawArg, int.class)
-		);
+		// EvitaDataTypes.toTargetType only returns null for null input; rawArg is non-null here.
+		return EvitaDataTypes.toTargetType((Serializable) rawArg, int.class);
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
@@ -29,7 +29,6 @@ import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.exception.MandatoryAttributesNotProvidedException;
 import io.evitadb.api.exception.ReferenceCardinalityViolatedException;
 import io.evitadb.api.proxy.mock.*;
-import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
@@ -3920,7 +3919,7 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 			reloaded.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class));
 	}
 
-	@DisplayName("Should treat @AttributeRef int-convertible parameter as attribute predicate, not referenced id")
+	@DisplayName("Should treat @AttributeRef parameter as attribute predicate, not referenced id")
 	@Order(47)
 	@Test
 	@UseDataSet(HUNDRED_PRODUCTS)
@@ -3983,7 +3982,7 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 		assertEquals(categoryBPk, remainingPersisted.get(0).getReferencedPrimaryKey());
 	}
 
-	@DisplayName("Should throw EvitaInvalidUsageException naming the reference when null Integer id is passed")
+	@DisplayName("Should throw EvitaInvalidUsageException naming reference on null id")
 	@Order(47)
 	@Test
 	@UseDataSet(HUNDRED_PRODUCTS)
@@ -4004,8 +4003,9 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 			() -> editor.removeRelatedProductByBoxedId(null),
 			"Null Integer referenced primary key must raise a typed EvitaInvalidUsageException"
 		);
+		assertNotNull(thrown.getMessage(), "Exception must carry a non-null message");
 		assertTrue(
-			thrown.getMessage() != null && thrown.getMessage().contains(Entities.PRODUCT),
+			thrown.getMessage().contains(Entities.PRODUCT),
 			"Exception message must name the reference schema; was: " + thrown.getMessage()
 		);
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
@@ -673,6 +673,17 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 
 		final int referenceCountAfterRemoving = editor2.entityBuilder().getReferences().size();
 		assertEquals(referenceCountAfterAdding - 1, referenceCountAfterRemoving);
+
+		// the surviving ref for the targeted related entity must be the CATEGORY_SIMILAR one
+		// (callers always remove the "accessory"-typed one)
+		final List<ReferenceContract> survivingForRelated = editor2.entityBuilder()
+			.getReferences(Entities.PRODUCT, related.getPrimaryKey());
+		assertEquals(1, survivingForRelated.size(),
+			"Exactly one reference must remain for the targeted related entity after the removal");
+		assertEquals(CATEGORY_SIMILAR,
+			survivingForRelated.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class),
+			"The 'accessory' reference must have been removed and the CATEGORY_SIMILAR one must survive");
+
 		editor2.upsertVia(evitaSession);
 
 		final SealedEntity after = evitaSession.getEntity(
@@ -681,6 +692,12 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 			entityFetchAllContent()
 		).orElseThrow();
 		assertEquals(referenceCountAfterRemoving, after.getReferences().size());
+
+		final List<ReferenceContract> survivingPersistedForRelated = after.getReferences(
+			Entities.PRODUCT, related.getPrimaryKey());
+		assertEquals(1, survivingPersistedForRelated.size());
+		assertEquals(CATEGORY_SIMILAR,
+			survivingPersistedForRelated.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class));
 	}
 
 	/**
@@ -3727,6 +3744,260 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 		));
 	}
 
+	@DisplayName("Should not remove unrelated reference when remove targets id of different ref")
+	@Order(47)
+	@Test
+	@UseDataSet(HUNDRED_PRODUCTS)
+	void shouldNotRemoveWrongReferenceWhenIdAndAttributePredicateProvided(
+		EvitaSessionContract evitaSession,
+		List<SealedEntity> originalProducts
+	) {
+		// Regression: see #1239 — @RemoveWhenExists(int + @AttributeRef) must match BOTH
+		// id AND attribute. Scenario from the bug report:
+		// references of type 'product' on a single main product:
+		//   (refId=A, relationType='similar')
+		//   (refId=B, relationType='different')
+		// then call remove(category='similar', productId=B)
+		//   expected: no-op (no reference matches BOTH id=B AND category='similar')
+		//   actual (bug): removes (A, 'similar') because the attribute predicate matches
+		//                 and the productId argument is silently ignored
+		final SealedEntity mainProduct = originalProducts.get(8);
+		final SealedEntity refA = originalProducts.get(9);
+		final SealedEntity refB = originalProducts.get(10);
+		final int idA = refA.getPrimaryKey();
+		final int idB = refB.getPrimaryKey();
+
+		// --- arrange: persist exactly two related-product references ---
+		final ProductInterfaceEditor setup = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		setup.removeAllRelatedProducts();
+		setup.addOrUpdateRelatedProduct(idA, CATEGORY_SIMILAR, rp -> {
+			rp.setLabel(Locale.ENGLISH, "Similar A");
+			rp.setLabel(CZECH_LOCALE, "Podobné A");
+		});
+		setup.addOrUpdateRelatedProduct(idB, CATEGORY_DIFFERENT, rp -> {
+			rp.setLabel(Locale.ENGLISH, "Different B");
+			rp.setLabel(CZECH_LOCALE, "Jiné B");
+		});
+		setup.upsertVia(evitaSession);
+
+		final SealedEntity persisted = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		assertEquals(2, persisted.getReferences(Entities.PRODUCT).size(),
+			"Precondition: main product must have exactly 2 related-product references");
+		assertEquals(1, persisted.getReferences(Entities.PRODUCT, idA).size());
+		assertEquals(1, persisted.getReferences(Entities.PRODUCT, idB).size());
+
+		// --- act (a): cross-call - attribute of ref A, id of ref B -> MUST be a no-op ---
+		final ProductInterfaceEditor crossEditor = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		crossEditor.removeRelatedProductByCategoryAndId(CATEGORY_SIMILAR, idB);
+
+		final List<ReferenceContract> afterCrossA = crossEditor.entityBuilder()
+			.getReferences(Entities.PRODUCT, idA);
+		final List<ReferenceContract> afterCrossB = crossEditor.entityBuilder()
+			.getReferences(Entities.PRODUCT, idB);
+		assertEquals(1, afterCrossA.size(),
+			"BUG: remove(category=SIMILAR, id=B) wrongly removed ref A whose category matches " +
+				"and whose id is NOT the argument B - the int productId argument must be honoured");
+		assertEquals(1, afterCrossB.size(),
+			"Ref B must remain untouched - its category is 'different', not 'similar'");
+
+		crossEditor.upsertVia(evitaSession);
+		final SealedEntity afterCrossPersisted = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		assertEquals(2, afterCrossPersisted.getReferences(Entities.PRODUCT).size(),
+			"Cross-arg remove must persist as a no-op - both references must still exist after reload");
+
+		// --- act (b): matching-call - attribute of ref A, id of ref A -> MUST remove exactly ref A ---
+		final ProductInterfaceEditor matchEditor = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		matchEditor.removeRelatedProductByCategoryAndId(CATEGORY_SIMILAR, idA);
+
+		final List<ReferenceContract> afterMatchA = matchEditor.entityBuilder()
+			.getReferences(Entities.PRODUCT, idA);
+		final List<ReferenceContract> afterMatchB = matchEditor.entityBuilder()
+			.getReferences(Entities.PRODUCT, idB);
+		assertEquals(0, afterMatchA.size(), "Ref A (matching both id and category) must be removed");
+		assertEquals(1, afterMatchB.size(), "Ref B must remain untouched");
+
+		matchEditor.upsertVia(evitaSession);
+		final SealedEntity afterMatchPersisted = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		assertEquals(1, afterMatchPersisted.getReferences(Entities.PRODUCT).size(),
+			"Exactly one reference (B) must remain after the matching-arg remove");
+		assertEquals(idB, afterMatchPersisted.getReferences(Entities.PRODUCT).iterator().next()
+			.getReferencedPrimaryKey());
+	}
+
+	@DisplayName("Should remove only the matching duplicate on id+representative-attribute remove")
+	@Order(47)
+	@Test
+	@UseDataSet(HUNDRED_PRODUCTS)
+	void shouldRemoveCorrectDuplicateWhenIdAndAttributePredicateProvided(
+		EvitaSessionContract evitaSession,
+		List<SealedEntity> originalProducts
+	) {
+		// Regression: see #1239 — @RemoveWhenExists(int + @AttributeRef) must match BOTH
+		// id AND attribute. Variant locking down the allowDuplicates + representative-attribute path:
+		// two references to the SAME referenced id distinguished by the representative attribute:
+		//   (refId=X, relationType='similar')
+		//   (refId=X, relationType='different')
+		// remove(category='similar', id=X) MUST remove only the 'similar' duplicate.
+		final SealedEntity mainProduct = originalProducts.get(11);
+		final SealedEntity related = originalProducts.get(12);
+		final int idX = related.getPrimaryKey();
+
+		final ProductInterfaceEditor setup = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		setup.removeAllRelatedProducts();
+		setup.addOrUpdateRelatedProduct(idX, CATEGORY_SIMILAR, rp -> {
+			rp.setLabel(Locale.ENGLISH, "Similar X");
+			rp.setLabel(CZECH_LOCALE, "Podobné X");
+		});
+		setup.addOrUpdateRelatedProduct(idX, CATEGORY_DIFFERENT, rp -> {
+			rp.setLabel(Locale.ENGLISH, "Different X");
+			rp.setLabel(CZECH_LOCALE, "Jiné X");
+		});
+		setup.upsertVia(evitaSession);
+
+		final SealedEntity persisted = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		assertEquals(2, persisted.getReferences(Entities.PRODUCT, idX).size(),
+			"Precondition: two duplicates of the same referenced id must exist");
+
+		// --- act: remove only the 'similar' duplicate ---
+		final ProductInterfaceEditor editor = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		editor.removeRelatedProductByCategoryAndId(CATEGORY_SIMILAR, idX);
+
+		final List<ReferenceContract> remaining = editor.entityBuilder()
+			.getReferences(Entities.PRODUCT, idX);
+		assertEquals(1, remaining.size(),
+			"After remove(category=SIMILAR, id=X) exactly one duplicate (the 'different' one) must remain");
+		assertEquals(CATEGORY_DIFFERENT,
+			remaining.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class),
+			"The surviving duplicate must be the 'different' one - id+category remove must NOT touch it");
+
+		editor.upsertVia(evitaSession);
+		final SealedEntity afterReload = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		final List<ReferenceContract> reloaded = afterReload.getReferences(Entities.PRODUCT, idX);
+		assertEquals(1, reloaded.size(),
+			"After persist+reload only one duplicate must remain");
+		assertEquals(CATEGORY_DIFFERENT,
+			reloaded.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class));
+	}
+
+	@DisplayName("Should update existing reference on repeat addOrUpdate, not duplicate it")
+	@Order(47)
+	@Test
+	@UseDataSet(HUNDRED_PRODUCTS)
+	void shouldUpdateExistingDuplicatedReferenceOnRepeatAddOrUpdate(
+		EvitaSessionContract evitaSession,
+		List<SealedEntity> originalProducts
+	) {
+		// Symmetry lockdown for #1239 — the create/update path already worked;
+		// this guards against regressing it.
+		// Lockdown for the create/update symmetric path: when a reference for (relatedPk, attribute)
+		// is already persisted, a second addOrUpdate call must FIND it and update its attributes
+		// rather than recreate (this path already worked - the test prevents regression).
+		final SealedEntity mainProduct = originalProducts.get(4);
+		final SealedEntity relatedProduct = originalProducts.get(5);
+		final int relatedPk = relatedProduct.getPrimaryKey();
+		final String relationType = CATEGORY_SIMILAR;
+
+		// Phase 1: clear any pre-existing related products and persist a single one
+		final ProductInterfaceEditor firstEditor = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		firstEditor.removeAllRelatedProducts();
+		firstEditor.addOrUpdateRelatedProduct(
+			relatedPk,
+			relationType,
+			rp -> {
+				rp.setLabel(Locale.ENGLISH, "Initial");
+				rp.setLabel(CZECH_LOCALE, "Počáteční");
+			}
+		);
+		firstEditor.upsertVia(evitaSession);
+
+		// Phase 2: reload (so the reference is part of the BASE references) and call addOrUpdate again
+		final ProductInterfaceEditor secondEditor = evitaSession.getEntity(
+			ProductInterfaceEditor.class,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		secondEditor.addOrUpdateRelatedProduct(
+			relatedPk,
+			relationType,
+			rp -> rp.setLabel(Locale.ENGLISH, "Updated")
+		);
+
+		final List<ReferenceContract> afterUpdate = secondEditor.entityBuilder()
+			.getReferences(Entities.PRODUCT, relatedPk);
+		assertEquals(1, afterUpdate.size(),
+			"addOrUpdate must FIND the existing persisted reference and update it - not create a duplicate");
+		assertEquals(
+			"Updated",
+			afterUpdate.get(0).getAttribute(ATTRIBUTE_PRODUCT_LABEL, Locale.ENGLISH, String.class),
+			"The new English label must be applied to the existing reference");
+		assertEquals(
+			"Počáteční",
+			afterUpdate.get(0).getAttribute(ATTRIBUTE_PRODUCT_LABEL, CZECH_LOCALE, String.class),
+			"Czech label from phase 1 must be preserved - if it is null, " +
+				"the reference was recreated rather than updated");
+
+		// Persist and verify after reload
+		secondEditor.upsertVia(evitaSession);
+		final SealedEntity reloaded = evitaSession.getEntity(
+			Entities.PRODUCT,
+			mainProduct.getPrimaryKey(),
+			entityFetchAllContent()
+		).orElseThrow();
+		final List<ReferenceContract> reloadedRefs = reloaded.getReferences(Entities.PRODUCT, relatedPk);
+		assertEquals(1, reloadedRefs.size(),
+			"After persistence there must still be exactly one reference for (refId, relationType)");
+		assertEquals(
+			"Updated",
+			reloadedRefs.get(0).getAttribute(ATTRIBUTE_PRODUCT_LABEL, Locale.ENGLISH, String.class));
+		assertEquals(
+			"Počáteční",
+			reloadedRefs.get(0).getAttribute(ATTRIBUTE_PRODUCT_LABEL, CZECH_LOCALE, String.class));
+	}
+
 	@DisplayName("Should update duplicated reference when predicate matches")
 	@Order(47)
 	@Test
@@ -3782,11 +4053,12 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 		EvitaSessionContract evitaSession,
 		List<SealedEntity> originalProducts
 	) {
+		final int relatedPk = originalProducts.get(6).getPrimaryKey();
 		shouldRemoveRelatedProductInternal(
 			evitaSession,
 			originalProducts,
 			5, 6,
-			editor -> editor.removeRelatedProduct(6, "accessory")
+			editor -> editor.removeRelatedProduct(relatedPk, "accessory")
 		);
 	}
 
@@ -3798,11 +4070,13 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 		EvitaSessionContract evitaSession,
 		List<SealedEntity> originalProducts
 	) {
+		final int relatedPk = originalProducts.get(8).getPrimaryKey();
 		shouldRemoveRelatedProductInternal(
 			evitaSession,
 			originalProducts,
 			7, 8,
-			editor -> editor.removeRelatedProduct(6, ref -> "accessory".equals(ref.getRelationType()))
+			editor -> editor.removeRelatedProduct(
+				relatedPk, ref -> "accessory".equals(ref.getRelationType()))
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/EntityEditorProxyingFunctionalTest.java
@@ -29,6 +29,7 @@ import io.evitadb.api.EvitaSessionContract;
 import io.evitadb.api.exception.MandatoryAttributesNotProvidedException;
 import io.evitadb.api.exception.ReferenceCardinalityViolatedException;
 import io.evitadb.api.proxy.mock.*;
+import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
@@ -3917,6 +3918,96 @@ public class EntityEditorProxyingFunctionalTest extends AbstractEntityProxyingFu
 			"After persist+reload only one duplicate must remain");
 		assertEquals(CATEGORY_DIFFERENT,
 			reloaded.get(0).getAttribute(ATTRIBUTE_RELATION_TYPE, String.class));
+	}
+
+	@DisplayName("Should treat @AttributeRef int-convertible parameter as attribute predicate, not referenced id")
+	@Order(47)
+	@Test
+	@UseDataSet(HUNDRED_PRODUCTS)
+	void shouldClassifyAttributeRefLongAsAttributePredicateNotReferencedId(
+		EvitaSessionContract evitaSession,
+		List<SealedEntity> originalProducts
+	) {
+		// Regression: see #1241 (finding A). With the bug, an @AttributeRef parameter of an
+		// int-convertible type was classified as `referencedIdIndex`, so the remove call would
+		// look up `getReferences("CATEGORY", priorityValue)` (treating the attribute value as a
+		// primary key) and remove the wrong reference (or nothing).
+		final SealedEntity mainProduct = originalProducts.get(13);
+		final int mainPk = mainProduct.getPrimaryKey();
+		final int categoryAPk = originalProducts.get(14).getPrimaryKey();
+		final int categoryBPk = originalProducts.get(15).getPrimaryKey();
+		final long priorityToRemove = 1_000_001L;
+		final long priorityToKeep = 1_000_002L;
+
+		// arrange: clear any pre-existing category refs, then add two with distinct priorities
+		final ProductInterfaceEditor setup = evitaSession.getEntity(
+			ProductInterfaceEditor.class, mainPk, entityFetchAllContent()
+		).orElseThrow();
+		setup.removeAllProductCategoriesAndReturnTheirIds();
+		setup.addProductCategory(categoryAPk, pc -> pc
+			.setOrderInCategory(priorityToRemove)
+			.setShadow(false)
+			.setLabel(CZECH_LOCALE, "A")
+			.setLabel(Locale.ENGLISH, "A"));
+		setup.addProductCategory(categoryBPk, pc -> pc
+			.setOrderInCategory(priorityToKeep)
+			.setShadow(false)
+			.setLabel(CZECH_LOCALE, "B")
+			.setLabel(Locale.ENGLISH, "B"));
+		setup.upsertVia(evitaSession);
+
+		// act: remove by the priority attribute predicate; with bug -> no-op (no category PK
+		// equals 1_000_001), so both refs survive and the test catches the regression.
+		final ProductInterfaceEditor editor = evitaSession.getEntity(
+			ProductInterfaceEditor.class, mainPk, entityFetchAllContent()
+		).orElseThrow();
+		editor.removeProductCategoryByPriority(priorityToRemove);
+
+		// in-builder
+		final List<ReferenceContract> remainingInBuilder = editor.entityBuilder()
+			.getReferences(Entities.CATEGORY)
+			.stream().toList();
+		assertEquals(1, remainingInBuilder.size(),
+			"Exactly one category reference must remain - the matching-priority one was removed");
+		assertEquals(categoryBPk, remainingInBuilder.get(0).getReferencedPrimaryKey(),
+			"The surviving reference must point to category B (priorityToKeep)");
+
+		// persisted
+		editor.upsertVia(evitaSession);
+		final SealedEntity reloaded = evitaSession.getEntity(
+			Entities.PRODUCT, mainPk, entityFetchAllContent()
+		).orElseThrow();
+		final List<ReferenceContract> remainingPersisted = reloaded.getReferences(Entities.CATEGORY)
+			.stream().toList();
+		assertEquals(1, remainingPersisted.size());
+		assertEquals(categoryBPk, remainingPersisted.get(0).getReferencedPrimaryKey());
+	}
+
+	@DisplayName("Should throw EvitaInvalidUsageException naming the reference when null Integer id is passed")
+	@Order(47)
+	@Test
+	@UseDataSet(HUNDRED_PRODUCTS)
+	void shouldThrowTypedExceptionOnNullReferencedIdArg(
+		EvitaSessionContract evitaSession,
+		List<SealedEntity> originalProducts
+	) {
+		// Regression: see #1241 (finding B). A null boxed-Integer argument used to surface as
+		// an opaque NullPointerException with no context. The classifier now throws a typed
+		// EvitaInvalidUsageException whose message names the reference schema.
+		final SealedEntity mainProduct = originalProducts.get(16);
+		final ProductInterfaceEditor editor = evitaSession.getEntity(
+			ProductInterfaceEditor.class, mainProduct.getPrimaryKey(), entityFetchAllContent()
+		).orElseThrow();
+
+		final EvitaInvalidUsageException thrown = assertThrows(
+			EvitaInvalidUsageException.class,
+			() -> editor.removeRelatedProductByBoxedId(null),
+			"Null Integer referenced primary key must raise a typed EvitaInvalidUsageException"
+		);
+		assertTrue(
+			thrown.getMessage() != null && thrown.getMessage().contains(Entities.PRODUCT),
+			"Exception message must name the reference schema; was: " + thrown.getMessage()
+		);
 	}
 
 	@DisplayName("Should update existing reference on repeat addOrUpdate, not duplicate it")

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
@@ -43,6 +43,7 @@ import io.evitadb.test.generator.DataGenerator.Labels;
 import io.evitadb.test.generator.DataGenerator.ReferencedFileSet;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Currency;
@@ -158,7 +159,7 @@ public interface ProductInterfaceEditor extends ProductInterface, WithEntityBuil
 	 */
 	@ReferenceRef(Entities.PRODUCT)
 	@RemoveWhenExists
-	void removeRelatedProductByBoxedId(@javax.annotation.Nullable Integer productId);
+	void removeRelatedProductByBoxedId(@Nullable Integer productId);
 
 	@ReferenceRef(Entities.CATEGORY)
 	@RemoveWhenExists

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
@@ -186,6 +186,19 @@ public interface ProductInterfaceEditor extends ProductInterface, WithEntityBuil
 		@AttributeRef(ATTRIBUTE_RELATION_TYPE) String category
 	);
 
+	/**
+	 * Reproduces the production bug shape — `void` return, attribute-first then id —
+	 * matching `WithPublishedMediaEditor.removeMediaById(@AttributeRef gallery, int mediaId)`.
+	 * Expected semantics: remove the reference with id == productId AND attribute == category;
+	 * no-op if no such reference exists.
+	 */
+	@ReferenceRef(Entities.PRODUCT)
+	@RemoveWhenExists
+	void removeRelatedProductByCategoryAndId(
+		@AttributeRef(ATTRIBUTE_RELATION_TYPE) String category,
+		int productId
+	);
+
 	@ReferenceRef(Entities.PRODUCT)
 	@RemoveWhenExists
 	RelatedProductInterface removeRelatedProduct(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/proxy/mock/ProductInterfaceEditor.java
@@ -141,6 +141,25 @@ public interface ProductInterfaceEditor extends ProductInterface, WithEntityBuil
 	@RemoveWhenExists
 	ProductInterfaceEditor removeProductCategoryById(int categoryId);
 
+	/**
+	 * Single-argument `@AttributeRef` of an int-convertible type. The argument is an attribute
+	 * predicate (filter by `ATTRIBUTE_CATEGORY_PRIORITY`), NOT the referenced primary key — see
+	 * #1241. With the bug, the classifier wrongly treated this as `referencedIdIndex` and tried
+	 * to remove the reference to category PK == priority.
+	 */
+	@ReferenceRef(Entities.CATEGORY)
+	@RemoveWhenExists
+	void removeProductCategoryByPriority(@AttributeRef(DataGenerator.ATTRIBUTE_CATEGORY_PRIORITY) Long priority);
+
+	/**
+	 * Boxed `Integer` referenced primary key — exists so a `null` argument can be passed at
+	 * runtime to verify the classifier raises a typed `EvitaInvalidUsageException` with the
+	 * reference name (instead of an opaque NPE — see #1241).
+	 */
+	@ReferenceRef(Entities.PRODUCT)
+	@RemoveWhenExists
+	void removeRelatedProductByBoxedId(@javax.annotation.Nullable Integer productId);
+
 	@ReferenceRef(Entities.CATEGORY)
 	@RemoveWhenExists
 	List<Integer> removeAllProductCategoriesAndReturnTheirIds();


### PR DESCRIPTION
Forward-port of [#1242](https://github.com/FgForrest/evitaDB/pull/1242) (against `release_2026-1`) to `dev`.

## Summary
- **#1239** — `@RemoveWhenExists` proxy methods declaring both an `int referencedId` and an `@AttributeRef` parameter silently dropped the id at dispatch and removed any reference matching the predicate alone. Fixed by threading `referencedIdIndex` through all three remove paths via a new `getReferencesForRemoval(...)` helper so the remove now matches on BOTH id AND predicate.
- **#1241** — Classifier was treating an `@AttributeRef`-annotated int-convertible parameter as the referenced primary key. Added an `attributeRef.isEmpty()` guard so `@AttributeRef int/long/Long` is correctly classified as a representative-attribute predicate. Centralised null-arg handling in a `requireReferencedId(...)` helper that throws a typed `EvitaInvalidUsageException` instead of a bare NPE (applied at 9 call sites).
- 5 regression tests covering both issues plus the duplicate-on-representative-attribute path.

## Cherry-pick provenance
Three commits cherry-picked verbatim from `release_2026-1` (PR #1242), no conflicts (auto-merges only):
- `f24145c29` → `f5a36335b` (fix: honour referenced id in `@RemoveWhenExists`)
- `76c54f8fe` → `3341ec9a9` (fix: classify `@AttributeRef int` as predicate)
- `69f0e5ea1` → `a3e192613` (chore: code-quality review polish)

## Test plan
- [x] `evita_api` + `evita_functional_tests` compile against dev
- [ ] Run proxy package tests on dev (`EntityEditorProxyingFunctionalTest`) — 389/389 passed on `release_2026-1`
- [ ] Verify no regression in adjacent `IsolatedEntityEditorProxyingFunctionalTest`

Closes #1239
Closes #1241