### PR TITLE
Fix range-typed bucketed histograms rendered with point semantics

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/Histogram.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/Histogram.java
@@ -54,9 +54,11 @@ public class Histogram implements HistogramContract {
 	 */
 	@Getter private final Bucket[] buckets;
 	/**
-	 * Number of distinct entities covered by the histogram. For point and price histograms this equals the sum of
-	 * occurrences across all buckets; for range (overlap) histograms a single record may overlap multiple buckets,
-	 * so the distinct count is smaller than the bucket-occurrence sum and must be stored explicitly.
+	 * Number of entities represented by the histogram. For point and price histograms, and for range histograms
+	 * under the frequency-equalised behaviors (`EQUALIZED` / `EQUALIZED_OPTIMIZED`), this equals the sum of
+	 * occurrences across all buckets; for range histograms under the overlap behaviors (`STANDARD` / `OPTIMIZED`) a
+	 * single record may overlap multiple buckets, so this is the distinct count — smaller than the bucket-occurrence
+	 * sum — and must be stored explicitly.
 	 */
 	private final int overallCount;
 	/**

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/Histogram.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/Histogram.java
@@ -45,8 +45,20 @@ import java.util.Optional;
 @EqualsAndHashCode
 public class Histogram implements HistogramContract {
 	@Serial private static final long serialVersionUID = -4037073601860571920L;
+	/**
+	 * Inclusive upper bound of the last bucket; the rightmost bucket stores only its lower threshold.
+	 */
 	private final BigDecimal max;
+	/**
+	 * Pre-computed buckets ordered by ascending threshold; never empty (enforced by the constructor).
+	 */
 	@Getter private final Bucket[] buckets;
+	/**
+	 * Number of distinct entities covered by the histogram. For point and price histograms this equals the sum of
+	 * occurrences across all buckets; for range (overlap) histograms a single record may overlap multiple buckets,
+	 * so the distinct count is smaller than the bucket-occurrence sum and must be stored explicitly.
+	 */
+	private final int overallCount;
 	/**
 	 * Referenced entity whose value anchors the minimum bucket of the histogram. Populated only for
 	 * histograms computed over references when the query requests an entity fetch for the reference.
@@ -72,6 +84,26 @@ public class Histogram implements HistogramContract {
 		@Nullable SealedEntity minReferencedEntity,
 		@Nullable SealedEntity maxReferencedEntity
 	) {
+		this(buckets, max, sumOccurrences(buckets), minReferencedEntity, maxReferencedEntity);
+	}
+
+	/**
+	 * Constructor variant accepting an explicit `overallCount`. Used by range (overlap) histograms where a single
+	 * record may overlap multiple buckets, so the distinct-record count differs from the bucket-occurrence sum.
+	 *
+	 * @param buckets             non-empty array of buckets with strictly monotonic thresholds
+	 * @param max                 inclusive right bound of the last bucket; must be `>= buckets[last].threshold()`
+	 * @param overallCount        number of distinct entities covered by the histogram
+	 * @param minReferencedEntity entity anchoring the first bucket, or `null` if unresolved
+	 * @param maxReferencedEntity entity anchoring the last bucket, or `null` if unresolved
+	 */
+	public Histogram(
+		@Nonnull Bucket[] buckets,
+		@Nonnull BigDecimal max,
+		int overallCount,
+		@Nullable SealedEntity minReferencedEntity,
+		@Nullable SealedEntity maxReferencedEntity
+	) {
 		Assert.isTrue(!ArrayUtils.isEmpty(buckets), "Buckets may never be empty!");
 		Assert.isTrue(
 			buckets[buckets.length - 1].threshold().compareTo(max) <= 0,
@@ -91,8 +123,20 @@ public class Histogram implements HistogramContract {
 		);
 		this.buckets = buckets;
 		this.max = max;
+		this.overallCount = overallCount;
 		this.minReferencedEntity = minReferencedEntity;
 		this.maxReferencedEntity = maxReferencedEntity;
+	}
+
+	/**
+	 * Sums the occurrences across all buckets — the point/price-histogram definition of overall count.
+	 */
+	private static int sumOccurrences(@Nonnull Bucket[] buckets) {
+		int sum = 0;
+		for (final Bucket bucket : buckets) {
+			sum += bucket.occurrences();
+		}
+		return sum;
 	}
 
 	@Override
@@ -123,11 +167,7 @@ public class Histogram implements HistogramContract {
 
 	@Override
 	public int getOverallCount() {
-		int sum = 0;
-		for (final Bucket bucket : this.buckets) {
-			sum += bucket.occurrences();
-		}
-		return sum;
+		return this.overallCount;
 	}
 
 	@Nonnull

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/HistogramContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/HistogramContract.java
@@ -112,9 +112,11 @@ public interface HistogramContract extends Serializable {
 	BigDecimal getMax();
 
 	/**
-	 * Returns count of all distinct entities that are covered by this histogram. For point and price histograms
-	 * this equals the sum of occurrences across all buckets. For range (overlap) histograms a single record may
-	 * overlap several buckets, so the distinct entity count is smaller than the bucket-occurrence sum.
+	 * Returns the number of entities represented by this histogram. For point and price histograms, and for range
+	 * histograms produced under the frequency-equalised behaviors (`EQUALIZED` / `EQUALIZED_OPTIMIZED`), this equals
+	 * the sum of occurrences across all buckets. For range histograms produced under the overlap behaviors
+	 * (`STANDARD` / `OPTIMIZED`) a single record may overlap several buckets, so this is the distinct entity count,
+	 * which is smaller than the bucket-occurrence sum.
 	 */
 	int getOverallCount();
 

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/HistogramContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/HistogramContract.java
@@ -112,8 +112,9 @@ public interface HistogramContract extends Serializable {
 	BigDecimal getMax();
 
 	/**
-	 * Returns count of all entities that are covered by this histogram. It's plain sum of occurrences of all buckets
-	 * in the histogram.
+	 * Returns count of all distinct entities that are covered by this histogram. For point and price histograms
+	 * this equals the sum of occurrences across all buckets. For range (overlap) histograms a single record may
+	 * overlap several buckets, so the distinct entity count is smaller than the bucket-occurrence sum.
 	 */
 	int getOverallCount();
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/cache/CacheableHistogram.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/cache/CacheableHistogram.java
@@ -38,7 +38,6 @@ import javax.annotation.Nullable;
 import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.function.Predicate;
 
 /**
@@ -83,6 +82,12 @@ public class CacheableHistogram implements CacheableHistogramContract {
 	 * contract.
 	 */
 	@Nullable private final Serializable rawMax;
+	/**
+	 * Number of distinct entities covered by the histogram. For point and price histograms this equals the sum of
+	 * occurrences across all buckets; for range (overlap) histograms a single record may overlap multiple buckets,
+	 * so the distinct count is smaller than the bucket-occurrence sum and must be stored explicitly.
+	 */
+	private final int overallCount;
 
 	/**
 	 * Legacy constructor — delegates to the four-argument form with {@code null} raw bounds. Retained for callers
@@ -107,6 +112,26 @@ public class CacheableHistogram implements CacheableHistogramContract {
 		@Nullable Serializable rawMin,
 		@Nullable Serializable rawMax
 	) {
+		this(buckets, max, rawMin, rawMax, sumOccurrences(buckets));
+	}
+
+	/**
+	 * Constructor variant accepting an explicit `overallCount`. Used by range (overlap) histograms where a single
+	 * record may overlap multiple buckets, so the distinct-record count differs from the bucket-occurrence sum.
+	 *
+	 * @param buckets      non-empty array of buckets with strictly monotonic thresholds
+	 * @param max          inclusive right bound of the last bucket; must be `>= buckets[last].threshold()`
+	 * @param rawMin       native-typed smallest attribute value observed, or {@code null} when unavailable
+	 * @param rawMax       native-typed largest attribute value observed, or {@code null} when unavailable
+	 * @param overallCount number of distinct entities covered by the histogram
+	 */
+	public CacheableHistogram(
+		@Nonnull CacheableBucket[] buckets,
+		@Nonnull BigDecimal max,
+		@Nullable Serializable rawMin,
+		@Nullable Serializable rawMax,
+		int overallCount
+	) {
 		Assert.isTrue(!ArrayUtils.isEmpty(buckets), "Buckets may never be empty!");
 		Assert.isTrue(buckets[buckets.length - 1].threshold().compareTo(max) <= 0, "Last bucket must have threshold lower than max!");
 		CacheableBucket lastBucket = null;
@@ -121,6 +146,18 @@ public class CacheableHistogram implements CacheableHistogramContract {
 		this.max = max;
 		this.rawMin = rawMin;
 		this.rawMax = rawMax;
+		this.overallCount = overallCount;
+	}
+
+	/**
+	 * Sums the occurrences across all buckets — the point/price-histogram definition of overall count.
+	 */
+	private static int sumOccurrences(@Nonnull CacheableBucket[] buckets) {
+		int sum = 0;
+		for (final CacheableBucket bucket : buckets) {
+			sum += bucket.occurrences();
+		}
+		return sum;
 	}
 
 	@Nonnull
@@ -148,12 +185,13 @@ public class CacheableHistogram implements CacheableHistogramContract {
 	}
 
 	/**
-	 * Returns the sum of occurrences across all buckets — the total number of entities covered by this histogram.
-	 * This is the raw cached value, not filtered by any query-time predicate.
+	 * Returns the number of distinct entities covered by this histogram. For point and price histograms this equals
+	 * the sum of bucket occurrences; for range (overlap) histograms it is the distinct-record count carried over from
+	 * the producer. This is the raw cached value, not filtered by any query-time predicate.
 	 */
 	@Override
 	public int getOverallCount() {
-		return Arrays.stream(this.buckets).mapToInt(CacheableBucket::occurrences).sum();
+		return this.overallCount;
 	}
 
 	@Override
@@ -176,11 +214,9 @@ public class CacheableHistogram implements CacheableHistogramContract {
 		@Nullable SealedEntity minReferencedEntity,
 		@Nullable SealedEntity maxReferencedEntity
 	) {
-		if (minReferencedEntity == null && maxReferencedEntity == null) {
-			return new Histogram(buildBuckets(requestedPredicate), this.max);
-		}
 		return new Histogram(
-			buildBuckets(requestedPredicate), this.max, minReferencedEntity, maxReferencedEntity
+			buildBuckets(requestedPredicate), this.max, this.overallCount,
+			minReferencedEntity, maxReferencedEntity
 		);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/cache/CacheableHistogram.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/cache/CacheableHistogram.java
@@ -83,9 +83,11 @@ public class CacheableHistogram implements CacheableHistogramContract {
 	 */
 	@Nullable private final Serializable rawMax;
 	/**
-	 * Number of distinct entities covered by the histogram. For point and price histograms this equals the sum of
-	 * occurrences across all buckets; for range (overlap) histograms a single record may overlap multiple buckets,
-	 * so the distinct count is smaller than the bucket-occurrence sum and must be stored explicitly.
+	 * Number of entities represented by the histogram. For point and price histograms, and for range histograms
+	 * under the frequency-equalised behaviors (`EQUALIZED` / `EQUALIZED_OPTIMIZED`), this equals the sum of
+	 * occurrences across all buckets; for range histograms under the overlap behaviors (`STANDARD` / `OPTIMIZED`) a
+	 * single record may overlap multiple buckets, so this is the distinct count — smaller than the bucket-occurrence
+	 * sum — and must be stored explicitly.
 	 */
 	private final int overallCount;
 
@@ -185,9 +187,11 @@ public class CacheableHistogram implements CacheableHistogramContract {
 	}
 
 	/**
-	 * Returns the number of distinct entities covered by this histogram. For point and price histograms this equals
-	 * the sum of bucket occurrences; for range (overlap) histograms it is the distinct-record count carried over from
-	 * the producer. This is the raw cached value, not filtered by any query-time predicate.
+	 * Returns the number of entities represented by this histogram. For point and price histograms, and for range
+	 * histograms under the frequency-equalised behaviors (`EQUALIZED` / `EQUALIZED_OPTIMIZED`), this equals the sum of
+	 * bucket occurrences; for range histograms under the overlap behaviors (`STANDARD` / `OPTIMIZED`) it is the
+	 * distinct-record count carried over from the producer. This is the raw cached value, not filtered by any
+	 * query-time predicate.
 	 */
 	@Override
 	public int getOverallCount() {

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/cache/CacheableHistogramContract.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/cache/CacheableHistogramContract.java
@@ -168,9 +168,11 @@ public interface CacheableHistogramContract extends Serializable {
 	}
 
 	/**
-	 * Returns count of all distinct entities that are covered by this histogram. For point and price histograms this
-	 * equals the sum of occurrences across all buckets. For range (overlap) histograms a single record may overlap
-	 * several buckets, so the distinct entity count is smaller than the bucket-occurrence sum.
+	 * Returns the number of entities represented by this histogram. For point and price histograms, and for range
+	 * histograms under the frequency-equalised behaviors (`EQUALIZED` / `EQUALIZED_OPTIMIZED`), this equals the sum of
+	 * occurrences across all buckets. For range histograms under the overlap behaviors (`STANDARD` / `OPTIMIZED`) a
+	 * single record may overlap several buckets, so this is the distinct entity count, which is smaller than the
+	 * bucket-occurrence sum.
 	 */
 	int getOverallCount();
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/cache/CacheableHistogramContract.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/cache/CacheableHistogramContract.java
@@ -168,8 +168,9 @@ public interface CacheableHistogramContract extends Serializable {
 	}
 
 	/**
-	 * Returns count of all entities that are covered by this histogram. It's plain sum of occurrences of all buckets
-	 * in the histogram.
+	 * Returns count of all distinct entities that are covered by this histogram. For point and price histograms this
+	 * equals the sum of occurrences across all buckets. For range (overlap) histograms a single record may overlap
+	 * several buckets, so the distinct entity count is smaller than the bucket-occurrence sum.
 	 */
 	int getOverallCount();
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/AttributeHistogramComputer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/AttributeHistogramComputer.java
@@ -421,16 +421,23 @@ public class AttributeHistogramComputer implements CacheableEvitaResponseExtraRe
 				// lose precision for BigDecimal attributes whose stored scale exceeds indexedDecimalPlaces
 				final Serializable rawMin = histogramBuckets[0].getValue();
 				final Serializable rawMax = histogramBuckets[histogramBuckets.length - 1].getValue();
-				// range-typed schemas render overlap histograms: a record whose value-range spans
-				// several buckets must contribute to each of them as a single distinct occurrence, and the
-				// overall count is the distinct-record cardinality — not the inflated per-threshold sum that the
-				// point-oriented HistogramDataCruncher would produce
+				// the equal-width range behaviors (STANDARD, OPTIMIZED) render overlap histograms: a record whose
+				// value-range spans several buckets contributes a single distinct occurrence to each, and the overall
+				// count is the distinct-record cardinality — not the inflated per-threshold sum the point-oriented
+				// HistogramDataCruncher would produce. OPTIMIZED additionally widens the grid to drop empty coverage
+				// gaps. The frequency-equalised behaviors (EQUALIZED, EQUALIZED_OPTIMIZED) deliberately fall through
+				// to the point/equalised path below: fed the range sweep, EqualizedHistogramDataCruncher accounts
+				// each record at every global stop its range covers (the sweep's rolling active set), which yields the
+				// fixed total mass cumulative-frequency equalisation requires — something overlap counting, whose
+				// bucket-occurrence sum varies with the grid, cannot provide
 				final boolean rangeTyped = EvitaDataTypes.resolveRangeInnerNumericType(
 					this.request.attributeSchema().getType()
 				) != null;
-				if (rangeTyped) {
+				final boolean overlapBehavior = this.behavior == HistogramBehavior.STANDARD
+					|| this.behavior == HistogramBehavior.OPTIMIZED;
+				if (rangeTyped && overlapBehavior) {
 					final RangeHistogramDataCruncher rangeCruncher = new RangeHistogramDataCruncher(
-						histogramBuckets, this.bucketCount, this.request.getDecimalPlaces()
+						histogramBuckets, this.bucketCount, this.request.getDecimalPlaces(), this.behavior
 					);
 					this.memoizedResult = new CacheableHistogram(
 						rangeCruncher.getHistogram(),

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/AttributeHistogramComputer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/AttributeHistogramComputer.java
@@ -411,25 +411,45 @@ public class AttributeHistogramComputer implements CacheableEvitaResponseExtraRe
 			final ValueToRecordBitmap[] histogramBuckets = computeNarrowedHistogramBuckets(
 				this, this.filterFormula, this.request.comparator()
 			);
-			final HistogramDataCruncherContract<?> histogramCruncher = createHistogramDataCruncher(
-				this, this.bucketCount, this.behavior, histogramBuckets
-			);
 
-			if (histogramCruncher != null) {
+			if (ArrayUtils.isEmpty(histogramBuckets)) {
+				this.memoizedResult = CacheableHistogramContract.EMPTY;
+			} else {
 				// capture raw (native-typed) min/max from the narrowed buckets so downstream callers (e.g.
 				// ReferenceHistogramAccumulator resolving boundary entities via FilterIndex.getRecordsEqualTo)
 				// can look up by the exact stored value without BigDecimal ↔ native-type coercion, which would
 				// lose precision for BigDecimal attributes whose stored scale exceeds indexedDecimalPlaces
 				final Serializable rawMin = histogramBuckets[0].getValue();
 				final Serializable rawMax = histogramBuckets[histogramBuckets.length - 1].getValue();
-				this.memoizedResult = new CacheableHistogram(
-					histogramCruncher.getHistogram(),
-					histogramCruncher.getMaxValue(),
-					rawMin,
-					rawMax
-				);
-			} else {
-				this.memoizedResult = CacheableHistogramContract.EMPTY;
+				// range-typed schemas render overlap histograms: a record whose value-range spans
+				// several buckets must contribute to each of them as a single distinct occurrence, and the
+				// overall count is the distinct-record cardinality — not the inflated per-threshold sum that the
+				// point-oriented HistogramDataCruncher would produce
+				final boolean rangeTyped = EvitaDataTypes.resolveRangeInnerNumericType(
+					this.request.attributeSchema().getType()
+				) != null;
+				if (rangeTyped) {
+					final RangeHistogramDataCruncher rangeCruncher = new RangeHistogramDataCruncher(
+						histogramBuckets, this.bucketCount, this.request.getDecimalPlaces()
+					);
+					this.memoizedResult = new CacheableHistogram(
+						rangeCruncher.getHistogram(),
+						rangeCruncher.getMaxValue(),
+						rawMin,
+						rawMax,
+						rangeCruncher.getOverallCount()
+					);
+				} else {
+					final HistogramDataCruncherContract<?> histogramCruncher = createHistogramDataCruncher(
+						this, this.bucketCount, this.behavior, histogramBuckets
+					);
+					this.memoizedResult = new CacheableHistogram(
+						Objects.requireNonNull(histogramCruncher).getHistogram(),
+						histogramCruncher.getMaxValue(),
+						rawMin,
+						rawMax
+					);
+				}
 			}
 
 			ofNullable(this.onComputationCallback).ifPresent(it -> it.accept(this));

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/AttributeHistogramComputer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/AttributeHistogramComputer.java
@@ -226,9 +226,18 @@ public class AttributeHistogramComputer implements CacheableEvitaResponseExtraRe
 				return converted;
 			};
 		} else if (BigDecimal.class.isAssignableFrom(effectiveType)) {
-			converter = value -> ((BigDecimal) value).stripTrailingZeros()
-				.scaleByPowerOfTen(histogramRequest.getDecimalPlaces())
-				.intValue();
+			converter = value -> {
+				// mirror the Long branch's overflow guard and the documented int-range contract below:
+				// surface a clear error instead of silently wrapping an out-of-range scaled value
+				final long scaled = ((BigDecimal) value).stripTrailingZeros()
+					.scaleByPowerOfTen(histogramRequest.getDecimalPlaces())
+					.longValueExact();
+				final int converted = (int) scaled;
+				if (scaled != (long) converted) {
+					throw new ArithmeticException("int overflow: " + value);
+				}
+				return converted;
+			};
 		} else {
 			throw new GenericEvitaInternalError(
 				"Unsupported histogram number type: " + schemaType +

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncher.java
@@ -24,6 +24,7 @@
 package io.evitadb.core.query.extraResult.translator.histogram.producer;
 
 import io.evitadb.api.exception.InvalidHistogramBucketCountException;
+import io.evitadb.api.query.require.HistogramBehavior;
 import io.evitadb.core.query.extraResult.translator.histogram.cache.CacheableHistogramContract.CacheableBucket;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.bitmap.BaseBitmap;
@@ -56,11 +57,21 @@ import java.util.Arrays;
  *
  * Output semantics:
  *
- * - the grid is at most `bucketCount` uniform buckets over `[minValue, maxValue]` (the distinct value span),
+ * - the grid is at most `bucketCount` buckets over `[minValue, maxValue]` (the distinct value span); under
+ *   {@link HistogramBehavior#STANDARD} the buckets are uniform-width, under {@link HistogramBehavior#OPTIMIZED} the
+ *   grid is widened to collapse runs of empty (uncovered) buckets — the same adaptive heuristic
+ *   {@link HistogramDataCruncher#createOptimalHistogram} applies to point histograms,
  * - per output bucket `[lo, hi)` (last bucket closed `[lo, max]`): occurrences = distinct records whose
  *   `[fromValue, toValue]` overlaps it (`from < hi AND to >= lo`; last bucket `from <= max AND to >= lo`),
  * - relativeFrequency = `(occurrences / maxBucketOccurrences) * 100`,
  * - {@link #getOverallCount()} = number of distinct records (union cardinality), NOT the bucket-occurrence sum.
+ *
+ * This cruncher serves only the equal-width behaviors ({@link HistogramBehavior#STANDARD},
+ * {@link HistogramBehavior#OPTIMIZED}). The frequency-equalised behaviors ({@link HistogramBehavior#EQUALIZED},
+ * {@link HistogramBehavior#EQUALIZED_OPTIMIZED}) are served by {@link EqualizedHistogramDataCruncher} fed with the
+ * same sweep: there each record is accounted at every global stop its `[from, to]` covers (the sweep's rolling
+ * active set), which yields the fixed total mass cumulative-frequency equalisation requires — a target that overlap
+ * counting, whose bucket-occurrence sum varies with the grid, cannot provide.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
@@ -98,11 +109,39 @@ public class RangeHistogramDataCruncher {
 		int bucketCount,
 		int decimalPlaces
 	) {
+		this(sourceData, bucketCount, decimalPlaces, HistogramBehavior.STANDARD);
+	}
+
+	/**
+	 * @param sourceData    ascending-by-threshold range sweep (the rolling active set per threshold) from
+	 *                      {@link io.evitadb.index.attribute.FilterIndex#getRangeHistogramOfAllRecords(Class, int)};
+	 *                      must be non-empty
+	 * @param bucketCount   requested maximum number of output buckets; the effective count may be lower when the value
+	 *                      span has fewer representable integer steps, or when {@code behavior} collapses empty runs.
+	 *                      Must be `> 1`
+	 * @param decimalPlaces decimal scale used to project thresholds to int keys and back to {@link BigDecimal},
+	 *                      mirroring {@link AttributeHistogramComputer}
+	 * @param behavior      must be {@link HistogramBehavior#STANDARD} (uniform grid) or
+	 *                      {@link HistogramBehavior#OPTIMIZED} (uniform grid widened to drop empty coverage gaps); the
+	 *                      frequency-equalised behaviors are not served here — see the class documentation
+	 * @throws InvalidHistogramBucketCountException when `bucketCount <= 1`
+	 * @throws io.evitadb.exception.EvitaInvalidUsageException when `sourceData` is empty
+	 */
+	public RangeHistogramDataCruncher(
+		@Nonnull ValueToRecordBitmap[] sourceData,
+		int bucketCount,
+		int decimalPlaces,
+		@Nonnull HistogramBehavior behavior
+	) {
 		Assert.isTrue(
 			bucketCount > 1,
 			() -> new InvalidHistogramBucketCountException("range histogram", bucketCount)
 		);
 		Assert.isTrue(sourceData.length > 0, "Source data for range histogram must not be empty!");
+		Assert.isTrue(
+			behavior == HistogramBehavior.STANDARD || behavior == HistogramBehavior.OPTIMIZED,
+			"RangeHistogramDataCruncher serves only STANDARD and OPTIMIZED behaviors; got " + behavior + "."
+		);
 
 		// 1) project each source threshold to an int key in the requested decimal scale; the keys are
 		// monotonically ascending by the sweep contract
@@ -133,7 +172,7 @@ public class RangeHistogramDataCruncher {
 			final Bitmap active = sourceData[i].getRecordIds();
 			final int[] activeArray = active.getArray();
 			for (final int k : activeArray) {
-				final int idx = indexOf(recordIds, k);
+				final int idx = Arrays.binarySearch(recordIds, k);
 				if (idx < 0) {
 					throw new GenericEvitaInternalError(
 						"Active record " + k + " missing from distinct record set — " +
@@ -167,19 +206,54 @@ public class RangeHistogramDataCruncher {
 			return;
 		}
 
-		// cap the bucket count so each grid threshold is a distinct int key at the requested scale — when the
-		// caller requests more buckets than there are representable integer steps, collapsing to the value span
-		// avoids zero-width / duplicate-threshold buckets
-		final int span = maxKey - minKey;
-		final int effectiveBucketCount = Math.min(bucketCount, span);
+		// 4) build the first-shot uniform grid; STANDARD uses it directly, OPTIMIZED may rebuild it once with a
+		// wider step to collapse the longest run of empty (uncovered) buckets
+		OverlapGrid grid = buildGrid(bucketCount, minKey, maxKey, fromKey, toKey, distinctCount, decimalPlaces);
+		if (behavior == HistogramBehavior.OPTIMIZED) {
+			final int optimizedBucketCount = chooseOptimizedBucketCount(grid, minKey, maxKey);
+			if (optimizedBucketCount != grid.occurrences().length) {
+				grid = buildGrid(optimizedBucketCount, minKey, maxKey, fromKey, toKey, distinctCount, decimalPlaces);
+			}
+		}
+		this.histogram = grid.buckets();
+	}
+
+	/**
+	 * Builds a uniform grid of at most {@code targetBucketCount} buckets over `[minKey, maxKey]` and counts, per
+	 * bucket, the number of distinct records whose `[fromKey, toKey]` interval overlaps it.
+	 *
+	 * The occupancy is computed with a difference array: because the buckets partition the value span contiguously,
+	 * each record overlaps exactly the contiguous run of buckets from the one containing its `fromKey` to the one
+	 * containing its `toKey`, so a single +1/-1 delta pair per record plus one prefix-sum pass yields every bucket's
+	 * occupancy — O(records × log buckets + buckets) rather than the O(buckets × records) pairwise overlap test.
+	 */
+	@Nonnull
+	private static OverlapGrid buildGrid(
+		int targetBucketCount,
+		int minKey,
+		int maxKey,
+		@Nonnull int[] fromKey,
+		@Nonnull int[] toKey,
+		int distinctCount,
+		int decimalPlaces
+	) {
+		// cap the bucket count so each grid threshold is a distinct int key at the requested scale — when more
+		// buckets are requested than there are representable integer steps, collapsing to the value span avoids
+		// zero-width / duplicate-threshold buckets. The span is computed in long because the full int range
+		// (Integer.MAX_VALUE - Integer.MIN_VALUE) overflows a signed int; the degenerate minKey == maxKey case
+		// is handled before this method, so span >= 1 always holds here.
+		final long span = (long) maxKey - (long) minKey;
+		final int effectiveBucketCount = (int) Math.min(targetBucketCount, span);
 		// integer lower-bound key per output bucket; the upper bound of bucket i is the lower bound of bucket i+1,
 		// and the last bucket's inclusive upper bound is maxKey
 		final int[] bucketLowerKey = new int[effectiveBucketCount];
 		for (int i = 0; i < effectiveBucketCount; i++) {
 			// evenly space lower bounds: floor of the proportional offset into the value span; the
-			// strict-increase fixup below resolves any duplicate keys produced by this flooring
-			final long offset = (long) span * i / effectiveBucketCount;
-			bucketLowerKey[i] = minKey + (int) offset;
+			// strict-increase fixup below resolves any duplicate keys produced by this flooring. The offset
+			// stays in long and is added to minKey before the int cast — truncating (int) offset first would
+			// corrupt the key for large spans, whereas minKey + offset always lies within [minKey, maxKey].
+			final long offset = span * i / effectiveBucketCount;
+			bucketLowerKey[i] = (int) (minKey + offset);
 		}
 		// guarantee strictly increasing lower bounds even under rounding collisions
 		for (int i = 1; i < effectiveBucketCount; i++) {
@@ -188,45 +262,86 @@ public class RangeHistogramDataCruncher {
 			}
 		}
 
-		// 4) compute overlap occurrences per output bucket
+		final int[] delta = new int[effectiveBucketCount + 1];
+		for (int r = 0; r < distinctCount; r++) {
+			final int bStart = bucketOf(bucketLowerKey, fromKey[r]);
+			final int bEnd = bucketOf(bucketLowerKey, toKey[r]);
+			delta[bStart]++;
+			delta[bEnd + 1]--;
+		}
 		final int[] occurrences = new int[effectiveBucketCount];
 		int maxOccurrences = 0;
+		int running = 0;
 		for (int b = 0; b < effectiveBucketCount; b++) {
-			final boolean last = b == effectiveBucketCount - 1;
-			final int lo = bucketLowerKey[b];
-			final int hi = last ? maxKey : bucketLowerKey[b + 1];
-			int count = 0;
-			for (int r = 0; r < distinctCount; r++) {
-				final boolean overlaps = last
-					// last bucket is closed [lo, maxKey]: from <= maxKey AND to >= lo
-					? fromKey[r] <= maxKey && toKey[r] >= lo
-					// half-open [lo, hi): from < hi AND to >= lo
-					: fromKey[r] < hi && toKey[r] >= lo;
-				if (overlaps) {
-					count++;
-				}
-			}
-			occurrences[b] = count;
-			if (count > maxOccurrences) {
-				maxOccurrences = count;
+			running += delta[b];
+			occurrences[b] = running;
+			if (running > maxOccurrences) {
+				maxOccurrences = running;
 			}
 		}
 
-		// 5) materialize output buckets with relativeFrequency normalized to the busiest bucket
-		final CacheableBucket[] result = new CacheableBucket[effectiveBucketCount];
+		// materialize output buckets with relativeFrequency normalized to the busiest bucket
+		final CacheableBucket[] buckets = new CacheableBucket[effectiveBucketCount];
 		for (int b = 0; b < effectiveBucketCount; b++) {
 			final BigDecimal relativeFrequency = maxOccurrences > 0
 				? BigDecimal.valueOf(occurrences[b])
 					.multiply(ONE_HUNDRED)
 					.divide(BigDecimal.valueOf(maxOccurrences), 2, RoundingMode.HALF_UP)
 				: BigDecimal.ZERO;
-			result[b] = new CacheableBucket(
+			buckets[b] = new CacheableBucket(
 				toBigDecimal(bucketLowerKey[b], decimalPlaces).setScale(decimalPlaces, RoundingMode.HALF_UP),
 				occurrences[b],
 				relativeFrequency
 			);
 		}
-		this.histogram = result;
+		return new OverlapGrid(buckets, bucketLowerKey, occurrences);
+	}
+
+	/**
+	 * Picks a (possibly smaller) bucket count that collapses the longest run of consecutive empty (uncovered)
+	 * buckets, mirroring {@link HistogramDataCruncher#createOptimalHistogram} in integer key space. When the largest
+	 * empty run would leave at most two non-empty buckets the grid drops to two buckets; when it spans at least two
+	 * buckets the step is widened by half the empty span and a new (smaller) count derived; otherwise the current
+	 * grid is kept. The result is clamped to `[2, current bucket count]`, so it never grows the grid.
+	 */
+	private static int chooseOptimizedBucketCount(@Nonnull OverlapGrid grid, int minKey, int maxKey) {
+		final int[] occurrences = grid.occurrences();
+		final int[] lowerKeys = grid.lowerKeys();
+		final int bucketCount = occurrences.length;
+		int longestRun = 0;
+		int spanStartKey = lowerKeys[0];
+		int spanEndKey = lowerKeys[0];
+		int currentRun = 0;
+		int previousNonEmptyKey = lowerKeys[0];
+		for (int b = 0; b < bucketCount; b++) {
+			if (occurrences[b] == 0) {
+				currentRun++;
+			} else {
+				if (currentRun > longestRun) {
+					// the gap is bracketed by the last non-empty bucket and this one; trailing gaps are ignored,
+					// matching the point-histogram heuristic which only records a gap once a later bar closes it
+					longestRun = currentRun;
+					spanStartKey = previousNonEmptyKey;
+					spanEndKey = lowerKeys[b];
+				}
+				currentRun = 0;
+				previousNonEmptyKey = lowerKeys[b];
+			}
+		}
+
+		final int emptyColumns = longestRun;
+		if (bucketCount - emptyColumns <= 2) {
+			return 2;
+		} else if (emptyColumns >= 2) {
+			// widen each operand to double before subtracting so the full int range does not overflow first
+			final double span = (double) maxKey - (double) minKey;
+			final double optimalStep = span / bucketCount;
+			final double recomputedStep = optimalStep + (spanEndKey - spanStartKey) / 2.0;
+			final int newBucketCount = (int) Math.floor(span / recomputedStep) + 2;
+			return Math.max(2, Math.min(newBucketCount, bucketCount));
+		} else {
+			return bucketCount;
+		}
 	}
 
 	/**
@@ -267,22 +382,25 @@ public class RangeHistogramDataCruncher {
 	}
 
 	/**
-	 * Binary search for `value` in the ascending `sortedArray`; returns the index or `-1` when absent.
+	 * Returns the index of the output bucket containing `value` — the rightmost bucket whose lower bound is
+	 * `<= value`. `bucketLowerKey` is strictly ascending and `value` is always within
+	 * `[bucketLowerKey[0], maxKey]`, so the result is never negative.
 	 */
-	private static int indexOf(@Nonnull int[] sortedArray, int value) {
-		int low = 0;
-		int high = sortedArray.length - 1;
-		while (low <= high) {
-			final int mid = (low + high) >>> 1;
-			final int midValue = sortedArray[mid];
-			if (midValue < value) {
-				low = mid + 1;
-			} else if (midValue > value) {
-				high = mid - 1;
-			} else {
-				return mid;
-			}
-		}
-		return -1;
+	private static int bucketOf(@Nonnull int[] bucketLowerKey, int value) {
+		final int idx = Arrays.binarySearch(bucketLowerKey, value);
+		// exact match → that bucket; miss → insertion point minus one is the floor (the containing bucket)
+		return idx >= 0 ? idx : -idx - 2;
+	}
+
+	/**
+	 * Immutable holder for one computed grid: the output {@code buckets}, their ascending integer lower-bound keys
+	 * ({@code lowerKeys}), and the per-bucket overlap {@code occurrences}. The latter two let the OPTIMIZED pass
+	 * locate empty runs without recomputing them.
+	 */
+	private record OverlapGrid(
+		@Nonnull CacheableBucket[] buckets,
+		@Nonnull int[] lowerKeys,
+		@Nonnull int[] occurrences
+	) {
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncher.java
@@ -83,11 +83,11 @@ public class RangeHistogramDataCruncher {
 	/**
 	 * Computed output histogram buckets ordered by ascending threshold. Never empty.
 	 */
-	@Getter private final CacheableBucket[] histogram;
+	@Getter @Nonnull private final CacheableBucket[] histogram;
 	/**
 	 * Inclusive upper bound of the last output bucket, expressed at the requested decimal scale.
 	 */
-	@Getter private final BigDecimal maxValue;
+	@Getter @Nonnull private final BigDecimal maxValue;
 	/**
 	 * Number of distinct records observed across the whole sweep.
 	 */
@@ -362,7 +362,14 @@ public class RangeHistogramDataCruncher {
 			}
 			return converted;
 		} else if (value instanceof BigDecimal bd) {
-			return bd.stripTrailingZeros().scaleByPowerOfTen(decimalPlaces).intValue();
+			// mirror the Long branch's overflow guard: surface a clear error instead of the silent
+			// int wrap plain intValue() would produce for an out-of-range scaled value
+			final long scaled = bd.stripTrailingZeros().scaleByPowerOfTen(decimalPlaces).longValueExact();
+			final int converted = (int) scaled;
+			if (scaled != (long) converted) {
+				throw new ArithmeticException("int overflow: " + value);
+			}
+			return converted;
 		} else {
 			throw new GenericEvitaInternalError(
 				"Unsupported range histogram threshold type: " + value.getClass().getName() +

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncher.java
@@ -331,7 +331,9 @@ public class RangeHistogramDataCruncher {
 
 		final int emptyColumns = longestRun;
 		if (bucketCount - emptyColumns <= 2) {
-			return 2;
+			// clamp to the current grid: a span==1 source yields a single bucket, and the heuristic must never
+			// return a larger count than it was given (it can only collapse the grid, never grow it)
+			return Math.min(2, bucketCount);
 		} else if (emptyColumns >= 2) {
 			// widen each operand to double before subtracting so the full int range does not overflow first —
 			// this applies to both the overall span and the empty-gap span bracketed by spanStartKey/spanEndKey

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncher.java
@@ -1,0 +1,288 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.extraResult.translator.histogram.producer;
+
+import io.evitadb.api.exception.InvalidHistogramBucketCountException;
+import io.evitadb.core.query.extraResult.translator.histogram.cache.CacheableHistogramContract.CacheableBucket;
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.bitmap.Bitmap;
+import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
+import io.evitadb.utils.Assert;
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Arrays;
+
+/**
+ * Computes a range-bucketed histogram with overlap semantics from the raw range sweep emitted by
+ * {@link io.evitadb.index.attribute.FilterIndex#getRangeHistogramOfAllRecords(Class, int)}.
+ *
+ * Unlike {@link HistogramDataCruncher}, which treats every source bucket as a single point and counts the records
+ * sitting exactly at that threshold, this cruncher reconstructs each distinct record's value interval
+ * `[fromValue, toValue]` and counts, per output bucket, how many DISTINCT records OVERLAP the bucket interval. A
+ * single record spanning the whole histogram therefore renders a SOLID BAR (occurrences = 1 in every bucket its
+ * range covers) instead of an inflated spike at each threshold it is active at.
+ *
+ * Input expectations (mirroring the sweep contract):
+ *
+ * - the source `ValueToRecordBitmap[]` is sorted ascending by threshold value,
+ * - each bitmap is the rolling ACTIVE SET — every record whose `[from, to]` covers that threshold,
+ * - thresholds are the source attribute's inner numeric values (`Byte`/`Short`/`Integer`/`Long`/`BigDecimal`).
+ *
+ * Output semantics:
+ *
+ * - the grid is at most `bucketCount` uniform buckets over `[minValue, maxValue]` (the distinct value span),
+ * - per output bucket `[lo, hi)` (last bucket closed `[lo, max]`): occurrences = distinct records whose
+ *   `[fromValue, toValue]` overlaps it (`from < hi AND to >= lo`; last bucket `from <= max AND to >= lo`),
+ * - relativeFrequency = `(occurrences / maxBucketOccurrences) * 100`,
+ * - {@link #getOverallCount()} = number of distinct records (union cardinality), NOT the bucket-occurrence sum.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class RangeHistogramDataCruncher {
+	/**
+	 * Constant for BigDecimal value of 100 used in relative-frequency computation.
+	 */
+	private static final BigDecimal ONE_HUNDRED = new BigDecimal("100");
+	/**
+	 * Computed output histogram buckets ordered by ascending threshold. Never empty.
+	 */
+	@Getter private final CacheableBucket[] histogram;
+	/**
+	 * Inclusive upper bound of the last output bucket, expressed at the requested decimal scale.
+	 */
+	@Getter private final BigDecimal maxValue;
+	/**
+	 * Number of distinct records observed across the whole sweep.
+	 */
+	@Getter private final int overallCount;
+
+	/**
+	 * @param sourceData    ascending-by-threshold range sweep (the rolling active set per threshold) from
+	 *                      {@link io.evitadb.index.attribute.FilterIndex#getRangeHistogramOfAllRecords(Class, int)};
+	 *                      must be non-empty
+	 * @param bucketCount   requested maximum number of uniform output buckets; the effective count may be lower when
+	 *                      the value span has fewer representable integer steps. Must be `> 1`
+	 * @param decimalPlaces decimal scale used to project thresholds to int keys and back to {@link BigDecimal},
+	 *                      mirroring {@link AttributeHistogramComputer}
+	 * @throws InvalidHistogramBucketCountException when `bucketCount <= 1`
+	 * @throws io.evitadb.exception.EvitaInvalidUsageException when `sourceData` is empty
+	 */
+	public RangeHistogramDataCruncher(
+		@Nonnull ValueToRecordBitmap[] sourceData,
+		int bucketCount,
+		int decimalPlaces
+	) {
+		Assert.isTrue(
+			bucketCount > 1,
+			() -> new InvalidHistogramBucketCountException("range histogram", bucketCount)
+		);
+		Assert.isTrue(sourceData.length > 0, "Source data for range histogram must not be empty!");
+
+		// 1) project each source threshold to an int key in the requested decimal scale; the keys are
+		// monotonically ascending by the sweep contract
+		final int sourceCount = sourceData.length;
+		final int[] thresholdKeys = new int[sourceCount];
+		for (int i = 0; i < sourceCount; i++) {
+			thresholdKeys[i] = toIntKey(sourceData[i].getValue(), decimalPlaces);
+		}
+
+		// 2) reconstruct each distinct record's [fromKey, toKey] interval: ascending pass records the first
+		// threshold a record appears at (fromKey); descending pass records the last (toKey). A union bitmap
+		// collects all distinct records, whose cardinality is the overallCount.
+		final BaseBitmap distinctRecords = new BaseBitmap();
+		for (final ValueToRecordBitmap sourceDatum : sourceData) {
+			distinctRecords.addAll(sourceDatum.getRecordIds());
+		}
+		final int distinctCount = distinctRecords.size();
+		this.overallCount = distinctCount;
+
+		final int[] recordIds = distinctRecords.getArray();
+		final int[] fromKey = new int[distinctCount];
+		final int[] toKey = new int[distinctCount];
+		Arrays.fill(fromKey, Integer.MAX_VALUE);
+		Arrays.fill(toKey, Integer.MIN_VALUE);
+		// map record id -> dense index via binary search on the ascending recordIds array
+		for (int i = 0; i < sourceCount; i++) {
+			final int key = thresholdKeys[i];
+			final Bitmap active = sourceData[i].getRecordIds();
+			final int[] activeArray = active.getArray();
+			for (final int k : activeArray) {
+				final int idx = indexOf(recordIds, k);
+				if (idx < 0) {
+					throw new GenericEvitaInternalError(
+						"Active record " + k + " missing from distinct record set — " +
+							"range sweep contract violated."
+					);
+				}
+				if (key < fromKey[idx]) {
+					fromKey[idx] = key;
+				}
+				if (key > toKey[idx]) {
+					toKey[idx] = key;
+				}
+			}
+		}
+
+		// 3) build the uniform output grid over [minKey, maxKey]
+		final int minKey = thresholdKeys[0];
+		final int maxKey = thresholdKeys[sourceCount - 1];
+		this.maxValue = toBigDecimal(maxKey, decimalPlaces).setScale(decimalPlaces, RoundingMode.UNNECESSARY);
+
+		if (minKey == maxKey) {
+			// degenerate span — emit a single bucket covering the only value
+			final BigDecimal relativeFrequency = distinctCount > 0 ? ONE_HUNDRED : BigDecimal.ZERO;
+			this.histogram = new CacheableBucket[] {
+				new CacheableBucket(
+					toBigDecimal(minKey, decimalPlaces).setScale(decimalPlaces, RoundingMode.HALF_UP),
+					distinctCount,
+					relativeFrequency.setScale(2, RoundingMode.HALF_UP)
+				)
+			};
+			return;
+		}
+
+		// cap the bucket count so each grid threshold is a distinct int key at the requested scale — when the
+		// caller requests more buckets than there are representable integer steps, collapsing to the value span
+		// avoids zero-width / duplicate-threshold buckets
+		final int span = maxKey - minKey;
+		final int effectiveBucketCount = Math.min(bucketCount, span);
+		// integer lower-bound key per output bucket; the upper bound of bucket i is the lower bound of bucket i+1,
+		// and the last bucket's inclusive upper bound is maxKey
+		final int[] bucketLowerKey = new int[effectiveBucketCount];
+		for (int i = 0; i < effectiveBucketCount; i++) {
+			// evenly space lower bounds: floor of the proportional offset into the value span; the
+			// strict-increase fixup below resolves any duplicate keys produced by this flooring
+			final long offset = (long) span * i / effectiveBucketCount;
+			bucketLowerKey[i] = minKey + (int) offset;
+		}
+		// guarantee strictly increasing lower bounds even under rounding collisions
+		for (int i = 1; i < effectiveBucketCount; i++) {
+			if (bucketLowerKey[i] <= bucketLowerKey[i - 1]) {
+				bucketLowerKey[i] = bucketLowerKey[i - 1] + 1;
+			}
+		}
+
+		// 4) compute overlap occurrences per output bucket
+		final int[] occurrences = new int[effectiveBucketCount];
+		int maxOccurrences = 0;
+		for (int b = 0; b < effectiveBucketCount; b++) {
+			final boolean last = b == effectiveBucketCount - 1;
+			final int lo = bucketLowerKey[b];
+			final int hi = last ? maxKey : bucketLowerKey[b + 1];
+			int count = 0;
+			for (int r = 0; r < distinctCount; r++) {
+				final boolean overlaps = last
+					// last bucket is closed [lo, maxKey]: from <= maxKey AND to >= lo
+					? fromKey[r] <= maxKey && toKey[r] >= lo
+					// half-open [lo, hi): from < hi AND to >= lo
+					: fromKey[r] < hi && toKey[r] >= lo;
+				if (overlaps) {
+					count++;
+				}
+			}
+			occurrences[b] = count;
+			if (count > maxOccurrences) {
+				maxOccurrences = count;
+			}
+		}
+
+		// 5) materialize output buckets with relativeFrequency normalized to the busiest bucket
+		final CacheableBucket[] result = new CacheableBucket[effectiveBucketCount];
+		for (int b = 0; b < effectiveBucketCount; b++) {
+			final BigDecimal relativeFrequency = maxOccurrences > 0
+				? BigDecimal.valueOf(occurrences[b])
+					.multiply(ONE_HUNDRED)
+					.divide(BigDecimal.valueOf(maxOccurrences), 2, RoundingMode.HALF_UP)
+				: BigDecimal.ZERO;
+			result[b] = new CacheableBucket(
+				toBigDecimal(bucketLowerKey[b], decimalPlaces).setScale(decimalPlaces, RoundingMode.HALF_UP),
+				occurrences[b],
+				relativeFrequency
+			);
+		}
+		this.histogram = result;
+	}
+
+	/**
+	 * Projects a source threshold value to an int key at the requested decimal scale. Mirrors the conversion in
+	 * {@link AttributeHistogramComputer} so the same threshold values map identically.
+	 */
+	private static int toIntKey(@Nonnull Serializable value, int decimalPlaces) {
+		if (value instanceof Byte b) {
+			return b;
+		} else if (value instanceof Short s) {
+			return s;
+		} else if (value instanceof Integer i) {
+			return i;
+		} else if (value instanceof Long l) {
+			final int converted = l.intValue();
+			if (l != (long) converted) {
+				throw new ArithmeticException("int overflow: " + value);
+			}
+			return converted;
+		} else if (value instanceof BigDecimal bd) {
+			return bd.stripTrailingZeros().scaleByPowerOfTen(decimalPlaces).intValue();
+		} else {
+			throw new GenericEvitaInternalError(
+				"Unsupported range histogram threshold type: " + value.getClass().getName() +
+					", supported are Byte, Short, Integer, Long, BigDecimal."
+			);
+		}
+	}
+
+	/**
+	 * Converts an int key back to a {@link BigDecimal} at the requested decimal scale.
+	 */
+	@Nonnull
+	private static BigDecimal toBigDecimal(int key, int decimalPlaces) {
+		return decimalPlaces == 0
+			? new BigDecimal(key)
+			: new BigDecimal(key).scaleByPowerOfTen(-1 * decimalPlaces);
+	}
+
+	/**
+	 * Binary search for `value` in the ascending `sortedArray`; returns the index or `-1` when absent.
+	 */
+	private static int indexOf(@Nonnull int[] sortedArray, int value) {
+		int low = 0;
+		int high = sortedArray.length - 1;
+		while (low <= high) {
+			final int mid = (low + high) >>> 1;
+			final int midValue = sortedArray[mid];
+			if (midValue < value) {
+				low = mid + 1;
+			} else if (midValue > value) {
+				high = mid - 1;
+			} else {
+				return mid;
+			}
+		}
+		return -1;
+	}
+}

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncher.java
@@ -333,10 +333,11 @@ public class RangeHistogramDataCruncher {
 		if (bucketCount - emptyColumns <= 2) {
 			return 2;
 		} else if (emptyColumns >= 2) {
-			// widen each operand to double before subtracting so the full int range does not overflow first
+			// widen each operand to double before subtracting so the full int range does not overflow first —
+			// this applies to both the overall span and the empty-gap span bracketed by spanStartKey/spanEndKey
 			final double span = (double) maxKey - (double) minKey;
 			final double optimalStep = span / bucketCount;
-			final double recomputedStep = optimalStep + (spanEndKey - spanStartKey) / 2.0;
+			final double recomputedStep = optimalStep + ((double) spanEndKey - (double) spanStartKey) / 2.0;
 			final int newBucketCount = (int) Math.floor(span / recomputedStep) + 2;
 			return Math.max(2, Math.min(newBucketCount, bucketCount));
 		} else {

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/cache/serializer/FlattenedHistogramComputerSerializer.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/cache/serializer/FlattenedHistogramComputerSerializer.java
@@ -56,6 +56,9 @@ public class FlattenedHistogramComputerSerializer extends AbstractFlattenedFormu
 		// non-attribute histograms (e.g. price histograms) do not supply raw bounds
 		kryo.writeClassAndObject(output, histogram.getRawMin());
 		kryo.writeClassAndObject(output, histogram.getRawMax());
+		// distinct-entity count stored explicitly — for range (overlap) histograms it differs from the
+		// bucket-occurrence sum, so it must survive the round-trip rather than being recomputed
+		output.writeVarInt(histogram.getOverallCount(), true);
 		final CacheableBucket[] buckets = histogram.getBuckets();
 		output.writeVarInt(buckets.length, true);
 		for (CacheableBucket bucket : buckets) {
@@ -73,6 +76,7 @@ public class FlattenedHistogramComputerSerializer extends AbstractFlattenedFormu
 		final BigDecimal max = kryo.readObject(input, BigDecimal.class);
 		final Serializable rawMin = (Serializable) kryo.readClassAndObject(input);
 		final Serializable rawMax = (Serializable) kryo.readClassAndObject(input);
+		final int overallCount = input.readVarInt(true);
 		final int bucketCount = input.readVarInt(true);
 		final CacheableBucket[] buckets = new CacheableBucket[bucketCount];
 		for(int i = 0; i < bucketCount; i++) {
@@ -84,7 +88,7 @@ public class FlattenedHistogramComputerSerializer extends AbstractFlattenedFormu
 
 		return new FlattenedHistogramComputer(
 			originalHash, transactionalIdHash, bitmapIds,
-			new CacheableHistogram(buckets, max, rawMin, rawMax)
+			new CacheableHistogram(buckets, max, rawMin, rawMax, overallCount)
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
@@ -39,8 +39,6 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.NavigableSet;
-import java.util.TreeSet;
 
 import static io.evitadb.api.query.Query.query;
 import static io.evitadb.api.query.QueryConstraints.collection;
@@ -149,9 +147,10 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 					"max " + histogram.getMax() + " must be <= 35"
 				);
 
-				// Range-overlap accounting: each PV must be counted at every distinct range
-				// endpoint its `[from, to]` covers (four overlapping ranges in `[10, 35]` yield
-				// 12 attributions, not 4). The oracle re-derives the expected per-bucket counts
+				// Range-overlap accounting: each PV's `[from, to]` renders a solid bar —
+				// it contributes a single distinct occurrence to every bucket interval its range
+				// overlaps. The overall count is the number of distinct seeded ranges (4), not the
+				// inflated per-endpoint sum. The oracle re-derives the expected per-bucket counts
 				// independently from the seeded ranges — plain integer math, never the histogram
 				// engine — and asserts the engine matches bucket-for-bucket.
 				assertTrue(
@@ -198,8 +197,7 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 				// The oracle is fed only the active ranges (PV 4 removed), so the independently
 				// derived per-bucket counts already exclude PV 4. A bucket-for-bucket match proves
 				// the filter removes PV 4's contributions without dropping or double-counting the
-				// surviving PVs — a real check, unlike the former `Σ occurrences == overallCount`
-				// which compared the sum to its own definition.
+				// surviving PVs, and the overall count drops to the 3 distinct surviving ranges.
 				assertTrue(
 					histogram.getOverallCount() > 0,
 					"overallCount must be positive when surviving PVs cover the range"
@@ -263,15 +261,23 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 		.toList();
 
 	/**
-	 * Number of supplied ranges whose closed interval `[from, to]` contains {@code endpoint}.
-	 * Mirrors the closed-interval semantics of {@code FilterIndex#getRangeHistogramOfAllRecords}:
-	 * a record's `starts` join the active set before the threshold bucket is snapshotted and its
-	 * `ends` leave only afterwards, so a range is counted at both its lower and upper endpoint.
+	 * Number of supplied ranges whose closed interval `[from, to]` OVERLAPS the bucket interval
+	 * `[lower, upper)` — or, for the last bucket, the closed interval `[lower, max]`.
+	 *
+	 * Overlap semantics: a range `[from, to]` overlaps a half-open bucket `[lower, upper)` iff
+	 * `from < upper AND to >= lower`; it overlaps the closed last bucket `[lower, max]` iff
+	 * `from <= max AND to >= lower`. Each overlapping range contributes exactly one distinct
+	 * occurrence to the bucket regardless of how much of the bucket it covers.
 	 */
-	private static int overlapCount(int endpoint, @Nonnull List<SeededRange> ranges) {
+	private static int overlapCount(
+		int lower, int upper, boolean lastBucket, @Nonnull List<SeededRange> ranges
+	) {
 		int count = 0;
 		for (final SeededRange range : ranges) {
-			if (range.from() <= endpoint && endpoint <= range.to()) {
+			final boolean overlaps = lastBucket
+				? range.from() <= upper && range.to() >= lower
+				: range.from() < upper && range.to() >= lower;
+			if (overlaps) {
 				count++;
 			}
 		}
@@ -282,12 +288,13 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 	 * Independently re-derives the expected per-bucket occurrences from the seeded {@code ranges}
 	 * and asserts the histogram the engine produced matches bucket-for-bucket.
 	 *
-	 * The model: each distinct range endpoint `E` carries weight {@link #overlapCount(int, List)}
-	 * (how many ranges cover it); the cruncher sums those weights into whichever emitted bucket
-	 * interval contains `E`. Intervals are half-open `[thresholdᵢ, thresholdᵢ₊₁)`, except the last,
-	 * which is closed `[thresholdₙ₋₁, max]`. The re-bucketing uses only plain integer math and the
-	 * emitted thresholds — it never calls the histogram engine — so a match proves every range was
-	 * accounted into every bucket its endpoints fall in, with no drops and no double-counts.
+	 * The model: each seeded range `[from, to]` renders a solid bar — it contributes a single distinct
+	 * occurrence to every emitted bucket interval its range overlaps. Intervals are half-open
+	 * `[thresholdᵢ, thresholdᵢ₊₁)`, except the last, which is closed `[thresholdₙ₋₁, max]`. The
+	 * re-derivation uses only plain integer math and the emitted thresholds — it never calls the
+	 * histogram engine — so a match proves the engine counts distinct overlapping ranges per bucket
+	 * with no drops and no double-counts. The overall count must equal the number of distinct seeded
+	 * ranges, NOT the sum of per-bucket occurrences.
 	 */
 	private static void assertBucketsMatchOverlapOracle(
 		@Nonnull HistogramContract histogram,
@@ -295,42 +302,25 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 	) {
 		final Bucket[] buckets = histogram.getBuckets();
 		final BigDecimal max = histogram.getMax();
-		// distinct integer endpoints of the surviving ranges, ascending
-		final NavigableSet<Integer> endpoints = new TreeSet<>();
-		for (final SeededRange range : ranges) {
-			endpoints.add(range.from());
-			endpoints.add(range.to());
-		}
-		int independentTotal = 0;
 		for (int i = 0; i < buckets.length; i++) {
 			final BigDecimal lower = buckets[i].threshold();
 			final boolean last = i == buckets.length - 1;
 			final BigDecimal upper = last ? max : buckets[i + 1].threshold();
-			int expected = 0;
-			for (final int endpoint : endpoints) {
-				final BigDecimal value = BigDecimal.valueOf(endpoint);
-				final boolean atOrAboveLower = value.compareTo(lower) >= 0;
-				// half-open upper bound for every bucket but the last, which owns `max` inclusively
-				final boolean belowUpper = last
-					? value.compareTo(upper) <= 0
-					: value.compareTo(upper) < 0;
-				if (atOrAboveLower && belowUpper) {
-					expected += overlapCount(endpoint, ranges);
-				}
-			}
+			// thresholds are integer-valued for the seeded integer ranges; intValueExact guards against
+			// any unexpected fractional grid emitted by the engine
+			final int expected = overlapCount(
+				lower.intValueExact(), upper.intValueExact(), last, ranges
+			);
 			assertEquals(
 				expected, buckets[i].occurrences(),
 				"Bucket " + (last ? "[" + lower + ", " + max + "]" : "[" + lower + ", " + upper + ")")
-					+ " must count every seeded range overlapping each endpoint it contains"
+					+ " must count every distinct seeded range overlapping it"
 			);
-			independentTotal += expected;
 		}
-		// Independent total cross-check. This replaces the former `Σ occurrences == overallCount`
-		// tautology — `getOverallCount()` is *defined* as that sum, so the old assertion compared a
-		// value to itself. Here the total is derived from the seeded ranges, so equality is real.
+		// distinct seeded ranges — the overlap-histogram overall count, independent of the per-bucket sum
 		assertEquals(
-			independentTotal, histogram.getOverallCount(),
-			"overallCount must equal the independently derived total attribution count"
+			ranges.size(), histogram.getOverallCount(),
+			"overallCount must equal the number of distinct seeded ranges"
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
@@ -24,6 +24,7 @@
 package io.evitadb.api.functional.histogram;
 
 import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.query.require.HistogramBehavior;
 import io.evitadb.api.requestResponse.EvitaResponse;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
 import io.evitadb.api.requestResponse.extraResult.HistogramContract;
@@ -35,6 +36,8 @@ import io.evitadb.test.annotation.UseDataSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import javax.annotation.Nonnull;
 import java.math.BigDecimal;
@@ -106,6 +109,43 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 		return histogram;
 	}
 
+	/**
+	 * Behavior-aware sibling of {@link #queryGroupHistogram(EvitaSessionContract, String, int)}: threads an explicit
+	 * {@link HistogramBehavior} into the `histogramStatistics(int, HistogramBehavior, String...)` require clause so the
+	 * caller can probe the routing fork inside
+	 * {@code AttributeHistogramComputer} — `STANDARD`/`OPTIMIZED` reach `RangeHistogramDataCruncher` (distinct-overlap
+	 * bars) while `EQUALIZED`/`EQUALIZED_OPTIMIZED` reach `EqualizedHistogramDataCruncher` fed the same range sweep.
+	 */
+	@Nonnull
+	private static HistogramContract queryGroupHistogram(
+		@Nonnull EvitaSessionContract session,
+		@Nonnull String histogramName,
+		int requestedBucketCount,
+		@Nonnull HistogramBehavior behavior
+	) {
+		final EvitaResponse<EntityReferenceContract> result = session.query(
+			query(
+				collection(ENTITY_PRODUCT),
+				require(
+					page(1, Integer.MAX_VALUE),
+					referenceSummaryOfReferenceWithHistograms(
+						REF_PARAM_VALUES, null, null, null,
+						histogramStatistics(requestedBucketCount, behavior, histogramName)
+					)
+				)
+			),
+			EntityReferenceContract.class
+		);
+		final ReferenceSummary referenceSummary = result.getExtraResult(ReferenceSummary.class);
+		assertNotNull(referenceSummary, "ReferenceSummary must be present in the response");
+		final ReferenceGroupStatistics group =
+			referenceSummary.getReferenceGroupStatistics(REF_PARAM_VALUES, RANGE_GROUP_PK);
+		assertNotNull(group, "Group " + RANGE_GROUP_PK + " must exist");
+		final HistogramContract histogram = group.getHistogramStatistics(histogramName);
+		assertNotNull(histogram, "Histogram '" + histogramName + "' must exist for group " + RANGE_GROUP_PK);
+		return histogram;
+	}
+
 	@Test
 	@UseDataSet(REFERENCE_HISTOGRAM_RANGE)
 	@DisplayName("should populate range histogram with bounded totals and monotonic thresholds")
@@ -153,9 +193,9 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 				// inflated per-endpoint sum. The oracle re-derives the expected per-bucket counts
 				// independently from the seeded ranges — plain integer math, never the histogram
 				// engine — and asserts the engine matches bucket-for-bucket.
-				assertTrue(
-					histogram.getOverallCount() > 0,
-					"overallCount must be positive when the histogram has buckets"
+				assertEquals(
+					ALL_RANGES.size(), histogram.getOverallCount(),
+					"overallCount must equal the " + ALL_RANGES.size() + " distinct seeded ranges"
 				);
 				assertBucketsMatchOverlapOracle(histogram, ALL_RANGES);
 			}
@@ -198,9 +238,10 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 				// derived per-bucket counts already exclude PV 4. A bucket-for-bucket match proves
 				// the filter removes PV 4's contributions without dropping or double-counting the
 				// surviving PVs, and the overall count drops to the 3 distinct surviving ranges.
-				assertTrue(
-					histogram.getOverallCount() > 0,
-					"overallCount must be positive when surviving PVs cover the range"
+				assertEquals(
+					ACTIVE_RANGES.size(), histogram.getOverallCount(),
+					"overallCount must drop to the " + ACTIVE_RANGES.size()
+						+ " distinct surviving ranges after PV 4 is deactivated"
 				);
 				assertBucketsMatchOverlapOracle(histogram, ACTIVE_RANGES);
 			}
@@ -225,6 +266,89 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 						queryGroupHistogram(session, HISTOGRAM_RANGE, requested);
 					assertBucketsMatchOverlapOracle(histogram, ALL_RANGES);
 				}
+			}
+		);
+	}
+
+	@Test
+	@UseDataSet(REFERENCE_HISTOGRAM_RANGE)
+	@DisplayName("should report distinct overallCount under STANDARD but stop-sum under EQUALIZED")
+	void shouldReportDistinctOverallCountForRangeStandardButStopSumForEqualized(@Nonnull Evita evita) {
+		// Probes the routing fork in AttributeHistogramComputer over the IDENTICAL source histogram and bucket
+		// count. STANDARD reaches RangeHistogramDataCruncher (overlap bars): overallCount is the count of DISTINCT
+		// seeded ranges (4) and the per-bucket overlap sum exceeds it because every range is counted in each bucket
+		// it spans. EQUALIZED reaches EqualizedHistogramDataCruncher fed the same range sweep: each range is
+		// accounted at every global stop its `[from, to]` covers (the rolling active set), so overallCount is the
+		// stop-sum and equals the per-bucket occurrence sum. The value span `[10, 35]` is identical across both
+		// because both consume the same sweep endpoints.
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final HistogramContract standard =
+					queryGroupHistogram(session, HISTOGRAM_RANGE, 10, HistogramBehavior.STANDARD);
+				final HistogramContract equalized =
+					queryGroupHistogram(session, HISTOGRAM_RANGE, 10, HistogramBehavior.EQUALIZED);
+
+				// STANDARD — distinct-overlap contract
+				assertEquals(
+					ALL_RANGES.size(), standard.getOverallCount(),
+					"STANDARD overallCount must equal the " + ALL_RANGES.size() + " distinct seeded ranges"
+				);
+				assertTrue(
+					occurrenceSum(standard) != standard.getOverallCount(),
+					"STANDARD overlap bars must inflate the per-bucket sum (" + occurrenceSum(standard)
+						+ ") above the distinct overallCount (" + standard.getOverallCount() + ")"
+				);
+
+				// EQUALIZED — stop-sum / point contract
+				assertEquals(
+					RANGE_STOP_SUM, equalized.getOverallCount(),
+					"EQUALIZED overallCount must equal the range-sweep stop-sum " + RANGE_STOP_SUM
+				);
+				assertEquals(
+					equalized.getOverallCount(), occurrenceSum(equalized),
+					"EQUALIZED per-bucket occurrences must sum to its stop-sum overallCount"
+				);
+
+				// the value span is identical — both behaviors consume the same sweep endpoints [10, 35]
+				assertEquals(
+					0, standard.getMin().compareTo(equalized.getMin()),
+					"min must be identical across STANDARD and EQUALIZED — both span the same sweep endpoints"
+				);
+				assertEquals(
+					0, standard.getMax().compareTo(equalized.getMax()),
+					"max must be identical across STANDARD and EQUALIZED — both span the same sweep endpoints"
+				);
+				assertEquals(
+					0, standard.getMin().compareTo(BigDecimal.valueOf(10)), "span must start at 10"
+				);
+				assertEquals(
+					0, standard.getMax().compareTo(BigDecimal.valueOf(35)), "span must end at 35"
+				);
+			}
+		);
+	}
+
+	@ParameterizedTest(name = "behavior={0}")
+	@EnumSource(HistogramBehavior.class)
+	@UseDataSet(REFERENCE_HISTOGRAM_RANGE)
+	@DisplayName("should apply the per-behavior overallCount rule for the range source")
+	void shouldApplyPerBehaviorOverallCountRuleForRangeSource(
+		@Nonnull HistogramBehavior behavior, @Nonnull Evita evita
+	) {
+		// Sweeps every HistogramBehavior over the same range source and bucket count, asserting the routing fork's
+		// per-behavior overallCount rule: the equal-width family (STANDARD/OPTIMIZED) renders distinct-overlap bars
+		// whose overallCount is the DISTINCT seeded-range count (4), whereas the frequency-equalised family
+		// (EQUALIZED/EQUALIZED_OPTIMIZED) accounts each range at every covered stop, yielding the stop-sum (12). The
+		// equalised family additionally satisfies the point-histogram invariant sum(occurrences) == overallCount;
+		// the overlap family does NOT and is intentionally exempt. ADAPTIVE *_OPTIMIZED behaviors may emit fewer
+		// buckets, so only the overallCount rule (not a fixed bucket count) is asserted.
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final HistogramContract histogram =
+					queryGroupHistogram(session, HISTOGRAM_RANGE, 10, behavior);
+				assertEqualisedAware(histogram, behavior);
 			}
 		);
 	}
@@ -259,6 +383,18 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 	private static final List<SeededRange> ACTIVE_RANGES = ALL_RANGES.stream()
 		.filter(SeededRange::active)
 		.toList();
+
+	/**
+	 * Independently re-derived stop-sum for the frequency-equalised range path: the sum, over every distinct
+	 * range-sweep stop, of the number of seeded ranges whose closed interval `[from, to]` covers that stop.
+	 *
+	 * The seeded ranges are `[10, 20]`, `[15, 25]`, `[20, 30]`, `[25, 35]`, giving the distinct stops
+	 * `10, 15, 20, 25, 30, 35` with active-set sizes `1, 2, 3, 3, 2, 1` respectively, so the stop-sum is
+	 * `1 + 2 + 3 + 3 + 2 + 1 = 12`. This is the `overallCount` the EQUALIZED / EQUALIZED_OPTIMIZED behaviors must
+	 * report (each range accounted at every covered stop), as opposed to the distinct-range count `4` reported by
+	 * the STANDARD / OPTIMIZED overlap path. Derived here by hand, never read from the histogram engine.
+	 */
+	private static final int RANGE_STOP_SUM = 12;
 
 	/**
 	 * Number of supplied ranges whose closed interval `[from, to]` OVERLAPS the bucket interval
@@ -322,6 +458,53 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 			ranges.size(), histogram.getOverallCount(),
 			"overallCount must equal the number of distinct seeded ranges"
 		);
+	}
+
+	/**
+	 * Sums the per-bucket occurrences of `histogram`.
+	 */
+	private static int occurrenceSum(@Nonnull HistogramContract histogram) {
+		int sum = 0;
+		for (final Bucket bucket : histogram.getBuckets()) {
+			sum += bucket.occurrences();
+		}
+		return sum;
+	}
+
+	/**
+	 * Asserts the per-behavior `overallCount` rule for the range source, branching on the histogram family rather
+	 * than applying one oracle to both.
+	 *
+	 * - Equal-width family (`STANDARD`, `OPTIMIZED`) — DISTINCT-OVERLAP semantics: `overallCount` equals the number
+	 *   of distinct seeded ranges ({@link #ALL_RANGES}`.size()` = 4) and the per-bucket occurrence sum is allowed
+	 *   to exceed it (each range is counted in every bucket it overlaps). The distinct-overlap bucket oracle
+	 *   {@link #assertBucketsMatchOverlapOracle} is applied here.
+	 * - Frequency-equalised family (`EQUALIZED`, `EQUALIZED_OPTIMIZED`) — STOP-SUM / point semantics: `overallCount`
+	 *   equals {@link #RANGE_STOP_SUM} (12) and the per-bucket occurrences sum exactly to it. The overlap oracle is
+	 *   deliberately NOT applied — it encodes distinct-overlap semantics and would falsely fail the equalised path.
+	 */
+	private static void assertEqualisedAware(
+		@Nonnull HistogramContract histogram, @Nonnull HistogramBehavior behavior
+	) {
+		final boolean equalised = behavior == HistogramBehavior.EQUALIZED
+			|| behavior == HistogramBehavior.EQUALIZED_OPTIMIZED;
+		if (equalised) {
+			assertEquals(
+				RANGE_STOP_SUM, histogram.getOverallCount(),
+				"equalised behavior " + behavior + " overallCount must equal the stop-sum " + RANGE_STOP_SUM
+			);
+			assertEquals(
+				histogram.getOverallCount(), occurrenceSum(histogram),
+				"equalised behavior " + behavior + " per-bucket occurrences must sum to overallCount"
+			);
+		} else {
+			assertEquals(
+				ALL_RANGES.size(), histogram.getOverallCount(),
+				"overlap behavior " + behavior + " overallCount must equal the " + ALL_RANGES.size()
+					+ " distinct seeded ranges"
+			);
+			assertBucketsMatchOverlapOracle(histogram, ALL_RANGES);
+		}
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
@@ -341,8 +341,9 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 		// whose overallCount is the DISTINCT seeded-range count (4), whereas the frequency-equalised family
 		// (EQUALIZED/EQUALIZED_OPTIMIZED) accounts each range at every covered stop, yielding the stop-sum (12). The
 		// equalised family additionally satisfies the point-histogram invariant sum(occurrences) == overallCount;
-		// the overlap family does NOT and is intentionally exempt. ADAPTIVE *_OPTIMIZED behaviors may emit fewer
-		// buckets, so only the overallCount rule (not a fixed bucket count) is asserted.
+		// the overlap family does NOT and is intentionally exempt. The gap-dropping *_OPTIMIZED behaviors
+		// (OPTIMIZED / EQUALIZED_OPTIMIZED) may emit fewer buckets, so only the overallCount rule (not a fixed
+		// bucket count) is asserted.
 		evita.queryCatalog(
 			TEST_CATALOG,
 			session -> {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
@@ -295,7 +295,7 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 					"STANDARD overallCount must equal the " + ALL_RANGES.size() + " distinct seeded ranges"
 				);
 				assertTrue(
-					occurrenceSum(standard) != standard.getOverallCount(),
+					occurrenceSum(standard) > standard.getOverallCount(),
 					"STANDARD overlap bars must inflate the per-bucket sum (" + occurrenceSum(standard)
 						+ ") above the distinct overallCount (" + standard.getOverallCount() + ")"
 				);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/extraResult/HistogramTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/extraResult/HistogramTest.java
@@ -359,6 +359,49 @@ class HistogramTest implements EvitaTestSupport {
 		}
 	}
 
+	@Nested
+	@DisplayName("Explicit overall count")
+	class ExplicitOverallCount {
+
+		@Test
+		@DisplayName("should retain an explicit overall count distinct from the bucket sum")
+		void shouldRetainExplicitOverallCountDistinctFromBucketSum() {
+			// buckets sum to 5 + 3 + 2 = 10, but the range (overlap) histogram carries 4 distinct records
+			final Bucket[] buckets = new Bucket[]{
+				new Bucket(BigDecimal.ONE, 5, false, new BigDecimal("50")),
+				new Bucket(new BigDecimal("5"), 3, false, new BigDecimal("30")),
+				new Bucket(BigDecimal.TEN, 2, false, new BigDecimal("20"))
+			};
+			final int explicitOverallCount = 4;
+			final Histogram histogram = new Histogram(
+				buckets, new BigDecimal("20"), explicitOverallCount, null, null
+			);
+
+			assertEquals(
+				explicitOverallCount, histogram.getOverallCount(),
+				"explicit overall count must be returned verbatim, not the bucket sum"
+			);
+		}
+
+		@Test
+		@DisplayName("should default overall count to the bucket sum via the legacy constructor")
+		void shouldDefaultOverallCountToBucketSumViaLegacyConstructor() {
+			final Bucket[] buckets = new Bucket[]{
+				new Bucket(BigDecimal.ONE, 5, false, new BigDecimal("50")),
+				new Bucket(new BigDecimal("5"), 3, false, new BigDecimal("30")),
+				new Bucket(BigDecimal.TEN, 2, false, new BigDecimal("20"))
+			};
+
+			// the two-argument constructor must default overallCount to the sum of bucket occurrences
+			final Histogram twoArg = new Histogram(buckets, new BigDecimal("20"));
+			assertEquals(10, twoArg.getOverallCount(), "two-arg constructor must sum bucket occurrences");
+
+			// the four-argument (anchor) constructor must likewise default to the bucket sum
+			final Histogram fourArg = new Histogram(buckets, new BigDecimal("20"), null, null);
+			assertEquals(10, fourArg.getOverallCount(), "four-arg constructor must sum bucket occurrences");
+		}
+	}
+
 	private static Histogram createHistogram() {
 		final Bucket[] buckets = new Bucket[]{
 			new Bucket(BigDecimal.ONE, 5, false, new BigDecimal("50")),

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/cache/CacheableHistogramTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/cache/CacheableHistogramTest.java
@@ -261,6 +261,52 @@ class CacheableHistogramTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("Explicit overall count")
+	class ExplicitOverallCount {
+
+		@Test
+		@DisplayName("should retain an explicit overall count distinct from the bucket sum")
+		void shouldRetainExplicitOverallCountDistinctFromBucketSum() {
+			// buckets sum to 3 + 5 + 2 = 10, but the range (overlap) histogram carries 4 distinct records
+			final CacheableBucket[] buckets = new CacheableBucket[]{
+				new CacheableBucket(new BigDecimal("1"), 3, new BigDecimal("30")),
+				new CacheableBucket(new BigDecimal("5"), 5, new BigDecimal("50")),
+				new CacheableBucket(new BigDecimal("10"), 2, new BigDecimal("20"))
+			};
+			final int explicitOverallCount = 4;
+			final CacheableHistogram histogram = new CacheableHistogram(
+				buckets, new BigDecimal("20"), null, null, explicitOverallCount
+			);
+
+			assertEquals(
+				explicitOverallCount, histogram.getOverallCount(),
+				"explicit overall count must be returned verbatim, not the bucket sum"
+			);
+		}
+
+		@Test
+		@DisplayName("should carry the explicit overall count through convertToHistogram")
+		void shouldCarryExplicitOverallCountThroughConvertToHistogram() {
+			final CacheableBucket[] buckets = new CacheableBucket[]{
+				new CacheableBucket(new BigDecimal("1"), 3, new BigDecimal("30")),
+				new CacheableBucket(new BigDecimal("5"), 5, new BigDecimal("50")),
+				new CacheableBucket(new BigDecimal("10"), 2, new BigDecimal("20"))
+			};
+			final int explicitOverallCount = 4;
+			final CacheableHistogram histogram = new CacheableHistogram(
+				buckets, new BigDecimal("20"), null, null, explicitOverallCount
+			);
+
+			final HistogramContract converted = histogram.convertToHistogram(NEVER_REQUESTED);
+
+			assertEquals(
+				explicitOverallCount, converted.getOverallCount(),
+				"convertToHistogram must propagate the explicit distinct count, not recompute the bucket sum"
+			);
+		}
+	}
+
 	/**
 	 * `CacheableHistogram` is serialized into the extra-result cache. This test pins one invariant:
 	 * Java serialization round-trips preserve equality so cache deserialization reconstructs the

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncherTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncherTest.java
@@ -606,6 +606,38 @@ class RangeHistogramDataCruncherTest {
 	}
 
 	@Test
+	@DisplayName("OPTIMIZED gap-widening does not overflow for an extreme Integer value span")
+	void shouldNotOverflowGapSpanUnderOptimizedForExtremeIntegerRange() {
+		// R1 occupies the two lowest buckets, R2 the two highest, leaving a six-bucket empty run across the middle
+		// of the full [Integer.MIN_VALUE, Integer.MAX_VALUE] span. That run triggers the OPTIMIZED gap-widening
+		// branch, where the bracketing bucket keys differ by more than Integer.MAX_VALUE: an int subtraction there
+		// would wrap negative, drive recomputedStep below zero and silently collapse the grid to two buckets. With
+		// the operands widened to double the heuristic widens the grid sanely (here to four buckets) instead.
+		final ValueToRecordBitmap[] source = {
+			bucket(Integer.MIN_VALUE, 1),
+			bucket(-1_500_000_000, 1),
+			bucket(1_500_000_000, 2),
+			bucket(Integer.MAX_VALUE, 2)
+		};
+
+		final RangeHistogramDataCruncher optimizedCruncher = new RangeHistogramDataCruncher(
+			source, 10, 0, HistogramBehavior.OPTIMIZED
+		);
+		final CacheableBucket[] optimized = optimizedCruncher.getHistogram();
+
+		assertTrue(
+			optimized.length > 2,
+			"OPTIMIZED must widen the grid sanely, not collapse to two buckets through int overflow — got "
+				+ optimized.length
+		);
+		assertEquals(2, optimizedCruncher.getOverallCount(), "overallCount stays the two distinct records");
+		assertEquals(
+			0, optimizedCruncher.getMaxValue().compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)),
+			"max must equal Integer.MAX_VALUE without truncation"
+		);
+	}
+
+	@Test
 	@DisplayName("OPTIMIZED still emits a single bucket for a degenerate single-value span")
 	void shouldEmitSingleBucketForDegenerateSpanEvenUnderOptimized() {
 		// every threshold collapses onto key 7 (minKey == maxKey); the degenerate-span early return fires before

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncherTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncherTest.java
@@ -1,0 +1,370 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.query.extraResult.translator.histogram.producer;
+
+import io.evitadb.api.exception.InvalidHistogramBucketCountException;
+import io.evitadb.core.query.extraResult.translator.histogram.cache.CacheableHistogramContract.CacheableBucket;
+import io.evitadb.index.bitmap.BaseBitmap;
+import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.math.BigDecimal;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.HISTOGRAM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies {@link RangeHistogramDataCruncher} renders range-bucketed histograms with overlap
+ * semantics rather than the point-histogram semantics of {@link HistogramDataCruncher}.
+ *
+ * The cruncher consumes the raw range sweep emitted by
+ * {@link io.evitadb.index.attribute.FilterIndex#getRangeHistogramOfAllRecords(Class, int)}: one
+ * {@link ValueToRecordBitmap} per range-boundary threshold whose bitmap is the rolling active set
+ * (every record whose `[from, to]` covers that threshold). The cruncher must:
+ *
+ * - reconstruct each distinct record's `[fromValue, toValue]` interval from those snapshots,
+ * - count, per output bucket, the number of DISTINCT records whose interval OVERLAPS the bucket,
+ * - report `overallCount` as the number of DISTINCT records (union cardinality), never the bucket sum.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("RangeHistogramDataCruncher — overlap semantics")
+@Tag(ENGINE)
+@Tag(HISTOGRAM)
+class RangeHistogramDataCruncherTest {
+
+	/**
+	 * Builds a single source bucket keyed by `threshold` carrying the supplied record ids in its
+	 * active-set bitmap.
+	 */
+	@Nonnull
+	private static ValueToRecordBitmap bucket(int threshold, @Nonnull int... recordIds) {
+		return new ValueToRecordBitmap(threshold, new BaseBitmap(recordIds));
+	}
+
+	/**
+	 * Builds a single source bucket keyed by a {@link BigDecimal} `threshold` carrying the supplied record
+	 * ids in its active-set bitmap. Used by the decimal-scale tests so the cruncher exercises its
+	 * `BigDecimal` threshold projection path.
+	 */
+	@Nonnull
+	private static ValueToRecordBitmap bucket(@Nonnull BigDecimal threshold, @Nonnull int... recordIds) {
+		return new ValueToRecordBitmap(threshold, new BaseBitmap(recordIds));
+	}
+
+	@Test
+	@DisplayName("Single record spanning the whole range renders a solid bar with overallCount = 1")
+	void shouldRenderSolidBarForSingleRecordSpanningRange() {
+		// one record (R = 1) active at 12 ascending thresholds T0..T11 = 0..11 — its range is [0, 11]
+		final ValueToRecordBitmap[] source = new ValueToRecordBitmap[12];
+		for (int i = 0; i < 12; i++) {
+			source[i] = bucket(i, 1);
+		}
+
+		final RangeHistogramDataCruncher cruncher = new RangeHistogramDataCruncher(source, 30, 0);
+
+		final CacheableBucket[] buckets = cruncher.getHistogram();
+		assertTrue(buckets.length > 0, "must produce at least one bucket");
+		// solid bar: every emitted bucket overlapping [0, 11] reports occurrences = 1
+		for (final CacheableBucket b : buckets) {
+			assertEquals(
+				1, b.occurrences(),
+				"single record must overlap every bucket of its own range — bucket " + b.threshold()
+			);
+		}
+		// distinct-record cardinality, NOT the sum of per-bucket occurrences
+		assertEquals(1, cruncher.getOverallCount(), "overallCount must be the distinct record count");
+		// uniform single-record histogram renders full-width bars across its whole range
+		for (final CacheableBucket b : buckets) {
+			assertEquals(
+				0, b.relativeFrequency().compareTo(new BigDecimal("100")),
+				"uniform histogram must render full-width bars (relativeFrequency = 100)"
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("Four overlapping ranges yield overlap counts 1,2,3,3,2 and overallCount = 4")
+	void shouldCountDistinctOverlapsAcrossFiveUniformBuckets() {
+		// R1[10,20] R2[15,25] R3[20,30] R4[25,35] — sweep over distinct endpoints 10,15,20,25,30,35
+		// active sets per threshold (closed-interval semantics):
+		//   10 -> {1}
+		//   15 -> {1,2}
+		//   20 -> {1,2,3}
+		//   25 -> {2,3,4}
+		//   30 -> {3,4}
+		//   35 -> {4}
+		final ValueToRecordBitmap[] source = {
+			bucket(10, 1),
+			bucket(15, 1, 2),
+			bucket(20, 1, 2, 3),
+			bucket(25, 2, 3, 4),
+			bucket(30, 3, 4),
+			bucket(35, 4)
+		};
+
+		// 5 uniform buckets over [10,35] -> B0[10,15) B1[15,20) B2[20,25) B3[25,30) B4[30,35]
+		final RangeHistogramDataCruncher cruncher = new RangeHistogramDataCruncher(source, 5, 0);
+
+		final CacheableBucket[] buckets = cruncher.getHistogram();
+		assertEquals(5, buckets.length, "expected 5 uniform buckets over [10,35]");
+
+		final int[] expectedOccurrences = {1, 2, 3, 3, 2};
+		final BigDecimal[] expectedThresholds = {
+			BigDecimal.valueOf(10), BigDecimal.valueOf(15), BigDecimal.valueOf(20),
+			BigDecimal.valueOf(25), BigDecimal.valueOf(30)
+		};
+		for (int i = 0; i < buckets.length; i++) {
+			assertEquals(
+				0, buckets[i].threshold().compareTo(expectedThresholds[i]),
+				"bucket " + i + " threshold mismatch — got " + buckets[i].threshold()
+			);
+			assertEquals(
+				expectedOccurrences[i], buckets[i].occurrences(),
+				"bucket " + i + " overlap occurrences mismatch"
+			);
+		}
+		assertEquals(0, cruncher.getMaxValue().compareTo(BigDecimal.valueOf(35)), "max must be 35");
+		// distinct records = 4, NOT Σ occurrences (1+2+3+3+2 = 11)
+		assertEquals(4, cruncher.getOverallCount(), "overallCount must be the distinct record count");
+		// relativeFrequency = occurrences / maxOccurrences * 100; maxOccurrences = 3
+		assertEquals(
+			0, buckets[2].relativeFrequency().compareTo(new BigDecimal("100")),
+			"busiest bucket must render a full-width bar"
+		);
+	}
+
+	@Test
+	@DisplayName("Bucket count of 1 or 0 is rejected with InvalidHistogramBucketCountException")
+	void shouldThrowInvalidHistogramBucketCountExceptionWhenBucketCountIsOne() {
+		// the cruncher contract requires bucketCount > 1 — a single- or zero-bucket histogram is meaningless
+		final ValueToRecordBitmap[] source = {bucket(0, 1), bucket(5, 1)};
+		assertThrows(
+			InvalidHistogramBucketCountException.class,
+			() -> new RangeHistogramDataCruncher(source, 1, 0),
+			"bucketCount = 1 must be rejected"
+		);
+		assertThrows(
+			InvalidHistogramBucketCountException.class,
+			() -> new RangeHistogramDataCruncher(source, 0, 0),
+			"bucketCount = 0 must be rejected"
+		);
+	}
+
+	@Test
+	@DisplayName("Empty source data is rejected with IllegalArgumentException")
+	void shouldThrowWhenSourceDataIsEmpty() {
+		final ValueToRecordBitmap[] source = new ValueToRecordBitmap[0];
+		final IllegalArgumentException ex = assertThrows(
+			IllegalArgumentException.class,
+			() -> new RangeHistogramDataCruncher(source, 5, 0)
+		);
+		assertTrue(
+			ex.getMessage() != null && ex.getMessage().contains("must not be empty"),
+			"message should explain the empty-source rejection — got: " + ex.getMessage()
+		);
+	}
+
+	@Test
+	@DisplayName("Degenerate single-value span (minKey == maxKey) emits one full-width bucket")
+	void shouldEmitSingleBucketForDegenerateSingleValueSpan() {
+		// every threshold collapses onto the same key 7 — the whole sweep covers a single value
+		final ValueToRecordBitmap[] source = {
+			bucket(7, 1, 2, 3)
+		};
+
+		final RangeHistogramDataCruncher cruncher = new RangeHistogramDataCruncher(source, 10, 0);
+
+		final CacheableBucket[] buckets = cruncher.getHistogram();
+		assertEquals(1, buckets.length, "a single-value span must collapse to exactly one bucket");
+		assertEquals(0, buckets[0].threshold().compareTo(BigDecimal.valueOf(7)), "the sole bucket sits at key 7");
+		// occurrences equals the number of distinct records — all three sit at the single value
+		assertEquals(3, buckets[0].occurrences(), "the bucket must count every distinct record");
+		assertEquals(
+			0, buckets[0].relativeFrequency().compareTo(new BigDecimal("100")),
+			"a single populated bucket is by definition the busiest — full-width bar"
+		);
+		assertEquals(3, cruncher.getOverallCount(), "overallCount must be the distinct record count");
+		assertEquals(0, cruncher.getMaxValue().compareTo(BigDecimal.valueOf(7)), "max must be the single value");
+	}
+
+	@Test
+	@DisplayName("Effective bucket count is capped to the value span when more buckets are requested")
+	void shouldCapEffectiveBucketCountToValueSpanWhenBucketCountExceedsSpan() {
+		// thresholds 0,1,2 -> span = 2; requesting 30 buckets must collapse to exactly 2 distinct-width buckets
+		final ValueToRecordBitmap[] source = {
+			bucket(0, 1),
+			bucket(1, 1, 2),
+			bucket(2, 2)
+		};
+
+		final RangeHistogramDataCruncher cruncher = new RangeHistogramDataCruncher(source, 30, 0);
+
+		final CacheableBucket[] buckets = cruncher.getHistogram();
+		assertEquals(2, buckets.length, "bucket count must be capped to the value span of 2");
+		// thresholds must be strictly increasing so no zero-width / duplicate-threshold bucket is emitted
+		for (int i = 1; i < buckets.length; i++) {
+			assertTrue(
+				buckets[i].threshold().compareTo(buckets[i - 1].threshold()) > 0,
+				"bucket " + i + " threshold must strictly exceed bucket " + (i - 1)
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("Output bucket thresholds are strictly increasing after capping")
+	void shouldProduceStrictlyIncreasingThresholdsUnderFlooringCollisions() {
+		// dense small span (0..4, span 4) with a moderate request — flooring could collide adjacent lower
+		// bounds; the cruncher's strict-increase fixup (post-cap) must keep thresholds monotonic
+		final ValueToRecordBitmap[] source = {
+			bucket(0, 1),
+			bucket(1, 1),
+			bucket(2, 1),
+			bucket(3, 1),
+			bucket(4, 1)
+		};
+
+		final RangeHistogramDataCruncher cruncher = new RangeHistogramDataCruncher(source, 4, 0);
+
+		final CacheableBucket[] buckets = cruncher.getHistogram();
+		assertTrue(buckets.length >= 2, "must emit multiple buckets for a span of 4");
+		// the strict-increase guarantee holds regardless of whether capping or the fixup resolved a collision
+		for (int i = 1; i < buckets.length; i++) {
+			assertTrue(
+				buckets[i].threshold().compareTo(buckets[i - 1].threshold()) > 0,
+				"adjacent thresholds must strictly increase — collision at bucket " + i
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("Open-ended record active across every threshold renders a solid bar")
+	void shouldRenderSolidBarForOpenEndedRecordActiveAcrossAllThresholds() {
+		// record 9 is active at every threshold (spans the whole range); short-lived records appear locally
+		final ValueToRecordBitmap[] source = {
+			bucket(0, 9, 1),
+			bucket(1, 9, 1),
+			bucket(2, 9),
+			bucket(3, 9, 2),
+			bucket(4, 9, 2)
+		};
+
+		final RangeHistogramDataCruncher cruncher = new RangeHistogramDataCruncher(source, 4, 0);
+
+		final CacheableBucket[] buckets = cruncher.getHistogram();
+		assertTrue(buckets.length >= 2, "span of 4 must produce multiple buckets");
+		// the spanning record overlaps every bucket, so each bucket counts at least the spanning record
+		for (final CacheableBucket b : buckets) {
+			assertTrue(
+				b.occurrences() >= 1,
+				"every bucket must include the all-spanning record — bucket " + b.threshold()
+			);
+		}
+		// distinct records = {9, 1, 2} = 3
+		assertEquals(3, cruncher.getOverallCount(), "overallCount must be the distinct record union (9,1,2)");
+	}
+
+	@Test
+	@DisplayName("Disjoint records are not counted in non-overlapping buckets")
+	void shouldNotCountDisjointRecordInNonOverlappingBuckets() {
+		// R1 spans keys [0,2], R2 spans keys [8,10]; the value span is [0,10] and the records never overlap
+		final ValueToRecordBitmap[] source = {
+			bucket(0, 1),
+			bucket(1, 1),
+			bucket(2, 1),
+			bucket(8, 2),
+			bucket(9, 2),
+			bucket(10, 2)
+		};
+
+		// 5 uniform buckets over span 10 -> lower bounds 0,2,4,6,8; last bucket [8,10]
+		final RangeHistogramDataCruncher cruncher = new RangeHistogramDataCruncher(source, 5, 0);
+
+		final CacheableBucket[] buckets = cruncher.getHistogram();
+		assertEquals(5, buckets.length, "expected 5 uniform buckets over [0,10]");
+		// lowest bucket [0,2) overlaps only R1
+		assertEquals(1, buckets[0].occurrences(), "lowest bucket must count only R1");
+		// a middle bucket [4,6) sits in the gap between the two records
+		assertEquals(0, buckets[2].occurrences(), "middle bucket must count no record (the gap)");
+		// highest bucket [8,10] overlaps only R2
+		assertEquals(1, buckets[4].occurrences(), "highest bucket must count only R2");
+		assertEquals(2, cruncher.getOverallCount(), "overallCount must be the two distinct records");
+	}
+
+	@Test
+	@DisplayName("BigDecimal thresholds round-trip at the requested decimal scale")
+	void shouldRoundTripBigDecimalThresholdsAtRequestedScale() {
+		// decimalPlaces = 2 -> keys 100,150,200; span 100, request 2 buckets -> lower bounds 100 (1.00) & 150 (1.50)
+		final ValueToRecordBitmap[] source = {
+			bucket(new BigDecimal("1.00"), 1),
+			bucket(new BigDecimal("1.50"), 1),
+			bucket(new BigDecimal("2.00"), 1)
+		};
+
+		final RangeHistogramDataCruncher cruncher = new RangeHistogramDataCruncher(source, 2, 2);
+
+		final CacheableBucket[] buckets = cruncher.getHistogram();
+		assertEquals(2, buckets.length, "span 100 with request 2 must yield 2 buckets");
+		// thresholds must be emitted at scale 2 and be numerically correct
+		assertEquals(2, buckets[0].threshold().scale(), "first threshold must carry scale 2");
+		assertEquals(0, buckets[0].threshold().compareTo(new BigDecimal("1.00")), "first threshold must equal 1.00");
+		assertEquals(2, buckets[1].threshold().scale(), "second threshold must carry scale 2");
+		assertEquals(0, buckets[1].threshold().compareTo(new BigDecimal("1.50")), "second threshold must equal 1.50");
+		// inclusive upper bound at scale 2
+		assertEquals(2, cruncher.getMaxValue().scale(), "max must carry scale 2");
+		assertEquals(0, cruncher.getMaxValue().compareTo(new BigDecimal("2.00")), "max must equal 2.00");
+	}
+
+	@Test
+	@DisplayName("Last bucket is closed and inclusive of the max value")
+	void shouldVerifyLastBucketIsClosedInclusiveOfMaxValue() {
+		// R1 spans keys [0,1] (entirely below the last bucket); R2 sits exactly at the max key 4
+		final ValueToRecordBitmap[] source = {
+			bucket(0, 1),
+			bucket(1, 1),
+			bucket(4, 2)
+		};
+
+		// span 4, request 2 -> lower bounds 0 & 2; last bucket [2,4] must include the record sitting at 4
+		final RangeHistogramDataCruncher cruncher = new RangeHistogramDataCruncher(source, 2, 0);
+
+		final CacheableBucket[] buckets = cruncher.getHistogram();
+		assertEquals(2, buckets.length, "span 4 with request 2 must yield 2 buckets");
+		assertEquals(0, cruncher.getMaxValue().compareTo(BigDecimal.valueOf(4)), "max must be 4");
+		// the first bucket [0,2) overlaps only R1, which ends at key 1
+		assertEquals(1, buckets[0].occurrences(), "first bucket must count only the record ending at key 1");
+		// the last bucket [2,4] is closed at the top, so the record at key 4 must be counted there
+		assertEquals(
+			1, buckets[1].occurrences(),
+			"the closed last bucket must include the record whose interval ends at the max value"
+		);
+		assertEquals(2, cruncher.getOverallCount(), "overallCount must be the two distinct records");
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncherTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/histogram/producer/RangeHistogramDataCruncherTest.java
@@ -24,6 +24,7 @@
 package io.evitadb.core.query.extraResult.translator.histogram.producer;
 
 import io.evitadb.api.exception.InvalidHistogramBucketCountException;
+import io.evitadb.api.query.require.HistogramBehavior;
 import io.evitadb.core.query.extraResult.translator.histogram.cache.CacheableHistogramContract.CacheableBucket;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
@@ -366,5 +367,285 @@ class RangeHistogramDataCruncherTest {
 			"the closed last bucket must include the record whose interval ends at the max value"
 		);
 		assertEquals(2, cruncher.getOverallCount(), "overallCount must be the two distinct records");
+	}
+
+	@Test
+	@DisplayName("OPTIMIZED widens the grid to collapse a wide empty coverage gap")
+	void shouldCollapseEmptyGapUnderOptimizedBehavior() {
+		// R1 spans keys [0,2], R2 spans keys [18,20]; the whole middle of [0,20] is uncovered. A 10-bucket
+		// STANDARD grid leaves a long run of empty buckets across the gap; OPTIMIZED must widen the grid so the
+		// empty run shrinks, while preserving solid-overlap occurrences and the distinct overall count.
+		final ValueToRecordBitmap[] source = {
+			bucket(0, 1), bucket(1, 1), bucket(2, 1),
+			bucket(18, 2), bucket(19, 2), bucket(20, 2)
+		};
+
+		final CacheableBucket[] standard = new RangeHistogramDataCruncher(
+			source, 10, 0, HistogramBehavior.STANDARD
+		).getHistogram();
+		final RangeHistogramDataCruncher optimizedCruncher = new RangeHistogramDataCruncher(
+			source, 10, 0, HistogramBehavior.OPTIMIZED
+		);
+		final CacheableBucket[] optimized = optimizedCruncher.getHistogram();
+
+		assertTrue(
+			optimized.length < standard.length,
+			"OPTIMIZED must emit fewer buckets than the " + standard.length + "-bucket STANDARD grid"
+		);
+		assertTrue(
+			longestEmptyRun(optimized) < longestEmptyRun(standard),
+			"OPTIMIZED must shrink the longest run of empty buckets (was " + longestEmptyRun(standard) + ")"
+		);
+		// occurrences stay solid-overlap: both records are still present, neither dropped nor double-counted
+		assertEquals(1, optimized[0].occurrences(), "first bucket must still count R1");
+		assertEquals(1, optimized[optimized.length - 1].occurrences(), "last bucket must still count R2");
+		assertEquals(2, optimizedCruncher.getOverallCount(), "overallCount stays the distinct record count");
+		assertEquals(0, optimizedCruncher.getMaxValue().compareTo(BigDecimal.valueOf(20)), "max must stay 20");
+	}
+
+	@Test
+	@DisplayName("OPTIMIZED leaves a gap-free grid identical to STANDARD")
+	void shouldLeaveGapFreeGridUnchangedUnderOptimizedBehavior() {
+		// the four overlapping ranges fill every bucket (occurrences 1,2,3,3,2 — no empties), so OPTIMIZED has
+		// no gap to collapse and must return exactly the STANDARD grid
+		final ValueToRecordBitmap[] source = {
+			bucket(10, 1), bucket(15, 1, 2), bucket(20, 1, 2, 3),
+			bucket(25, 2, 3, 4), bucket(30, 3, 4), bucket(35, 4)
+		};
+
+		final CacheableBucket[] standard = new RangeHistogramDataCruncher(
+			source, 5, 0, HistogramBehavior.STANDARD
+		).getHistogram();
+		final CacheableBucket[] optimized = new RangeHistogramDataCruncher(
+			source, 5, 0, HistogramBehavior.OPTIMIZED
+		).getHistogram();
+
+		assertEquals(standard.length, optimized.length, "gap-free OPTIMIZED grid must match STANDARD bucket count");
+		for (int i = 0; i < standard.length; i++) {
+			assertEquals(
+				0, optimized[i].threshold().compareTo(standard[i].threshold()),
+				"bucket " + i + " threshold must match STANDARD"
+			);
+			assertEquals(
+				standard[i].occurrences(), optimized[i].occurrences(),
+				"bucket " + i + " occurrences must match STANDARD"
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("Frequency-equalised behaviors are rejected — the equaliser serves them instead")
+	void shouldRejectEqualizedBehaviors() {
+		final ValueToRecordBitmap[] source = {bucket(0, 1), bucket(5, 1)};
+		// EQUALIZED / EQUALIZED_OPTIMIZED are handled by EqualizedHistogramDataCruncher over the same sweep;
+		// this cruncher serves only the equal-width family and must reject the equalised behaviors outright
+		assertThrows(
+			IllegalArgumentException.class,
+			() -> new RangeHistogramDataCruncher(source, 5, 0, HistogramBehavior.EQUALIZED),
+			"EQUALIZED must be rejected by the overlap cruncher"
+		);
+		assertThrows(
+			IllegalArgumentException.class,
+			() -> new RangeHistogramDataCruncher(source, 5, 0, HistogramBehavior.EQUALIZED_OPTIMIZED),
+			"EQUALIZED_OPTIMIZED must be rejected by the overlap cruncher"
+		);
+	}
+
+	@Test
+	@DisplayName("The three-arg constructor defaults to STANDARD behavior")
+	void shouldDefaultToStandardBehaviorForThreeArgConstructor() {
+		final ValueToRecordBitmap[] source = {
+			bucket(10, 1), bucket(15, 1, 2), bucket(20, 1, 2, 3),
+			bucket(25, 2, 3, 4), bucket(30, 3, 4), bucket(35, 4)
+		};
+		final CacheableBucket[] threeArg = new RangeHistogramDataCruncher(source, 5, 0).getHistogram();
+		final CacheableBucket[] explicitStandard = new RangeHistogramDataCruncher(
+			source, 5, 0, HistogramBehavior.STANDARD
+		).getHistogram();
+		assertEquals(explicitStandard.length, threeArg.length, "default must equal explicit STANDARD");
+		for (int i = 0; i < explicitStandard.length; i++) {
+			assertEquals(
+				explicitStandard[i].occurrences(), threeArg[i].occurrences(),
+				"bucket " + i + " occurrences must match explicit STANDARD"
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("OPTIMIZED collapses to two buckets when the gap leaves at most two non-empty columns")
+	void shouldCollapseToTwoBucketsWhenGapLeavesAtMostTwoNonEmptyColumns() {
+		// R1 spans keys [0,1], R2 spans keys [20,21]; on a 10-bucket STANDARD grid only the first and last
+		// buckets are non-empty, so the longest empty run leaves at most two non-empty columns and the OPTIMIZED
+		// heuristic collapses the grid to exactly two buckets — one per cluster.
+		final ValueToRecordBitmap[] source = {
+			bucket(0, 1), bucket(1, 1),
+			bucket(20, 2), bucket(21, 2)
+		};
+
+		final RangeHistogramDataCruncher optimizedCruncher = new RangeHistogramDataCruncher(
+			source, 10, 0, HistogramBehavior.OPTIMIZED
+		);
+		final CacheableBucket[] optimized = optimizedCruncher.getHistogram();
+
+		assertEquals(2, optimized.length, "the gap must collapse the grid to exactly two buckets");
+		// each cluster lands in its own bucket, neither dropped
+		assertEquals(1, optimized[0].occurrences(), "first bucket must count R1");
+		assertEquals(1, optimized[1].occurrences(), "second bucket must count R2");
+		assertEquals(2, optimizedCruncher.getOverallCount(), "overallCount stays the distinct record count");
+		assertEquals(0, optimizedCruncher.getMaxValue().compareTo(BigDecimal.valueOf(21)), "max must stay 21");
+	}
+
+	@Test
+	@DisplayName("OPTIMIZED collapses the longest of several empty runs and keeps every cluster")
+	void shouldCollapseLongestOfMultipleEmptyRunsUnderOptimized() {
+		// three clusters separated by two empty runs of different lengths: a short gap between R1[0,2] and
+		// R2[40,42] and a longer gap between R2 and R3[80,82]. OPTIMIZED targets the longest run, so the widened
+		// grid must reduce the longest empty run relative to STANDARD without dropping any cluster.
+		final ValueToRecordBitmap[] source = {
+			bucket(0, 1), bucket(1, 1), bucket(2, 1),
+			bucket(40, 2), bucket(41, 2), bucket(42, 2),
+			bucket(80, 3), bucket(81, 3), bucket(82, 3)
+		};
+
+		final CacheableBucket[] standard = new RangeHistogramDataCruncher(
+			source, 20, 0, HistogramBehavior.STANDARD
+		).getHistogram();
+		final RangeHistogramDataCruncher optimizedCruncher = new RangeHistogramDataCruncher(
+			source, 20, 0, HistogramBehavior.OPTIMIZED
+		);
+		final CacheableBucket[] optimized = optimizedCruncher.getHistogram();
+
+		assertTrue(
+			longestEmptyRun(optimized) < longestEmptyRun(standard),
+			"OPTIMIZED must shrink the longest empty run (was " + longestEmptyRun(standard) + ")"
+		);
+		assertEquals(3, optimizedCruncher.getOverallCount(), "every distinct cluster record must survive");
+		// the three clusters remain represented — first and last buckets stay populated
+		assertTrue(optimized[0].occurrences() >= 1, "first bucket must still count R1");
+		assertTrue(
+			optimized[optimized.length - 1].occurrences() >= 1,
+			"last bucket must still count R3"
+		);
+	}
+
+	@Test
+	@DisplayName("OPTIMIZED collapses a wide empty gap at BigDecimal scale 2")
+	void shouldCollapseEmptyGapAtBigDecimalScaleUnderOptimized() {
+		// two scale-2 clusters around 1.00 and 9.00 with a wide empty middle; decimalPlaces = 2. OPTIMIZED must
+		// emit fewer buckets than STANDARD, shrink the longest empty run, and preserve scale-2, strictly
+		// increasing thresholds with a scale-2 inclusive max.
+		final ValueToRecordBitmap[] source = {
+			bucket(new BigDecimal("1.00"), 1), bucket(new BigDecimal("1.10"), 1),
+			bucket(new BigDecimal("8.90"), 2), bucket(new BigDecimal("9.00"), 2)
+		};
+
+		final CacheableBucket[] standard = new RangeHistogramDataCruncher(
+			source, 20, 2, HistogramBehavior.STANDARD
+		).getHistogram();
+		final RangeHistogramDataCruncher optimizedCruncher = new RangeHistogramDataCruncher(
+			source, 20, 2, HistogramBehavior.OPTIMIZED
+		);
+		final CacheableBucket[] optimized = optimizedCruncher.getHistogram();
+
+		assertTrue(
+			optimized.length < standard.length,
+			"OPTIMIZED must emit fewer buckets than the " + standard.length + "-bucket STANDARD grid"
+		);
+		assertTrue(
+			longestEmptyRun(optimized) < longestEmptyRun(standard),
+			"OPTIMIZED must shrink the longest empty run (was " + longestEmptyRun(standard) + ")"
+		);
+		// thresholds carry scale 2 and strictly increase
+		for (int i = 0; i < optimized.length; i++) {
+			assertEquals(
+				2, optimized[i].threshold().scale(),
+				"bucket " + i + " threshold must carry scale 2 — got " + optimized[i].threshold()
+			);
+			if (i > 0) {
+				assertTrue(
+					optimized[i].threshold().compareTo(optimized[i - 1].threshold()) > 0,
+					"bucket " + i + " threshold must strictly exceed bucket " + (i - 1)
+				);
+			}
+		}
+		assertEquals(2, optimizedCruncher.getMaxValue().scale(), "max must carry scale 2");
+		assertEquals(
+			0, optimizedCruncher.getMaxValue().compareTo(new BigDecimal("9.00")), "max must equal 9.00"
+		);
+		assertEquals(2, optimizedCruncher.getOverallCount(), "overallCount stays the distinct record count");
+	}
+
+	@Test
+	@DisplayName("Extreme Integer value span does not overflow the grid arithmetic")
+	void shouldNotOverflowSpanForExtremeIntegerRange() {
+		// thresholds Integer.MIN_VALUE, 0, Integer.MAX_VALUE — the value span Integer.MAX_VALUE -
+		// Integer.MIN_VALUE exceeds Integer.MAX_VALUE, so an int subtraction wraps to a negative span and
+		// would crash the grid allocation. The span arithmetic must widen to long so the grid builds normally.
+		final ValueToRecordBitmap[] source = {
+			bucket(Integer.MIN_VALUE, 1),
+			bucket(0, 1, 2),
+			bucket(Integer.MAX_VALUE, 2)
+		};
+
+		final RangeHistogramDataCruncher cruncher = new RangeHistogramDataCruncher(source, 5, 0);
+
+		final CacheableBucket[] buckets = cruncher.getHistogram();
+		assertTrue(buckets.length >= 2, "an extreme span must still produce multiple buckets");
+		// flooring the proportional offset in long space must keep the thresholds strictly increasing
+		for (int i = 1; i < buckets.length; i++) {
+			assertTrue(
+				buckets[i].threshold().compareTo(buckets[i - 1].threshold()) > 0,
+				"adjacent thresholds must strictly increase even across the full int range — bucket " + i
+			);
+		}
+		assertEquals(2, cruncher.getOverallCount(), "overallCount must be the two distinct records");
+		assertEquals(
+			0, cruncher.getMaxValue().compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)),
+			"max must equal Integer.MAX_VALUE without truncation"
+		);
+	}
+
+	@Test
+	@DisplayName("OPTIMIZED still emits a single bucket for a degenerate single-value span")
+	void shouldEmitSingleBucketForDegenerateSpanEvenUnderOptimized() {
+		// every threshold collapses onto key 7 (minKey == maxKey); the degenerate-span early return fires before
+		// the OPTIMIZED heuristic, so the result is one full-width bucket regardless of behavior
+		final ValueToRecordBitmap[] source = {
+			bucket(7, 1, 2, 3)
+		};
+
+		final RangeHistogramDataCruncher optimizedCruncher = new RangeHistogramDataCruncher(
+			source, 10, 0, HistogramBehavior.OPTIMIZED
+		);
+		final CacheableBucket[] optimized = optimizedCruncher.getHistogram();
+
+		assertEquals(1, optimized.length, "a single-value span must collapse to exactly one bucket under OPTIMIZED");
+		assertEquals(0, optimized[0].threshold().compareTo(BigDecimal.valueOf(7)), "the sole bucket sits at key 7");
+		assertEquals(3, optimized[0].occurrences(), "the bucket must count every distinct record");
+		assertEquals(3, optimizedCruncher.getOverallCount(), "overallCount must be the distinct record count");
+		assertEquals(
+			0, optimized[0].relativeFrequency().compareTo(new BigDecimal("100")),
+			"the sole populated bucket is by definition full-width (relativeFrequency = 100)"
+		);
+	}
+
+	/**
+	 * Returns the length of the longest run of consecutive empty (zero-occurrence) buckets — the quantity the
+	 * OPTIMIZED behavior is designed to shrink.
+	 */
+	private static int longestEmptyRun(@Nonnull CacheableBucket[] buckets) {
+		int longest = 0;
+		int current = 0;
+		for (final CacheableBucket b : buckets) {
+			if (b.occurrences() == 0) {
+				current++;
+				if (current > longest) {
+					longest = current;
+				}
+			} else {
+				current = 0;
+			}
+		}
+		return longest;
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/cache/serializer/FlattenedHistogramComputerSerializerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/cache/serializer/FlattenedHistogramComputerSerializerTest.java
@@ -1,0 +1,163 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.cache.serializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import io.evitadb.core.query.extraResult.translator.histogram.cache.CacheableHistogram;
+import io.evitadb.core.query.extraResult.translator.histogram.cache.CacheableHistogramContract;
+import io.evitadb.core.query.extraResult.translator.histogram.cache.CacheableHistogramContract.CacheableBucket;
+import io.evitadb.core.query.extraResult.translator.histogram.cache.FlattenedHistogramComputer;
+import io.evitadb.store.shared.kryo.KryoFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+
+import static io.evitadb.test.TestTags.HISTOGRAM;
+import static io.evitadb.test.TestTags.SERIALIZATION;
+import static io.evitadb.test.TestTags.STORAGE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Verifies {@link FlattenedHistogramComputerSerializer} round-trips a {@link CacheableHistogram} whose explicit
+ * `overallCount` differs from the sum of bucket occurrences — the range (overlap) histogram case. The distinct
+ * count must survive write→read intact instead of being recomputed from the bucket sum.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("FlattenedHistogramComputerSerializer — overallCount round-trip")
+@Tag(STORAGE)
+@Tag(HISTOGRAM)
+@Tag(SERIALIZATION)
+class FlattenedHistogramComputerSerializerTest {
+
+	@Test
+	@DisplayName("Distinct overallCount different from the bucket sum survives the round-trip")
+	void shouldRetainExplicitOverallCountAcrossRoundTrip() {
+		// buckets sum to 1+2+3+3+2 = 11 occurrences, but only 4 distinct records exist (overlap histogram)
+		final CacheableBucket[] buckets = {
+			new CacheableBucket(BigDecimal.valueOf(10), 1, new BigDecimal("33.33")),
+			new CacheableBucket(BigDecimal.valueOf(15), 2, new BigDecimal("66.67")),
+			new CacheableBucket(BigDecimal.valueOf(20), 3, new BigDecimal("100.00")),
+			new CacheableBucket(BigDecimal.valueOf(25), 3, new BigDecimal("100.00")),
+			new CacheableBucket(BigDecimal.valueOf(30), 2, new BigDecimal("66.67"))
+		};
+		final int distinctOverallCount = 4;
+		final CacheableHistogram histogram = new CacheableHistogram(
+			buckets, BigDecimal.valueOf(35), 10, 35, distinctOverallCount
+		);
+		// sanity: the value we want to protect is genuinely different from the bucket sum
+		assertEquals(11, sumOccurrences(buckets), "fixture must have a bucket sum distinct from overallCount");
+		assertEquals(distinctOverallCount, histogram.getOverallCount());
+
+		final FlattenedHistogramComputer original = new FlattenedHistogramComputer(
+			1L, 2L, new long[] {3L, 4L}, histogram
+		);
+
+		final Kryo kryo = KryoFactory.createKryo();
+		final FlattenedHistogramComputerSerializer serializer = new FlattenedHistogramComputerSerializer();
+
+		final ByteArrayOutputStream os = new ByteArrayOutputStream(512);
+		try (final Output output = new Output(os, 512)) {
+			serializer.write(kryo, output, original);
+		}
+
+		final FlattenedHistogramComputer deserialized;
+		try (final Input input = new Input(os.toByteArray())) {
+			deserialized = serializer.read(kryo, input, FlattenedHistogramComputer.class);
+		}
+
+		assertEquals(
+			distinctOverallCount, deserialized.compute().getOverallCount(),
+			"distinct overallCount must survive the round-trip, not be recomputed from the bucket sum"
+		);
+		assertEquals(
+			0, deserialized.compute().getMax().compareTo(BigDecimal.valueOf(35)),
+			"max must round-trip"
+		);
+		assertEquals(
+			buckets.length, deserialized.compute().getBuckets().length,
+			"bucket count must round-trip"
+		);
+	}
+
+	@Test
+	@DisplayName("Null raw bounds and bucket-sum overall count survive the round-trip for a price-style histogram")
+	void shouldRoundTripNullRawBoundsForPriceStyleHistogram() {
+		// price histograms use the two-argument constructor: null raw bounds, overallCount = bucket sum
+		final CacheableBucket[] buckets = {
+			new CacheableBucket(BigDecimal.valueOf(10), 4, new BigDecimal("80.00")),
+			new CacheableBucket(BigDecimal.valueOf(20), 5, new BigDecimal("100.00")),
+			new CacheableBucket(BigDecimal.valueOf(30), 1, new BigDecimal("20.00"))
+		};
+		final CacheableHistogram histogram = new CacheableHistogram(buckets, BigDecimal.valueOf(40));
+		// sanity: the legacy constructor leaves raw bounds null and sums occurrences for overallCount
+		assertNull(histogram.getRawMin(), "price-style histogram must carry a null raw min");
+		assertNull(histogram.getRawMax(), "price-style histogram must carry a null raw max");
+		assertEquals(10, histogram.getOverallCount(), "overall count must default to the bucket sum 4+5+1");
+
+		final FlattenedHistogramComputer original = new FlattenedHistogramComputer(
+			5L, 6L, new long[] {7L, 8L}, histogram
+		);
+
+		final Kryo kryo = KryoFactory.createKryo();
+		final FlattenedHistogramComputerSerializer serializer = new FlattenedHistogramComputerSerializer();
+
+		final ByteArrayOutputStream os = new ByteArrayOutputStream(512);
+		try (final Output output = new Output(os, 512)) {
+			serializer.write(kryo, output, original);
+		}
+
+		final FlattenedHistogramComputer deserialized;
+		try (final Input input = new Input(os.toByteArray())) {
+			deserialized = serializer.read(kryo, input, FlattenedHistogramComputer.class);
+		}
+
+		final CacheableHistogramContract result = deserialized.compute();
+		assertNull(result.getRawMin(), "null raw min must survive the round-trip");
+		assertNull(result.getRawMax(), "null raw max must survive the round-trip");
+		assertEquals(10, result.getOverallCount(), "bucket-sum overall count must survive the round-trip");
+		assertEquals(
+			0, result.getMax().compareTo(BigDecimal.valueOf(40)),
+			"max must round-trip"
+		);
+		assertEquals(buckets.length, result.getBuckets().length, "bucket count must round-trip");
+	}
+
+	/**
+	 * Sums the occurrences across all buckets — the point/price-histogram definition of overall count.
+	 */
+	private static int sumOccurrences(CacheableBucket[] buckets) {
+		int sum = 0;
+		for (final CacheableBucket bucket : buckets) {
+			sum += bucket.occurrences();
+		}
+		return sum;
+	}
+}


### PR DESCRIPTION
Closes #1245

Range-typed (`NumberRange`) reference/attribute bucketed histograms were rendered with **point-histogram semantics**: a record whose value-range spans the histogram was counted once per active threshold, inflating `overallCount` and leaving covered buckets at `0` (sparse spikes instead of a solid bar).

## Fix
- New `RangeHistogramDataCruncher` reconstructs each distinct record's `[from, to]` from the range sweep and renders **overlap occupancy** — a record fills every bucket its range overlaps (solid bar).
- `overallCount` is now the **distinct-record count**, decoupled from the bucket-occurrence sum and stored explicitly on `Histogram` / `CacheableHistogram`. Point and price histograms keep their `Σ occurrences` semantics — unchanged.
- `AttributeHistogramComputer.compute()` dispatches range-typed schemas to the new cruncher; the scalar/price path is untouched.
- The current cache serializer persists `overallCount` so it survives the cache round-trip. The gRPC/GraphQL/REST wire formats already carry the field — **no proto/schema break**.

## Tests
- `RangeHistogramDataCruncherTest` — overlap occupancy, distinct count, degenerate span, bucket-count capping, `BigDecimal` scale round-trip, open-ended ranges, disjoint records, closed last bucket.
- `ReferenceRangeHistogramFunctionalTest` — oracle rewritten to overlap + distinct semantics (independent re-derivation).
- `FlattenedHistogramComputerSerializerTest` — round-trip guard proving `overallCount != Σ` survives.
- Explicit-`overallCount` guards added to `HistogramTest` / `CacheableHistogramTest`.
- 181 histogram + serializer + reference-range tests green; point/price regression unaffected.
