### PR TITLE
Fix filterGroupBy ignored by reference histogramStatistics path

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/producer/ReferenceHistogramAccumulator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/producer/ReferenceHistogramAccumulator.java
@@ -72,6 +72,7 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Function;
+import java.util.function.IntPredicate;
 import java.util.function.Predicate;
 
 import static io.evitadb.utils.CollectionUtils.createHashMap;
@@ -151,6 +152,10 @@ final class ReferenceHistogramAccumulator {
 	 *                                          facet-bearing groups produced by the first fabrication phase.
 	 *                                          Returns {@code null} when no fetcher is available — the accumulator
 	 *                                          then falls back to a bare {@link EntityReference}.
+	 * @param groupPredicateByReferenceName  resolves the per-reference `filterGroupBy` predicate so the histogram
+	 *                                       path drops groups the caller did not select — mirroring the facet path's
+	 *                                       group filtering. Returns {@code null} when no `filterGroupBy` was supplied
+	 *                                       for the reference, which means "no group filtering" (every group passes).
 	 */
 	@Nonnull
 	static <T extends ReferenceGroupStatistics> Map<String, Collection<T>> injectHistograms(
@@ -160,7 +165,8 @@ final class ReferenceHistogramAccumulator {
 		@Nonnull QueryExecutionContext context,
 		@Nonnull ReferenceSummaryResultAdapter<T> resultAdapter,
 		@Nonnull Function<String, NestedContextSorter> facetSorterByReferenceName,
-		@Nonnull Function<String, Function<int[], EntityClassifier[]>> groupEntityFetcherByReferenceName
+		@Nonnull Function<String, Function<int[], EntityClassifier[]>> groupEntityFetcherByReferenceName,
+		@Nonnull Function<String, IntPredicate> groupPredicateByReferenceName
 	) {
 		final Map<String, Collection<T>> result = createLinkedHashMap(statisticsByReferenceName.size());
 		result.putAll(statisticsByReferenceName);
@@ -175,9 +181,11 @@ final class ReferenceHistogramAccumulator {
 			final Collection<T> existing = result.getOrDefault(referenceName, List.of());
 			final NestedContextSorter facetSorter = facetSorterByReferenceName.apply(referenceName);
 			final Function<int[], EntityClassifier[]> groupEntityFetcher = groupEntityFetcherByReferenceName.apply(referenceName);
+			final IntPredicate groupPredicate = groupPredicateByReferenceName.apply(referenceName);
 			final Collection<T> rebuilt = computeForReference(
 				referenceSchema, requests, existing,
-				attributeHistogramBaselineFormula, context, resultAdapter, facetSorter, groupEntityFetcher
+				attributeHistogramBaselineFormula, context, resultAdapter, facetSorter, groupEntityFetcher,
+				groupPredicate
 			);
 			result.put(referenceName, rebuilt);
 		}
@@ -206,7 +214,8 @@ final class ReferenceHistogramAccumulator {
 		@Nonnull QueryExecutionContext context,
 		@Nonnull ReferenceSummaryResultAdapter<T> resultAdapter,
 		@Nullable NestedContextSorter facetSorter,
-		@Nullable Function<int[], EntityClassifier[]> groupEntityFetcher
+		@Nullable Function<int[], EntityClassifier[]> groupEntityFetcher,
+		@Nullable IntPredicate groupPredicate
 	) {
 		final boolean grouped = referenceSchema.getReferencedGroupType() != null
 			&& referenceSchema.isReferencedGroupTypeManaged();
@@ -260,7 +269,7 @@ final class ReferenceHistogramAccumulator {
 				if (grouped) {
 					collectGroupedPending(
 						resolvedReq, entityType, referenceName, scope,
-						attributeHistogramBaselineFormula, context, facetSorter, pending
+						attributeHistogramBaselineFormula, context, facetSorter, groupPredicate, pending
 					);
 				} else {
 					collectNonGroupedPending(
@@ -299,6 +308,11 @@ final class ReferenceHistogramAccumulator {
 	 * Collects a pending histogram per {@link ReducedGroupEntityIndex} tracked by the reference's
 	 * {@code REFERENCED_GROUP_ENTITY_TYPE} index in the given scope. Iterates all known group PKs
 	 * and their per-group storage indexes.
+	 *
+	 * When a {@code groupPredicate} is supplied (the caller attached a `filterGroupBy` to the
+	 * enclosing `referenceSummaryOfReference`), group PKs that fail the predicate are skipped — the
+	 * same group selection the facet path applies, so the histogram path never emits histograms for
+	 * groups the caller did not request. A {@code null} predicate means "no group filtering".
 	 */
 	private static void collectGroupedPending(
 		@Nonnull ResolvedRequest resolved,
@@ -308,6 +322,7 @@ final class ReferenceHistogramAccumulator {
 		@Nullable Formula attributeHistogramBaselineFormula,
 		@Nonnull QueryExecutionContext context,
 		@Nullable NestedContextSorter facetSorter,
+		@Nullable IntPredicate groupPredicate,
 		@Nonnull List<PendingHistogram> pending
 	) {
 		final EntityIndexKey rteiKey = new EntityIndexKey(
@@ -336,6 +351,11 @@ final class ReferenceHistogramAccumulator {
 					"Group primary key must be non-zero — PK `0` is reserved as the non-grouped " +
 						"sentinel. Got: 0 for reference `" + referenceName + "`."
 				);
+			}
+			// honour the enclosing referenceSummary's `filterGroupBy`: a group failing the predicate
+			// is intentional filtering (the caller did not select it), mirroring the facet path
+			if (groupPredicate != null && !groupPredicate.test(groupPk)) {
+				continue;
 			}
 			final int[] rgeiPks = rtei.getAllReferenceIndexes(groupPk);
 			for (final int rgeiPk : rgeiPks) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/producer/ReferenceSummaryProducer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/translator/reference/producer/ReferenceSummaryProducer.java
@@ -436,7 +436,8 @@ public class ReferenceSummaryProducer implements ExtraResultProducer {
 				referenceName -> ofNullable(this.referenceSummaryRequests.get(referenceName))
 					.map(ReferenceSummaryRequest::facetSorter)
 					.orElse(null),
-				referenceName -> resolveGroupEntityFetcher(referenceName, context)
+				referenceName -> resolveGroupEntityFetcher(referenceName, context),
+				this::resolveGroupPredicate
 			);
 		}
 		return resultAdapter.createResult(statisticsByReferenceName);
@@ -477,6 +478,40 @@ public class ReferenceSummaryProducer implements ExtraResultProducer {
 		final ReferenceSchemaContract referenceSchema = requests.get(0).referenceSchema();
 		return buildFromDefault(referenceSchema, new AtomicInteger())
 			.getGroupEntityFetcher(context, referenceSchema);
+	}
+
+	/**
+	 * Resolves the `filterGroupBy` predicate for the histogram accumulator, mirroring the
+	 * specific-or-default merge {@link #resolveGroupEntityFetcher} performs. Returns the predicate
+	 * cached on the explicit {@link ReferenceSummaryRequest} when one was registered for the
+	 * reference; otherwise derives it per-schema from {@link #defaultRequest}, the same fallback
+	 * {@link #mergeSpecificWithDefault} and {@link #buildFromDefault} apply during phase 1. This is
+	 * what lets the histogram path drop groups the caller did not select — the facet path already
+	 * applies this predicate in {@code accumulator()}. Returns {@code null} when no `filterGroupBy`
+	 * is in effect for the reference (no group filtering — every group passes).
+	 */
+	@Nullable
+	private IntPredicate resolveGroupPredicate(@Nonnull String referenceName) {
+		final ReferenceSummaryRequest specific = this.referenceSummaryRequests.get(referenceName);
+		if (specific != null) {
+			if (specific.groupPredicate() != null) {
+				return specific.groupPredicate();
+			}
+			return this.defaultRequest == null
+				? null
+				: applyToSchema(this.defaultRequest.groupPredicate(), specific.referenceSchema());
+		}
+		if (this.defaultRequest == null) {
+			return null;
+		}
+		// histogramRequests is the only place this producer keeps the reference schema for
+		// references not registered in referenceSummaryRequests — guaranteed to carry an entry
+		// because the accumulator only reaches this resolver while iterating its own keys.
+		final List<HistogramRequest> requests = this.histogramRequests.get(referenceName);
+		if (requests == null || requests.isEmpty()) {
+			return null;
+		}
+		return applyToSchema(this.defaultRequest.groupPredicate(), requests.get(0).referenceSchema());
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceSummaryHistogramFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceSummaryHistogramFunctionalTest.java
@@ -1036,6 +1036,55 @@ public class ReferenceSummaryHistogramFunctionalTest extends AbstractReferenceSu
 				}
 			);
 		}
+
+		@Test
+		@UseDataSet(REFERENCE_HISTOGRAM_SMALL)
+		@DisplayName("NONE depth + filterGroupBy selecting one group must drop the other group's histogram")
+		void shouldOnlyEmitHistogramForGroupSelectedByFilterGroupByWithNoneDepth(@Nonnull Evita evita) {
+			evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					final EvitaResponse<EntityReferenceContract> result = session.query(
+						query(
+							collection(ENTITY_PRODUCT),
+							require(
+								referenceSummaryOfReferenceWithHistograms(
+									REF_PARAM_VALUES, FacetStatisticsDepth.NONE,
+									null,                                       // facetFilterBy
+									filterGroupBy(entityPrimaryKeyInSet(1)),    // facetGroupFilterBy: only group 1
+									null, null,                                 // facetOrderBy, facetGroupOrderBy
+									null, null,                                 // entityFetch, entityGroupFetch
+									histogramStatistics(10, HISTOGRAM_PRICE)
+								)
+							)
+						),
+						EntityReferenceContract.class
+					);
+					final ReferenceSummary referenceSummary = result.getExtraResult(ReferenceSummary.class);
+					assertNotNull(referenceSummary);
+					// NONE depth strips the reference from the statistics map before histogram injection,
+					// so each surviving group is synthesised purely from histogram data — that synthesis must
+					// still honour filterGroupBy: group 1 emerges (carrying its histogram) and group 2 is gone
+					final ReferenceGroupStatistics group1 = referenceSummary.getReferenceGroupStatistics(
+						REF_PARAM_VALUES, 1
+					);
+					final ReferenceGroupStatistics group2 = referenceSummary.getReferenceGroupStatistics(
+						REF_PARAM_VALUES, 2
+					);
+					assertNotNull(group1, "Group 1 must appear as a histogram-only synthetic group");
+					assertArrayEquals(
+						new String[]{HISTOGRAM_PRICE},
+						group1.getHistogramStatistics().keySet().toArray(new String[0]),
+						"Selected group 1 must expose exactly the requested histogram entry"
+					);
+					assertNull(
+						group2,
+						"Group 2 must be absent — filtered out by filterGroupBy even in NONE depth"
+					);
+					return null;
+				}
+			);
+		}
 	}
 
 	// ==========================================================================================

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceSummaryHistogramFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceSummaryHistogramFunctionalTest.java
@@ -29,6 +29,7 @@ import io.evitadb.api.query.Query;
 import io.evitadb.api.query.RequireConstraint;
 import io.evitadb.api.query.expression.ExpressionFactory;
 import io.evitadb.api.query.filter.FilterBy;
+import io.evitadb.api.query.require.FacetStatisticsDepth;
 import io.evitadb.api.query.require.HistogramBehavior;
 import io.evitadb.api.requestResponse.EvitaResponse;
 import io.evitadb.api.requestResponse.data.EntityClassifier;
@@ -69,6 +70,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.evitadb.test.TestTags.CONTRACT;
 import static io.evitadb.test.TestTags.HISTOGRAM;
@@ -892,6 +894,144 @@ public class ReferenceSummaryHistogramFunctionalTest extends AbstractReferenceSu
 						new String[]{HISTOGRAM_PRICE},
 						group2.getHistogramStatistics().keySet().toArray(new String[0])
 					);
+					return null;
+				}
+			);
+		}
+
+		@Test
+		@UseDataSet(REFERENCE_HISTOGRAM_SMALL)
+		@DisplayName("filterGroupBy selecting one group must drop the other group's histogram")
+		void shouldOnlyEmitHistogramForGroupSelectedByFilterGroupBy(@Nonnull Evita evita) {
+			evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					final EvitaResponse<EntityReferenceContract> result = session.query(
+						query(
+							collection(ENTITY_PRODUCT),
+							require(
+								referenceSummaryOfReferenceWithHistograms(
+									REF_PARAM_VALUES, FacetStatisticsDepth.COUNTS,
+									null,                                       // facetFilterBy
+									filterGroupBy(entityPrimaryKeyInSet(1)),    // facetGroupFilterBy: only group 1
+									null, null,                                 // facetOrderBy, facetGroupOrderBy
+									null, null,                                 // entityFetch, entityGroupFetch
+									histogramStatistics(10, HISTOGRAM_PRICE)
+								)
+							)
+						),
+						EntityReferenceContract.class
+					);
+					final ReferenceSummary referenceSummary = result.getExtraResult(ReferenceSummary.class);
+					assertNotNull(referenceSummary);
+					// filterGroupBy picks only group 1 — the histogram-stats path must honour it the
+					// same way the facet path does: group 1 stays (with its histogram) and group 2 is gone
+					final ReferenceGroupStatistics group1 = referenceSummary.getReferenceGroupStatistics(
+						REF_PARAM_VALUES, 1
+					);
+					final ReferenceGroupStatistics group2 = referenceSummary.getReferenceGroupStatistics(
+						REF_PARAM_VALUES, 2
+					);
+					assertNotNull(group1, "Group 1 must appear — it was selected by filterGroupBy");
+					assertArrayEquals(
+						new String[]{HISTOGRAM_PRICE},
+						group1.getHistogramStatistics().keySet().toArray(new String[0]),
+						"Selected group 1 must expose exactly the requested histogram entry"
+					);
+					assertNull(
+						group2,
+						"Group 2 must be absent — it was not selected by filterGroupBy"
+					);
+					return null;
+				}
+			);
+		}
+
+		@Test
+		@UseDataSet(REFERENCE_HISTOGRAM_SMALL)
+		@DisplayName("all-references fan-out filterGroupBy selecting one group must drop the other group's histogram")
+		void shouldOnlyEmitHistogramForGroupSelectedByAllReferencesFilterGroupBy(@Nonnull Evita evita) {
+			evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					final EvitaResponse<EntityReferenceContract> result = session.query(
+						query(
+							collection(ENTITY_PRODUCT),
+							require(
+								referenceSummaryWithHistograms(
+									FacetStatisticsDepth.COUNTS,
+									null,                                       // facetFilterBy
+									filterGroupBy(entityPrimaryKeyInSet(1)),    // facetGroupFilterBy: only group 1
+									null, null,                                 // facetOrderBy, facetGroupOrderBy
+									null, null,                                 // entityFetch, entityGroupFetch
+									histogramStatistics(10, HISTOGRAM_PRICE)
+								)
+							)
+						),
+						EntityReferenceContract.class
+					);
+					final ReferenceSummary referenceSummary = result.getExtraResult(ReferenceSummary.class);
+					assertNotNull(referenceSummary);
+					// the all-references fan-out leaves the reference out of `referenceSummaryRequests`,
+					// so group-predicate resolution falls to the `defaultRequest`-derived branch — that
+					// branch must honour filterGroupBy identically: group 1 (with its histogram) survives
+					// and group 2 is dropped
+					final ReferenceGroupStatistics group1 = referenceSummary.getReferenceGroupStatistics(
+						REF_PARAM_VALUES, 1
+					);
+					final ReferenceGroupStatistics group2 = referenceSummary.getReferenceGroupStatistics(
+						REF_PARAM_VALUES, 2
+					);
+					assertNotNull(group1, "Group 1 must appear — it was selected by filterGroupBy");
+					assertArrayEquals(
+						new String[]{HISTOGRAM_PRICE},
+						group1.getHistogramStatistics().keySet().toArray(new String[0]),
+						"Selected group 1 must expose exactly the requested histogram entry"
+					);
+					assertNull(
+						group2,
+						"Group 2 must be absent — it was not selected by filterGroupBy"
+					);
+					return null;
+				}
+			);
+		}
+
+		@Test
+		@UseDataSet(REFERENCE_HISTOGRAM_SMALL)
+		@DisplayName("filterGroupBy matching no group must drop every group's histogram")
+		void shouldEmitNoGroupHistogramWhenFilterGroupBySelectsNoGroup(@Nonnull Evita evita) {
+			evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					final EvitaResponse<EntityReferenceContract> result = session.query(
+						query(
+							collection(ENTITY_PRODUCT),
+							require(
+								referenceSummaryOfReferenceWithHistograms(
+									REF_PARAM_VALUES, FacetStatisticsDepth.COUNTS,
+									null,                                         // facetFilterBy
+									filterGroupBy(entityPrimaryKeyInSet(999)),    // facetGroupFilterBy: no such group
+									null, null,                                   // facetOrderBy, facetGroupOrderBy
+									null, null,                                   // entityFetch, entityGroupFetch
+									histogramStatistics(10, HISTOGRAM_PRICE)
+								)
+							)
+						),
+						EntityReferenceContract.class
+					);
+					final ReferenceSummary referenceSummary = result.getExtraResult(ReferenceSummary.class);
+					assertNotNull(referenceSummary);
+					// group 999 does not exist, so the predicate matches no group — every group's
+					// histogram is dropped with no all-groups fallback and no exception
+					final ReferenceGroupStatistics group1 = referenceSummary.getReferenceGroupStatistics(
+						REF_PARAM_VALUES, 1
+					);
+					final ReferenceGroupStatistics group2 = referenceSummary.getReferenceGroupStatistics(
+						REF_PARAM_VALUES, 2
+					);
+					assertNull(group1, "Group 1 must be absent — filterGroupBy matched no group");
+					assertNull(group2, "Group 2 must be absent — filterGroupBy matched no group");
 					return null;
 				}
 			);


### PR DESCRIPTION
Closes #1246

`filterGroupBy` was ignored by the reference `histogramStatistics` path. The accumulator iterated **every** group primary key and emitted a histogram per group, so callers received histograms for groups they did not request — and when the requested group's histogram was empty it was silently dropped and a different group surfaced instead. The facet-summary path honoured `filterGroupBy` correctly; only the histogram-stats path did not.

## Fix
- `ReferenceSummaryProducer.resolveGroupPredicate(referenceName)` resolves the effective per-reference group predicate using the same specific-or-default merge as `resolveGroupEntityFetcher` / `mergeSpecificWithDefault` / `buildFromDefault`.
- `ReferenceHistogramAccumulator` threads that `IntPredicate` through `injectHistograms → computeForReference → collectGroupedPending` and skips group PKs that fail it — identical semantics to the facet path's group filtering. A `null` predicate (no `filterGroupBy`) means "no group filtering", preserving prior behaviour. The non-grouped path is untouched.

## Tests
Three functional tests in `ReferenceSummaryHistogramFunctionalTest.GroupFilter` (all keepers):
- per-reference `referenceSummaryOfReference(filterGroupBy: …)` selecting one group drops the other;
- all-references `referenceSummary(filterGroupBy: …)` fan-out (exercises the `defaultRequest`-derived branch);
- `filterGroupBy` matching no group drops every group (no fallback, no crash).

Full histogram functional suite green; code-quality pipeline clean (no production changes beyond the fix).