### PR TITLE
fix: normalize BigDecimal range values at the histogram-index write boundary

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/expression/trigger/HistogramValueDescriptor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/expression/trigger/HistogramValueDescriptor.java
@@ -50,6 +50,10 @@ import java.io.Serializable;
  * @param innerNumericType    when `plainType` is a `NumberRange` subtype, the matching inner numeric type
  *                            (e.g., `IntegerNumberRange.class` -> `Integer.class`); null for non-Range
  *                            `plainType` values
+ * @param indexedDecimalPlaces the source attribute schema's indexed decimal places — the authoritative
+ *                            scale at which `BigDecimalNumberRange` (and scalar `BigDecimal`) values must
+ *                            be encoded before insertion into the histogram index, mirroring the regular
+ *                            attribute-index write path. `0` for non-decimal source attributes
  * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 public record HistogramValueDescriptor(
@@ -60,7 +64,8 @@ public record HistogramValueDescriptor(
 	boolean arrayType,
 	boolean localized,
 	@Nullable Number defaultValue,
-	@Nullable Class<? extends Number> innerNumericType
+	@Nullable Class<? extends Number> innerNumericType,
+	int indexedDecimalPlaces
 ) {
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/expression/trigger/HistogramValueDescriptorFactory.java
+++ b/evita_engine/src/main/java/io/evitadb/core/expression/trigger/HistogramValueDescriptorFactory.java
@@ -199,7 +199,7 @@ public class HistogramValueDescriptorFactory {
 			}
 			return new HistogramValueDescriptor(
 				source, sourceEntityType, attributeName, plainType, arrayType, localized,
-				null, innerNumericType
+				null, innerNumericType, attributeSchema.getIndexedDecimalPlaces()
 			);
 		}
 
@@ -220,7 +220,7 @@ public class HistogramValueDescriptorFactory {
 
 		return new HistogramValueDescriptor(
 			source, sourceEntityType, attributeName, plainType, arrayType, localized,
-			defaultValue, null
+			defaultValue, null, attributeSchema.getIndexedDecimalPlaces()
 		);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
@@ -139,7 +139,6 @@ import static java.util.Optional.ofNullable;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-@SuppressWarnings("deprecation")
 public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 	private static final Map<Class<? extends RequireConstraint>, RequireConstraintTranslator<? extends RequireConstraint>>
 		TRANSLATORS;

--- a/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/extraResult/ExtraResultPlanningVisitor.java
@@ -139,6 +139,7 @@ import static java.util.Optional.ofNullable;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
+@SuppressWarnings("deprecation")
 public class ExtraResultPlanningVisitor implements ConstraintVisitor {
 	private static final Map<Class<? extends RequireConstraint>, RequireConstraintTranslator<? extends RequireConstraint>>
 		TRANSLATORS;

--- a/evita_engine/src/main/java/io/evitadb/index/HistogramCapableEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/HistogramCapableEntityIndex.java
@@ -63,32 +63,51 @@ public interface HistogramCapableEntityIndex {
 	 * Inserts a histogram value for the given owner entity. Delegates to the appropriate
 	 * {@link HistogramIndex}, creating it lazily if needed.
 	 *
-	 * @param histogramName the name of the histogram definition
-	 * @param locale        the locale for localized histograms, or `null` for non-localized
-	 * @param value         the histogram value in its original type (a `Number` for plain numeric
-	 *                      attributes or a `Range` instance for Range-typed attributes)
-	 * @param ownerPK       the primary key of the owner entity
-	 * @param valueType     the plain type of the value (used for lazy index creation)
+	 * This is the single scale-normalization boundary for histogram-index writes: the supplied
+	 * `value` is re-encoded to `indexedDecimalPlaces` via
+	 * {@link io.evitadb.utils.NumberUtils#normalizeForIndexing(Serializable, int)} before storage,
+	 * symmetric to how {@code AttributeIndexMutator.executeAttributeUpsert} is the boundary for the
+	 * standard attribute-index path. Callers therefore pass the value in its raw type and the source
+	 * attribute schema's indexed decimal places — they must NOT pre-normalize.
+	 *
+	 * @param histogramName        the name of the histogram definition
+	 * @param locale               the locale for localized histograms, or `null` for non-localized
+	 * @param value                the histogram value in its original type (a `Number` for plain numeric
+	 *                             attributes or a `Range` instance for Range-typed attributes)
+	 * @param ownerPK              the primary key of the owner entity
+	 * @param valueType            the plain type of the value (used for lazy index creation)
+	 * @param indexedDecimalPlaces the source attribute schema's indexed decimal places — the scale at
+	 *                             which `BigDecimal`/`BigDecimalNumberRange` values are encoded
 	 */
 	void insertHistogramValue(
 		@Nonnull String histogramName,
 		@Nullable Locale locale,
 		@Nonnull Serializable value,
 		int ownerPK,
-		@Nonnull Class<? extends Serializable> valueType
+		@Nonnull Class<? extends Serializable> valueType,
+		int indexedDecimalPlaces
 	);
 
 	/**
 	 * Removes a histogram value for the given owner entity. Delegates to the appropriate
 	 * {@link HistogramIndex} and removes it from the map if it becomes empty.
 	 *
-	 * @param histogramName the name of the histogram definition
-	 * @param locale        the locale for localized histograms, or `null` for non-localized
-	 * @param value         the histogram value in its original numeric type
-	 * @param ownerPK       the primary key of the owner entity
+	 * Applies the same `indexedDecimalPlaces` normalization as {@link #insertHistogramValue} so the
+	 * removed value's encoded form matches what was stored — insert and remove must stay symmetric.
+	 *
+	 * @param histogramName        the name of the histogram definition
+	 * @param locale               the locale for localized histograms, or `null` for non-localized
+	 * @param value                the histogram value in its original numeric type
+	 * @param ownerPK              the primary key of the owner entity
+	 * @param indexedDecimalPlaces the source attribute schema's indexed decimal places — must match
+	 *                             the scale used at insert time
 	 */
 	void removeHistogramValue(
-		@Nonnull String histogramName, @Nullable Locale locale, @Nonnull Serializable value, int ownerPK
+		@Nonnull String histogramName,
+		@Nullable Locale locale,
+		@Nonnull Serializable value,
+		int ownerPK,
+		int indexedDecimalPlaces
 	);
 
 }

--- a/evita_engine/src/main/java/io/evitadb/index/HistogramIndexOperations.java
+++ b/evita_engine/src/main/java/io/evitadb/index/HistogramIndexOperations.java
@@ -27,6 +27,7 @@ import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.index.bool.TransactionalBoolean;
 import io.evitadb.index.map.TransactionalMap;
 import io.evitadb.utils.Assert;
+import io.evitadb.utils.NumberUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -43,6 +44,16 @@ import java.util.Locale;
  * between the two subclasses ({@code getRepresentativeReferenceKey().referenceName()} on
  * `ReducedGroupEntityIndex` vs {@code getReferenceName()} on `ReferencedTypeEntityIndex`).
  *
+ * This helper is the single scale-normalization boundary for histogram-index writes: both
+ * {@link #insertHistogramValue} and {@link #removeHistogramValue} re-encode the value to the source
+ * attribute's `indexedDecimalPlaces` via
+ * {@link NumberUtils#normalizeForIndexing(java.io.Serializable, int)} exactly once before delegating
+ * to {@link HistogramIndex}. This mirrors {@code AttributeIndexMutator.executeAttributeUpsert}, which
+ * is the equivalent boundary for the standard attribute-index path — both paths share the same
+ * {@code normalizeForIndexing} primitive at their respective write boundaries rather than relying on
+ * callers to pre-normalize. Keep normalization here (not scattered across the trigger paths) so the
+ * `BigDecimalNumberRange`-scale invariant cannot be reintroduced by a non-local change.
+ *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 final class HistogramIndexOperations {
@@ -55,14 +66,16 @@ final class HistogramIndexOperations {
 	 * first use. The created index is locale-aware iff `locale` is non-`null`. Sets the supplied
 	 * `dirty` flag to signal that the owning entity index has pending changes.
 	 *
-	 * @param histograms    the subclass-owned histogram index map
-	 * @param dirty         the subclass-owned dirty flag to mark as `true` after the insert
-	 * @param referenceName the reference name to attach to a newly-created histogram index
-	 * @param histogramName the name of the histogram definition
-	 * @param locale        the locale for localized histograms, or `null` for non-localized
-	 * @param value         the histogram value in its original type (a `Number` or `Range`)
-	 * @param ownerPK       the primary key of the owner entity
-	 * @param valueType     the plain type of the value (used for lazy index creation)
+	 * @param histograms           the subclass-owned histogram index map
+	 * @param dirty                the subclass-owned dirty flag to mark as `true` after the insert
+	 * @param referenceName        the reference name to attach to a newly-created histogram index
+	 * @param histogramName        the name of the histogram definition
+	 * @param locale               the locale for localized histograms, or `null` for non-localized
+	 * @param value                the histogram value in its original type (a `Number` or `Range`)
+	 * @param ownerPK              the primary key of the owner entity
+	 * @param valueType            the plain type of the value (used for lazy index creation)
+	 * @param indexedDecimalPlaces the source attribute schema's indexed decimal places — the scale at
+	 *                             which the value is re-encoded before storage
 	 */
 	static void insertHistogramValue(
 		@Nonnull TransactionalMap<String, HistogramIndex> histograms,
@@ -72,7 +85,8 @@ final class HistogramIndexOperations {
 		@Nullable Locale locale,
 		@Nonnull Serializable value,
 		int ownerPK,
-		@Nonnull Class<? extends Serializable> valueType
+		@Nonnull Class<? extends Serializable> valueType,
+		int indexedDecimalPlaces
 	) {
 		final HistogramIndex histogramIndex = histograms.computeIfAbsent(
 			histogramName,
@@ -80,7 +94,9 @@ final class HistogramIndexOperations {
 				? new LocalizedHistogramIndex(histogramName, referenceName, valueType)
 				: new SimpleHistogramIndex(histogramName, referenceName, valueType)
 		);
-		histogramIndex.insertValue(locale, value, ownerPK);
+		// single normalization boundary for histogram writes — re-encode `BigDecimalNumberRange`
+		// (and scalar `BigDecimal`) bounds to the schema scale; non-decimal types pass through
+		histogramIndex.insertValue(locale, NumberUtils.normalizeForIndexing(value, indexedDecimalPlaces), ownerPK);
 		dirty.setToTrue();
 	}
 
@@ -99,6 +115,9 @@ final class HistogramIndexOperations {
 	 *                                  non-localized
 	 * @param value                     the histogram value to remove
 	 * @param ownerPK                   the primary key of the owner entity
+	 * @param indexedDecimalPlaces      the source attribute schema's indexed decimal places — must
+	 *                                  match the scale used at insert time so the removed value's
+	 *                                  encoded form lines up with what was stored
 	 */
 	static void removeHistogramValue(
 		@Nonnull TransactionalMap<String, HistogramIndex> histograms,
@@ -107,14 +126,16 @@ final class HistogramIndexOperations {
 		@Nonnull String histogramName,
 		@Nullable Locale locale,
 		@Nonnull Serializable value,
-		int ownerPK
+		int ownerPK,
+		int indexedDecimalPlaces
 	) {
 		final HistogramIndex histogramIndex = histograms.get(histogramName);
 		Assert.isPremiseValid(
 			histogramIndex != null,
 			() -> "Histogram index for histogram " + histogramName + " not found."
 		);
-		histogramIndex.removeValue(locale, value, ownerPK);
+		// symmetric with insertHistogramValue — same normalization so encoded longs match the stored form
+		histogramIndex.removeValue(locale, NumberUtils.normalizeForIndexing(value, indexedDecimalPlaces), ownerPK);
 		dirty.setToTrue();
 		// if the histogram index is now empty, remove it from the map and clean up transactional layers
 		if (histogramIndex.isEmpty()) {

--- a/evita_engine/src/main/java/io/evitadb/index/ReducedGroupEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/ReducedGroupEntityIndex.java
@@ -813,12 +813,13 @@ public class ReducedGroupEntityIndex extends AbstractReducedEntityIndex implemen
 		@Nullable Locale locale,
 		@Nonnull Serializable value,
 		int ownerPK,
-		@Nonnull Class<? extends Serializable> valueType
+		@Nonnull Class<? extends Serializable> valueType,
+		int indexedDecimalPlaces
 	) {
 		HistogramIndexOperations.insertHistogramValue(
 			this.histogramIndexes, this.dirty,
 			getRepresentativeReferenceKey().referenceName(),
-			histogramName, locale, value, ownerPK, valueType
+			histogramName, locale, value, ownerPK, valueType, indexedDecimalPlaces
 		);
 	}
 
@@ -827,11 +828,12 @@ public class ReducedGroupEntityIndex extends AbstractReducedEntityIndex implemen
 		@Nonnull String histogramName,
 		@Nullable Locale locale,
 		@Nonnull Serializable value,
-		int ownerPK
+		int ownerPK,
+		int indexedDecimalPlaces
 	) {
 		HistogramIndexOperations.removeHistogramValue(
 			this.histogramIndexes, this.dirty, getTransactionalLayerMaintainer(),
-			histogramName, locale, value, ownerPK
+			histogramName, locale, value, ownerPK, indexedDecimalPlaces
 		);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/ReferencedTypeEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/ReferencedTypeEntityIndex.java
@@ -668,11 +668,12 @@ public class ReferencedTypeEntityIndex extends EntityIndex implements
 		@Nullable Locale locale,
 		@Nonnull Serializable value,
 		int ownerPK,
-		@Nonnull Class<? extends Serializable> valueType
+		@Nonnull Class<? extends Serializable> valueType,
+		int indexedDecimalPlaces
 	) {
 		HistogramIndexOperations.insertHistogramValue(
 			this.histogramIndexes, this.dirty, getReferenceName(),
-			histogramName, locale, value, ownerPK, valueType
+			histogramName, locale, value, ownerPK, valueType, indexedDecimalPlaces
 		);
 	}
 
@@ -681,11 +682,12 @@ public class ReferencedTypeEntityIndex extends EntityIndex implements
 		@Nonnull String histogramName,
 		@Nullable Locale locale,
 		@Nonnull Serializable value,
-		int ownerPK
+		int ownerPK,
+		int indexedDecimalPlaces
 	) {
 		HistogramIndexOperations.removeHistogramValue(
 			this.histogramIndexes, this.dirty, getTransactionalLayerMaintainer(),
-			histogramName, locale, value, ownerPK
+			histogramName, locale, value, ownerPK, indexedDecimalPlaces
 		);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/ReevaluateExpressionExecutor.java
@@ -60,6 +60,7 @@ import io.evitadb.index.invertedIndex.ValueToRecordBitmap;
 import io.evitadb.index.mutation.local.ReferenceIndexMutator;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
 import io.evitadb.utils.Assert;
+import io.evitadb.utils.NumberUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.RoaringBitmapWriter;
@@ -682,7 +683,7 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 					for (int ownerPK : matched) {
 						removeHistogramValue(
 							histogramName, locale, value, ownerPK,
-							group, rtei, isGrouped, target
+							group, rtei, isGrouped, target, resolution.indexedDecimalPlaces()
 						);
 					}
 				}
@@ -931,7 +932,7 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 						for (int ownerPK : matched) {
 							insertHistogramValue(
 								histogramName, locale, emittedValue, ownerPK, group, rtei, isGrouped,
-								target, plainType
+								target, plainType, resolution.indexedDecimalPlaces()
 							);
 						}
 					}
@@ -950,7 +951,7 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 						for (int ownerPK : matched) {
 							insertHistogramValue(
 								histogramName, locale, defaultValue, ownerPK, group, rtei, isGrouped,
-								target, plainType
+								target, plainType, resolution.indexedDecimalPlaces()
 							);
 						}
 					}
@@ -1090,7 +1091,7 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 			resolution, filterIndex, shouldBeIndexedBitmap, group,
 			(value, ownerPK) -> insertHistogramValue(
 				histogramName, locale, value, ownerPK, group, rtei, isGrouped,
-				target, plainType
+				target, plainType, resolution.indexedDecimalPlaces()
 			)
 		);
 	}
@@ -1269,7 +1270,8 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		processRefAttrFilterIndexBuckets(
 			resolution, filterIndex, ownerPKsToRemove, group,
 			(value, ownerPK) -> removeHistogramValue(
-				histogramName, locale, value, ownerPK, group, rtei, isGrouped, target
+				histogramName, locale, value, ownerPK, group, rtei, isGrouped, target,
+				resolution.indexedDecimalPlaces()
 			)
 		);
 	}
@@ -1287,7 +1289,8 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		@Nonnull AffectedReferenceGroup group,
 		@Nonnull ReferencedTypeEntityIndex rtei,
 		boolean isGrouped,
-		@Nonnull IndexMutationTarget target
+		@Nonnull IndexMutationTarget target,
+		int indexedDecimalPlaces
 	) {
 		if (isGrouped && group.groupPK() != null) {
 			final int[] storagePKs = rtei.getAllReferenceIndexes(group.groupPK());
@@ -1295,13 +1298,21 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 				final ReducedGroupEntityIndex rgei = asReducedGroupEntityIndex(
 					target.getOrCreateIndexByPrimaryKey(storagePK), storagePK
 				);
-				if (histogramContainsOwner(rgei.getHistogramIndex(histogramName), locale, value, ownerPK)) {
-					rgei.removeHistogramValue(histogramName, locale, value, ownerPK);
+				if (
+					histogramContainsOwner(
+						rgei.getHistogramIndex(histogramName), locale, value, ownerPK, indexedDecimalPlaces
+					)
+				) {
+					rgei.removeHistogramValue(histogramName, locale, value, ownerPK, indexedDecimalPlaces);
 				}
 			}
 		}
-		if (histogramContainsOwner(rtei.getHistogramIndex(histogramName), locale, value, ownerPK)) {
-			rtei.removeHistogramValue(histogramName, locale, value, ownerPK);
+		if (
+			histogramContainsOwner(
+				rtei.getHistogramIndex(histogramName), locale, value, ownerPK, indexedDecimalPlaces
+			)
+		) {
+			rtei.removeHistogramValue(histogramName, locale, value, ownerPK, indexedDecimalPlaces);
 		}
 	}
 
@@ -1312,13 +1323,15 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 	 *
 	 * Comparison uses `Object.equals` on the bucket value — `Range` subtypes implement value-based equality
 	 * over both bounds (and inner numeric type), so the lookup is symmetric for both scalar `Number` values
-	 * and range-typed bucket values.
+	 * and range-typed bucket values. The probe `value` is normalized to `indexedDecimalPlaces` first so it
+	 * matches the stored bucket value, which was normalized at the histogram-index write boundary.
 	 */
 	private static boolean histogramContainsOwner(
 		@Nullable HistogramIndex histogramIndex,
 		@Nullable Locale locale,
 		@Nonnull Serializable value,
-		int ownerPK
+		int ownerPK,
+		int indexedDecimalPlaces
 	) {
 		if (histogramIndex == null) {
 			return false;
@@ -1327,9 +1340,10 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		if (filterIndex == null) {
 			return false;
 		}
+		final Serializable normalizedValue = NumberUtils.normalizeForIndexing(value, indexedDecimalPlaces);
 		final ValueToRecordBitmap[] buckets = filterIndex.getHistogramOfAllRecords().getHistogramBuckets();
 		for (final ValueToRecordBitmap bucket : buckets) {
-			if (bucket.getValue().equals(value)) {
+			if (bucket.getValue().equals(normalizedValue)) {
 				return bucket.getRecordIds().contains(ownerPK);
 			}
 		}
@@ -1347,9 +1361,11 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 	 * @param ownerPK        primary key of the owner entity
 	 * @param group          the group for reduced-index routing
 	 * @param rtei           the top-level referenced-type index
-	 * @param isGrouped      `true` when the reference has a group type
-	 * @param target         access to entity collection indexes
-	 * @param valueType      the plain type of the attribute
+	 * @param isGrouped            `true` when the reference has a group type
+	 * @param target               access to entity collection indexes
+	 * @param valueType            the plain type of the attribute
+	 * @param indexedDecimalPlaces the source attribute schema's indexed decimal places, threaded to the
+	 *                             histogram-index write boundary for scale normalization
 	 */
 	private static void insertHistogramValue(
 		@Nonnull String histogramName,
@@ -1360,7 +1376,8 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		@Nonnull ReferencedTypeEntityIndex rtei,
 		boolean isGrouped,
 		@Nonnull IndexMutationTarget target,
-		@Nonnull Class<? extends Serializable> valueType
+		@Nonnull Class<? extends Serializable> valueType,
+		int indexedDecimalPlaces
 	) {
 		if (isGrouped && group.groupPK() != null) {
 			final int[] storagePKs = rtei.getAllReferenceIndexes(group.groupPK());
@@ -1368,10 +1385,10 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 				final ReducedGroupEntityIndex rgei = asReducedGroupEntityIndex(
 					target.getOrCreateIndexByPrimaryKey(storagePK), storagePK
 				);
-				rgei.insertHistogramValue(histogramName, locale, value, ownerPK, valueType);
+				rgei.insertHistogramValue(histogramName, locale, value, ownerPK, valueType, indexedDecimalPlaces);
 			}
 		}
-		rtei.insertHistogramValue(histogramName, locale, value, ownerPK, valueType);
+		rtei.insertHistogramValue(histogramName, locale, value, ownerPK, valueType, indexedDecimalPlaces);
 	}
 
 	/**
@@ -1778,7 +1795,7 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 		@Nonnull EntityPrimaryKeyInSet pkConstraint,
 		boolean isGroupScope
 	) {
-		return (FilterBy) ConstraintCloneVisitor.clone(
+		final FilterBy rewritten = (FilterBy) ConstraintCloneVisitor.clone(
 			filterBy,
 			(visitor, constraint) -> constraint instanceof final ReferenceHaving rh
 				&& rh.getReferenceName().equals(referenceName)
@@ -1786,6 +1803,16 @@ class ReevaluateExpressionExecutor implements IndexMutationExecutor<ReevaluateEx
 				&& !visitor.isWithin(GroupHaving.class)
 				? injectPkScope(rh, referenceName, pkConstraint, isGroupScope)
 				: constraint
+		);
+		// ConstraintCloneVisitor.clone is @Nullable because it returns null when the cloned tree
+		// collapses to a non-applicable constraint. That cannot happen here: the trigger `filterBy`
+		// always carries an applicable `referenceHaving`, and the translator only injects PK scope —
+		// it never drops children — so the clone is at least as applicable as the input. Assert the
+		// invariant explicitly to keep the @Nonnull contract sound rather than propagate a silent null.
+		return Objects.requireNonNull(
+			rewritten,
+			"Rewritten referenceHaving filter unexpectedly collapsed to null — the trigger `filterBy` " +
+				"must always retain an applicable constraint after PK-scope injection."
 		);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/ReferenceIndexMutator.java
@@ -72,6 +72,7 @@ import io.evitadb.spi.store.catalog.persistence.accessor.EntityStoragePartAccess
 import io.evitadb.spi.store.catalog.persistence.storageParts.entity.EntityBodyStoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.entity.ReferencesStoragePart;
 import io.evitadb.utils.Assert;
+import io.evitadb.utils.NumberUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -1675,10 +1676,11 @@ public interface ReferenceIndexMutator {
 		@Nullable Locale locale,
 		@Nonnull Scope scope
 	) {
+		final int indexedDecimalPlaces = trigger.getValueDescriptor().indexedDecimalPlaces();
 		for (final Serializable value : oldValues) {
 			removeSingleHistogramValue(
 				executor, referenceKey.referenceName(), trigger.getHistogramIndexName(),
-				locale, value, ownerPK, groupId, scope
+				locale, value, ownerPK, groupId, scope, indexedDecimalPlaces
 			);
 		}
 	}
@@ -1755,7 +1757,7 @@ public interface ReferenceIndexMutator {
 			if (values.length > 0) {
 				removeHistogramValuesWithGuard(
 					executor, referenceKey.referenceName(), trigger.getHistogramIndexName(),
-					locale, values, ownerPK, groupId, scope
+					locale, values, ownerPK, groupId, scope, resolution.indexedDecimalPlaces()
 				);
 			}
 		}
@@ -1800,7 +1802,7 @@ public interface ReferenceIndexMutator {
 					if (values.length > 0) {
 						removeHistogramValuesWithGuard(
 							executor, referenceKey.referenceName(), trigger.getHistogramIndexName(),
-							locale, values, entityPrimaryKey, groupId, scope
+							locale, values, entityPrimaryKey, groupId, scope, resolution.indexedDecimalPlaces()
 						);
 					}
 				}
@@ -1849,13 +1851,20 @@ public interface ReferenceIndexMutator {
 					executor, referenceKey, resolution, refAttrSupplier, locale, scope
 				);
 				final Serializable[] values = resolveHistogramValues(rawValue, resolution);
+				final int indexedDecimalPlaces = resolution.indexedDecimalPlaces();
 				for (final Serializable value : values) {
 					for (final int storagePK : groupStoragePKs) {
 						final EntityIndex reducedIndex =
 							executor.getEntityIndexByPrimaryKeyForModification(storagePK);
 						if (reducedIndex instanceof HistogramCapableEntityIndex hcei) {
-							if (isValueInHistogram(hcei, trigger.getHistogramIndexName(), locale, value, ownerPK)) {
-								hcei.removeHistogramValue(trigger.getHistogramIndexName(), locale, value, ownerPK);
+							if (
+								isValueInHistogram(
+									hcei, trigger.getHistogramIndexName(), locale, value, ownerPK, indexedDecimalPlaces
+								)
+							) {
+								hcei.removeHistogramValue(
+									trigger.getHistogramIndexName(), locale, value, ownerPK, indexedDecimalPlaces
+								);
 							}
 						}
 					}
@@ -1913,6 +1922,9 @@ public interface ReferenceIndexMutator {
 			}
 			return new Serializable[0];
 		}
+		// values are returned raw — scale normalization happens once at the histogram-index write
+		// boundary (HistogramIndexOperations); the removal existence guards normalize their probe
+		// with the same scale (see removeHistogramValuesWithGuard / removeSingleHistogramValue)
 		if (resolution.arrayType() && rawValue instanceof Serializable[] array) {
 			int count = 0;
 			for (final Serializable element : array) {
@@ -2968,14 +2980,16 @@ public interface ReferenceIndexMutator {
 	 * Values may be `Number` instances (for plain-numeric histograms) or `Range` instances (for
 	 * range-typed histograms). The downstream index APIs accept `Serializable` directly.
 	 *
-	 * @param executor      the mutation executor
-	 * @param referenceName the reference name
-	 * @param histogramName the histogram definition name
-	 * @param locale        the locale, or `null` for non-localized
-	 * @param values        the histogram values to remove (`Number` or `Range` instances)
-	 * @param ownerPK       the primary key of the owner entity
-	 * @param groupId       the group primary key (null for ungrouped)
-	 * @param scope         the current scope
+	 * @param executor             the mutation executor
+	 * @param referenceName        the reference name
+	 * @param histogramName        the histogram definition name
+	 * @param locale               the locale, or `null` for non-localized
+	 * @param values               the histogram values to remove (`Number` or `Range` instances)
+	 * @param ownerPK              the primary key of the owner entity
+	 * @param groupId              the group primary key (null for ungrouped)
+	 * @param scope                the current scope
+	 * @param indexedDecimalPlaces the source attribute schema's indexed decimal places (probe +
+	 *                             write-boundary normalization scale)
 	 */
 	private static void removeHistogramValuesWithGuard(
 		@Nonnull EntityIndexLocalMutationExecutor executor,
@@ -2985,7 +2999,8 @@ public interface ReferenceIndexMutator {
 		@Nonnull Serializable[] values,
 		int ownerPK,
 		@Nullable Integer groupId,
-		@Nonnull Scope scope
+		@Nonnull Scope scope,
+		int indexedDecimalPlaces
 	) {
 		for (final Serializable value : values) {
 			if (groupId != null) {
@@ -2999,8 +3014,8 @@ public interface ReferenceIndexMutator {
 						final EntityIndex reducedIndex =
 							executor.getEntityIndexByPrimaryKeyForModification(storagePK);
 						if (reducedIndex instanceof HistogramCapableEntityIndex hcei) {
-							if (isValueInHistogram(hcei, histogramName, locale, value, ownerPK)) {
-								hcei.removeHistogramValue(histogramName, locale, value, ownerPK);
+							if (isValueInHistogram(hcei, histogramName, locale, value, ownerPK, indexedDecimalPlaces)) {
+								hcei.removeHistogramValue(histogramName, locale, value, ownerPK, indexedDecimalPlaces);
 							}
 						}
 					}
@@ -3011,9 +3026,9 @@ public interface ReferenceIndexMutator {
 				);
 				final EntityIndex typeIndex = executor.getIndexIfExists(typeKey);
 				if (typeIndex instanceof HistogramCapableEntityIndex hcei) {
-					if (isValueInHistogram(hcei, histogramName, locale, value, ownerPK)) {
+					if (isValueInHistogram(hcei, histogramName, locale, value, ownerPK, indexedDecimalPlaces)) {
 						executor.getOrCreateIndex(typeKey);
-						hcei.removeHistogramValue(histogramName, locale, value, ownerPK);
+						hcei.removeHistogramValue(histogramName, locale, value, ownerPK, indexedDecimalPlaces);
 					}
 				}
 			}
@@ -3027,14 +3042,16 @@ public interface ReferenceIndexMutator {
 	 * expression may have been `false` when the value was originally indexed — the attribute existed
 	 * in storage but was never added to the histogram.
 	 *
-	 * @param executor      the mutation executor
-	 * @param referenceName the reference name
-	 * @param histogramName the histogram definition name
-	 * @param locale        the locale, or `null` for non-localized
-	 * @param value         the histogram value to remove (`Number` or `Range` instance)
-	 * @param ownerPK       the primary key of the owner entity
-	 * @param groupId       the group primary key (null for ungrouped)
-	 * @param scope         the current scope
+	 * @param executor             the mutation executor
+	 * @param referenceName        the reference name
+	 * @param histogramName        the histogram definition name
+	 * @param locale               the locale, or `null` for non-localized
+	 * @param value                the histogram value to remove (`Number` or `Range` instance)
+	 * @param ownerPK              the primary key of the owner entity
+	 * @param groupId              the group primary key (null for ungrouped)
+	 * @param scope                the current scope
+	 * @param indexedDecimalPlaces the source attribute schema's indexed decimal places (probe +
+	 *                             write-boundary normalization scale)
 	 */
 	private static void removeSingleHistogramValue(
 		@Nonnull EntityIndexLocalMutationExecutor executor,
@@ -3044,7 +3061,8 @@ public interface ReferenceIndexMutator {
 		@Nonnull Serializable value,
 		int ownerPK,
 		@Nullable Integer groupId,
-		@Nonnull Scope scope
+		@Nonnull Scope scope,
+		int indexedDecimalPlaces
 	) {
 		if (groupId != null) {
 			final EntityIndexKey groupTypeKey = new EntityIndexKey(
@@ -3056,8 +3074,8 @@ public interface ReferenceIndexMutator {
 				for (final int storagePK : storagePKs) {
 					final EntityIndex reducedIndex = executor.getEntityIndexByPrimaryKeyForModification(storagePK);
 					if (reducedIndex instanceof HistogramCapableEntityIndex hcei) {
-						if (isValueInHistogram(hcei, histogramName, locale, value, ownerPK)) {
-							hcei.removeHistogramValue(histogramName, locale, value, ownerPK);
+						if (isValueInHistogram(hcei, histogramName, locale, value, ownerPK, indexedDecimalPlaces)) {
+							hcei.removeHistogramValue(histogramName, locale, value, ownerPK, indexedDecimalPlaces);
 						}
 					}
 				}
@@ -3068,9 +3086,9 @@ public interface ReferenceIndexMutator {
 			);
 			final EntityIndex typeIndex = executor.getIndexIfExists(typeKey);
 			if (typeIndex instanceof HistogramCapableEntityIndex hcei) {
-				if (isValueInHistogram(hcei, histogramName, locale, value, ownerPK)) {
+				if (isValueInHistogram(hcei, histogramName, locale, value, ownerPK, indexedDecimalPlaces)) {
 					executor.getOrCreateIndex(typeKey);
-					hcei.removeHistogramValue(histogramName, locale, value, ownerPK);
+					hcei.removeHistogramValue(histogramName, locale, value, ownerPK, indexedDecimalPlaces);
 				}
 			}
 		}
@@ -3084,11 +3102,17 @@ public interface ReferenceIndexMutator {
 	 * This is an O(B) point lookup where B is the number of distinct values (typically 10-200 for
 	 * e-commerce histograms). RoaringBitmap `contains()` is O(1).
 	 *
-	 * @param entityIndex   the histogram-capable entity index
-	 * @param histogramName the histogram definition name
-	 * @param locale        the locale, or `null` for non-localized
-	 * @param value         the value to check
-	 * @param ownerPK       the owner PK to check
+	 * The stored bucket values were normalized to `indexedDecimalPlaces` at the histogram-index write
+	 * boundary, so the probe `value` is normalized with the same scale before the equality lookup —
+	 * otherwise a raw `BigDecimalNumberRange` whose intrinsic scale differs from the schema scale would
+	 * never match its stored (re-scaled) counterpart and the guard would suppress a valid removal.
+	 *
+	 * @param entityIndex          the histogram-capable entity index
+	 * @param histogramName        the histogram definition name
+	 * @param locale               the locale, or `null` for non-localized
+	 * @param value                the value to check
+	 * @param ownerPK              the owner PK to check
+	 * @param indexedDecimalPlaces the source attribute schema's indexed decimal places (probe scale)
 	 * @return `true` if the histogram contains the (value, ownerPK) pair
 	 */
 	private static boolean isValueInHistogram(
@@ -3096,7 +3120,8 @@ public interface ReferenceIndexMutator {
 		@Nonnull String histogramName,
 		@Nullable Locale locale,
 		@Nonnull Serializable value,
-		int ownerPK
+		int ownerPK,
+		int indexedDecimalPlaces
 	) {
 		final HistogramIndex histogramIndex = entityIndex.getHistogramIndex(histogramName);
 		if (histogramIndex == null) {
@@ -3106,9 +3131,10 @@ public interface ReferenceIndexMutator {
 		if (filterIndex == null) {
 			return false;
 		}
+		final Serializable normalizedValue = NumberUtils.normalizeForIndexing(value, indexedDecimalPlaces);
 		final ValueToRecordBitmap[] buckets = filterIndex.getHistogramOfAllRecords().getHistogramBuckets();
 		for (final ValueToRecordBitmap bucket : buckets) {
-			if (bucket.getValue().equals(value)) {
+			if (bucket.getValue().equals(normalizedValue)) {
 				return bucket.getRecordIds().contains(ownerPK);
 			}
 		}
@@ -3142,16 +3168,19 @@ public interface ReferenceIndexMutator {
 		@Nonnull Scope scope
 	) {
 		final Class<? extends Serializable> plainType = resolution.plainType();
+		final int indexedDecimalPlaces = resolution.indexedDecimalPlaces();
 		if (rawValue == null) {
 			// apply default value if specified (already converted to plainType at build time)
 			if (resolution.defaultValue() != null) {
 				insertSingleHistogramValue(
 					executor, referenceName, histogramName, locale,
-					resolution.defaultValue(), ownerPK, groupId, scope, plainType
+					resolution.defaultValue(), ownerPK, groupId, scope, plainType, indexedDecimalPlaces
 				);
 			}
 			return;
 		}
+		// values are passed raw — scale normalization happens once at the histogram-index write
+		// boundary (HistogramIndexOperations), so this path stays free of scale semantics
 		// enforce the array/scalar contract declared by the resolution before dispatching — a
 		// mismatch between `arrayType` and the runtime shape of `rawValue` is a programming error
 		// (schema vs. value drift) that must surface immediately rather than silently mis-index
@@ -3171,12 +3200,12 @@ public interface ReferenceIndexMutator {
 				if (element instanceof Number number) {
 					insertSingleHistogramValue(
 						executor, referenceName, histogramName, locale,
-						number, ownerPK, groupId, scope, plainType
+						number, ownerPK, groupId, scope, plainType, indexedDecimalPlaces
 					);
 				} else if (element instanceof Range<?> range) {
 					insertSingleHistogramValue(
 						executor, referenceName, histogramName, locale,
-						range, ownerPK, groupId, scope, plainType
+						range, ownerPK, groupId, scope, plainType, indexedDecimalPlaces
 					);
 				} else if (element != null) {
 					throw new GenericEvitaInternalError(
@@ -3189,12 +3218,12 @@ public interface ReferenceIndexMutator {
 		} else if (rawValue instanceof Number number) {
 			insertSingleHistogramValue(
 				executor, referenceName, histogramName, locale,
-				number, ownerPK, groupId, scope, plainType
+				number, ownerPK, groupId, scope, plainType, indexedDecimalPlaces
 			);
 		} else if (rawValue instanceof Range<?> range) {
 			insertSingleHistogramValue(
 				executor, referenceName, histogramName, locale,
-				range, ownerPK, groupId, scope, plainType
+				range, ownerPK, groupId, scope, plainType, indexedDecimalPlaces
 			);
 		} else {
 			throw new GenericEvitaInternalError(
@@ -3215,10 +3244,12 @@ public interface ReferenceIndexMutator {
 	 * @param locale        the locale for localized histograms, or `null` for non-localized
 	 * @param value         the histogram value in its original type (a `Number` for plain numeric
 	 *                      attributes or a `Range` instance for Range-typed attributes)
-	 * @param ownerPK       the primary key of the owner entity
-	 * @param groupId       the group primary key (null for ungrouped)
-	 * @param scope         the current scope
-	 * @param valueType     the plain type of the value (used for lazy index creation)
+	 * @param ownerPK              the primary key of the owner entity
+	 * @param groupId              the group primary key (null for ungrouped)
+	 * @param scope                the current scope
+	 * @param valueType            the plain type of the value (used for lazy index creation)
+	 * @param indexedDecimalPlaces the source attribute schema's indexed decimal places, threaded to
+	 *                             the histogram-index write boundary for scale normalization
 	 */
 	private static void insertSingleHistogramValue(
 		@Nonnull EntityIndexLocalMutationExecutor executor,
@@ -3229,7 +3260,8 @@ public interface ReferenceIndexMutator {
 		int ownerPK,
 		@Nullable Integer groupId,
 		@Nonnull Scope scope,
-		@Nonnull Class<? extends Serializable> valueType
+		@Nonnull Class<? extends Serializable> valueType,
+		int indexedDecimalPlaces
 	) {
 		if (groupId != null) {
 			// grouped reference: find the ReducedGroupEntityIndex via the group type index
@@ -3280,7 +3312,7 @@ public interface ReferenceIndexMutator {
 							reducedIndex.getClass().getName() + "."
 					);
 				}
-				hcei.insertHistogramValue(histogramName, locale, value, ownerPK, valueType);
+				hcei.insertHistogramValue(histogramName, locale, value, ownerPK, valueType, indexedDecimalPlaces);
 			}
 		} else {
 			// ungrouped reference: insert into ReferencedTypeEntityIndex
@@ -3310,7 +3342,7 @@ public interface ReferenceIndexMutator {
 			}
 			// mark the index dirty — it is modified via insertHistogramValue below
 			executor.getOrCreateIndex(typeKey);
-			hcei.insertHistogramValue(histogramName, locale, value, ownerPK, valueType);
+			hcei.insertHistogramValue(histogramName, locale, value, ownerPK, valueType, indexedDecimalPlaces);
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
@@ -24,6 +24,7 @@
 package io.evitadb.api.functional.histogram;
 
 import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.query.expression.ExpressionFactory;
 import io.evitadb.api.query.require.HistogramBehavior;
 import io.evitadb.api.requestResponse.EvitaResponse;
 import io.evitadb.api.requestResponse.data.EntityReferenceContract;
@@ -31,7 +32,10 @@ import io.evitadb.api.requestResponse.extraResult.HistogramContract;
 import io.evitadb.api.requestResponse.extraResult.HistogramContract.Bucket;
 import io.evitadb.api.requestResponse.extraResult.ReferenceSummary;
 import io.evitadb.api.requestResponse.extraResult.ReferenceSummary.ReferenceGroupStatistics;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.ReferenceIndexedComponents;
 import io.evitadb.core.Evita;
+import io.evitadb.dataType.BigDecimalNumberRange;
 import io.evitadb.test.annotation.UseDataSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -249,6 +253,97 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 	}
 
 	@Test
+	@DisplayName("should render BigDecimalNumberRange thresholds at the schema indexed scale")
+	void shouldRenderBigDecimalRangeHistogramAtSchemaScaleWhenValueScaleIsLower() {
+		// A referenced entity carries a `BigDecimalNumberRange` attribute declared with
+		// `indexDecimalPlaces(4)`, but the seeded values have a lower natural scale (integer bounds →
+		// effective retained scale 0). The regular attribute index normalizes the range to the schema
+		// scale before storing; the histogram-index population path must do the same — otherwise the
+		// histogram FilterIndex stores comparable longs at the value's intrinsic scale (0) while the
+		// read side decodes them at the schema scale (4), shrinking every threshold by 10^4.
+		final int indexedDecimalPlaces = 4;
+		final String rangeAttribute = "rangeValue";
+		final String rangeHistogram = "bigDecimalRangeBucket";
+		runWithInlineSchema(
+			"bigDecimalRangeHistogramScale",
+			session -> {
+				session.defineEntitySchema(ENTITY_PARAMETER)
+					.updateVia(session);
+				session.defineEntitySchema(ENTITY_PARAMETER_VALUE)
+					.withAttribute(
+						rangeAttribute, BigDecimalNumberRange.class,
+						whichIs -> whichIs.filterable().indexDecimalPlaces(indexedDecimalPlaces).nullable()
+					)
+					.updateVia(session);
+				session.defineEntitySchema(ENTITY_PRODUCT)
+					.withReferenceToEntity(
+						REF_PARAM_VALUES, ENTITY_PARAMETER_VALUE, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs
+							.indexedForFilteringAndPartitioning()
+							.indexedWithComponents(ReferenceIndexedComponents.values())
+							.faceted()
+							.withGroupTypeRelatedToEntity(ENTITY_PARAMETER)
+							.bucketed(
+								rangeHistogram,
+								ExpressionFactory.parse(
+									"$reference.referencedEntity?.attributes['" + rangeAttribute + "']"
+								)
+							)
+					)
+					.updateVia(session);
+			},
+			session -> {
+				session.createNewEntity(ENTITY_PARAMETER, RANGE_GROUP_PK)
+					.upsertVia(session);
+				// integer-valued bounds → effective retained scale 0, below the schema's
+				// indexDecimalPlaces(4): the scale mismatch the histogram-index path must normalize away
+				createParameterValueWithBigDecimalRange(session, 1, rangeAttribute, "1", "10");
+				createParameterValueWithBigDecimalRange(session, 2, rangeAttribute, "20", "88");
+				session.createNewEntity(ENTITY_PRODUCT, 100)
+					.setReference(
+						REF_PARAM_VALUES, 1,
+						whichIs -> whichIs.setGroup(ENTITY_PARAMETER, RANGE_GROUP_PK)
+					)
+					.upsertVia(session);
+				session.createNewEntity(ENTITY_PRODUCT, 101)
+					.setReference(
+						REF_PARAM_VALUES, 2,
+						whichIs -> whichIs.setGroup(ENTITY_PARAMETER, RANGE_GROUP_PK)
+					)
+					.upsertVia(session);
+			},
+			evita -> evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					final HistogramContract histogram =
+						queryGroupHistogram(session, rangeHistogram, 10);
+					final Bucket[] buckets = histogram.getBuckets();
+					assertTrue(buckets.length > 0, "Range histogram must produce at least one bucket");
+
+					// the seeded ranges span [1, 88]; correct thresholds must lie in that band, never
+					// be shrunk to sub-unit fractions like 0.0001 (the 10^4-too-small defect signature)
+					assertTrue(
+						histogram.getMin().compareTo(BigDecimal.ONE) >= 0,
+						"min " + histogram.getMin() + " must be >= 1 (seeded lower bound) — a value "
+							+ "below 1 proves the threshold was decoded at the wrong scale"
+					);
+					assertTrue(
+						histogram.getMax().compareTo(BigDecimal.valueOf(88)) <= 0,
+						"max " + histogram.getMax() + " must be <= 88 (seeded upper bound)"
+					);
+					for (final Bucket bucket : buckets) {
+						assertTrue(
+							bucket.threshold().compareTo(BigDecimal.ONE) >= 0,
+							"threshold " + bucket.threshold() + " must be >= 1 — a sub-unit threshold "
+								+ "is the 10^" + indexedDecimalPlaces + "-too-small scale defect"
+						);
+					}
+				}
+			)
+		);
+	}
+
+	@Test
 	@UseDataSet(REFERENCE_HISTOGRAM_RANGE)
 	@DisplayName("should account each range into every overlapping bucket across bucket counts")
 	void shouldAccountEachRangeIntoEveryOverlappingBucket(@Nonnull Evita evita) {
@@ -352,6 +447,26 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 				assertEqualisedAware(histogram, behavior);
 			}
 		);
+	}
+
+	/**
+	 * Creates a single `parameterValue` entity carrying a `BigDecimalNumberRange` attribute whose
+	 * bounds are parsed from the supplied decimal strings. The bounds are intentionally given
+	 * integer string forms so the range's effective retained scale is `0`, lower than the schema's
+	 * `indexDecimalPlaces`, exercising the scale-normalization gap on the histogram-index path.
+	 */
+	private static void createParameterValueWithBigDecimalRange(
+		@Nonnull EvitaSessionContract session,
+		int pk,
+		@Nonnull String attributeName,
+		@Nonnull String from, @Nonnull String to
+	) {
+		session.createNewEntity(ENTITY_PARAMETER_VALUE, pk)
+			.setAttribute(
+				attributeName,
+				BigDecimalNumberRange.between(new BigDecimal(from), new BigDecimal(to))
+			)
+			.upsertVia(session);
 	}
 
 	// ---------------------------------------------------------------------

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/histogram/ReferenceRangeHistogramFunctionalTest.java
@@ -344,6 +344,112 @@ public class ReferenceRangeHistogramFunctionalTest extends AbstractReferenceSumm
 	}
 
 	@Test
+	@DisplayName("should drop a BigDecimalNumberRange histogram entry on removal despite a lower value scale")
+	void shouldRemoveBigDecimalRangeHistogramEntryAtSchemaScaleWhenValueScaleIsLower() {
+		// Removal-path companion to shouldRenderBigDecimalRangeHistogramAtSchemaScaleWhenValueScaleIsLower.
+		// The existence guard that runs before a histogram-index remove compares its probe against the STORED
+		// bucket value, which the write path normalized to the schema scale (4). A raw probe carrying the
+		// value's intrinsic scale (0) would never match its re-scaled stored counterpart, so the removal would
+		// be silently suppressed and the histogram would keep a phantom entry that can never be reclaimed. The
+		// guard must therefore normalize its probe with the same scale; this test fails if it does not.
+		final int indexedDecimalPlaces = 4;
+		final String rangeAttribute = "rangeValue";
+		final String rangeHistogram = "bigDecimalRangeBucket";
+		runWithInlineSchema(
+			"bigDecimalRangeHistogramScaleRemoval",
+			session -> {
+				session.defineEntitySchema(ENTITY_PARAMETER)
+					.updateVia(session);
+				session.defineEntitySchema(ENTITY_PARAMETER_VALUE)
+					.withAttribute(
+						rangeAttribute, BigDecimalNumberRange.class,
+						whichIs -> whichIs.filterable().indexDecimalPlaces(indexedDecimalPlaces).nullable()
+					)
+					.updateVia(session);
+				session.defineEntitySchema(ENTITY_PRODUCT)
+					.withReferenceToEntity(
+						REF_PARAM_VALUES, ENTITY_PARAMETER_VALUE, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs
+							.indexedForFilteringAndPartitioning()
+							.indexedWithComponents(ReferenceIndexedComponents.values())
+							.faceted()
+							.withGroupTypeRelatedToEntity(ENTITY_PARAMETER)
+							.bucketed(
+								rangeHistogram,
+								ExpressionFactory.parse(
+									"$reference.referencedEntity?.attributes['" + rangeAttribute + "']"
+								)
+							)
+					)
+					.updateVia(session);
+			},
+			session -> {
+				session.createNewEntity(ENTITY_PARAMETER, RANGE_GROUP_PK)
+					.upsertVia(session);
+				// scale-0 bounds, below the schema's indexDecimalPlaces(4) — the same scale mismatch the
+				// removal guard must normalize away to match the stored (scale-4) bucket value
+				createParameterValueWithBigDecimalRange(session, 1, rangeAttribute, "1", "10");
+				createParameterValueWithBigDecimalRange(session, 2, rangeAttribute, "20", "88");
+				session.createNewEntity(ENTITY_PRODUCT, 100)
+					.setReference(
+						REF_PARAM_VALUES, 1,
+						whichIs -> whichIs.setGroup(ENTITY_PARAMETER, RANGE_GROUP_PK)
+					)
+					.upsertVia(session);
+				session.createNewEntity(ENTITY_PRODUCT, 101)
+					.setReference(
+						REF_PARAM_VALUES, 2,
+						whichIs -> whichIs.setGroup(ENTITY_PARAMETER, RANGE_GROUP_PK)
+					)
+					.upsertVia(session);
+			},
+			evita -> {
+				// baseline: both ranges contribute, so the group histogram spans the full [1, 88] band
+				evita.queryCatalog(
+					TEST_CATALOG,
+					session -> {
+						final HistogramContract histogram =
+							queryGroupHistogram(session, rangeHistogram, 10);
+						assertTrue(
+							histogram.getMax().compareTo(BigDecimal.valueOf(88)) >= 0,
+							"baseline max " + histogram.getMax() + " must reach the seeded upper bound 88"
+						);
+					}
+				);
+				// remove the product contributing the [20, 88] range — drives the histogram-index removal
+				// path through the existence guard whose probe must be normalized to the schema scale
+				evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						assertTrue(
+							session.deleteEntity(ENTITY_PRODUCT, 101),
+							"product 101 must exist and be deleted"
+						);
+					}
+				);
+				// only the [1, 10] range survives; the upper bound must collapse to <= 10. A max still near 88
+				// proves the [20, 88] removal was suppressed by a scale-mismatched guard probe (phantom entry).
+				evita.queryCatalog(
+					TEST_CATALOG,
+					session -> {
+						final HistogramContract histogram =
+							queryGroupHistogram(session, rangeHistogram, 10);
+						assertTrue(
+							histogram.getMin().compareTo(BigDecimal.ONE) >= 0,
+							"surviving min " + histogram.getMin() + " must stay >= 1 — scale must remain correct"
+						);
+						assertTrue(
+							histogram.getMax().compareTo(BigDecimal.valueOf(10)) <= 0,
+							"surviving max " + histogram.getMax() + " must collapse to <= 10 after the [20, 88] "
+								+ "range is removed — a value near 88 means the removal was silently suppressed"
+						);
+					}
+				);
+			}
+		);
+	}
+
+	@Test
 	@UseDataSet(REFERENCE_HISTOGRAM_RANGE)
 	@DisplayName("should account each range into every overlapping bucket across bucket counts")
 	void shouldAccountEachRangeIntoEveryOverlappingBucket(@Nonnull Evita evita) {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/catalog/DefaultCatalogExpressionTriggerRegistryTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/catalog/DefaultCatalogExpressionTriggerRegistryTest.java
@@ -1252,7 +1252,7 @@ class DefaultCatalogExpressionTriggerRegistryTest {
 				false,
 				true,
 				null,
-				null
+				null, 0
 			);
 			final DefaultHistogramExpressionTrigger histogramTrigger =
 				new DefaultHistogramExpressionTrigger(
@@ -1288,7 +1288,7 @@ class DefaultCatalogExpressionTriggerRegistryTest {
 				false,
 				false,
 				null,
-				null
+				null, 0
 			);
 			final DefaultHistogramExpressionTrigger histogramTrigger =
 				new DefaultHistogramExpressionTrigger(
@@ -1317,7 +1317,7 @@ class DefaultCatalogExpressionTriggerRegistryTest {
 				false,
 				true,
 				null,
-				null
+				null, 0
 			);
 			final DefaultHistogramExpressionTrigger histogramTrigger =
 				new DefaultHistogramExpressionTrigger(
@@ -1352,7 +1352,7 @@ class DefaultCatalogExpressionTriggerRegistryTest {
 				false,
 				false,
 				null,
-				null
+				null, 0
 			);
 			final DefaultHistogramExpressionTrigger histogramTrigger =
 				new DefaultHistogramExpressionTrigger(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/reference/ReferenceHistogramStatisticsTranslatorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/extraResult/translator/reference/ReferenceHistogramStatisticsTranslatorTest.java
@@ -148,7 +148,8 @@ class ReferenceHistogramStatisticsTranslatorTest {
 			false,
 			localized,
 			null,
-			null
+			null,
+			0
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/EntityIndexRoundTripTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/EntityIndexRoundTripTest.java
@@ -96,11 +96,7 @@ import java.util.Set;
 import static io.evitadb.test.TestTags.INDEXING;
 import static io.evitadb.test.TestTags.MANAGEMENT;
 import static io.evitadb.test.TestTags.STORAGE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -591,7 +587,7 @@ class EntityIndexRoundTripTest {
 		 * @return a populated `GlobalEntityIndex`
 		 */
 		@Nonnull
-		private GlobalEntityIndex buildPopulatedIndex() {
+		private static GlobalEntityIndex buildPopulatedIndex() {
 			final EntityIndexKey key = new EntityIndexKey(EntityIndexType.GLOBAL, Scope.LIVE);
 			final GlobalEntityIndex index = new GlobalEntityIndex(INDEX_PK, ENTITY_TYPE, key);
 			final EntitySchemaContract schema = createSchema(Set.of(Locale.ENGLISH));
@@ -641,7 +637,7 @@ class EntityIndexRoundTripTest {
 		 * @return a freshly-loaded `GlobalEntityIndex`
 		 */
 		@Nonnull
-		private GlobalEntityIndex reload(@Nonnull CapturedStorage storage) {
+		private static GlobalEntityIndex reload(@Nonnull CapturedStorage storage) {
 			final EntityIndexStoragePart manifest = storage.requireManifest();
 			// GlobalEntityIndex is entity-scoped — uses EntityAttributeIndex
 			final AttributeIndex attributeIndex = reloadAttributeIndex(storage, ENTITY_TYPE, null, false);
@@ -722,12 +718,12 @@ class EntityIndexRoundTripTest {
 
 			// AttributeIndex subclass identity must survive reload: GlobalEntityIndex carries
 			// an EntityAttributeIndex with ENTITY scope
-			assertTrue(
-				original.attributeIndex instanceof EntityAttributeIndex,
+			assertInstanceOf(
+				EntityAttributeIndex.class, original.attributeIndex,
 				"GlobalEntityIndex must construct an EntityAttributeIndex"
 			);
-			assertTrue(
-				reloaded.attributeIndex instanceof EntityAttributeIndex,
+			assertInstanceOf(
+				EntityAttributeIndex.class, reloaded.attributeIndex,
 				"Reloaded GlobalEntityIndex must reconstruct an EntityAttributeIndex"
 			);
 			assertEquals(AttributeScope.ENTITY, reloaded.attributeIndex.getScope());
@@ -750,7 +746,7 @@ class EntityIndexRoundTripTest {
 		 * @return a populated `ReducedEntityIndex`
 		 */
 		@Nonnull
-		private ReducedEntityIndex buildPopulatedIndex() {
+		private static ReducedEntityIndex buildPopulatedIndex() {
 			final RepresentativeReferenceKey rrk =
 				new RepresentativeReferenceKey(new ReferenceKey(REFERENCE_NAME, 5));
 			final EntityIndexKey key =
@@ -806,7 +802,7 @@ class EntityIndexRoundTripTest {
 		 * @return a freshly-loaded `ReducedEntityIndex`
 		 */
 		@Nonnull
-		private ReducedEntityIndex reload(@Nonnull CapturedStorage storage) {
+		private static ReducedEntityIndex reload(@Nonnull CapturedStorage storage) {
 			final EntityIndexStoragePart manifest = storage.requireManifest();
 			final RepresentativeReferenceKey rrk =
 				(RepresentativeReferenceKey) manifest.getEntityIndexKey().discriminator();
@@ -879,12 +875,12 @@ class EntityIndexRoundTripTest {
 
 			// AttributeIndex subclass identity must survive reload: ReducedEntityIndex carries
 			// a ReferenceAttributeIndex with REFERENCE scope
-			assertTrue(
-				original.attributeIndex instanceof ReferenceAttributeIndex,
+			assertInstanceOf(
+				ReferenceAttributeIndex.class, original.attributeIndex,
 				"ReducedEntityIndex must construct a ReferenceAttributeIndex"
 			);
-			assertTrue(
-				reloaded.attributeIndex instanceof ReferenceAttributeIndex,
+			assertInstanceOf(
+				ReferenceAttributeIndex.class, reloaded.attributeIndex,
 				"Reloaded ReducedEntityIndex must reconstruct a ReferenceAttributeIndex"
 			);
 			assertEquals(AttributeScope.REFERENCE, reloaded.attributeIndex.getScope());
@@ -909,7 +905,7 @@ class EntityIndexRoundTripTest {
 		 * @return a populated `ReducedGroupEntityIndex`
 		 */
 		@Nonnull
-		private ReducedGroupEntityIndex buildPopulatedIndex() {
+		private static ReducedGroupEntityIndex buildPopulatedIndex() {
 			final RepresentativeReferenceKey rrk =
 				new RepresentativeReferenceKey(new ReferenceKey(REFERENCE_NAME, GROUP_PK));
 			final EntityIndexKey key =
@@ -939,8 +935,8 @@ class EntityIndexRoundTripTest {
 			index.insertFilterAttribute(refSchema, nameSchema, allowedLocales, null, "Watch", 13);
 
 			// histogram — must round-trip via the manifest
-			index.insertHistogramValue(HISTOGRAM_NAME, null, 100, 13, Integer.class);
-			index.insertHistogramValue(HISTOGRAM_NAME, null, 200, 14, Integer.class);
+			index.insertHistogramValue(HISTOGRAM_NAME, null, 100, 13, Integer.class, 0);
+			index.insertHistogramValue(HISTOGRAM_NAME, null, 200, 14, Integer.class, 0);
 
 			// price ref-index intentionally NOT populated here for the same reason as in
 			// ReducedEntityIndexRoundTripTest: PriceListAndCurrencyPriceRefIndex requires a
@@ -960,7 +956,7 @@ class EntityIndexRoundTripTest {
 		 * @return a freshly-loaded `ReducedGroupEntityIndex`
 		 */
 		@Nonnull
-		private ReducedGroupEntityIndex reload(@Nonnull CapturedStorage storage) {
+		private static ReducedGroupEntityIndex reload(@Nonnull CapturedStorage storage) {
 			final EntityIndexStoragePart manifest = storage.requireManifest();
 			final RepresentativeReferenceKey rrk =
 				(RepresentativeReferenceKey) manifest.getEntityIndexKey().discriminator();
@@ -1042,12 +1038,12 @@ class EntityIndexRoundTripTest {
 
 			// AttributeIndex subclass identity must survive reload: ReducedGroupEntityIndex
 			// carries a ReferenceAttributeIndex with REFERENCE scope
-			assertTrue(
-				original.attributeIndex instanceof ReferenceAttributeIndex,
+			assertInstanceOf(
+				ReferenceAttributeIndex.class, original.attributeIndex,
 				"ReducedGroupEntityIndex must construct a ReferenceAttributeIndex"
 			);
-			assertTrue(
-				reloaded.attributeIndex instanceof ReferenceAttributeIndex,
+			assertInstanceOf(
+				ReferenceAttributeIndex.class, reloaded.attributeIndex,
 				"Reloaded ReducedGroupEntityIndex must reconstruct a ReferenceAttributeIndex"
 			);
 			assertEquals(AttributeScope.REFERENCE, reloaded.attributeIndex.getScope());
@@ -1069,7 +1065,7 @@ class EntityIndexRoundTripTest {
 		 * @return a populated `ReferencedTypeEntityIndex`
 		 */
 		@Nonnull
-		private ReferencedTypeEntityIndex buildPopulatedIndex() {
+		private static ReferencedTypeEntityIndex buildPopulatedIndex() {
 			final EntityIndexKey key = new EntityIndexKey(
 				EntityIndexType.REFERENCED_ENTITY_TYPE, Scope.LIVE, REFERENCE_NAME
 			);
@@ -1090,8 +1086,8 @@ class EntityIndexRoundTripTest {
 			index.insertFilterAttribute(refSchema, nameSchema, allowedLocales, null, "Lamp", 15);
 			index.insertFilterAttribute(refSchema, nameSchema, allowedLocales, null, "Lamp", 15);
 
-			index.insertHistogramValue(HISTOGRAM_NAME, null, 11, 15, Integer.class);
-			index.insertHistogramValue(HISTOGRAM_NAME, null, 22, 16, Integer.class);
+			index.insertHistogramValue(HISTOGRAM_NAME, null, 11, 15, Integer.class, 0);
+			index.insertHistogramValue(HISTOGRAM_NAME, null, 22, 16, Integer.class, 0);
 
 			index.addFacet(null, new ReferenceKey(REFERENCE_NAME, 50), GROUP_PK, 15);
 			return index;
@@ -1105,7 +1101,7 @@ class EntityIndexRoundTripTest {
 		 * @return a freshly-loaded `ReferencedTypeEntityIndex`
 		 */
 		@Nonnull
-		private ReferencedTypeEntityIndex reload(@Nonnull CapturedStorage storage) {
+		private static ReferencedTypeEntityIndex reload(@Nonnull CapturedStorage storage) {
 			final EntityIndexStoragePart manifest = storage.requireManifest();
 			// ReferencedTypeEntityIndex is reference-scoped even though the AttributeIndex receives a
 			// null representative key — its discriminator is a String reference name
@@ -1171,12 +1167,12 @@ class EntityIndexRoundTripTest {
 			// AttributeIndex subclass identity must survive reload: ReferencedTypeEntityIndex
 			// carries a ReferenceAttributeIndex with REFERENCE scope even though it has no
 			// RepresentativeReferenceKey
-			assertTrue(
-				original.attributeIndex instanceof ReferenceAttributeIndex,
+			assertInstanceOf(
+				ReferenceAttributeIndex.class, original.attributeIndex,
 				"ReferencedTypeEntityIndex must construct a ReferenceAttributeIndex"
 			);
-			assertTrue(
-				reloaded.attributeIndex instanceof ReferenceAttributeIndex,
+			assertInstanceOf(
+				ReferenceAttributeIndex.class, reloaded.attributeIndex,
 				"Reloaded ReferencedTypeEntityIndex must reconstruct a ReferenceAttributeIndex"
 			);
 			assertEquals(AttributeScope.REFERENCE, reloaded.attributeIndex.getScope());

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/ReducedGroupEntityIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/ReducedGroupEntityIndexTest.java
@@ -1146,7 +1146,7 @@ class ReducedGroupEntityIndexTest
 				ReducedGroupEntityIndexTest.this.index,
 				original -> {
 					original.insertPrimaryKeyIfMissing(10, 1);
-					original.insertHistogramValue(HISTOGRAM_NAME, null, 42, 10, Integer.class);
+					original.insertHistogramValue(HISTOGRAM_NAME, null, 42, 10, Integer.class, 0);
 
 					final FilterIndex filter = original.getHistogramFilterIndex(HISTOGRAM_NAME, null);
 					assertNotNull(filter, "Filter index should be accessible via convenience method");
@@ -1169,7 +1169,7 @@ class ReducedGroupEntityIndexTest
 			assertStateAfterCommit(
 				ReducedGroupEntityIndexTest.this.index,
 				original -> {
-					original.insertHistogramValue(HISTOGRAM_NAME, null, 99, 10, Integer.class);
+					original.insertHistogramValue(HISTOGRAM_NAME, null, 99, 10, Integer.class, 0);
 					assertFalse(original.isEmpty(), "Index with histogram data should not be empty");
 				},
 				(original, committed) -> {
@@ -1184,10 +1184,10 @@ class ReducedGroupEntityIndexTest
 		@DisplayName("should isolate histogram filter indexes per locale so values from one locale never leak into another")
 		void shouldIsolateHistogramFilterIndexesPerLocale() {
 			ReducedGroupEntityIndexTest.this.index.insertHistogramValue(
-				HISTOGRAM_NAME, Locale.ENGLISH, 42, 10, Integer.class
+				HISTOGRAM_NAME, Locale.ENGLISH, 42, 10, Integer.class, 0
 			);
 			ReducedGroupEntityIndexTest.this.index.insertHistogramValue(
-				HISTOGRAM_NAME, Locale.GERMAN, 43, 11, Integer.class
+				HISTOGRAM_NAME, Locale.GERMAN, 43, 11, Integer.class, 0
 			);
 
 			final FilterIndex englishFilter = ReducedGroupEntityIndexTest.this.index
@@ -1207,13 +1207,13 @@ class ReducedGroupEntityIndexTest
 		@DisplayName("should dispose the histogram filter index once the last value under a given name/locale is removed")
 		void shouldDisposeHistogramFilterIndexWhenLastValueRemoved() {
 			ReducedGroupEntityIndexTest.this.index.insertHistogramValue(
-				HISTOGRAM_NAME, null, 42, 10, Integer.class
+				HISTOGRAM_NAME, null, 42, 10, Integer.class, 0
 			);
 			assertNotNull(
 				ReducedGroupEntityIndexTest.this.index.getHistogramFilterIndex(HISTOGRAM_NAME, null)
 			);
 
-			ReducedGroupEntityIndexTest.this.index.removeHistogramValue(HISTOGRAM_NAME, null, 42, 10);
+			ReducedGroupEntityIndexTest.this.index.removeHistogramValue(HISTOGRAM_NAME, null, 42, 10, 0);
 
 			// removing the last value must reclaim the filter-index slot itself (not just empty it) —
 			// downstream accumulators use `null` as the signal that the histogram has no buckets.
@@ -1249,10 +1249,10 @@ class ReducedGroupEntityIndexTest
 			assertStateAfterRollback(
 				ReducedGroupEntityIndexTest.this.index,
 				original -> {
-					original.insertHistogramValue(HISTOGRAM_NAME, null, 42, 10, Integer.class);
-					original.insertHistogramValue(HISTOGRAM_NAME, null, 43, 11, Integer.class);
+					original.insertHistogramValue(HISTOGRAM_NAME, null, 42, 10, Integer.class, 0);
+					original.insertHistogramValue(HISTOGRAM_NAME, null, 43, 11, Integer.class, 0);
 					original.insertHistogramValue(
-						"other", Locale.ENGLISH, 99, 12, Integer.class
+						"other", Locale.ENGLISH, 99, 12, Integer.class, 0
 					);
 				},
 				(original, committed) -> {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/ReferencedTypeEntityIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/ReferencedTypeEntityIndexTest.java
@@ -1103,7 +1103,7 @@ class ReferencedTypeEntityIndexTest extends AbstractEntityIndexTest<ReferencedTy
 				ReferencedTypeEntityIndexTest.this.index,
 				original -> {
 					original.insertPrimaryKeyIfMissing(10, 1);
-					original.insertHistogramValue(HISTOGRAM_NAME, null, 42, 10, Integer.class);
+					original.insertHistogramValue(HISTOGRAM_NAME, null, 42, 10, Integer.class, 0);
 
 					final FilterIndex filter = original.getHistogramFilterIndex(HISTOGRAM_NAME, null);
 					assertNotNull(filter, "Filter index should be accessible via convenience method");
@@ -1125,7 +1125,7 @@ class ReferencedTypeEntityIndexTest extends AbstractEntityIndexTest<ReferencedTy
 			assertStateAfterCommit(
 				ReferencedTypeEntityIndexTest.this.index,
 				original -> {
-					original.insertHistogramValue(HISTOGRAM_NAME, null, 99, 10, Integer.class);
+					original.insertHistogramValue(HISTOGRAM_NAME, null, 99, 10, Integer.class, 0);
 					assertFalse(original.isEmpty(), "Index with histogram data should not be empty");
 				},
 				(original, committed) -> {
@@ -1139,10 +1139,10 @@ class ReferencedTypeEntityIndexTest extends AbstractEntityIndexTest<ReferencedTy
 		@DisplayName("should isolate histogram values per locale so one locale's records never leak into another")
 		void shouldIsolateHistogramValuesPerLocale() {
 			ReferencedTypeEntityIndexTest.this.index.insertHistogramValue(
-				HISTOGRAM_NAME, Locale.ENGLISH, 42, 10, Integer.class
+				HISTOGRAM_NAME, Locale.ENGLISH, 42, 10, Integer.class, 0
 			);
 			ReferencedTypeEntityIndexTest.this.index.insertHistogramValue(
-				HISTOGRAM_NAME, Locale.GERMAN, 42, 11, Integer.class
+				HISTOGRAM_NAME, Locale.GERMAN, 42, 11, Integer.class, 0
 			);
 
 			final FilterIndex englishFilter = ReferencedTypeEntityIndexTest.this.index
@@ -1162,14 +1162,14 @@ class ReferencedTypeEntityIndexTest extends AbstractEntityIndexTest<ReferencedTy
 		@DisplayName("should dispose the histogram filter index once the last value under a given name/locale is removed")
 		void shouldDisposeHistogramFilterIndexWhenLastValueRemoved() {
 			ReferencedTypeEntityIndexTest.this.index.insertHistogramValue(
-				HISTOGRAM_NAME, null, 42, 10, Integer.class
+				HISTOGRAM_NAME, null, 42, 10, Integer.class, 0
 			);
 			assertNotNull(
 				ReferencedTypeEntityIndexTest.this.index.getHistogramFilterIndex(HISTOGRAM_NAME, null)
 			);
 
 			ReferencedTypeEntityIndexTest.this.index.removeHistogramValue(
-				HISTOGRAM_NAME, null, 42, 10
+				HISTOGRAM_NAME, null, 42, 10, 0
 			);
 
 			assertNull(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/PreMutationHistogramSnapshotTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/PreMutationHistogramSnapshotTest.java
@@ -82,7 +82,7 @@ class PreMutationHistogramSnapshotTest implements EvitaTestSupport {
 				HISTOGRAM_INDEX,
 				new HistogramValueDescriptor(
 					HistogramValueSource.REFERENCE_ATTRIBUTE, null, WEIGHT_ATTR,
-					Integer.class, false, false, null, null
+					Integer.class, false, false, null, null, 0
 				)
 			);
 			final ExistingAttributeValueSupplier supplier = createSupplier(
@@ -104,7 +104,7 @@ class PreMutationHistogramSnapshotTest implements EvitaTestSupport {
 		void shouldApplyDefaultValueWhenAttributeIsNull() {
 			final HistogramValueDescriptor descriptor = new HistogramValueDescriptor(
 				HistogramValueSource.REFERENCE_ATTRIBUTE, null, WEIGHT_ATTR,
-				Integer.class, false, false, 0, null
+				Integer.class, false, false, 0, null, 0
 			);
 			final HistogramExpressionTrigger trigger = createUnconditionalTrigger(HISTOGRAM_INDEX, descriptor);
 			final ExistingAttributeValueSupplier supplier = createSupplier(Map.of());
@@ -121,7 +121,7 @@ class PreMutationHistogramSnapshotTest implements EvitaTestSupport {
 		void shouldReturnEmptyArrayWhenAttributeIsNullAndNoDefault() {
 			final HistogramValueDescriptor descriptor = new HistogramValueDescriptor(
 				HistogramValueSource.REFERENCE_ATTRIBUTE, null, WEIGHT_ATTR,
-				Integer.class, false, false, null, null
+				Integer.class, false, false, null, null, 0
 			);
 			final HistogramExpressionTrigger trigger = createUnconditionalTrigger(HISTOGRAM_INDEX, descriptor);
 			final ExistingAttributeValueSupplier supplier = createSupplier(Map.of());
@@ -145,7 +145,7 @@ class PreMutationHistogramSnapshotTest implements EvitaTestSupport {
 				HISTOGRAM_INDEX,
 				new HistogramValueDescriptor(
 					HistogramValueSource.REFERENCE_ATTRIBUTE, null, WEIGHT_ATTR,
-					Integer.class, false, true, null, null
+					Integer.class, false, true, null, null, 0
 				)
 			);
 			final Map<AttributeKey, Serializable> attributes = new HashMap<>(2);
@@ -177,7 +177,7 @@ class PreMutationHistogramSnapshotTest implements EvitaTestSupport {
 				HISTOGRAM_INDEX,
 				new HistogramValueDescriptor(
 					HistogramValueSource.REFERENCE_ATTRIBUTE, null, WEIGHT_ATTR,
-					Integer.class, true, false, null, null
+					Integer.class, true, false, null, null, 0
 				)
 			);
 			final ExistingAttributeValueSupplier supplier = createSupplier(
@@ -203,7 +203,7 @@ class PreMutationHistogramSnapshotTest implements EvitaTestSupport {
 				HISTOGRAM_INDEX,
 				new HistogramValueDescriptor(
 					HistogramValueSource.REFERENCE_ATTRIBUTE, null, PRICE_ATTR,
-					Integer.class, false, false, null, null
+					Integer.class, false, false, null, null, 0
 				)
 			);
 			final ExistingAttributeValueSupplier supplier = createSupplier(
@@ -224,7 +224,7 @@ class PreMutationHistogramSnapshotTest implements EvitaTestSupport {
 				HISTOGRAM_INDEX,
 				new HistogramValueDescriptor(
 					HistogramValueSource.REFERENCED_ENTITY_ATTRIBUTE, ENTITY_TYPE, WEIGHT_ATTR,
-					Integer.class, false, false, null, null
+					Integer.class, false, false, null, null, 0
 				)
 			);
 			final ExistingAttributeValueSupplier supplier = createSupplier(
@@ -249,7 +249,7 @@ class PreMutationHistogramSnapshotTest implements EvitaTestSupport {
 				HISTOGRAM_INDEX,
 				new HistogramValueDescriptor(
 					HistogramValueSource.REFERENCE_ATTRIBUTE, null, WEIGHT_ATTR,
-					Integer.class, false, false, null, null
+					Integer.class, false, false, null, null, 0
 				)
 			);
 			assertFalse(snapshot.isValueSourceChanged(anyTrigger));
@@ -267,7 +267,7 @@ class PreMutationHistogramSnapshotTest implements EvitaTestSupport {
 				HISTOGRAM_INDEX,
 				new HistogramValueDescriptor(
 					HistogramValueSource.REFERENCE_ATTRIBUTE, null, PRICE_ATTR,
-					Integer.class, false, false, null, null
+					Integer.class, false, false, null, null, 0
 				)
 			);
 			final PreMutationHistogramSnapshot snapshot =


### PR DESCRIPTION
## Summary

Reference range-histograms over a `BigDecimalNumberRange` attribute rendered thresholds **10^N too small** when the value's intrinsic scale was lower than the source attribute schema's `indexedDecimalPlaces` (e.g. `88.0` rendered as `0.0088` with `indexedDecimalPlaces=4`).

### Root cause
Two index-write paths handle attribute values, but only one normalized the scale:
- The regular attribute-index path (`AttributeIndexMutator.executeAttributeUpsert`) calls `NumberUtils.normalizeForIndexing(value, indexedDecimalPlaces)`, re-encoding range bounds to the schema scale. **Correct.**
- The histogram-index population path inserted raw stored values verbatim, so the histogram `FilterIndex` stored comparable longs at the value's intrinsic scale, while the read side (`FilterIndex.toBucketKey = BigDecimal.valueOf(threshold, indexedDecimalPlaces)`) decoded at the schema scale → mismatch.

### Fix
Centralize the normalization at the **single histogram-index write boundary** — `HistogramIndexOperations.insertHistogramValue` / `removeHistogramValue` — mirroring the regular attribute-index boundary. The schema scale is threaded as a new `indexedDecimalPlaces` field on `HistogramValueDescriptor` through `HistogramCapableEntityIndex` and its implementations (`ReducedGroupEntityIndex`, `ReferencedTypeEntityIndex`). Both population callers (`ReferenceIndexMutator`, `ReevaluateExpressionExecutor`) pass it; the `ReevaluateExpressionExecutor` source values are already normalized, so the central normalize is idempotent there.

Existence guards (`isValueInHistogram`, `histogramContainsOwner`) compare a probe against the **stored, normalized** bucket value and run *before* the index remove, so they now normalize their probe with the same scale — otherwise a raw range would never match its re-scaled stored counterpart and the removal would be silently suppressed.

### Drive-by
Hardened `ReevaluateExpressionExecutor#rewriteMatchingReferenceHavings` (declared `@Nonnull`) against a possible null from the `@Nullable` `ConstraintCloneVisitor.clone` via an explicit `Objects.requireNonNull` assertion documenting why the clone cannot collapse here.

## Test
Adds `ReferenceRangeHistogramFunctionalTest#shouldRenderBigDecimalRangeHistogramAtSchemaScaleWhenValueScaleIsLower` — a self-contained reproduction (`runWithInlineSchema`, `indexDecimalPlaces(4)`, integer-bound ranges) that fails RED before the fix and passes after. The remaining test edits adapt fixture constructors / direct interface calls to the new `indexedDecimalPlaces` argument.