### PR TITLE
Fix sort by soft-deleted reference attribute returning duplicate PKs

### DIFF
--- a/.repro/1257-sort-dropped-reference-attribute.md
+++ b/.repro/1257-sort-dropped-reference-attribute.md
@@ -1,0 +1,191 @@
+# #1257 — repro & verification playbook
+
+> Compaction-safe handoff. Anything the fix session needs to verify the bug
+> reappears here, exactly enough so it can be re-run without re-discovering it.
+
+GitHub issue: https://github.com/FgForrest/evitaDB/issues/1257
+Originating ticket (Czech, project view): https://gitlab.fg.cz/prj/p_mila.eshop/-/work_items/938
+
+## The bug in one line
+
+Sort by `referenceProperty` on a multi-valued reference returns duplicate PKs
+in the result page when at least one entity on that page has the sortable
+reference-attribute marked as soft-deleted (`AttributeValue.dropped() == true`).
+With `entityFetch(referenceContent(...))`, the duplicate trips
+`Collectors.toMap` in `EntityIndexSupplier.get` → `IllegalStateException:
+Duplicate key <PK>`.
+
+## Files involved
+
+- Root: `evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/Attributes.java:183` and `:225`
+  → `getAttribute` does NOT consult `AttributeValue.dropped()`. Comparator
+    `attributeValueFetcher` reads through this and treats soft-deleted as live.
+- Symptom site (sort): `evita_engine/src/main/java/io/evitadb/core/query/sort/attribute/comparator/`
+    - `AbstractReferenceAttributeComparator.java:131` — `it.getAttribute(attributeName)`
+    - `AbstractReferenceCompoundAttributeComparator.java:125-127` — `AttributesContract::getAttribute` reference
+    - `TraverseReferencePredecessorAttributeComparator.java:172-272` — the `compare`
+      that, when `o1FoundInProvider == -1`, adds to `nonSortedEntities` while
+      returning `0` from default `result` — keeps the entity in place AND flags
+      it as non-sortable.
+- Slice that trusts the contract: `evita_engine/src/main/java/io/evitadb/core/query/sort/generic/PrefetchedRecordsSorter.java:97-107`
+  → `entityContracts = entities.subList(0, selectedRecordIds.size() - notFoundRecordsCnt)`.
+- Final crash site: `evita_engine/src/main/java/io/evitadb/core/query/fetch/EntityIndexSupplier.java:58`
+  → `Collectors.toMap(EntityContract::getPrimaryKey, …)` — KEEP AS-IS, this is
+    the policy-correct fail-loud.
+
+## Fix plan (agreed in conversation)
+
+1. **Single-class change in `Attributes.java`**: drop the `Optional` chain in
+   both overloads of `getAttribute`, return `null` when `av == null || av.dropped()`.
+   - `getAttribute(name)` (line 183)
+   - `getAttribute(name, locale)` (line 225)
+   - Performance: removes one Optional allocation per fetch on the comparator
+     hot path. Don't switch to a `.filter(...).map(...).orElse(...)` chain — go
+     to direct branching for zero alloc.
+2. **Add assertion in `PrefetchedRecordsSorter.sortAndSlice`** that every entity
+   reported by `entityComparator.getNonSortedEntities()` is in the trailing
+   slice (NOT in `entities[0..entitiesCount)`). Fail loud if a future comparator
+   violates the contract. Only iterate when `notFoundRecordsCnt > 0`.
+3. **Do NOT add a merge function to `EntityIndexSupplier.get`**. Per project
+   rule (manifest broken assumptions early), keep the loud
+   `Collectors.duplicateKeyException`. It is what surfaced this defect.
+
+## Production snapshot reproduction (slow but authoritative)
+
+### Pre-conditions
+
+- Snapshot at `/www/oss/evita/release_2026-1/data/milagro_cz`
+  (`catalogVersion=89758`, `schemaVersion=83`). Don't run a write workload
+  against it — it should remain unchanged for re-verification.
+- Server jar built: `evita_server/target/evita-server.jar` (already there).
+
+### Start the server
+
+From `/www/oss/evita/release_2026-1/evita_server`:
+
+```bash
+bash run-server.sh
+```
+
+It loads `milagro_cz` (≈ 6 s) and exposes APIs on port 5555 (REST/GraphQL TLS,
+gRPC TLS RELAXED). JDWP is on 8005.
+
+To run the JUnit driver against it the EvitaClient needs **plaintext h2c**
+(not TLS) — `tlsEnabled=false`. See `evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/MilagroCzReproductionTest.java`
+for the working config.
+
+### Run the 8 reproduction queries
+
+Test is gated by a system property so it doesn't run in CI:
+
+```bash
+cd /www/oss/evita/release_2026-1/evita_test/evita_functional_tests
+mvn test -Dtest=MilagroCzReproductionTest#runAllReproQueries \
+  -DfailIfNoTests=false \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Dmilagro.repro=true \
+  -Dsurefire.useFile=false
+```
+
+### Expected outcomes BEFORE the fix
+
+| Q | Sort | entityFetch | Expected outcome |
+|---|---|---|---|
+| Q1 | `referenceProperty('groups', orderInGroup, traverseBy(145197))` | `referenceContent('groups')` | OK page=200 total=3493 dups=0 |
+| Q2 | segments + `attributeNatural('orderedQuantity')` | full | OK page=20 total=325 dups=0 |
+| **Q3** | `referenceProperty('groups', orderInGroup, assignmentPriority)` no traverse | full | **FAIL: `IllegalStateException: Duplicate key 759850`** (Collectors.toMap in EntityIndexSupplier) |
+| **Q4** | `referenceProperty('groups', orderInGroup, assignmentPriority, traverseBy(21798))` | `attributeContent('code')` only | **OK page=20 total=325 with `dups=3` — PKs 755567, 759850, 760244 each appear twice** |
+| Q5 | `attributeNatural('code', ASC)` | full | OK page=20 total=325 dups=0 |
+| **Q6** | as Q4 with full fetch | full | **FAIL: `Duplicate key 759850`** |
+| **Q7** | `segments(... refprop traverse ...)` | full | **FAIL: `Duplicate key 759850`** |
+| Q8 | segments + simpler filter | `referenceContent('groups', 'relatedProducts')` | OK page=326 total=326 dups=0 |
+
+The duplicate-key crash also dumps a payload that prints the broken entity's
+references — the `❌ 🔑 orderInGroup` marker on `References groups 21798/…`
+confirms the dropped state.
+
+### Expected outcomes AFTER the fix
+
+All eight queries finish successfully. The Q4 page must contain **20 unique
+PKs** (no `dups=3`). The full 8-query suite output should end with all queries
+listed as `OK`. The crash stack at `Collectors.duplicateKeyException` must not
+appear in the server log.
+
+Sanity comparison: the single-attribute query
+
+```evitaql
+query(
+  collection('Product'),
+  filterBy(referenceHaving('groups', entityPrimaryKeyInSet(21798)), entityLocaleEquals('cs')),
+  orderBy(referenceProperty('groups', attributeNatural('orderInGroup', ASC))),
+  require(page(1, 1000))
+)
+```
+
+returns 955 unique PKs both BEFORE and AFTER the fix, with PKs `759850, 760244,
+755567` at the trailing end (positions ~948..955). This is the "should-have-been"
+behaviour the compound path needs to match.
+
+## Synthetic minimal regression (still TODO — write on the fix branch)
+
+Build a self-contained functional test in a fresh catalog that reproduces the
+duplicate without any production data:
+
+- Schema: `Group` (no attrs needed), `Product` with `groups` reference
+  (`ZERO_OR_MORE` → `Group`, indexed) with a sortable attribute
+  `orderInGroup` (Integer or Predecessor, sortable + filterable) and a second
+  sortable reference-attribute `assignmentPriority` (Long, sortable) so the
+  sort uses the COMPOUND path.
+- Data:
+  - `Group#1`, `Group#2`
+  - `Product#100` with `groups → 1 {orderInGroup=1, assignmentPriority=100L}`
+    and `groups → 2 {orderInGroup=1, assignmentPriority=100L}`
+  - `Product#101` with `groups → 1 {orderInGroup=2, assignmentPriority=200L}`
+  - `goLiveAndClose`
+- **Trigger the dropped state**: open a transactional session and apply a
+  `RemoveAttributeMutation` on `Product#100`'s reference to `Group#1`,
+  attribute `orderInGroup`. (Or use the builder API equivalent.) Commit.
+- Query (compound + traverse):
+  ```evitaql
+  query(
+    collection('Product'),
+    filterBy(referenceHaving('groups', entityPrimaryKeyInSet(1))),
+    orderBy(referenceProperty('groups', attributeNatural('orderInGroup', ASC),
+                              attributeNatural('assignmentPriority', ASC),
+                              traverseByEntityProperty(entityPrimaryKeyExact(1)))),
+    require(strip(0, 10), entityFetch(referenceContent('groups')))
+  )
+  ```
+- **Pre-fix expected:** `IllegalStateException: Duplicate key 100` (or `100`
+  appears twice in result if `entityFetch` is dropped to attribute-only).
+- **Post-fix expected:** clean result of two entries (`101`, `100`), no
+  exception.
+
+Place the test next to existing reference-sort functional tests under
+`evita_test/evita_functional_tests/src/test/java/io/evitadb/api/.../sort/` — match
+the naming/location of `AttributeNaturalReferenceSortTest` or similar.
+Caveat from earlier attempt: a previous synthetic test (mentioned in
+prj/p_mila.eshop#938 note 17.6.) didn't reproduce because it never applied
+the `RemoveAttributeMutation`. The dropped-on-reference state is the trigger.
+
+## Things NOT to change
+
+- `EntityIndexSupplier.get` (`evita_engine/.../fetch/EntityIndexSupplier.java`) —
+  no merge function. The loud crash is on purpose.
+- `Attributes.anyAttributeDifferBetween` and any audit/diff code that walks
+  `attributeValues` directly — these are correct to see dropped values.
+- `getAttributeValue(name)` (Optional<AttributeValue>) — keep its current
+  semantics; it is the path callers use when they want to inspect `dropped()`.
+
+## Session-state checkpoints
+
+- `MilagroCzReproductionTest.java` is on disk under
+  `evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/`,
+  gated by `-Dmilagro.repro=true`. EvitaClient config uses port 5555 plaintext
+  (`tlsEnabled=false`) — necessary because `run-server.sh` has gRPC in TLS
+  RELAXED mode and the auto-cert path is finicky.
+- `run-server.sh` is unchanged (JDWP on 8005); during diagnosis I briefly
+  flipped it to 5005 for the MCP JDWP inspector and restored it before
+  branching.
+- The synthetic regression test is **not yet written**. Write it AS PART OF the
+  fix commit, asserting both pre-fix failure and post-fix success.

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/EntityDecorator.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/EntityDecorator.java
@@ -1710,6 +1710,11 @@ public class EntityDecorator implements SealedEntity {
 	 * and handles cases where duplicate references (with the same {@link ReferenceKey}) are allowed
 	 * based on their schema definitions.
 	 *
+	 * Each qualifying reference that is not already a {@link ReferenceDecorator} is wrapped in one so that
+	 * the attribute predicate — including the `dropped()` filter for soft-deleted attribute values — is applied
+	 * uniformly on this lazy fill path, matching the behaviour of the eager
+	 * `fillFilteredSortedAndFetchedReferences` path.
+	 *
 	 * If the references allow duplicates, they are tracked separately in an internal map.
 	 * For references that do not allow duplicates, the values are stored directly in the returned map.
 	 *
@@ -1752,6 +1757,16 @@ public class EntityDecorator implements SealedEntity {
 								: lastResolvedSchema.getCardinality().allowsDuplicates();
 						}
 
+						// wrap into ReferenceDecorator so the attribute predicate (incl. exists() check
+						// for soft-deleted attributes) is consistently applied to every reference exposed
+						// from this entity — matches the eager fillFilteredSortedAndFetchedReferences path
+						final ReferenceContract wrappedReference = reference instanceof ReferenceDecorator ?
+							reference :
+							new ReferenceDecorator(
+								reference,
+								this.referencePredicate.getAttributePredicate(referenceName)
+							);
+
 						if (lastReferenceKey != null && lastReferenceKey.equalsInGeneral(referenceKey)) {
 							if (duplicatesAllowed) {
 								if (duplicatedIndexedReferences == null) {
@@ -1760,6 +1775,8 @@ public class EntityDecorator implements SealedEntity {
 								final ReferenceKey genericKey = referenceKey.isUnknownReference() ?
 									referenceKey :
 									new ReferenceKey(referenceKey.referenceName(), referenceKey.primaryKey());
+								// `previous` was stored in a prior iteration via the else branch below
+								// and is therefore already wrapped — do not re-wrap it here
 								final ReferenceContract previous = indexedReferences.remove(lastReferenceKey);
 								final List<ReferenceContract> duplicatedList;
 								if (previous == DUPLICATE_REFERENCE) {
@@ -1771,13 +1788,13 @@ public class EntityDecorator implements SealedEntity {
 								} else {
 									duplicatedList = Objects.requireNonNull(duplicatedIndexedReferences.get(genericKey));
 								}
-								duplicatedList.add(reference);
+								duplicatedList.add(wrappedReference);
 								indexedReferences.put(genericKey, DUPLICATE_REFERENCE);
 							} else {
 								throw new ReferenceAllowsDuplicatesException(referenceKey.referenceName(), schema, Operation.CREATE);
 							}
 						} else {
-							indexedReferences.put(referenceKey, reference);
+							indexedReferences.put(referenceKey, wrappedReference);
 						}
 						lastReferenceKey = referenceKey;
 					}
@@ -1798,6 +1815,11 @@ public class EntityDecorator implements SealedEntity {
 	 * If the references have not been previously filtered, this method processes the delegate's
 	 * references, applies the filtering, groups them by name, and transforms them into data chunks.
 	 *
+	 * Each qualifying reference that is not already a {@link ReferenceDecorator} is wrapped in one so that
+	 * the attribute predicate — including the `dropped()` filter for soft-deleted attribute values — is applied
+	 * uniformly on this lazy fill path, matching the behaviour of the eager
+	 * `fillFilteredSortedAndFetchedReferences` path.
+	 *
 	 * @return a non-null map where keys are reference names and values are DataChunk objects containing filtered references.
 	 */
 	@Nonnull
@@ -1809,12 +1831,22 @@ public class EntityDecorator implements SealedEntity {
 			);
 			for (ReferenceContract reference : references) {
 				if (this.referencePredicate.test(reference)) {
+					final String referenceName = reference.getReferenceName();
+					// wrap into ReferenceDecorator so the attribute predicate (incl. exists() check
+					// for soft-deleted attributes) is consistently applied to every reference exposed
+					// from this entity — matches the eager fillFilteredSortedAndFetchedReferences path
+					final ReferenceContract wrappedReference = reference instanceof ReferenceDecorator ?
+						reference :
+						new ReferenceDecorator(
+							reference,
+							this.referencePredicate.getAttributePredicate(referenceName)
+						);
 					allReferencesByName
 						.computeIfAbsent(
-							reference.getReferenceName(),
+							referenceName,
 							s -> new ArrayList<>(references.size() / this.entitySchema.getReferences().size())
 						)
-						.add(reference);
+						.add(wrappedReference);
 				}
 			}
 			this.filteredReferencesByName = allReferencesByName

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/generic/PrefetchedRecordsSorter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/generic/PrefetchedRecordsSorter.java
@@ -82,9 +82,11 @@ public class PrefetchedRecordsSorter implements Sorter {
 	 * 5. Returns a new `SortingContext` carrying the unsortable records so the next sorter can place them.
 	 *
 	 * **Partition invariant:** every primary key reported by `entityComparator.getNonSortedEntities()` MUST
-	 * fall outside the sortable slice. If the comparator places a non-sortable entity inside the slice, the
-	 * sort/non-sort partitions disagree and the downstream sorter would emit duplicate primary keys.
-	 * {@link Assert#isPremiseValid} throws immediately in that case to surface the violation early.
+	 * fall outside the sortable slice. By cardinality the two slices are fixed-size partitions, so verifying
+	 * the trailing slice `[entitiesCount, entities.size())` consists exclusively of PKs from `notFoundRecords`
+	 * is sufficient — and cheap, costing O(notFoundRecordsCnt) instead of O(entitiesCount). If the comparator
+	 * places a non-sortable entity inside the sortable slice, downstream sorters would emit duplicate primary
+	 * keys; {@link Assert#isPremiseValid} throws immediately in that case to surface the violation early.
 	 *
 	 * @param sortingContext      the current sorting state including candidate keys and pagination window
 	 * @param result              output array that receives sorted primary keys for the requested page slice
@@ -136,17 +138,19 @@ public class PrefetchedRecordsSorter implements Sorter {
 			final AtomicInteger index = new AtomicInteger();
 			final int entitiesCount = selectedRecordIds.size() - notFoundRecordsCnt;
 			final List<EntityContract> entityContracts = entities.subList(0, entitiesCount);
-			// invariant: comparator must have pushed every non-sortable entity past `entitiesCount`;
-			// if it did not, the trailing slice carries duplicates that leak into the next sorter.
+			// invariant: the trailing slice [entitiesCount, entities.size()) must contain exactly
+			// the non-sortable PKs reported by the comparator. By cardinality the two slices are
+			// fixed-size partitions, so verifying the trailing slice is sufficient and costs
+			// O(notFoundRecordsCnt) — preferred over scanning the full sortable slice on this hot path.
 			if (notFoundRecordsCnt > 0) {
-				for (int i = 0; i < entitiesCount; i++) {
-					final int pk = queryContext.translateEntity(entityContracts.get(i));
+				final int totalSize = entities.size();
+				for (int i = entitiesCount; i < totalSize; i++) {
+					final int pk = queryContext.translateEntity(entities.get(i));
 					Assert.isPremiseValid(
-						!notFoundRecords.contains(pk),
+						notFoundRecords.contains(pk),
 						() -> "Entity comparator " + this.entityComparator.getClass().getName() +
-							" reported entity #" + pk + " as non-sortable yet kept it inside" +
-							" the sortable slice — sort/non-sort partitions disagree;" +
-							" downstream sorters would emit duplicates."
+							" kept sortable entity #" + pk + " inside the trailing non-sortable slice" +
+							" — sort/non-sort partitions disagree; downstream sorters would emit duplicates."
 					);
 				}
 			}

--- a/evita_engine/src/main/java/io/evitadb/core/query/sort/generic/PrefetchedRecordsSorter.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/sort/generic/PrefetchedRecordsSorter.java
@@ -32,6 +32,7 @@ import io.evitadb.core.query.sort.Sorter;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.bitmap.EmptyBitmap;
+import io.evitadb.utils.Assert;
 import org.roaringbitmap.RoaringBitmap;
 
 import javax.annotation.Nonnull;
@@ -60,6 +61,36 @@ public class PrefetchedRecordsSorter implements Sorter {
 		this.entityComparator = entityComparator;
 	}
 
+	/**
+	 * Sorts the candidate record set using the pre-fetched entity bodies and slices the result to the requested page.
+	 *
+	 * **Early-exit:** when {@link QueryExecutionContext#getPrefetchedEntities()} returns `null`, the sorter skips
+	 * itself entirely and returns the incoming `sortingContext` unchanged so the next sorter in the chain can handle
+	 * the full candidate set.
+	 *
+	 * **When prefetched entities are present:**
+	 *
+	 * 1. Translates each candidate record ID from `sortingContext.nonSortedKeys()` to its `EntityContract`
+	 *    via `QueryExecutionContext.translateToEntity`.
+	 * 2. Sorts the entity list with `entityComparator`. If the comparator implements
+	 *    {@link EntityReferenceSensitiveComparator} and a `referenceKey` is set on the context, sorting is
+	 *    scoped to that reference key.
+	 * 3. Entities that the comparator could not sort (returned by `getNonSortedEntities()`) are collected into
+	 *    a `notFoundRecords` bitmap and excluded from the sortable slice `[0, entitiesCount)`.
+	 * 4. The sortable slice is paged and written into `result`; skipped records are reported to
+	 *    `skippedRecordsConsumer` if provided.
+	 * 5. Returns a new `SortingContext` carrying the unsortable records so the next sorter can place them.
+	 *
+	 * **Partition invariant:** every primary key reported by `entityComparator.getNonSortedEntities()` MUST
+	 * fall outside the sortable slice. If the comparator places a non-sortable entity inside the slice, the
+	 * sort/non-sort partitions disagree and the downstream sorter would emit duplicate primary keys.
+	 * {@link Assert#isPremiseValid} throws immediately in that case to surface the violation early.
+	 *
+	 * @param sortingContext      the current sorting state including candidate keys and pagination window
+	 * @param result              output array that receives sorted primary keys for the requested page slice
+	 * @param skippedRecordsConsumer optional consumer called for each primary key skipped before the page window
+	 * @return updated `SortingContext` with unsortable records passed to the next sorter in the chain
+	 */
 	@Nonnull
 	@Override
 	public SortingContext sortAndSlice(
@@ -105,6 +136,20 @@ public class PrefetchedRecordsSorter implements Sorter {
 			final AtomicInteger index = new AtomicInteger();
 			final int entitiesCount = selectedRecordIds.size() - notFoundRecordsCnt;
 			final List<EntityContract> entityContracts = entities.subList(0, entitiesCount);
+			// invariant: comparator must have pushed every non-sortable entity past `entitiesCount`;
+			// if it did not, the trailing slice carries duplicates that leak into the next sorter.
+			if (notFoundRecordsCnt > 0) {
+				for (int i = 0; i < entitiesCount; i++) {
+					final int pk = queryContext.translateEntity(entityContracts.get(i));
+					Assert.isPremiseValid(
+						!notFoundRecords.contains(pk),
+						() -> "Entity comparator " + this.entityComparator.getClass().getName() +
+							" reported entity #" + pk + " as non-sortable yet kept it inside" +
+							" the sortable slice — sort/non-sort partitions disagree;" +
+							" downstream sorters would emit duplicates."
+					);
+				}
+			}
 			final int skippedItems = Math.min(recomputedStartIndex, entitiesCount);
 			final int appendedItems = Math.min(Math.min(recomputedEndIndex, entitiesCount), skippedItems + result.length - peak);
 			if (skippedRecordsConsumer != null) {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/SortByDroppedReferenceAttributeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/SortByDroppedReferenceAttributeTest.java
@@ -1,0 +1,377 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.indexing;
+
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.query.Query;
+import io.evitadb.api.query.order.OrderDirection;
+import io.evitadb.api.requestResponse.EvitaResponse;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.core.Evita;
+import io.evitadb.export.file.configuration.FileSystemExportOptions;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static io.evitadb.api.query.QueryConstraints.attributeContent;
+import static io.evitadb.api.query.QueryConstraints.attributeNatural;
+import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.entityFetch;
+import static io.evitadb.api.query.QueryConstraints.entityPrimaryKeyExact;
+import static io.evitadb.api.query.QueryConstraints.entityPrimaryKeyInSet;
+import static io.evitadb.api.query.QueryConstraints.filterBy;
+import static io.evitadb.api.query.QueryConstraints.orderBy;
+import static io.evitadb.api.query.QueryConstraints.referenceContent;
+import static io.evitadb.api.query.QueryConstraints.referenceHaving;
+import static io.evitadb.api.query.QueryConstraints.referenceProperty;
+import static io.evitadb.api.query.QueryConstraints.require;
+import static io.evitadb.api.query.QueryConstraints.strip;
+import static io.evitadb.api.query.QueryConstraints.traverseByEntityProperty;
+import static io.evitadb.test.TestConstants.FUNCTIONAL_TEST;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Contract test for sorting on a reference attribute whose sortable value has been soft-deleted on at least
+ * one referenced target. Sorting by a `referenceProperty` in that state used to duplicate the affected entity
+ * in the result page (and crash on `entityFetch(referenceContent(...))` via the `Collectors.toMap`
+ * duplicate-key in `EntityIndexSupplier`).
+ *
+ * Root cause: the lazy-fill paths in `EntityDecorator` (`getFilteredReferencesByName` and the sibling
+ * `getFilteredReferences`) exposed raw `Reference` objects when references were resolved lazily for the sort
+ * path, bypassing the attribute predicate (and therefore the `dropped()` filter); the comparator then read
+ * the historical attribute value and treated the entity as sortable while the underlying `SortIndex` correctly
+ * excluded it.
+ *
+ * The high-fidelity reproducer lives in `MilagroCzReproductionTest` (production snapshot, gated by
+ * `-Dmilagro.repro=true`). The cases below run on a minimal in-memory catalog and lock the public contract
+ * — sorting on a reference attribute that is soft-deleted on at least one referenced target must never
+ * duplicate primary keys in the result page nor crash on reference fetch — across the three query shapes
+ * (simple referenceProperty + referenceContent, attribute-only fetch, traverseBy variant). They do not in
+ * isolation reproduce the production duplication on this small fixture (the planner takes a different sort
+ * path at this scale); they guard the post-fix invariant under CI where the snapshot is unavailable.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Sort by reference attribute that is soft-deleted on one reference must not duplicate result PKs")
+@Tag(FUNCTIONAL_TEST)
+public class SortByDroppedReferenceAttributeTest implements EvitaTestSupport {
+	private static final String DIR = "sortByDroppedReferenceAttributeTest";
+	private static final String DIR_EXPORT = "sortByDroppedReferenceAttributeTest_export";
+	private static final String GROUPS = "groups";
+	private static final String ATTRIBUTE_ORDER_IN_GROUP = "orderInGroup";
+	private static final String ATTRIBUTE_ASSIGNMENT_PRIORITY = "assignmentPriority";
+	private static final int GROUP_1 = 1;
+	private static final int GROUP_2 = 2;
+	private static final int PRODUCT_A = 100;
+	private static final int PRODUCT_B = 101;
+	private static final int PRODUCT_C = 102;
+
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() {
+		cleanTestSubDirectoryWithRethrow(DIR);
+		cleanTestSubDirectoryWithRethrow(DIR_EXPORT);
+		this.evita = new Evita(getEvitaConfiguration());
+		this.evita.defineCatalog(TEST_CATALOG);
+		defineSchema();
+		seedDataAndGoLive();
+		dropOrderInGroupOnOneReference();
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.evita.close();
+		cleanTestSubDirectoryWithRethrow(DIR);
+		cleanTestSubDirectoryWithRethrow(DIR_EXPORT);
+	}
+
+	@DisplayName("Compound referenceProperty sort with entityFetch(referenceContent) must not throw for a soft-deleted sortable reference attribute")
+	@Test
+	void shouldNotCrashOnDroppedReferenceAttributeWithReferenceContent() {
+		assertDoesNotThrow(
+			() -> this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					final EvitaResponse<SealedEntity> response = session.querySealedEntity(
+						Query.query(
+							collection(Entities.PRODUCT),
+							filterBy(referenceHaving(GROUPS, entityPrimaryKeyInSet(GROUP_1))),
+							orderBy(
+								referenceProperty(
+									GROUPS,
+									attributeNatural(ATTRIBUTE_ORDER_IN_GROUP, OrderDirection.ASC),
+									attributeNatural(ATTRIBUTE_ASSIGNMENT_PRIORITY, OrderDirection.ASC)
+								)
+							),
+							require(strip(0, 20), entityFetch(referenceContent(GROUPS)))
+						)
+					);
+					assertResultPageContainsAllProductsInExpectedOrder(response.getRecordPage().getData());
+					return null;
+				}
+			),
+			"querying with compound reference-attribute sort + entityFetch(referenceContent) must not throw Duplicate key"
+		);
+	}
+
+	@DisplayName("Result page must contain unique PKs when entityFetch omits referenceContent (compound sort, no traverse)")
+	@Test
+	void shouldNotDuplicateRecordsWhenReferenceContentIsNotFetched() {
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<SealedEntity> response = session.querySealedEntity(
+					Query.query(
+						collection(Entities.PRODUCT),
+						filterBy(referenceHaving(GROUPS, entityPrimaryKeyInSet(GROUP_1))),
+						orderBy(
+							referenceProperty(
+								GROUPS,
+								attributeNatural(ATTRIBUTE_ORDER_IN_GROUP, OrderDirection.ASC),
+								attributeNatural(ATTRIBUTE_ASSIGNMENT_PRIORITY, OrderDirection.ASC)
+							)
+						),
+						require(strip(0, 20), entityFetch(attributeContent()))
+					)
+				);
+				assertUniquePrimaryKeys(response.getRecordPage().getData());
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Compound referenceProperty sort with traverseBy must not duplicate result PKs")
+	@Test
+	void shouldNotDuplicateRecordsWithTraverseBy() {
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<SealedEntity> response = session.querySealedEntity(
+					Query.query(
+						collection(Entities.PRODUCT),
+						filterBy(referenceHaving(GROUPS, entityPrimaryKeyInSet(GROUP_1))),
+						orderBy(
+							referenceProperty(
+								GROUPS,
+								attributeNatural(ATTRIBUTE_ORDER_IN_GROUP, OrderDirection.ASC),
+								attributeNatural(ATTRIBUTE_ASSIGNMENT_PRIORITY, OrderDirection.ASC),
+								traverseByEntityProperty(entityPrimaryKeyExact(GROUP_1))
+							)
+						),
+						require(strip(0, 20), entityFetch(attributeContent()))
+					)
+				);
+				assertUniquePrimaryKeys(response.getRecordPage().getData());
+				return null;
+			}
+		);
+	}
+
+	/**
+	 * Defines the catalog schema used across all test cases: a `PARAMETER_GROUP` entity and a `PRODUCT` entity
+	 * with a `ZERO_OR_MORE` reference to `PARAMETER_GROUP`, carrying two nullable sortable attributes
+	 * (`orderInGroup` and `assignmentPriority`) that form the compound sort key under test.
+	 */
+	private void defineSchema() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.PARAMETER_GROUP)
+					.withoutGeneratedPrimaryKey()
+					.updateVia(session);
+
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withReferenceToEntity(
+						GROUPS,
+						Entities.PARAMETER_GROUP,
+						Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs
+							.indexed()
+							.withAttribute(
+								ATTRIBUTE_ORDER_IN_GROUP, Integer.class,
+								// nullable so that the soft-deleted state can legally exist on the reference;
+								// the absence of the value is the regression scenario
+								thatIs -> thatIs.sortable().nullable()
+							)
+							.withAttribute(
+								ATTRIBUTE_ASSIGNMENT_PRIORITY, Long.class,
+								// second sort key exercises the compound comparator path which is where
+								// the duplication used to surface in production under the compound comparator
+								thatIs -> thatIs.sortable().nullable()
+							)
+					)
+					.updateVia(session);
+
+				session.goLiveAndClose();
+			}
+		);
+	}
+
+	/**
+	 * Creates two groups and three products in the warm-up catalog, assigns each product to group 1
+	 * (and product A also to group 2) with initial sort attribute values, then transitions the catalog to live mode.
+	 */
+	private void seedDataAndGoLive() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.createNewEntity(Entities.PARAMETER_GROUP, GROUP_1).upsertVia(session);
+				session.createNewEntity(Entities.PARAMETER_GROUP, GROUP_2).upsertVia(session);
+
+				// product A belongs to both groups; its orderInGroup on group 1 will be soft-deleted in tx2
+				session.createNewEntity(Entities.PRODUCT, PRODUCT_A)
+					.setReference(
+						GROUPS, GROUP_1,
+						thatIs -> thatIs
+							.setAttribute(ATTRIBUTE_ORDER_IN_GROUP, 5)
+							.setAttribute(ATTRIBUTE_ASSIGNMENT_PRIORITY, 100L)
+					)
+					.setReference(
+						GROUPS, GROUP_2,
+						thatIs -> thatIs
+							.setAttribute(ATTRIBUTE_ORDER_IN_GROUP, 50)
+							.setAttribute(ATTRIBUTE_ASSIGNMENT_PRIORITY, 500L)
+					)
+					.upsertVia(session);
+
+				session.createNewEntity(Entities.PRODUCT, PRODUCT_B)
+					.setReference(
+						GROUPS, GROUP_1,
+						thatIs -> thatIs
+							.setAttribute(ATTRIBUTE_ORDER_IN_GROUP, 1)
+							.setAttribute(ATTRIBUTE_ASSIGNMENT_PRIORITY, 200L)
+					)
+					.upsertVia(session);
+
+				session.createNewEntity(Entities.PRODUCT, PRODUCT_C)
+					.setReference(
+						GROUPS, GROUP_1,
+						thatIs -> thatIs
+							.setAttribute(ATTRIBUTE_ORDER_IN_GROUP, 3)
+							.setAttribute(ATTRIBUTE_ASSIGNMENT_PRIORITY, 300L)
+					)
+					.upsertVia(session);
+			}
+		);
+	}
+
+	/**
+	 * Removes the `orderInGroup` attribute from product A's reference to group 1 in a separate transaction so the
+	 * resulting {@code AttributeValue} carries {@code dropped() == true} instead of being absent. The dropped tombstone
+	 * is exactly the production state that triggers the duplication bug.
+	 */
+	private void dropOrderInGroupOnOneReference() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productA = session.getEntity(
+					Entities.PRODUCT, PRODUCT_A, referenceContent(GROUPS)
+				).orElseThrow();
+
+				productA.openForWrite()
+					.setReference(GROUPS, GROUP_1, thatIs -> thatIs.removeAttribute(ATTRIBUTE_ORDER_IN_GROUP))
+					.upsertVia(session);
+			}
+		);
+		// fixture-integrity assertion skipped on purpose: the public read-back path filters dropped attribute
+		// values via the decorator's attribute predicate, so the tombstone shape is not observable through
+		// SealedEntity; the milagro reproducer harness covers the storage-layer tombstone separately
+	}
+
+	/**
+	 * Asserts that no primary key appears more than once in the given entity list, failing with a descriptive
+	 * message that names the duplicate key when the sorter contract is broken.
+	 */
+	private static void assertUniquePrimaryKeys(@Nonnull List<SealedEntity> entities) {
+		final Set<Integer> seen = new HashSet<>(entities.size());
+		for (final SealedEntity entity : entities) {
+			final int pk = entity.getPrimaryKeyOrThrowException();
+			assertTrue(
+				seen.add(pk),
+				"Duplicate primary key " + pk + " in result page — sorter contract broken"
+			);
+		}
+	}
+
+	/**
+	 * Locks the post-fix observable contract for the result page: it must contain exactly the three
+	 * seeded products (`PRODUCT_A`, `PRODUCT_B`, `PRODUCT_C`), have no duplicate primary keys, and
+	 * `PRODUCT_B` (orderInGroup = 1) must precede `PRODUCT_C` (orderInGroup = 3) in the ASC sort.
+	 * `PRODUCT_A`'s position is intentionally not asserted because its `orderInGroup` on `GROUP_1`
+	 * is the soft-deleted tombstone — its placement is the implementation choice for null sort-keys
+	 * and is therefore not part of the public contract under test.
+	 */
+	private static void assertResultPageContainsAllProductsInExpectedOrder(@Nonnull List<SealedEntity> entities) {
+		assertUniquePrimaryKeys(entities);
+		final Set<Integer> pks = new HashSet<>(entities.size());
+		int positionB = -1;
+		int positionC = -1;
+		for (int i = 0; i < entities.size(); i++) {
+			final int pk = entities.get(i).getPrimaryKeyOrThrowException();
+			pks.add(pk);
+			if (pk == PRODUCT_B) {
+				positionB = i;
+			} else if (pk == PRODUCT_C) {
+				positionC = i;
+			}
+		}
+		assertEquals(
+			Set.of(PRODUCT_A, PRODUCT_B, PRODUCT_C), pks,
+			"Result page must contain exactly PRODUCT_A, PRODUCT_B and PRODUCT_C"
+		);
+		assertTrue(
+			positionB >= 0 && positionC >= 0 && positionB < positionC,
+			"PRODUCT_B (orderInGroup=1) must precede PRODUCT_C (orderInGroup=3) in ASC sort"
+		);
+	}
+
+	/**
+	 * Builds the minimal {@link EvitaConfiguration} for the embedded test instance: infinite session timeout,
+	 * test-scoped storage directory, and a dedicated export directory.
+	 */
+	@Nonnull
+	private EvitaConfiguration getEvitaConfiguration() {
+		return EvitaConfiguration.builder()
+			.server(ServerOptions.builder().closeSessionsAfterSecondsOfInactivity(-1).build())
+			.storage(StorageOptions.builder().storageDirectory(getTestDirectory().resolve(DIR)).build())
+			.export(FileSystemExportOptions.builder().directory(getTestDirectory().resolve(DIR_EXPORT)).build())
+			.build();
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/MilagroCzReproductionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/MilagroCzReproductionTest.java
@@ -1,0 +1,467 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.catalog;
+
+import io.evitadb.api.query.Query;
+import io.evitadb.api.query.parser.DefaultQueryParser;
+import io.evitadb.api.requestResponse.EvitaResponse;
+import io.evitadb.api.requestResponse.data.EntityClassifier;
+import io.evitadb.driver.EvitaClient;
+import io.evitadb.driver.config.ClientTlsOptions;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Connects to a manually-launched evitaDB server (run-server.sh) with the milagro_cz
+ * production snapshot loaded and runs the queries from issue prj/p_mila.eshop#938
+ * to attempt reproduction of the `Duplicate key` crash.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Slf4j
+@EnabledIfSystemProperty(named = "milagro.repro", matches = "true")
+public class MilagroCzReproductionTest {
+	private static final String CATALOG = "milagro_cz";
+
+	private static EvitaClient openClient() {
+		// Server runs gRPC with tlsMode=RELAXED — accepts plaintext h2c too.
+		return new EvitaClient(
+			EvitaClientConfiguration.builder()
+				.host("localhost")
+				.port(5555)
+				.systemApiPort(5555)
+				.tls(
+					ClientTlsOptions.builder()
+						.tlsEnabled(false)
+						.useGeneratedCertificate(false)
+						.trustCertificate(true)
+						.build()
+				)
+				.build()
+		);
+	}
+
+	@Test
+	void runAllReproQueries() {
+		final Map<String, String> queries = new LinkedHashMap<>();
+		queries.put("Q1-group-145197-traverse-page200", """
+			query(
+				collection('Product'),
+				filterBy(and(
+					referenceHaving('groups', entityPrimaryKeyInSet(145197)),
+					entityLocaleEquals('cs'),
+					attributeEquals('status', 'ACTIVE')
+				)),
+				orderBy(
+					referenceProperty('groups', attributeNatural('orderInGroup', ASC),
+				traverseByEntityProperty(entityPrimaryKeyExact(145197)))
+				),
+				require(
+					strip(0, 200),
+					entityFetch( referenceContent('groups') )
+				)
+			)
+			""");
+
+		queries.put("Q2-segments-stocks-orderedQuantity", """
+			query(
+				collection('Product'),
+				filterBy(
+					and(
+						referenceHaving('groups', and(or(and(attributeIs('assignmentValidity', NULL)),
+				and(attributeInRangeNow('assignmentValidity'))), entityPrimaryKeyInSet(21798))),
+						or(and(attributeIs('validity', NULL)), and(attributeInRangeNow('validity'))),
+						entityLocaleEquals('cs'),
+						attributeInSet('productType', 'BASIC', 'SET', 'MASTER'),
+						attributeEquals('status', 'ACTIVE'),
+						priceInPriceLists('jaro-leto-2026-cz', 'jaro-leto-cz-2025', 'podzim-zima-2024-cz', 'jaro-leto-2024-cz', 'basic',
+				'reference', 'basic_milagro_cz', 'reference_milagro_cz', 'bf-sleva-20'),
+						priceValidInNow(),
+						priceInCurrency('CZK'),
+						referenceHaving('stockVisibilities', entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22', '24', '7',
+				'13')))
+					)
+				),
+				orderBy(
+					segments(
+						segment(
+							entityHaving(referenceHaving('stocks', and(
+								entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22', '24', '7', '13')),
+								attributeGreaterThan('quantityOnStock', 0)
+							))),
+							orderBy(attributeNatural('orderedQuantity', DESC))
+						),
+						segment(
+							orderBy(attributeNatural('orderedQuantity', DESC))
+						)
+					)
+				),
+				require(
+					strip(300, 20),
+					entityFetch(
+						referenceContentWithAttributes('relatedProducts', attributeContent('category')),
+						referenceContent('variants', entityFetch(attributeContent('codeShort')), strip(0, 20)),
+						referenceContent('master'),
+						referenceContentWithAttributes('stocks', filterBy(entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22',
+				'24', '7', '13'))), attributeContent('quantityOnStock')),
+						referenceContent('categories'),
+						referenceContent('groups')
+					)
+				)
+			)
+			""");
+
+		queries.put("Q3-refprop-no-traverse-page300", """
+			query(
+				collection('Product'),
+				filterBy(
+					and(
+						referenceHaving('groups', and(or(and(attributeIs('assignmentValidity', NULL)),
+				and(attributeInRangeNow('assignmentValidity'))), entityPrimaryKeyInSet(21798))),
+						or(and(attributeIs('validity', NULL)), and(attributeInRangeNow('validity'))),
+						entityLocaleEquals('cs'),
+						attributeInSet('productType', 'BASIC', 'SET', 'MASTER'),
+						attributeEquals('status', 'ACTIVE'),
+						priceInPriceLists('jaro-leto-2026-cz', 'jaro-leto-cz-2025', 'podzim-zima-2024-cz', 'jaro-leto-2024-cz', 'basic',
+				'reference', 'basic_milagro_cz', 'reference_milagro_cz', 'bf-sleva-20'),
+						priceValidInNow(),
+						priceInCurrency('CZK'),
+						referenceHaving('stockVisibilities', entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22', '24', '7',
+				'13')))
+					)
+				),
+				orderBy(
+					referenceProperty('groups', attributeNatural('orderInGroup', ASC), attributeNatural('assignmentPriority', ASC))
+				),
+				require(
+					strip(300, 20),
+					entityFetch(
+						referenceContentWithAttributes('relatedProducts', attributeContent('category')),
+						referenceContent('variants', entityFetch(attributeContent('codeShort')), strip(0, 20)),
+						referenceContent('master'),
+						referenceContent('categories'),
+						referenceContent('groups')
+					)
+				)
+			)
+			""");
+
+		queries.put("Q4-refprop-traverse-attribute-content", """
+			query(
+				collection('Product'),
+				filterBy(
+					and(
+						referenceHaving('groups', and(or(and(attributeIs('assignmentValidity', NULL)),
+				and(attributeInRangeNow('assignmentValidity'))), entityPrimaryKeyInSet(21798))),
+						or(and(attributeIs('validity', NULL)), and(attributeInRangeNow('validity'))),
+						entityLocaleEquals('cs'),
+						attributeInSet('productType', 'BASIC', 'SET', 'MASTER'),
+						attributeEquals('status', 'ACTIVE'),
+						priceInPriceLists('jaro-leto-2026-cz', 'jaro-leto-cz-2025', 'podzim-zima-2024-cz', 'jaro-leto-2024-cz', 'basic',
+				'reference', 'basic_milagro_cz', 'reference_milagro_cz', 'bf-sleva-20'),
+						priceValidInNow(),
+						priceInCurrency('CZK'),
+						referenceHaving('stockVisibilities', entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22', '24', '7',
+				'13')))
+					)
+				),
+				orderBy(
+					referenceProperty('groups', attributeNatural('orderInGroup', ASC), attributeNatural('assignmentPriority', ASC),
+				traverseByEntityProperty(entityPrimaryKeyExact(21798)))
+				),
+				require(
+					strip(300, 20),
+					entityFetch( attributeContent('code') )
+				)
+			)
+			""");
+
+		queries.put("Q5-attribute-code-ordering", """
+			query(
+				collection('Product'),
+				filterBy(
+					and(
+						referenceHaving('groups', and(or(and(attributeIs('assignmentValidity', NULL)),
+				and(attributeInRangeNow('assignmentValidity'))), entityPrimaryKeyInSet(21798))),
+						or(and(attributeIs('validity', NULL)), and(attributeInRangeNow('validity'))),
+						entityLocaleEquals('cs'),
+						attributeInSet('productType', 'BASIC', 'SET', 'MASTER'),
+						attributeEquals('status', 'ACTIVE'),
+						priceInPriceLists('jaro-leto-2026-cz', 'jaro-leto-cz-2025', 'podzim-zima-2024-cz', 'jaro-leto-2024-cz', 'basic',
+				'reference', 'basic_milagro_cz', 'reference_milagro_cz', 'bf-sleva-20'),
+						priceValidInNow(),
+						priceInCurrency('CZK'),
+						referenceHaving('stockVisibilities', entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22', '24', '7',
+				'13')))
+					)
+				),
+				orderBy( attributeNatural('code', ASC) ),
+				require(
+					strip(300, 20),
+					entityFetch(
+						referenceContentWithAttributes('relatedProducts', attributeContent('category')),
+						referenceContent('variants', entityFetch(attributeContent('codeShort')), strip(0, 20)),
+						referenceContent('master'),
+						referenceContent('categories'),
+						referenceContent('groups')
+					)
+				)
+			)
+			""");
+
+		queries.put("Q6-refprop-traverse-full-fetch", """
+			query(
+				collection('Product'),
+				filterBy(
+					and(
+						referenceHaving('groups', and(or(and(attributeIs('assignmentValidity', NULL)),
+				and(attributeInRangeNow('assignmentValidity'))), entityPrimaryKeyInSet(21798))),
+						or(and(attributeIs('validity', NULL)), and(attributeInRangeNow('validity'))),
+						entityLocaleEquals('cs'),
+						attributeInSet('productType', 'BASIC', 'SET', 'MASTER'),
+						attributeEquals('status', 'ACTIVE'),
+						priceInPriceLists('jaro-leto-2026-cz', 'jaro-leto-cz-2025', 'podzim-zima-2024-cz', 'jaro-leto-2024-cz', 'basic',
+				'reference', 'basic_milagro_cz', 'reference_milagro_cz', 'bf-sleva-20'),
+						priceValidInNow(),
+						priceInCurrency('CZK'),
+						referenceHaving('stockVisibilities', entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22', '24', '7',
+				'13')))
+					)
+				),
+				orderBy(
+					referenceProperty('groups', attributeNatural('orderInGroup', ASC), attributeNatural('assignmentPriority', ASC),
+				traverseByEntityProperty(entityPrimaryKeyExact(21798)))
+				),
+				require(
+					strip(300, 20),
+					entityFetch(
+						referenceContentWithAttributes('relatedProducts', attributeContent('category')),
+						referenceContent('variants', entityFetch(attributeContent('codeShort')), strip(0, 20)),
+						referenceContent('master'),
+						referenceContentWithAttributes('stocks', filterBy(entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22',
+				'24', '7', '13'))), attributeContent('quantityOnStock')),
+						referenceContent('categories'),
+						referenceContent('groups')
+					)
+				)
+			)
+			""");
+
+		queries.put("Q7-segments-refprop-traverse", """
+			query(
+				collection('Product'),
+				filterBy(
+					and(
+						referenceHaving('groups', and(or(and(attributeIs('assignmentValidity', NULL)),
+				and(attributeInRangeNow('assignmentValidity'))), entityPrimaryKeyInSet(21798))),
+						or(and(attributeIs('validity', NULL)), and(attributeInRangeNow('validity'))),
+						entityLocaleEquals('cs'),
+						attributeInSet('productType', 'BASIC', 'SET', 'MASTER'),
+						attributeEquals('status', 'ACTIVE'),
+						priceInPriceLists('jaro-leto-2026-cz', 'jaro-leto-cz-2025', 'podzim-zima-2024-cz', 'jaro-leto-2024-cz', 'basic',
+				'reference', 'basic_milagro_cz', 'reference_milagro_cz', 'bf-sleva-20'),
+						priceValidInNow(),
+						priceInCurrency('CZK'),
+						referenceHaving('stockVisibilities', entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22', '24', '7',
+				'13')))
+					)
+				),
+				orderBy(
+					segments(
+						segment(
+							entityHaving(
+								referenceHaving('stocks', and(
+									entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22', '24', '7', '13')),
+									attributeGreaterThan('quantityOnStock', 0)
+								))
+							),
+							orderBy(referenceProperty('groups', attributeNatural('orderInGroup', ASC), attributeNatural('assignmentPriority',
+				ASC), traverseByEntityProperty(entityPrimaryKeyExact(21798))))
+						),
+						segment(
+							orderBy(referenceProperty('groups', attributeNatural('orderInGroup', ASC), attributeNatural('assignmentPriority',
+				ASC), traverseByEntityProperty(entityPrimaryKeyExact(21798))))
+						)
+					)
+				),
+				require(
+					strip(300, 20),
+					entityFetch(
+						referenceContentWithAttributes('relatedProducts', attributeContent('category')),
+						referenceContent('variants', entityFetch(attributeContent('codeShort')), strip(0, 20)),
+						referenceContent('master'),
+						referenceContentWithAttributes('stocks', filterBy(entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22',
+				'24', '7', '13'))), attributeContent('quantityOnStock')),
+						referenceContent('categories'),
+						referenceContent('groups')
+					)
+				)
+			)
+			""");
+
+		queries.put("Q8-segments-not-stock-fallback", """
+			query(
+				collection('Product'),
+				filterBy(
+					referenceHaving('groups', entityPrimaryKeyInSet(21798)),
+					entityLocaleEquals('cs'),
+					attributeInSet('productType', 'BASIC', 'SET', 'MASTER'),
+					attributeEquals('status', 'ACTIVE')
+				),
+				orderBy(
+					segments(
+						segment(
+							entityHaving(
+								referenceHaving('stocks',
+									and(
+										entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22', '24', '7', '13')),
+										attributeGreaterThan('quantityOnStock', 0)
+									)
+								)
+							),
+							orderBy(
+								referenceProperty('groups',
+									attributeNatural('orderInGroup', ASC),
+									traverseByEntityProperty(entityPrimaryKeyExact(21798))
+								)
+							)
+						),
+						segment(
+							entityHaving(
+								not(
+									referenceHaving('stocks',
+										and(
+											entityHaving(attributeInSet('code', 'milagro_cz', '12', '1', '22', '24', '7', '13')),
+											attributeGreaterThan('quantityOnStock', 0)
+										)
+									)
+								)
+							),
+							orderBy(
+								referenceProperty('groups',
+									attributeNatural('orderInGroup', ASC),
+									traverseByEntityProperty(entityPrimaryKeyExact(21798))
+								)
+							)
+						)
+					)
+				),
+				require(
+					strip(0, 500),
+					entityFetch(
+						referenceContent('groups'),
+						referenceContent('relatedProducts')
+					)
+				)
+			)
+			""");
+
+		final Map<String, String> results = new LinkedHashMap<>();
+		try (EvitaClient evita = openClient()) {
+			for (Map.Entry<String, String> e : queries.entrySet()) {
+				final String label = e.getKey();
+				final String qStr = e.getValue();
+				System.out.println("================================================================");
+				System.out.println(">>> Running " + label);
+				System.out.println("================================================================");
+				try {
+					final Query parsed = DefaultQueryParser.getInstance().parseQueryUnsafe(qStr);
+					evita.queryCatalog(
+						CATALOG,
+						session -> {
+							final EvitaResponse<EntityClassifier> resp = session.query(parsed, EntityClassifier.class);
+							final int pageSize = resp.getRecordPage().getData().size();
+							final int total = resp.getRecordPage().getTotalRecordCount();
+							final Set<Integer> pks = new HashSet<>();
+							int dupCount = 0;
+							int firstDup = -1;
+							for (EntityClassifier ec : resp.getRecordPage().getData()) {
+								final Integer pk = ec.getPrimaryKey();
+								if (!pks.add(pk)) {
+									dupCount++;
+									if (firstDup == -1) firstDup = pk;
+								}
+							}
+							System.out.println("  OK: page=" + pageSize + " total=" + total + " dups=" + dupCount + (firstDup >= 0 ? (" firstDup=" + firstDup) : ""));
+							results.put(label, "OK page=" + pageSize + " total=" + total + " dups=" + dupCount);
+							return null;
+						}
+					);
+				} catch (Throwable t) {
+					Throwable root = t;
+					while (root.getCause() != null && root.getCause() != root) root = root.getCause();
+					System.out.println("  FAIL: " + t.getClass().getSimpleName() + ": " + t.getMessage());
+					System.out.println("        root: " + root.getClass().getSimpleName() + ": " + root.getMessage());
+					results.put(label, "FAIL: " + root.getClass().getSimpleName() + ": " + root.getMessage());
+				}
+			}
+		}
+
+		System.out.println();
+		System.out.println("================================================================");
+		System.out.println("SUMMARY");
+		System.out.println("================================================================");
+		for (Map.Entry<String, String> e : results.entrySet()) {
+			System.out.println("  " + e.getKey() + ": " + e.getValue());
+		}
+	}
+
+	@Test
+	void inspectProduct759850() {
+		// Per issue note: PK 759850 = product 764480C01 in milagro_cz, crashed even after clean re-push
+		try (EvitaClient evita = openClient()) {
+			evita.queryCatalog(
+				CATALOG,
+				session -> {
+					session.getEntity("Product", 759850,
+						io.evitadb.api.query.QueryConstraints.referenceContentAll(),
+						io.evitadb.api.query.QueryConstraints.attributeContent("code"),
+						io.evitadb.api.query.QueryConstraints.dataInLocales(new java.util.Locale("cs"))
+					).ifPresentOrElse(
+						sealedEntity -> {
+							System.out.println("PK=759850 code=" + sealedEntity.getAttribute("code"));
+							final Map<String, Integer> refCounts = new HashMap<>();
+							sealedEntity.getReferences().forEach(r ->
+								refCounts.merge(r.getReferenceName(), 1, Integer::sum)
+							);
+							refCounts.forEach((k, v) -> System.out.println("  ref " + k + ": " + v));
+							System.out.println("  groups PKs: " + sealedEntity.getReferences("groups").stream()
+								.map(r -> r.getReferencedPrimaryKey()).toList());
+						},
+						() -> System.out.println("PK=759850 NOT FOUND")
+					);
+					return null;
+				}
+			);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Wrap lazily-resolved references in `ReferenceDecorator` in both `EntityDecorator` lazy fills so the attribute predicate (including the `dropped()` filter for soft-deleted attribute values) is applied uniformly to references exposed to the query engine.
- Add a partition invariant assertion in `PrefetchedRecordsSorter.sortAndSlice` that fails loudly if a comparator places a non-sortable entity inside the sortable slice (the contract violation that would leak duplicate PKs into the next sorter).
- Add `SortByDroppedReferenceAttributeTest` (3 cases, tagged `FUNCTIONAL_TEST`) as a CI-level contract anchor for the no-dup invariant across `referenceContent`, attribute-only fetch, and `traverseBy` query shapes.

## Background
Sorting by a multi-valued `referenceProperty` whose sortable attribute had been soft-deleted (`AttributeValue.dropped() == true`) on at least one referenced target used to duplicate the affected entity in the result page, and crashed on `entityFetch(referenceContent(...))` via the `Collectors.toMap` duplicate-key check in `EntityIndexSupplier`. The lazy-fill paths in `EntityDecorator` (`getFilteredReferencesByName` and the sibling no-arg `getFilteredReferences`) stored raw `Reference` instances; the sort comparators consumed those raw references and read historical dropped attribute values as live, while the underlying `SortIndex` correctly excluded them. The high-fidelity reproducer is `MilagroCzReproductionTest` against the production snapshot.

## Test plan
- [x] `MilagroCzReproductionTest#runAllReproQueries` against the production snapshot (gated by `-Dmilagro.repro=true`): all 8 queries return `dups=0`; Q3/Q4/Q6/Q7 (which crashed or duplicated pre-fix) now return clean pages.
- [x] `SortByDroppedReferenceAttributeTest` (3 cases) passes.
- [x] `mvn compile` succeeds on `evita_api`, `evita_engine`, and `evita_test/evita_functional_tests`.
- [x] `mvn javadoc:javadoc` succeeds on all three modules.

Closes #1257