### PR TITLE
perf: reduce allocation churn in entity mutation index path

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/AttributeIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/AttributeIndexMutator.java
@@ -52,6 +52,7 @@ import io.evitadb.utils.NumberUtils;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -60,9 +61,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
-
-import static java.util.Optional.ofNullable;
 
 /**
  * Co-locates the procedural, index-maintenance routines for attribute mutations, keeping
@@ -515,34 +513,32 @@ public interface AttributeIndexMutator {
 
 		final EntitySchema entitySchema = executor.getEntitySchema();
 		final Scope scope = entityIndex.getIndexKey().scope();
-		final Stream<SortableAttributeCompoundSchema> allCompounds = sortableAttributeCompounds
-			.values()
-			.stream()
-			// we retrieve schemas from EntitySchema, so we can safely cast them here
-			.map(SortableAttributeCompoundSchema.class::cast)
-			.filter(it -> it.isIndexedInScope(scope));
-
-		final Stream<SortableAttributeCompoundSchema> filteredCompounds = locale == null ?
-			allCompounds.filter(it -> !it.isLocalized(attributeSchemaProvider::getAttributeSchema)) :
-			// filter only localized compound schemas
-			allCompounds.filter(it -> it.isLocalized(attributeSchemaProvider::getAttributeSchema));
-
 		final int entityPrimaryKey = executor.getPrimaryKeyToIndex(IndexType.ATTRIBUTE_SORT_INDEX, Target.NEW);
-		filteredCompounds.forEach(
-			it -> insertNewCompound(
-				entityPrimaryKey, entityIndex, it,
+		// schema resolver and value provider are loop invariant - allocate them once instead of per compound
+		final Function<String, ? extends AttributeSchemaContract> schemaResolver = attributeSchemaProvider::getAttributeSchema;
+		final boolean wantLocalized = locale != null;
+		final Function<AttributeElement, AttributeValue> attributeElementValueProvider = createAttributeElementToAttributeValueProvider(
+			attributeSchemaProvider,
+			attributeKey -> entityAttributeValueSupplier.getAttributeValue(attributeKey).orElse(null),
+			locale
+		);
+		for (final SortableAttributeCompoundSchemaContract rawCompound : sortableAttributeCompounds.values()) {
+			// we retrieve schemas from EntitySchema, so we can safely cast them here
+			final SortableAttributeCompoundSchema compound = (SortableAttributeCompoundSchema) rawCompound;
+			// index only compounds active in this scope, matching the requested localization
+			if (!compound.isIndexedInScope(scope) || compound.isLocalized(schemaResolver) != wantLocalized) {
+				continue;
+			}
+			insertNewCompound(
+				entityPrimaryKey, entityIndex, compound,
 				null, null,
 				locale,
 				entitySchema,
 				referenceSchema,
 				attributeSchemaProvider,
-				createAttributeElementToAttributeValueProvider(
-					attributeSchemaProvider,
-					attributeKey -> entityAttributeValueSupplier.getAttributeValue(attributeKey).orElse(null),
-					locale
-				)
-			)
-		);
+				attributeElementValueProvider
+			);
+		}
 	}
 
 	/**
@@ -587,33 +583,30 @@ public interface AttributeIndexMutator {
 	) {
 		final EntitySchema entitySchema = executor.getEntitySchema();
 		final Scope scope = entityIndex.getIndexKey().scope();
-		final Stream<SortableAttributeCompoundSchema> allCompounds = compoundProvider.getSortableAttributeCompounds()
-			.values()
-			.stream()
-			// we retrieve schemas from EntitySchema, so we can safely cast them here
-			.map(SortableAttributeCompoundSchema.class::cast)
-			.filter(it -> it.isIndexedInScope(scope));
-
-		final Stream<SortableAttributeCompoundSchema> filteredCompounds = locale == null ?
-			allCompounds.filter(it -> !it.isLocalized(attributeSchemaProvider::getAttributeSchema)) :
-			// filter only localized compound schemas
-			allCompounds.filter(it -> it.isLocalized(attributeSchemaProvider::getAttributeSchema));
-
 		final int entityPrimaryKey = executor.getPrimaryKeyToIndex(IndexType.ATTRIBUTE_SORT_INDEX, Target.EXISTING);
-		filteredCompounds.forEach(
-			it -> removeOldCompound(
-				entityPrimaryKey, entityIndex, it,
+		// schema resolver and value provider are loop invariant - allocate them once instead of per compound
+		final Function<String, ? extends AttributeSchemaContract> schemaResolver = attributeSchemaProvider::getAttributeSchema;
+		final boolean wantLocalized = locale != null;
+		final Function<AttributeElement, AttributeValue> attributeElementValueProvider = createAttributeElementToAttributeValueProvider(
+			attributeSchemaProvider,
+			attributeKey -> entityAttributeValueSupplier.getAttributeValue(attributeKey).orElse(null),
+			locale
+		);
+		for (final SortableAttributeCompoundSchemaContract rawCompound : compoundProvider.getSortableAttributeCompounds().values()) {
+			// we retrieve schemas from EntitySchema, so we can safely cast them here
+			final SortableAttributeCompoundSchema compound = (SortableAttributeCompoundSchema) rawCompound;
+			// remove only compounds active in this scope, matching the requested localization
+			if (!compound.isIndexedInScope(scope) || compound.isLocalized(schemaResolver) != wantLocalized) {
+				continue;
+			}
+			removeOldCompound(
+				entityPrimaryKey, entityIndex, compound,
 				locale,
 				entitySchema,
 				referenceSchema,
-				attributeSchemaProvider,
-				createAttributeElementToAttributeValueProvider(
-					attributeSchemaProvider,
-					attributeKey -> entityAttributeValueSupplier.getAttributeValue(attributeKey).orElse(null),
-					locale
-				)
-			)
-		);
+				attributeElementValueProvider
+			);
+		}
 	}
 
 	/**
@@ -763,7 +756,7 @@ public interface AttributeIndexMutator {
 			removeOldCompound(
 				executor.getPrimaryKeyToIndex(IndexType.ATTRIBUTE_SORT_INDEX, Target.EXISTING),
 				indexForRemoval, compound, locale,
-				entitySchema, referenceSchema, attributeSchemaProvider, attributeElementValueProvider
+				entitySchema, referenceSchema, attributeElementValueProvider
 			);
 
 			insertNewCompound(
@@ -810,16 +803,17 @@ public interface AttributeIndexMutator {
 		@Nonnull AttributeAndCompoundSchemaProvider attributeSchemaProvider,
 		@Nonnull Function<AttributeElement, AttributeValue> attributeElementValueProvider
 	) {
-		final Serializable[] newCompoundValues = compound.getAttributeElements()
-			.stream()
-			.map(
-				it -> Objects.equals(it.attributeName(), updatedAttributeName) ?
-					valueToUpdate :
-					ofNullable(attributeElementValueProvider.apply(it))
-						.map(AttributeValue::value)
-						.orElse(null)
-			)
-			.toArray(Serializable[]::new);
+		final List<AttributeElement> attributeElements = compound.getAttributeElements();
+		final Serializable[] newCompoundValues = new Serializable[attributeElements.size()];
+		for (int i = 0; i < attributeElements.size(); i++) {
+			final AttributeElement element = attributeElements.get(i);
+			if (Objects.equals(element.attributeName(), updatedAttributeName)) {
+				newCompoundValues[i] = valueToUpdate;
+			} else {
+				final AttributeValue elementValue = attributeElementValueProvider.apply(element);
+				newCompoundValues[i] = elementValue == null ? null : elementValue.value();
+			}
+		}
 
 		if (!ArrayUtils.isEmptyOrItsValuesNull(newCompoundValues)) {
 			entityIndex.insertSortAttributeCompound(
@@ -846,7 +840,6 @@ public interface AttributeIndexMutator {
 	 * @param locale                       the locale of the compound entry; `null` for non-localized compounds
 	 * @param entitySchema                 the entity schema (required for index persistence metadata)
 	 * @param referenceSchema              the reference schema for reference attributes, `null` for entity attributes
-	 * @param attributeSchemaProvider      supplies attribute schemas for type resolution during undo registration
 	 * @param attributeElementValueProvider resolves pre-mutation attribute values for each compound element
 	 */
 	private static void removeOldCompound(
@@ -856,17 +849,14 @@ public interface AttributeIndexMutator {
 		@Nullable Locale locale,
 		@Nonnull EntitySchemaContract entitySchema,
 		@Nullable ReferenceSchemaContract referenceSchema,
-		@Nonnull AttributeAndCompoundSchemaProvider attributeSchemaProvider,
 		@Nonnull Function<AttributeElement, AttributeValue> attributeElementValueProvider
 	) {
-		final Serializable[] oldCompoundValues = compound.getAttributeElements()
-			.stream()
-			.map(
-				it -> ofNullable(attributeElementValueProvider.apply(it))
-					.map(AttributeValue::value)
-					.orElse(null)
-			)
-			.toArray(Serializable[]::new);
+		final List<AttributeElement> attributeElements = compound.getAttributeElements();
+		final Serializable[] oldCompoundValues = new Serializable[attributeElements.size()];
+		for (int i = 0; i < attributeElements.size(); i++) {
+			final AttributeValue elementValue = attributeElementValueProvider.apply(attributeElements.get(i));
+			oldCompoundValues[i] = elementValue == null ? null : elementValue.value();
+		}
 
 		if (!ArrayUtils.isEmptyOrItsValuesNull(oldCompoundValues)) {
 			entityIndex.removeSortAttributeCompound(

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/EntityIndexLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/EntityIndexLocalMutationExecutor.java
@@ -2025,26 +2025,24 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 		@Nonnull GlobalEntityIndex globalIndex,
 		@Nonnull EntityExistingDataFactory existingDataSupplierFactory
 	) {
-		entity.getAttributeValues()
-			.stream()
-			.filter(Droppable::exists)
-			.forEach(
-				attributeValue -> {
-					final AttributeKey key = attributeValue.key();
-					AttributeIndexMutator.executeAttributeRemoval(
-						this,
-						null,
-						new EntitySchemaAttributeAndCompoundSchemaProvider(entitySchema),
-						existingDataSupplierFactory.getNormalizedEntityAttributeValueSupplier(),
-						globalIndex,
-						globalIndex,
-						key,
-						true,
-						true
-					);
-					existingDataSupplierFactory.registerRemoval(key);
-				}
+		for (final AttributeValue attributeValue : entity.getAttributeValues()) {
+			if (!attributeValue.exists()) {
+				continue;
+			}
+			final AttributeKey key = attributeValue.key();
+			AttributeIndexMutator.executeAttributeRemoval(
+				this,
+				null,
+				new EntitySchemaAttributeAndCompoundSchemaProvider(entitySchema),
+				existingDataSupplierFactory.getNormalizedEntityAttributeValueSupplier(),
+				globalIndex,
+				globalIndex,
+				key,
+				true,
+				true
 			);
+			existingDataSupplierFactory.registerRemoval(key);
+		}
 
 		// unindex all non-localized attribute compounds
 		removeEntireSuiteOfSortableAttributeCompounds(
@@ -2241,26 +2239,24 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 		@Nonnull EntityExistingDataFactory existingDataSupplierFactory
 	) {
 		// now index all attributes
-		entity.getAttributeValues()
-			.stream()
-			.filter(Droppable::exists)
-			.forEach(
-				attributeValue -> {
-					final AttributeKey key = attributeValue.key();
-					AttributeIndexMutator.executeAttributeUpsert(
-						this,
-						null,
-						new EntitySchemaAttributeAndCompoundSchemaProvider(entitySchema),
-						ExistingAttributeValueSupplier.NO_EXISTING_VALUE_SUPPLIER,
-						globalIndex,
-						globalIndex,
-						key,
-						attributeValue.valueOrThrowException(),
-						true,
-						false
-					);
-				}
+		for (final AttributeValue attributeValue : entity.getAttributeValues()) {
+			if (!attributeValue.exists()) {
+				continue;
+			}
+			final AttributeKey key = attributeValue.key();
+			AttributeIndexMutator.executeAttributeUpsert(
+				this,
+				null,
+				new EntitySchemaAttributeAndCompoundSchemaProvider(entitySchema),
+				ExistingAttributeValueSupplier.NO_EXISTING_VALUE_SUPPLIER,
+				globalIndex,
+				globalIndex,
+				key,
+				attributeValue.valueOrThrowException(),
+				true,
+				false
 			);
+		}
 
 		// index all non-localized attribute compounds
 		insertInitialSuiteOfSortableAttributeCompounds(

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/dataAccess/ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceKeySupplier.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/dataAccess/ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceKeySupplier.java
@@ -29,6 +29,7 @@ import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
 import io.evitadb.api.requestResponse.data.Droppable;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
 import io.evitadb.api.requestResponse.data.mutation.EntityMutation.EntityExistence;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
 import io.evitadb.api.requestResponse.data.structure.RepresentativeReferenceKey;
 import io.evitadb.api.requestResponse.schema.dto.ReferenceSchema;
 import io.evitadb.spi.store.catalog.persistence.accessor.WritableEntityStorageContainerAccessor;
@@ -150,23 +151,35 @@ class ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceK
 		// the entire reference is replaced, so we need to retrieve it again
 		if (isReferenceNullOrObsolete(references)) {
 			this.memoizedReferenceIndex = -1;
+			// hoist the target reference keys so the pre-filter below can skip references that cannot match without
+			// allocating a RepresentativeReferenceKey (and computing representative values) for every reference
+			final ReferenceKey currentTargetKey = this.currentReferenceKey.referenceKey();
+			final ReferenceKey storedTargetKey = this.storedReferenceKey.referenceKey();
 			for (int i = 0; i < references.length; i++) {
 				final ReferenceContract reference = references[i];
-				if (reference.exists()) {
-					final RepresentativeReferenceKey theReferenceKey =
-						this.referenceSchema.getName().equals(reference.getReferenceName()) &&
-							this.referenceSchema.getCardinality().allowsDuplicates() ?
-							new RepresentativeReferenceKey(
-								reference.getReferenceKey(),
-								this.referenceSchema.getRepresentativeAttributeDefinition()
-									.getRepresentativeValues(reference)
-							) :
-							new RepresentativeReferenceKey(reference.getReferenceKey());
-					if (Objects.equals(theReferenceKey, this.currentReferenceKey) || Objects.equals(theReferenceKey, this.storedReferenceKey)) {
-						this.memoizedReference = Optional.of(reference);
-						this.memoizedReferenceIndex = i;
-						break;
-					}
+				if (!reference.exists()) {
+					continue;
+				}
+				final ReferenceKey referenceKey = reference.getReferenceKey();
+				// RepresentativeReferenceKey equality requires the ReferenceKey to match in general (reference name
+				// and primary key); a reference matching neither target key can never match, so skip it before the
+				// (relatively expensive) RepresentativeReferenceKey allocation and representative-value computation
+				if (!referenceKey.equalsInGeneral(currentTargetKey) && !referenceKey.equalsInGeneral(storedTargetKey)) {
+					continue;
+				}
+				final RepresentativeReferenceKey theReferenceKey =
+					this.referenceSchema.getName().equals(reference.getReferenceName()) &&
+						this.referenceSchema.getCardinality().allowsDuplicates() ?
+						new RepresentativeReferenceKey(
+							referenceKey,
+							this.referenceSchema.getRepresentativeAttributeDefinition()
+								.getRepresentativeValues(reference)
+						) :
+						new RepresentativeReferenceKey(referenceKey);
+				if (Objects.equals(theReferenceKey, this.currentReferenceKey) || Objects.equals(theReferenceKey, this.storedReferenceKey)) {
+					this.memoizedReference = Optional.of(reference);
+					this.memoizedReferenceIndex = i;
+					break;
 				}
 			}
 			if (this.memoizedReferenceIndex == -1) {

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
@@ -124,7 +124,6 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
@@ -216,15 +215,22 @@ public final class ContainerizedLocalMutationExecutor
 	 */
 	@Nonnull
 	private static Set<AttributeKey> collectAttributeKeys(@Nullable AttributesStoragePart storagePart) {
-		return ofNullable(storagePart)
-			.map(AttributesStoragePart::getAttributes)
-			.map(
-				it -> Arrays.stream(it)
-					.filter(Droppable::exists)
-					.map(AttributeValue::key)
-					.collect(Collectors.toSet())
-			)
-			.orElse(Collections.emptySet());
+		if (storagePart == null) {
+			return Collections.emptySet();
+		}
+		final AttributeValue[] attributes = storagePart.getAttributes();
+		if (attributes.length == 0) {
+			return Collections.emptySet();
+		}
+		// allocation-optimized loop (avoids Optional + stream pipeline on this hot mutation path);
+		// pre-sized for the worst case where every attribute exists
+		final Set<AttributeKey> result = CollectionUtils.createHashSet(attributes.length);
+		for (final AttributeValue attribute : attributes) {
+			if (attribute.exists()) {
+				result.add(attribute.key());
+			}
+		}
+		return result;
 	}
 
 	/**
@@ -232,11 +238,19 @@ public final class ContainerizedLocalMutationExecutor
 	 */
 	@Nonnull
 	private static Set<AttributeKey> collectAttributeKeys(@Nonnull ReferenceContract referenceContract) {
-		return referenceContract.getAttributeValues()
-			.stream()
-			.filter(Droppable::exists)
-			.map(AttributeValue::key)
-			.collect(Collectors.toSet());
+		final Collection<AttributeValue> attributeValues = referenceContract.getAttributeValues();
+		if (attributeValues.isEmpty()) {
+			return Collections.emptySet();
+		}
+		// allocation-optimized loop (avoids stream pipeline on this hot mutation path);
+		// pre-sized for the worst case where every attribute exists
+		final Set<AttributeKey> result = CollectionUtils.createHashSet(attributeValues.size());
+		for (final AttributeValue attributeValue : attributeValues) {
+			if (attributeValue.exists()) {
+				result.add(attributeValue.key());
+			}
+		}
+		return result;
 	}
 
 	/**
@@ -253,23 +267,23 @@ public final class ContainerizedLocalMutationExecutor
 		@Nonnull Set<AttributeKey> availableAttributes,
 		@Nonnull MissingAttributeHandler missingAttributeHandler
 	) {
-		referenceSchema.getNonNullableOrDefaultValueAttributes()
-			.values()
-			.forEach(attributeSchema -> {
-				final Serializable defaultValue = attributeSchema.getDefaultValue();
-				if (attributeSchema.isLocalized()) {
-					entityLocales.stream()
-						.map(locale -> new AttributeKey(attributeSchema.getName(), locale))
-						.map(key -> availableAttributes.contains(key) ? null : key)
-						.filter(Objects::nonNull)
-						.forEach(it -> missingAttributeHandler.accept(defaultValue, attributeSchema.isNullable(), it));
-				} else {
-					final AttributeKey attributeKey = new AttributeKey(attributeSchema.getName());
+		for (final AttributeSchemaContract attributeSchema : referenceSchema.getNonNullableOrDefaultValueAttributes().values()) {
+			final Serializable defaultValue = attributeSchema.getDefaultValue();
+			final boolean nullable = attributeSchema.isNullable();
+			if (attributeSchema.isLocalized()) {
+				for (final Locale locale : entityLocales) {
+					final AttributeKey attributeKey = new AttributeKey(attributeSchema.getName(), locale);
 					if (!availableAttributes.contains(attributeKey)) {
-						missingAttributeHandler.accept(defaultValue, attributeSchema.isNullable(), attributeKey);
+						missingAttributeHandler.accept(defaultValue, nullable, attributeKey);
 					}
 				}
-			});
+			} else {
+				final AttributeKey attributeKey = new AttributeKey(attributeSchema.getName());
+				if (!availableAttributes.contains(attributeKey)) {
+					missingAttributeHandler.accept(defaultValue, nullable, attributeKey);
+				}
+			}
+		}
 	}
 
 	/**
@@ -1251,18 +1265,17 @@ public final class ContainerizedLocalMutationExecutor
 		final BiConsumer<Long, StoragePart> updater = this.trapChanges ?
 			this.dataStoreUpdater::trapUpdate : this.dataStoreUpdater::update;
 		// now store all dirty containers
-		getChangedEntityStorageParts()
-			.forEach(part -> {
-				if (part.isEmpty()) {
-					remover.accept(this.catalogVersion, part);
-				} else {
-					Assert.isPremiseValid(
-						!this.entityRemovedEntirely,
-						"Only removal operations are expected to happen!"
-					);
-					updater.accept(this.catalogVersion, part);
-				}
-			});
+		for (final EntityStoragePart part : getChangedEntityStorageParts()) {
+			if (part.isEmpty()) {
+				remover.accept(this.catalogVersion, part);
+			} else {
+				Assert.isPremiseValid(
+					!this.entityRemovedEntirely,
+					"Only removal operations are expected to happen!"
+				);
+				updater.accept(this.catalogVersion, part);
+			}
+		}
 	}
 
 	@Override
@@ -1334,14 +1347,23 @@ public final class ContainerizedLocalMutationExecutor
 				final List<Object> missingMandatedAttributes = new LinkedList<>();
 				// we need to check only changed parts
 				if (implicitMutationBehavior.contains(ImplicitMutationBehavior.GENERATE_ATTRIBUTES)) {
+					// null-safe dirty checks (avoid Optional + a per-entity stream().anyMatch)
+					final boolean globalAttributesDirty = this.globalAttributesStorageContainer != null
+						&& this.globalAttributesStorageContainer.isDirty();
+					boolean localizedAttributesDirty = false;
+					if (this.languageSpecificAttributesContainer != null) {
+						for (final AttributesStoragePart part : this.languageSpecificAttributesContainer.values()) {
+							if (part.isDirty()) {
+								localizedAttributesDirty = true;
+								break;
+							}
+						}
+					}
 					verifyMandatoryAttributes(
 						this.entityContainer,
 						missingMandatedAttributes,
-						ofNullable(this.globalAttributesStorageContainer).map(AttributesStoragePart::isDirty).orElse(false),
-						ofNullable(this.languageSpecificAttributesContainer)
-							.map(it -> it.values().stream()
-								.anyMatch(AttributesStoragePart::isDirty))
-							.orElse(false),
+						globalAttributesDirty,
+						localizedAttributesDirty,
 						mutationCollector
 					);
 				}
@@ -1473,19 +1495,35 @@ public final class ContainerizedLocalMutationExecutor
 	 */
 	@Nonnull
 	public EntityStoragePart[] getEntityStorageParts() {
-		return Stream.of(
-				Stream.of(this.entityContainer),
-				Stream.of(this.globalAttributesStorageContainer),
-				this.languageSpecificAttributesContainer == null ?
-					Stream.<AttributesStoragePart>empty() : this.languageSpecificAttributesContainer.values().stream(),
-				Stream.of(this.pricesContainer),
-				Stream.of(this.referencesStorageContainer),
-				this.associatedDataContainers == null ?
-					Stream.<AssociatedDataStoragePart>empty() : this.associatedDataContainers.values().stream()
-			)
-			.flatMap(Function.identity())
-			.filter(Objects::nonNull)
-			.toArray(EntityStoragePart[]::new);
+		// allocation-optimized assembly (avoids the nested Stream.of/flatMap pipeline)
+		final List<EntityStoragePart> parts = new ArrayList<>(8);
+		addIfNonNull(parts, this.entityContainer);
+		addIfNonNull(parts, this.globalAttributesStorageContainer);
+		if (this.languageSpecificAttributesContainer != null) {
+			for (final AttributesStoragePart part : this.languageSpecificAttributesContainer.values()) {
+				addIfNonNull(parts, part);
+			}
+		}
+		addIfNonNull(parts, this.pricesContainer);
+		addIfNonNull(parts, this.referencesStorageContainer);
+		if (this.associatedDataContainers != null) {
+			for (final AssociatedDataStoragePart part : this.associatedDataContainers.values()) {
+				addIfNonNull(parts, part);
+			}
+		}
+		return parts.toArray(EntityStoragePart[]::new);
+	}
+
+	/**
+	 * Adds the given storage part to the target list when it is not {@code null}.
+	 *
+	 * @param target the list to add the part to
+	 * @param part   the storage part to add, may be {@code null}
+	 */
+	private static void addIfNonNull(@Nonnull List<EntityStoragePart> target, @Nullable EntityStoragePart part) {
+		if (part != null) {
+			target.add(part);
+		}
 	}
 
 	/**
@@ -1497,40 +1535,42 @@ public final class ContainerizedLocalMutationExecutor
 	@Nonnull
 	public EntityStoragePart[] getAllEntityStorageParts() {
 		final EntityBodyStoragePart entityStorageContainer = getEntityStorageContainer();
-		return Stream.of(
-				Stream.of(entityStorageContainer),
-				Stream.of(
-					ofNullable(this.globalAttributesStorageContainer)
-						.orElseGet(() -> getAttributeStoragePart(this.entityType, this.entityPrimaryKey))
-				),
-				entityStorageContainer.getAttributeLocales()
-					.stream()
-					.map(
-						locale -> ofNullable(this.languageSpecificAttributesContainer)
-							.map(it -> it.get(locale))
-							.orElseGet(() -> getAttributeStoragePart(this.entityType, this.entityPrimaryKey, locale))
-					),
-				getEntitySchema().isWithPrice() ?
-					Stream.of(
-						ofNullable(this.pricesContainer)
-							.orElseGet(() -> getPriceStoragePart(this.entityType, this.entityPrimaryKey))
-					) :
-					Stream.<PricesStoragePart>empty(),
-				Stream.of(
-					ofNullable(this.referencesStorageContainer)
-						.orElseGet(() -> getReferencesStoragePart(this.entityType, this.entityPrimaryKey))
-				),
-				entityStorageContainer.getAssociatedDataKeys()
-					.stream()
-					.map(
-						associatedDataKey -> ofNullable(this.associatedDataContainers)
-							.map(it -> it.get(associatedDataKey))
-							.orElseGet(() -> getAssociatedDataStoragePart(this.entityType, this.entityPrimaryKey, associatedDataKey))
-					)
-			)
-			.flatMap(Function.identity())
-			.filter(Objects::nonNull)
-			.toArray(EntityStoragePart[]::new);
+		// allocation-optimized assembly (avoids the nested Stream.of/flatMap pipeline); each branch
+		// resolves to a non-null part (cached value or freshly fetched/created), so no null filtering
+		final List<EntityStoragePart> parts = new ArrayList<>(16);
+		parts.add(entityStorageContainer);
+		parts.add(
+			this.globalAttributesStorageContainer != null
+				? this.globalAttributesStorageContainer
+				: getAttributeStoragePart(this.entityType, this.entityPrimaryKey)
+		);
+		for (final Locale locale : entityStorageContainer.getAttributeLocales()) {
+			final AttributesStoragePart cached = this.languageSpecificAttributesContainer == null
+				? null : this.languageSpecificAttributesContainer.get(locale);
+			parts.add(cached != null ? cached : getAttributeStoragePart(this.entityType, this.entityPrimaryKey, locale));
+		}
+		if (getEntitySchema().isWithPrice()) {
+			parts.add(
+				this.pricesContainer != null
+					? this.pricesContainer
+					: getPriceStoragePart(this.entityType, this.entityPrimaryKey)
+			);
+		}
+		parts.add(
+			this.referencesStorageContainer != null
+				? this.referencesStorageContainer
+				: getReferencesStoragePart(this.entityType, this.entityPrimaryKey)
+		);
+		for (final AssociatedDataKey associatedDataKey : entityStorageContainer.getAssociatedDataKeys()) {
+			final AssociatedDataStoragePart cached = this.associatedDataContainers == null
+				? null : this.associatedDataContainers.get(associatedDataKey);
+			parts.add(
+				cached != null
+					? cached
+					: getAssociatedDataStoragePart(this.entityType, this.entityPrimaryKey, associatedDataKey)
+			);
+		}
+		return parts.toArray(EntityStoragePart[]::new);
 	}
 
 	/**
@@ -1764,12 +1804,38 @@ public final class ContainerizedLocalMutationExecutor
 		final AttributeKey affectedAttribute = attributeMutation.getAttributeKey();
 
 		if (attributeMutation instanceof UpsertAttributeMutation) {
-			ofNullable(affectedAttribute.locale())
-				.ifPresent(locale -> {
+			final Locale locale = affectedAttribute.locale();
+			if (locale != null) {
+				final EntityBodyStoragePart ebsp = getEntityStoragePart(
+					this.entityType, this.entityPrimaryKey, EntityExistence.MUST_EXIST
+				);
+				final LocaleModificationResult localeModificationResult = ebsp.addAttributeLocale(locale);
+				if (localeModificationResult.anyChangeOccurred()) {
+					this.localesIdentityHash++;
+					final EnumSet<LocaleScope> scopesAffected = EnumSet.noneOf(LocaleScope.class);
+					if (localeModificationResult.attributeLocalesChanged()) {
+						scopesAffected.add(LocaleScope.ATTRIBUTE);
+					}
+					if (localeModificationResult.entityLocalesChanged()) {
+						scopesAffected.add(LocaleScope.ENTITY);
+					}
+					registerAddedLocale(locale, scopesAffected);
+				}
+			}
+		} else if (attributeMutation instanceof RemoveAttributeMutation) {
+			final Locale locale = affectedAttribute.locale();
+			if (locale != null) {
+				final AttributesStoragePart attributeStoragePart = getAttributeStoragePart(
+					this.entityType, this.entityPrimaryKey, locale
+				);
+				final ReferencesStoragePart referencesStoragePart =
+					getReferencesStoragePart(this.entityType, this.entityPrimaryKey);
+
+				if (attributeStoragePart.isEmpty() && !referencesStoragePart.isLocalePresent(locale)) {
 					final EntityBodyStoragePart ebsp = getEntityStoragePart(
 						this.entityType, this.entityPrimaryKey, EntityExistence.MUST_EXIST
 					);
-					final LocaleModificationResult localeModificationResult = ebsp.addAttributeLocale(locale);
+					final LocaleModificationResult localeModificationResult = ebsp.removeAttributeLocale(locale);
 					if (localeModificationResult.anyChangeOccurred()) {
 						this.localesIdentityHash++;
 						final EnumSet<LocaleScope> scopesAffected = EnumSet.noneOf(LocaleScope.class);
@@ -1779,36 +1845,10 @@ public final class ContainerizedLocalMutationExecutor
 						if (localeModificationResult.entityLocalesChanged()) {
 							scopesAffected.add(LocaleScope.ENTITY);
 						}
-						registerAddedLocale(locale, scopesAffected);
+						registerRemovedLocale(locale, scopesAffected);
 					}
-				});
-		} else if (attributeMutation instanceof RemoveAttributeMutation) {
-			ofNullable(affectedAttribute.locale())
-				.ifPresent(locale -> {
-					final AttributesStoragePart attributeStoragePart = getAttributeStoragePart(
-						this.entityType, this.entityPrimaryKey, locale
-					);
-					final ReferencesStoragePart referencesStoragePart =
-						getReferencesStoragePart(this.entityType, this.entityPrimaryKey);
-
-					if (attributeStoragePart.isEmpty() && !referencesStoragePart.isLocalePresent(locale)) {
-						final EntityBodyStoragePart ebsp = getEntityStoragePart(
-						this.entityType, this.entityPrimaryKey, EntityExistence.MUST_EXIST
-					);
-						final LocaleModificationResult localeModificationResult = ebsp.removeAttributeLocale(locale);
-						if (localeModificationResult.anyChangeOccurred()) {
-							this.localesIdentityHash++;
-							final EnumSet<LocaleScope> scopesAffected = EnumSet.noneOf(LocaleScope.class);
-							if (localeModificationResult.attributeLocalesChanged()) {
-								scopesAffected.add(LocaleScope.ATTRIBUTE);
-							}
-							if (localeModificationResult.entityLocalesChanged()) {
-								scopesAffected.add(LocaleScope.ENTITY);
-							}
-							registerRemovedLocale(locale, scopesAffected);
-						}
-					}
-				});
+				}
+			}
 		} else if (attributeMutation instanceof ApplyDeltaAttributeMutation) {
 			// DO NOTHING
 		} else {
@@ -1849,15 +1889,18 @@ public final class ContainerizedLocalMutationExecutor
 		final Set<AttributeKey> availableGlobalAttributes = checkGlobal ?
 			collectAttributeKeys(this.globalAttributesStorageContainer) : Collections.emptySet();
 		final Set<Locale> entityLocales = entityStorageContainer.getLocales();
-		final Map<Locale, Set<AttributeKey>> availableLocalizedAttributes = checkLocalized ?
-			entityLocales
-				.stream()
-				.collect(
-					Collectors.toMap(
-						Function.identity(),
-						it -> collectAttributeKeys(getAttributeStoragePart(this.entityType, this.entityPrimaryKey, it))
-					)
-				) : Collections.emptyMap();
+		final Map<Locale, Set<AttributeKey>> availableLocalizedAttributes;
+		if (checkLocalized && !entityLocales.isEmpty()) {
+			availableLocalizedAttributes = CollectionUtils.createHashMap(entityLocales.size());
+			for (final Locale locale : entityLocales) {
+				availableLocalizedAttributes.put(
+					locale,
+					collectAttributeKeys(getAttributeStoragePart(this.entityType, this.entityPrimaryKey, locale))
+				);
+			}
+		} else {
+			availableLocalizedAttributes = Collections.emptyMap();
+		}
 
 		final MissingAttributeHandler missingAttributeHandler = (defaultValue, nullable, attributeKey) -> {
 			Assert.isPremiseValid(attributeKey != null, "Attribute key must not be null!");
@@ -1872,22 +1915,24 @@ public final class ContainerizedLocalMutationExecutor
 			}
 		};
 
-		nonNullableOrDefaultValueAttributes
-			.forEach(attribute -> {
-				final Serializable defaultValue = attribute.getDefaultValue();
-				if (checkLocalized && attribute.isLocalized()) {
-					entityLocales.stream()
-						.map(locale -> new AttributeKey(attribute.getName(), locale))
-						.flatMap(key -> ofNullable(availableLocalizedAttributes.get(key.locale()))
-							.map(it -> it.contains(key)).orElse(false) ? Stream.empty() : Stream.of(key))
-						.forEach(it -> missingAttributeHandler.accept(defaultValue, attribute.isNullable(), it));
-				} else if (checkGlobal && !attribute.isLocalized()) {
-					final AttributeKey attributeKey = new AttributeKey(attribute.getName());
-					if (!availableGlobalAttributes.contains(attributeKey)) {
-						missingAttributeHandler.accept(defaultValue, attribute.isNullable(), attributeKey);
+		for (final EntityAttributeSchemaContract attribute : nonNullableOrDefaultValueAttributes) {
+			final Serializable defaultValue = attribute.getDefaultValue();
+			final boolean nullable = attribute.isNullable();
+			if (checkLocalized && attribute.isLocalized()) {
+				for (final Locale locale : entityLocales) {
+					final AttributeKey attributeKey = new AttributeKey(attribute.getName(), locale);
+					final Set<AttributeKey> localeAttributes = availableLocalizedAttributes.get(locale);
+					if (localeAttributes == null || !localeAttributes.contains(attributeKey)) {
+						missingAttributeHandler.accept(defaultValue, nullable, attributeKey);
 					}
 				}
-			});
+			} else if (checkGlobal && !attribute.isLocalized()) {
+				final AttributeKey attributeKey = new AttributeKey(attribute.getName());
+				if (!availableGlobalAttributes.contains(attributeKey)) {
+					missingAttributeHandler.accept(defaultValue, nullable, attributeKey);
+				}
+			}
+		}
 
 		// verify that entity retains at least one locale if non-nullable localized attributes exist
 		if (checkLocalized && entityLocales.isEmpty()) {
@@ -2439,6 +2484,12 @@ public final class ContainerizedLocalMutationExecutor
 					!referenceSchema.getName().equals(reference.getReferenceName())) {
 					referenceSchema = entitySchema.getReferenceOrThrowException(reference.getReferenceName());
 				}
+				// skip references whose schema declares no mandatory / default-valued attributes -
+				// there is nothing to verify or default here, so we avoid collecting the reference
+				// attribute keys and allocating the per-reference handler for the common case
+				if (referenceSchema.getNonNullableOrDefaultValueAttributes().isEmpty()) {
+					continue;
+				}
 				missingReferenceMandatedAttribute.clear();
 				final Set<AttributeKey> availableAttributes = collectAttributeKeys(reference);
 				final MissingAttributeHandler missingAttributeHandler = (defaultValue, nullable, attributeKey) -> {
@@ -2650,23 +2701,30 @@ public final class ContainerizedLocalMutationExecutor
 		final Set<AssociatedDataKey> availableAssociatedDataKeys = this.entityContainer.getAssociatedDataKeys();
 		final Set<Locale> entityLocales = entityStorageContainer.getLocales();
 
-		final List<AssociatedDataKey> missingMandatedAssociatedData = nonNullableAssociatedData
-			.stream()
-			.flatMap(associatedData -> {
-				if (associatedData.isLocalized()) {
-					return entityLocales.stream()
-						.map(locale -> new AssociatedDataKey(associatedData.getName(), locale))
-						.flatMap(key -> availableAssociatedDataKeys.contains(key) ? Stream.empty() : Stream.of(key));
-				} else {
-					final AssociatedDataKey associatedDataKey = new AssociatedDataKey(associatedData.getName());
-					return availableAssociatedDataKeys.contains(associatedDataKey)
-						? Stream.empty()
-						: Stream.of(associatedDataKey);
+		List<AssociatedDataKey> missingMandatedAssociatedData = null;
+		for (final AssociatedDataSchema associatedData : nonNullableAssociatedData) {
+			if (associatedData.isLocalized()) {
+				for (final Locale locale : entityLocales) {
+					final AssociatedDataKey key = new AssociatedDataKey(associatedData.getName(), locale);
+					if (!availableAssociatedDataKeys.contains(key)) {
+						if (missingMandatedAssociatedData == null) {
+							missingMandatedAssociatedData = new LinkedList<>();
+						}
+						missingMandatedAssociatedData.add(key);
+					}
 				}
-			})
-			.toList();
+			} else {
+				final AssociatedDataKey key = new AssociatedDataKey(associatedData.getName());
+				if (!availableAssociatedDataKeys.contains(key)) {
+					if (missingMandatedAssociatedData == null) {
+						missingMandatedAssociatedData = new LinkedList<>();
+					}
+					missingMandatedAssociatedData.add(key);
+				}
+			}
+		}
 
-		if (!missingMandatedAssociatedData.isEmpty()) {
+		if (missingMandatedAssociatedData != null && !missingMandatedAssociatedData.isEmpty()) {
 			throw new MandatoryAssociatedDataNotProvidedException(entitySchema.getName(), missingMandatedAssociatedData);
 		}
 
@@ -2711,33 +2769,41 @@ public final class ContainerizedLocalMutationExecutor
 	 *                                                     localized associated data are defined in the schema
 	 */
 	private void verifyRemovedMandatoryAssociatedData() {
-		final AtomicReference<Set<String>> mandatoryAssociatedData = new AtomicReference<>();
 		final Set<Locale> entityLocales = this.entityContainer.getLocales();
-		final List<AssociatedDataKey> missingMandatedAssociatedData = ofNullable(this.associatedDataContainers)
-			.map(Map::values)
-			.orElse(Collections.emptyList())
-			.stream()
-			.filter(AssociatedDataStoragePart::isDirty)
-			.filter(AssociatedDataStoragePart::isEmpty)
-			.filter(it -> {
-				if (mandatoryAssociatedData.get() == null) {
-					final EntitySchema entitySchema = this.schemaAccessor.get();
-					mandatoryAssociatedData.set(
-						entitySchema.getNonNullableAssociatedData()
-							.stream()
-							.map(AssociatedDataSchema::getName)
-							.collect(Collectors.toSet())
-					);
+		List<AssociatedDataKey> missingMandatedAssociatedData = null;
+		Set<String> mandatoryAssociatedData = null;
+		if (this.associatedDataContainers != null) {
+			for (final AssociatedDataStoragePart part : this.associatedDataContainers.values()) {
+				// only dirty containers that have been emptied are candidates for a missing mandatory value
+				if (!part.isDirty() || !part.isEmpty()) {
+					continue;
 				}
-				final AssociatedDataValue value = it.getValue();
-				return value != null && mandatoryAssociatedData.get().contains(value.key().associatedDataName());
-			})
-			.map(it -> it.getValue().key())
-			// skip localized associated data whose locale has been dropped from the entity
-			.filter(key -> key.locale() == null || entityLocales.contains(key.locale()))
-			.toList();
+				// lazily resolve the set of mandatory associated data names on the first candidate
+				if (mandatoryAssociatedData == null) {
+					final Collection<AssociatedDataSchema> nonNullableAssociatedData =
+						this.schemaAccessor.get().getNonNullableAssociatedData();
+					mandatoryAssociatedData = CollectionUtils.createHashSet(nonNullableAssociatedData.size());
+					for (final AssociatedDataSchema associatedData : nonNullableAssociatedData) {
+						mandatoryAssociatedData.add(associatedData.getName());
+					}
+				}
+				final AssociatedDataValue value = part.getValue();
+				if (value == null || !mandatoryAssociatedData.contains(value.key().associatedDataName())) {
+					continue;
+				}
+				final AssociatedDataKey key = value.key();
+				// skip localized associated data whose locale has been dropped from the entity
+				if (key.locale() != null && !entityLocales.contains(key.locale())) {
+					continue;
+				}
+				if (missingMandatedAssociatedData == null) {
+					missingMandatedAssociatedData = new LinkedList<>();
+				}
+				missingMandatedAssociatedData.add(key);
+			}
+		}
 
-		if (!missingMandatedAssociatedData.isEmpty()) {
+		if (missingMandatedAssociatedData != null && !missingMandatedAssociatedData.isEmpty()) {
 			throw new MandatoryAssociatedDataNotProvidedException(this.entityType, missingMandatedAssociatedData);
 		}
 
@@ -2858,22 +2924,36 @@ public final class ContainerizedLocalMutationExecutor
 	 * automatically fetched from the underlying storage and modified, new containers are created on the fly.
 	 */
 	@Nonnull
-	private Stream<? extends EntityStoragePart> getChangedEntityStorageParts() {
-		// now return all affected containers
-		return Stream.of(
-				Stream.of(
-					this.getEntityStorageContainer(),
-					this.pricesContainer,
-					this.globalAttributesStorageContainer,
-					this.referencesStorageContainer
-				),
-				ofNullable(this.languageSpecificAttributesContainer).stream().flatMap(it -> it.values().stream()),
-				ofNullable(this.associatedDataContainers).stream().flatMap(it -> it.values().stream())
-			)
-			.flatMap(it -> it)
-			.filter(Objects::nonNull)
-			/* return only parts that have been changed */
-			.filter(EntityStoragePart::isDirty);
+	private List<EntityStoragePart> getChangedEntityStorageParts() {
+		// allocation-optimized collection of the changed containers (avoids the nested Stream pipeline)
+		final List<EntityStoragePart> dirtyParts = new ArrayList<>(8);
+		addIfDirty(dirtyParts, this.getEntityStorageContainer());
+		addIfDirty(dirtyParts, this.pricesContainer);
+		addIfDirty(dirtyParts, this.globalAttributesStorageContainer);
+		addIfDirty(dirtyParts, this.referencesStorageContainer);
+		if (this.languageSpecificAttributesContainer != null) {
+			for (final AttributesStoragePart part : this.languageSpecificAttributesContainer.values()) {
+				addIfDirty(dirtyParts, part);
+			}
+		}
+		if (this.associatedDataContainers != null) {
+			for (final AssociatedDataStoragePart part : this.associatedDataContainers.values()) {
+				addIfDirty(dirtyParts, part);
+			}
+		}
+		return dirtyParts;
+	}
+
+	/**
+	 * Adds the given storage part to the target list when it is not {@code null} and has been changed.
+	 *
+	 * @param target the list to add the part to
+	 * @param part   the storage part to add, may be {@code null}
+	 */
+	private static void addIfDirty(@Nonnull List<EntityStoragePart> target, @Nullable EntityStoragePart part) {
+		if (part != null && part.isDirty()) {
+			target.add(part);
+		}
 	}
 
 	/**
@@ -2899,11 +2979,11 @@ public final class ContainerizedLocalMutationExecutor
 				"Attribute `" + attributeKey.attributeName() +
 					"` is not known for entity `" + entitySchema.getName() + "`."
 			));
-		final AttributesStoragePart attributesStorageContainer = ofNullable(attributeKey.locale())
-			// get or create locale specific attributes container
-			.map(it -> getAttributeStoragePart(this.entityType, this.entityPrimaryKey, it))
-			// get or create locale agnostic container (global one)
-			.orElseGet(() -> getAttributeStoragePart(this.entityType, this.entityPrimaryKey));
+		// get or create the locale-specific attributes container, or the locale-agnostic (global) one
+		final Locale attributeLocale = attributeKey.locale();
+		final AttributesStoragePart attributesStorageContainer = attributeLocale != null
+			? getAttributeStoragePart(this.entityType, this.entityPrimaryKey, attributeLocale)
+			: getAttributeStoragePart(this.entityType, this.entityPrimaryKey);
 
 		// now replace the attribute contents in the container
 		attributesStorageContainer.upsertAttribute(
@@ -3045,9 +3125,11 @@ public final class ContainerizedLocalMutationExecutor
 		pricesStorageContainer.replaceOrAddPrice(
 			localMutation.getPriceKey(),
 			priceContract -> localMutation.mutateLocal(entitySchema, priceContract),
-			priceKey -> ofNullable(this.assignedInternalPriceIdIndex)
-				.map(it -> it.get(priceKey))
-				.orElseGet(this.priceInternalIdSupplier::getAsInt)
+			priceKey -> {
+				final Integer assignedPriceId = this.assignedInternalPriceIdIndex == null
+					? null : this.assignedInternalPriceIdIndex.get(priceKey);
+				return assignedPriceId == null ? this.priceInternalIdSupplier.getAsInt() : assignedPriceId;
+			}
 		);
 		// change in entity parts also change the entity itself (we need to update the version)
 		if (pricesStorageContainer.isDirty()) {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/dataAccess/ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceKeySupplierTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/dataAccess/ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceKeySupplierTest.java
@@ -1,0 +1,691 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.mutation.local.dataAccess;
+
+import io.evitadb.api.requestResponse.data.AssociatedDataContract.AssociatedDataKey;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeValue;
+import io.evitadb.api.requestResponse.data.mutation.EntityMutation.EntityExistence;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
+import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
+import io.evitadb.api.requestResponse.data.structure.Reference;
+import io.evitadb.api.requestResponse.data.structure.RepresentativeReferenceKey;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.dto.AttributeSchema;
+import io.evitadb.api.requestResponse.schema.dto.EntitySchema;
+import io.evitadb.api.requestResponse.schema.dto.ReferenceSchema;
+import io.evitadb.api.requestResponse.schema.mutation.reference.ScopedReferenceIndexType;
+import io.evitadb.dataType.Scope;
+import io.evitadb.spi.store.catalog.persistence.accessor.WritableEntityStorageContainerAccessor;
+import io.evitadb.spi.store.catalog.persistence.storageParts.entity.AssociatedDataStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.entity.AttributesStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.entity.EntityBodyStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.entity.PricesStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.entity.ReferencesStoragePart;
+import io.evitadb.utils.NamingConvention;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Characterization (regression) tests for
+ * {@link ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceKeySupplier}.
+ *
+ * The supplier resolves a single {@link io.evitadb.api.requestResponse.data.ReferenceContract} out of the
+ * entity's {@link ReferencesStoragePart} — the one whose
+ * {@link RepresentativeReferenceKey} equals either the current or the stored key it was constructed with — and
+ * exposes that reference's existing (non-dropped) attribute values. For a reference schema whose cardinality
+ * {@link Cardinality#allowsDuplicates()} the key is built from the representative attribute values of each
+ * candidate reference, so that two references sharing the same {@link ReferenceKey} (same reference name and
+ * primary key) are disambiguated by those values; otherwise the plain {@link ReferenceKey} is used.
+ *
+ * These tests pin the current, observable behavior of the supplier so that a subsequent allocation optimization
+ * of its private resolution logic can be verified not to change semantics. All assertions go through the public
+ * {@link ExistingAttributeValueSupplier} surface — {@code getAttributeValue}, {@code getAttributeValues},
+ * {@code getAttributeValues(Locale)} and {@code getEntityExistingAttributeLocales}.
+ *
+ * The tests do not boot an evitaDB instance: they hand-build schemas, references and a minimal
+ * {@link WritableEntityStorageContainerAccessor} stub whose only meaningful behavior is to return a chosen
+ * {@link ReferencesStoragePart} (and an {@link EntityBodyStoragePart} for the locales path).
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+@DisplayName("ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceKeySupplier — existing attribute resolution")
+@Tag(INDEXING)
+@Tag(REFERENCE)
+@Tag(ATTRIBUTE)
+class ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceKeySupplierTest {
+	private static final String ENTITY_TYPE = "product";
+	private static final int ENTITY_PK = 1;
+	private static final String REFERENCE_NAME = "brand";
+	private static final String ATTRIBUTE_CODE = "code";
+	private static final String ATTRIBUTE_OLD_CODE = "oldCode";
+	private static final String ATTRIBUTE_VARIANT = "variant";
+	private static final String ATTRIBUTE_LABEL = "label";
+	/**
+	 * Shared, immutable, minimal entity schema owning the references. It carries no attributes of its own — the
+	 * reference schema alone defines the attributes the supplier ever resolves — and is safe to share read-only
+	 * across all tests.
+	 */
+	private static final EntitySchema ENTITY_SCHEMA = EntitySchema._internalBuild(ENTITY_TYPE);
+
+	@Nested
+	@DisplayName("Reference resolution by key")
+	class ReferenceResolution {
+
+		@Test
+		@DisplayName("should resolve the matching reference's attributes for a non-duplicate schema")
+		void shouldResolveReferenceAttributesWhenSingleNonDuplicateMatch() {
+			final ReferenceSchema referenceSchema = referenceSchema(
+				Cardinality.ZERO_OR_ONE, Map.of(ATTRIBUTE_CODE, attribute(ATTRIBUTE_CODE, false, false))
+			);
+			final Reference reference = reference(
+				referenceSchema, 10, 1, false,
+				attributeValues(new AttributeValue(new AttributeKey(ATTRIBUTE_CODE), "acme"))
+			);
+			final StubContainerAccessor accessor = new StubContainerAccessor(storagePart(reference));
+			final ExistingAttributeValueSupplier supplier = supplier(
+				accessor, referenceSchema, key(999), key(10)
+			);
+
+			final Optional<AttributeValue> resolved = supplier.getAttributeValue(new AttributeKey(ATTRIBUTE_CODE));
+
+			assertTrue(resolved.isPresent(), "The matching reference must be resolved");
+			assertEquals("acme", resolved.get().value());
+			assertSingleValue(supplier.getAttributeValues(), ATTRIBUTE_CODE, "acme");
+		}
+
+		@Test
+		@DisplayName("should resolve the reference matching the stored key when the current key is absent")
+		void shouldResolveReferenceMatchingStoredKeyWhenCurrentKeyAbsent() {
+			final ReferenceSchema referenceSchema = referenceSchema(
+				Cardinality.ZERO_OR_ONE, Map.of(ATTRIBUTE_CODE, attribute(ATTRIBUTE_CODE, false, false))
+			);
+			final Reference reference = reference(
+				referenceSchema, 10, 1, false,
+				attributeValues(new AttributeValue(new AttributeKey(ATTRIBUTE_CODE), "acme"))
+			);
+			final StubContainerAccessor accessor = new StubContainerAccessor(storagePart(reference));
+			// current key points at a non-existing reference (pk 999), only the stored key (pk 10) matches
+			final ExistingAttributeValueSupplier supplier = supplier(
+				accessor, referenceSchema, key(10), key(999)
+			);
+
+			final Optional<AttributeValue> resolved = supplier.getAttributeValue(new AttributeKey(ATTRIBUTE_CODE));
+
+			assertTrue(resolved.isPresent(), "The reference matching the stored key must be resolved");
+			assertEquals("acme", resolved.get().value());
+		}
+
+		@Test
+		@DisplayName("should return empty results when no reference matches either key")
+		void shouldReturnEmptyWhenNoReferenceMatches() {
+			final ReferenceSchema referenceSchema = referenceSchema(
+				Cardinality.ZERO_OR_ONE, Map.of(ATTRIBUTE_CODE, attribute(ATTRIBUTE_CODE, false, false))
+			);
+			final Reference reference = reference(
+				referenceSchema, 10, 1, false,
+				attributeValues(new AttributeValue(new AttributeKey(ATTRIBUTE_CODE), "acme"))
+			);
+			final StubContainerAccessor accessor = new StubContainerAccessor(storagePart(reference));
+			// neither the stored nor the current key matches the only present reference (pk 10)
+			final ExistingAttributeValueSupplier supplier = supplier(
+				accessor, referenceSchema, key(998), key(999)
+			);
+
+			assertTrue(
+				supplier.getAttributeValue(new AttributeKey(ATTRIBUTE_CODE)).isEmpty(),
+				"No attribute value must be returned when no reference matches"
+			);
+			assertEquals(
+				0, supplier.getAttributeValues().count(),
+				"The attribute value stream must be empty when no reference matches"
+			);
+		}
+
+		@Test
+		@DisplayName("should skip a dropped reference and resolve the live reference sharing the same key")
+		void shouldResolveLiveReferenceAndSkipDroppedReferenceWithSameKey() {
+			final ReferenceSchema referenceSchema = referenceSchema(
+				Cardinality.ZERO_OR_ONE, Map.of(ATTRIBUTE_CODE, attribute(ATTRIBUTE_CODE, false, false))
+			);
+			// a dropped tombstone (listed first) and a live replacement, both with business key (brand, 10)
+			final Reference dropped = reference(
+				referenceSchema, 10, 1, true,
+				attributeValues(new AttributeValue(new AttributeKey(ATTRIBUTE_CODE), "stale"))
+			);
+			final Reference live = reference(
+				referenceSchema, 10, 2, false,
+				attributeValues(new AttributeValue(new AttributeKey(ATTRIBUTE_CODE), "fresh"))
+			);
+			final StubContainerAccessor accessor = new StubContainerAccessor(storagePart(dropped, live));
+			final ExistingAttributeValueSupplier supplier = supplier(
+				accessor, referenceSchema, key(999), key(10)
+			);
+
+			final Optional<AttributeValue> resolved = supplier.getAttributeValue(new AttributeKey(ATTRIBUTE_CODE));
+
+			assertTrue(resolved.isPresent(), "The live reference must be resolved even though a dropped one precedes it");
+			assertEquals(
+				"fresh", resolved.get().value(),
+				"The dropped reference must be skipped and the live reference resolved"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Duplicate-cardinality disambiguation by representative values")
+	class DuplicateDisambiguation {
+
+		@Test
+		@DisplayName("should resolve the second reference when the key targets its representative values")
+		void shouldResolveSecondReferenceWhenKeyTargetsItsRepresentativeValues() {
+			final ReferenceSchema referenceSchema = duplicateSchema();
+			// two references with the SAME business key (brand, 10) but different representative variant values;
+			// the "red" reference is listed FIRST on purpose so a naive "match by ReferenceKey only" would pick it
+			final Reference red = reference(
+				referenceSchema, 10, 1, false,
+				attributeValues(new AttributeValue(new AttributeKey(ATTRIBUTE_VARIANT), "red"))
+			);
+			final Reference blue = reference(
+				referenceSchema, 10, 2, false,
+				attributeValues(new AttributeValue(new AttributeKey(ATTRIBUTE_VARIANT), "blue"))
+			);
+			final StubContainerAccessor accessor = new StubContainerAccessor(storagePart(red, blue));
+			final ExistingAttributeValueSupplier supplier = supplier(
+				accessor, referenceSchema, key(999), key(10, "blue")
+			);
+
+			final Optional<AttributeValue> resolved = supplier.getAttributeValue(new AttributeKey(ATTRIBUTE_VARIANT));
+
+			assertTrue(resolved.isPresent(), "The reference matching the representative values must be resolved");
+			assertEquals(
+				"blue", resolved.get().value(),
+				"The key targeting the second reference's representative values must resolve that reference, not the first"
+			);
+		}
+
+		@Test
+		@DisplayName("should resolve the first reference when the key targets its representative values")
+		void shouldResolveFirstReferenceWhenKeyTargetsItsRepresentativeValues() {
+			final ReferenceSchema referenceSchema = duplicateSchema();
+			final Reference red = reference(
+				referenceSchema, 10, 1, false,
+				attributeValues(new AttributeValue(new AttributeKey(ATTRIBUTE_VARIANT), "red"))
+			);
+			final Reference blue = reference(
+				referenceSchema, 10, 2, false,
+				attributeValues(new AttributeValue(new AttributeKey(ATTRIBUTE_VARIANT), "blue"))
+			);
+			final StubContainerAccessor accessor = new StubContainerAccessor(storagePart(red, blue));
+			final ExistingAttributeValueSupplier supplier = supplier(
+				accessor, referenceSchema, key(999), key(10, "red")
+			);
+
+			final Optional<AttributeValue> resolved = supplier.getAttributeValue(new AttributeKey(ATTRIBUTE_VARIANT));
+
+			assertTrue(resolved.isPresent(), "The reference matching the representative values must be resolved");
+			assertEquals(
+				"red", resolved.get().value(),
+				"The key targeting the first reference's representative values must resolve that reference"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Attribute value filtering")
+	class AttributeValueFiltering {
+
+		@Test
+		@DisplayName("should exclude a dropped attribute value while returning a present one")
+		void shouldExcludeDroppedAttributeValueFromGetAttributeValue() {
+			final ReferenceSchema referenceSchema = referenceSchema(
+				Cardinality.ZERO_OR_ONE,
+				Map.of(
+					ATTRIBUTE_CODE, attribute(ATTRIBUTE_CODE, false, false),
+					ATTRIBUTE_OLD_CODE, attribute(ATTRIBUTE_OLD_CODE, false, false)
+				)
+			);
+			final Reference reference = reference(
+				referenceSchema, 10, 1, false,
+				attributeValues(
+					new AttributeValue(new AttributeKey(ATTRIBUTE_CODE), "present"),
+					// dropped attribute (tombstone) — version 1, dropped == true
+					new AttributeValue(1, new AttributeKey(ATTRIBUTE_OLD_CODE), "obsolete", true)
+				)
+			);
+			final StubContainerAccessor accessor = new StubContainerAccessor(storagePart(reference));
+			final ExistingAttributeValueSupplier supplier = supplier(
+				accessor, referenceSchema, key(999), key(10)
+			);
+
+			final Optional<AttributeValue> present = supplier.getAttributeValue(new AttributeKey(ATTRIBUTE_CODE));
+			assertTrue(present.isPresent(), "The present attribute value must be returned");
+			assertEquals("present", present.get().value());
+
+			assertTrue(
+				supplier.getAttributeValue(new AttributeKey(ATTRIBUTE_OLD_CODE)).isEmpty(),
+				"A dropped attribute value must not be returned"
+			);
+		}
+
+		@Test
+		@DisplayName("should return only the requested locale's attribute values")
+		void shouldReturnOnlyRequestedLocaleValuesFromGetAttributeValues() {
+			final ReferenceSchema referenceSchema = referenceSchema(
+				Cardinality.ZERO_OR_ONE,
+				Map.of(
+					ATTRIBUTE_LABEL, attribute(ATTRIBUTE_LABEL, true, false),
+					ATTRIBUTE_CODE, attribute(ATTRIBUTE_CODE, false, false)
+				)
+			);
+			final Reference reference = reference(
+				referenceSchema, 10, 1, false,
+				attributeValues(
+					new AttributeValue(new AttributeKey(ATTRIBUTE_LABEL, Locale.ENGLISH), "hello"),
+					new AttributeValue(new AttributeKey(ATTRIBUTE_LABEL, Locale.GERMAN), "hallo"),
+					// a locale-agnostic (global) value that must be excluded by the locale filter
+					new AttributeValue(new AttributeKey(ATTRIBUTE_CODE), "global")
+				)
+			);
+			final StubContainerAccessor accessor = new StubContainerAccessor(storagePart(reference));
+			final ExistingAttributeValueSupplier supplier = supplier(
+				accessor, referenceSchema, key(999), key(10)
+			);
+
+			final List<AttributeValue> englishValues = supplier.getAttributeValues(Locale.ENGLISH).toList();
+
+			assertEquals(1, englishValues.size(), "Only the English value must be returned");
+			assertEquals(Locale.ENGLISH, englishValues.get(0).key().locale());
+			assertEquals("hello", englishValues.get(0).value());
+		}
+	}
+
+	@Nested
+	@DisplayName("Memoization and obsolescence")
+	class Memoization {
+
+		@Test
+		@DisplayName("should re-resolve the reference after the underlying references are replaced")
+		void shouldReResolveReferenceAfterUnderlyingReferencesAreReplaced() {
+			final ReferenceSchema referenceSchema = referenceSchema(
+				Cardinality.ZERO_OR_ONE, Map.of(ATTRIBUTE_CODE, attribute(ATTRIBUTE_CODE, false, false))
+			);
+			final Reference original = reference(
+				referenceSchema, 10, 1, false,
+				attributeValues(new AttributeValue(new AttributeKey(ATTRIBUTE_CODE), "v1"))
+			);
+			final StubContainerAccessor accessor = new StubContainerAccessor(storagePart(original));
+			final ExistingAttributeValueSupplier supplier = supplier(
+				accessor, referenceSchema, key(999), key(10)
+			);
+
+			final Optional<AttributeValue> firstRead = supplier.getAttributeValue(new AttributeKey(ATTRIBUTE_CODE));
+			assertTrue(firstRead.isPresent());
+			assertEquals("v1", firstRead.get().value(), "First read must observe the original reference");
+
+			// replace the underlying references with a fresh storage part holding a replaced reference (same key)
+			final Reference replacement = reference(
+				referenceSchema, 10, 1, false,
+				attributeValues(new AttributeValue(new AttributeKey(ATTRIBUTE_CODE), "v2"))
+			);
+			accessor.setReferencesStoragePart(storagePart(replacement));
+
+			final Optional<AttributeValue> secondRead = supplier.getAttributeValue(new AttributeKey(ATTRIBUTE_CODE));
+			assertTrue(secondRead.isPresent());
+			assertEquals(
+				"v2", secondRead.get().value(),
+				"Second read must re-resolve the replaced reference and not return stale memoized data"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Entity attribute locales")
+	class EntityAttributeLocales {
+
+		@Test
+		@DisplayName("should expose the entity's existing attribute locales")
+		void shouldExposeEntityExistingAttributeLocales() {
+			final ReferenceSchema referenceSchema = referenceSchema(
+				Cardinality.ZERO_OR_ONE, Map.of(ATTRIBUTE_CODE, attribute(ATTRIBUTE_CODE, false, false))
+			);
+			final StubContainerAccessor accessor = new StubContainerAccessor(storagePart());
+			// the entity body carries English + German among its attribute locales
+			accessor.setEntityStoragePart(
+				new EntityBodyStoragePart(
+					1, ENTITY_PK, Scope.LIVE, null,
+					Set.of(), Set.of(Locale.ENGLISH, Locale.GERMAN), Set.of(), -1
+				)
+			);
+			final ExistingAttributeValueSupplier supplier = supplier(
+				accessor, referenceSchema, key(999), key(10)
+			);
+
+			assertEquals(
+				Set.of(Locale.ENGLISH, Locale.GERMAN),
+				supplier.getEntityExistingAttributeLocales(),
+				"The supplier must surface the entity body's attribute locales"
+			);
+		}
+	}
+
+	/**
+	 * Builds a reference schema whose cardinality allows duplicates and that declares a single representative
+	 * attribute ({@link #ATTRIBUTE_VARIANT}). This is the schema flavour under which the supplier disambiguates
+	 * references sharing the same {@link ReferenceKey} by their representative attribute values.
+	 *
+	 * @return a duplicate-cardinality reference schema with one representative attribute
+	 */
+	@Nonnull
+	private static ReferenceSchema duplicateSchema() {
+		return referenceSchema(
+			Cardinality.ZERO_OR_MORE_WITH_DUPLICATES,
+			Map.of(ATTRIBUTE_VARIANT, attribute(ATTRIBUTE_VARIANT, false, true))
+		);
+	}
+
+	/**
+	 * Builds a minimal, non-indexed, non-faceted reference schema named {@link #REFERENCE_NAME} that references an
+	 * unmanaged entity type of the same name.
+	 *
+	 * @param cardinality the cardinality of the reference (drives whether duplicates and representative values apply)
+	 * @param attributes  the reference attribute schemas keyed by attribute name
+	 * @return the constructed reference schema
+	 */
+	@Nonnull
+	private static ReferenceSchema referenceSchema(
+		@Nonnull Cardinality cardinality,
+		@Nonnull Map<String, AttributeSchemaContract> attributes
+	) {
+		return ReferenceSchema._internalBuild(
+			REFERENCE_NAME, NamingConvention.generate(REFERENCE_NAME), null, null,
+			REFERENCE_NAME, NamingConvention.generate(REFERENCE_NAME), false,
+			cardinality, null, null, false,
+			ScopedReferenceIndexType.EMPTY, null,
+			Scope.NO_SCOPE, null, null, null,
+			attributes, Map.of()
+		);
+	}
+
+	/**
+	 * Builds a String-typed reference attribute schema.
+	 *
+	 * @param name           the attribute name
+	 * @param localized      whether the attribute is localized
+	 * @param representative whether the attribute participates in the representative reference key
+	 * @return the constructed attribute schema
+	 */
+	@Nonnull
+	private static AttributeSchemaContract attribute(
+		@Nonnull String name,
+		boolean localized,
+		boolean representative
+	) {
+		return AttributeSchema._internalBuild(
+			name, null, null, null,
+			localized, false, representative,
+			String.class, null
+		);
+	}
+
+	/**
+	 * Builds a {@link Reference} owned by {@link #ENTITY_SCHEMA} and described by the given reference schema.
+	 *
+	 * @param referenceSchema    the schema describing the reference
+	 * @param primaryKey         the referenced entity primary key (business key part)
+	 * @param internalPrimaryKey the internal primary key distinguishing references sharing the same business key
+	 * @param dropped            whether the reference is a dropped tombstone
+	 * @param attributes         the reference attribute values keyed by attribute key
+	 * @return the constructed reference
+	 */
+	@Nonnull
+	private static Reference reference(
+		@Nonnull ReferenceSchema referenceSchema,
+		int primaryKey,
+		int internalPrimaryKey,
+		boolean dropped,
+		@Nonnull Map<AttributeKey, AttributeValue> attributes
+	) {
+		return new Reference(
+			ENTITY_SCHEMA, referenceSchema, 1,
+			new ReferenceKey(REFERENCE_NAME, primaryKey, internalPrimaryKey),
+			null, attributes, dropped
+		);
+	}
+
+	/**
+	 * Wraps the given references into a {@link ReferencesStoragePart} for {@link #ENTITY_PK}. The supplier reads
+	 * references from this container verbatim (no sorting or validation is performed).
+	 *
+	 * @param references the references to expose, in iteration order
+	 * @return the references storage part
+	 */
+	@Nonnull
+	private static ReferencesStoragePart storagePart(@Nonnull Reference... references) {
+		return new ReferencesStoragePart(ENTITY_PK, references.length, references, -1);
+	}
+
+	/**
+	 * Indexes the given attribute values by their key, preserving insertion order.
+	 *
+	 * @param values the attribute values to index
+	 * @return a mutable map of attribute key to attribute value
+	 */
+	@Nonnull
+	private static Map<AttributeKey, AttributeValue> attributeValues(@Nonnull AttributeValue... values) {
+		final Map<AttributeKey, AttributeValue> result = new LinkedHashMap<>(values.length);
+		for (final AttributeValue value : values) {
+			result.put(value.key(), value);
+		}
+		return result;
+	}
+
+	/**
+	 * Builds a {@link RepresentativeReferenceKey} for {@link #REFERENCE_NAME} with the given primary key and
+	 * representative attribute values.
+	 *
+	 * @param primaryKey          the referenced entity primary key
+	 * @param representativeValues the representative attribute values (empty for a non-duplicate schema)
+	 * @return the representative reference key
+	 */
+	@Nonnull
+	private static RepresentativeReferenceKey key(int primaryKey, @Nonnull Serializable... representativeValues) {
+		return new RepresentativeReferenceKey(new ReferenceKey(REFERENCE_NAME, primaryKey), representativeValues);
+	}
+
+	/**
+	 * Constructs the supplier under test bound to the given accessor, schema and keys, targeting
+	 * {@link #ENTITY_TYPE} / {@link #ENTITY_PK}.
+	 *
+	 * @param accessor        the storage container accessor stub
+	 * @param referenceSchema the reference schema
+	 * @param storedKey       the stored representative reference key
+	 * @param currentKey      the current representative reference key
+	 * @return the supplier under test
+	 */
+	@Nonnull
+	private static ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceKeySupplier supplier(
+		@Nonnull StubContainerAccessor accessor,
+		@Nonnull ReferenceSchema referenceSchema,
+		@Nonnull RepresentativeReferenceKey storedKey,
+		@Nonnull RepresentativeReferenceKey currentKey
+	) {
+		return new ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceKeySupplier(
+			accessor, referenceSchema, storedKey, currentKey, ENTITY_TYPE, ENTITY_PK
+		);
+	}
+
+	/**
+	 * Asserts the given stream contains exactly one attribute value with the expected name and value.
+	 *
+	 * @param stream        the stream of attribute values to inspect
+	 * @param attributeName the expected attribute name
+	 * @param expectedValue the expected attribute value
+	 */
+	private static void assertSingleValue(
+		@Nonnull Stream<AttributeValue> stream,
+		@Nonnull String attributeName,
+		@Nonnull Serializable expectedValue
+	) {
+		final List<AttributeValue> values = stream.toList();
+		assertEquals(1, values.size(), "Expected exactly one attribute value");
+		assertEquals(attributeName, values.get(0).key().attributeName());
+		assertEquals(expectedValue, values.get(0).value());
+	}
+
+	/**
+	 * Minimal {@link WritableEntityStorageContainerAccessor} stub for the supplier under test. It returns a chosen
+	 * {@link ReferencesStoragePart} (swappable, to exercise memoization/obsolescence) and an optional
+	 * {@link EntityBodyStoragePart} (needed by the attribute-locales path). Locale-change tracking reports no
+	 * changes. All other operations are unused by the supplier and therefore throw
+	 * {@link UnsupportedOperationException}.
+	 */
+	private static final class StubContainerAccessor implements WritableEntityStorageContainerAccessor {
+		private ReferencesStoragePart referencesStoragePart;
+		@Nullable private EntityBodyStoragePart entityBodyStoragePart;
+
+		StubContainerAccessor(@Nonnull ReferencesStoragePart referencesStoragePart) {
+			this.referencesStoragePart = referencesStoragePart;
+		}
+
+		/**
+		 * Replaces the references container returned to the supplier, simulating an in-session change of the
+		 * entity's references.
+		 *
+		 * @param referencesStoragePart the new references container
+		 */
+		void setReferencesStoragePart(@Nonnull ReferencesStoragePart referencesStoragePart) {
+			this.referencesStoragePart = referencesStoragePart;
+		}
+
+		/**
+		 * Sets the entity body returned by {@link #getEntityStoragePart(String, int, EntityExistence)}.
+		 *
+		 * @param entityBodyStoragePart the entity body storage part
+		 */
+		void setEntityStoragePart(@Nonnull EntityBodyStoragePart entityBodyStoragePart) {
+			this.entityBodyStoragePart = entityBodyStoragePart;
+		}
+
+		@Nonnull
+		@Override
+		public ReferencesStoragePart getReferencesStoragePart(@Nonnull String entityType, int entityPrimaryKey) {
+			return this.referencesStoragePart;
+		}
+
+		@Nonnull
+		@Override
+		public EntityBodyStoragePart getEntityStoragePart(
+			@Nonnull String entityType, int entityPrimaryKey, @Nonnull EntityExistence expects
+		) {
+			return this.entityBodyStoragePart != null
+				? this.entityBodyStoragePart
+				: new EntityBodyStoragePart(entityPrimaryKey);
+		}
+
+		@Nonnull
+		@Override
+		public LocaleWithScope[] getAddedLocales() {
+			return new LocaleWithScope[0];
+		}
+
+		@Nonnull
+		@Override
+		public LocaleWithScope[] getRemovedLocales() {
+			return new LocaleWithScope[0];
+		}
+
+		@Override
+		public int getLocalesIdentityHash() {
+			return 0;
+		}
+
+		@Override
+		public boolean isEntityRemovedEntirely() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void registerAssignedPriceId(int entityPrimaryKey, @Nonnull PriceKey priceKey, int internalPriceId) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Nonnull
+		@Override
+		public OptionalInt findExistingInternalId(
+			@Nonnull String entityType, int entityPrimaryKey, @Nonnull PriceKey priceKey
+		) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Nonnull
+		@Override
+		public AttributesStoragePart getAttributeStoragePart(@Nonnull String entityType, int entityPrimaryKey) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Nonnull
+		@Override
+		public AttributesStoragePart getAttributeStoragePart(
+			@Nonnull String entityType, int entityPrimaryKey, @Nonnull Locale locale
+		) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Nonnull
+		@Override
+		public AssociatedDataStoragePart getAssociatedDataStoragePart(
+			@Nonnull String entityType, int entityPrimaryKey, @Nonnull AssociatedDataKey key
+		) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Nonnull
+		@Override
+		public PricesStoragePart getPriceStoragePart(@Nonnull String entityType, int entityPrimaryKey) {
+			throw new UnsupportedOperationException();
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Reduces allocation churn in the local entity-mutation index path, which dominates GC time during single-threaded WARM_UP bulk upserts (profiled via async-profiler on a large catalog copy).

## Changes

- **`ContainerizedLocalMutationExecutor`** — de-streamed both `collectAttributeKeys` overloads into pre-sized `HashSet` loops and added an early-out in reference-attribute verification when the reference schema has no default-value attributes (the single biggest per-reference allocator).
- **`AttributeIndexMutator`** — de-streamed the sortable-compound suite insert/remove routines (hoisting the loop-invariant value-provider and schema-resolver out of the per-compound loop) and pre-sized the compound value arrays; removed the dead `attributeSchemaProvider` parameter from `removeOldCompound` (leftover from a since-removed undo path).
- **`EntityIndexLocalMutationExecutor`** — replaced attribute-value stream filters with allocation-free enhanced-for loops.
- **`ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceKeySupplier`** — gated the per-reference `RepresentativeReferenceKey` allocation in `getMemoizedReference()` behind a cheap `equalsInGeneral` pre-filter. The original wrapper build and `Objects.equals` comparison are kept verbatim, so the behavior is provably unchanged (a reference the pre-filter skips could never have matched).

## Testing

- New characterization test `ReferenceEntityStoragePartAccessorAttributeValueByRepresentativeReferenceKeySupplierTest` (10 tests) — written before the supplier fix, green on the unmodified engine and after.
- Reference/attribute/compound indexing regression suites green.
- Full `unitAndFunctional` suite: 19,976 tests, 0 failures (the only 6 errors were `parallel=all` gRPC-transport flakes in the networked EvitaClient classes; both classes pass 149/149 when rerun non-parallel).

No behavioral change intended — this is an allocation/GC optimization plus a dead-parameter cleanup.
