### PR TITLE
fix: expose groupHaving in REST/GraphQL reference filter schema

### DIFF
--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/builder/constraint/ConstraintSchemaBuilder.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/builder/constraint/ConstraintSchemaBuilder.java
@@ -371,7 +371,8 @@ public abstract class ConstraintSchemaBuilder<CTX extends ConstraintSchemaBuildi
 			return List.of();
 		}
 
-		final ReferenceSchemaContract referenceSchema = this.sharedContext.getEntitySchemaOrThrowException(parentDataLocator.entityType())
+		final ReferenceSchemaContract referenceSchema = this.sharedContext
+			.getEntitySchemaOrThrowException(parentDataLocator.entityType())
 			.getReferenceOrThrowException(dataLocatorWithReference.referenceName());
 		final String referencedGroupType = referenceSchema.getReferencedGroupType();
 		if (referencedGroupType == null) {

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/builder/constraint/ConstraintSchemaBuilder.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/builder/constraint/ConstraintSchemaBuilder.java
@@ -358,6 +358,42 @@ public abstract class ConstraintSchemaBuilder<CTX extends ConstraintSchemaBuildi
 
 	/**
 	 * Builds fields representing children of constraint container from constraint descriptors of these children.
+	 * This is shortcut method for building all children of {@link ConstraintPropertyType#GROUP} property type.
+	 * Unlike {@link #buildEntityChildren}, there's no root-level fallback: a GROUP-typed constraint only makes
+	 * sense when nested in a reference/facet scope whose reference schema actually declares a group type.
+	 */
+	@Nonnull
+	protected List<OBJECT_FIELD> buildGroupChildren(@Nonnull ConstraintBuildContext buildContext,
+	                                                @Nonnull AllowedConstraintPredicate allowedChildrenPredicate) {
+		final DataLocator parentDataLocator = buildContext.dataLocator();
+		if (!(parentDataLocator instanceof final DataLocatorWithReference dataLocatorWithReference) ||
+			dataLocatorWithReference.referenceName() == null) {
+			return List.of();
+		}
+
+		final ReferenceSchemaContract referenceSchema = this.sharedContext.getEntitySchemaOrThrowException(parentDataLocator.entityType())
+			.getReferenceOrThrowException(dataLocatorWithReference.referenceName());
+		final String referencedGroupType = referenceSchema.getReferencedGroupType();
+		if (referencedGroupType == null) {
+			// the reference has no group type configured, so there's no group entity to filter/order/require by
+			return List.of();
+		}
+
+		final DataLocator childDataLocator = new EntityDataLocator(
+			referenceSchema.isReferencedGroupTypeManaged()
+				? new ManagedEntityTypePointer(referencedGroupType)
+				: new ExternalEntityTypePointer(referencedGroupType)
+		);
+
+		return buildBasicChildren(
+			buildContext.switchToChildContext(childDataLocator),
+			allowedChildrenPredicate,
+			ConstraintPropertyType.GROUP
+		);
+	}
+
+	/**
+	 * Builds fields representing children of constraint container from constraint descriptors of these children.
 	 * This is shortcut method for building all children of {@link ConstraintPropertyType#ATTRIBUTE} property type.
 	 */
 	@Nonnull

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/constraint/GraphQLConstraintSchemaBuilder.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/constraint/GraphQLConstraintSchemaBuilder.java
@@ -101,6 +101,7 @@ public abstract class GraphQLConstraintSchemaBuilder extends ConstraintSchemaBui
 		final List<GraphQLInputObjectField> children = new LinkedList<>();
 		children.addAll(buildGenericChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildEntityChildren(buildContext, allowedChildrenPredicate));
+		children.addAll(buildGroupChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildAttributeChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildAssociatedDataChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildPriceChildren(buildContext, allowedChildrenPredicate));

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/builder/constraint/OpenApiConstraintSchemaBuilder.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/builder/constraint/OpenApiConstraintSchemaBuilder.java
@@ -103,6 +103,7 @@ public abstract class OpenApiConstraintSchemaBuilder
 		final List<OpenApiProperty> children = new LinkedList<>();
 		children.addAll(buildGenericChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildEntityChildren(buildContext, allowedChildrenPredicate));
+		children.addAll(buildGroupChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildAttributeChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildAssociatedDataChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildPriceChildren(buildContext, allowedChildrenPredicate));

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLQueryEntityQueryFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLQueryEntityQueryFunctionalTest.java
@@ -9804,6 +9804,101 @@ public class CatalogGraphQLQueryEntityQueryFunctionalTest extends CatalogGraphQL
 
 	@Test
 	@UseDataSet(GRAPHQL_THOUSAND_PRODUCTS)
+	@DisplayName("Should narrow results via groupHaving nested in the generic referenceParameterHaving container")
+	void shouldApplyGroupHavingInReferenceHaving(Evita evita, GraphQLTester tester, List<SealedEntity> originalProductEntities) {
+		// Regression: the schema builder never generated the GROUP constraint slot for generic
+		// referenceXxxHaving/facetXxxHaving containers — only histogramHaving's own dedicated
+		// groupSelector slot worked. This exercises groupHaving nested in referenceParameterHaving.
+		final SealedEntity sampleProduct = originalProductEntities.stream()
+			.filter(it -> it.getReferences(Entities.PARAMETER).stream()
+				.anyMatch(reference -> reference.getGroup().isPresent()))
+			.findFirst()
+			.orElseThrow();
+		final ReferenceContract sampleParameterReference = sampleProduct.getReferences(Entities.PARAMETER)
+			.stream()
+			.filter(reference -> reference.getGroup().isPresent())
+			.findFirst()
+			.orElseThrow();
+		final int groupPk = sampleParameterReference.getGroup().orElseThrow().getPrimaryKey();
+		final String groupCode = evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				return session.getEntity(Entities.PARAMETER_GROUP, groupPk, attributeContent(ATTRIBUTE_CODE));
+			}
+		).orElseThrow().getAttribute(ATTRIBUTE_CODE);
+		assertNotNull(groupCode, "sampled parameter group must carry a code — fixture sanity check");
+
+		final EvitaResponse<EntityReference> baselineResponse = evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				return session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							referenceHaving(
+								Entities.PARAMETER,
+								groupHaving(attributeEquals(ATTRIBUTE_CODE, groupCode))
+							)
+						),
+						require(page(1, 1))
+					),
+					EntityReference.class
+				);
+			}
+		);
+		final int expectedCount = baselineResponse.getTotalRecordCount();
+		assertTrue(expectedCount > 0, "baseline query must match at least the sample product — fixture sanity check");
+
+		final EvitaResponse<EntityReference> catalogWideResponse = evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				return session.query(
+					query(collection(Entities.PRODUCT), require(page(1, 1))),
+					EntityReference.class
+				);
+			}
+		);
+		final int catalogWideProductCount = catalogWideResponse.getTotalRecordCount();
+		assertTrue(expectedCount < catalogWideProductCount,
+			"groupHaving must strictly narrow the result set (got " + expectedCount +
+				" with the group filter vs " + catalogWideProductCount + " catalog-wide)");
+
+		tester.test(TEST_CATALOG)
+			.document(
+				"""
+					query {
+						queryProduct(
+							filterBy: {
+								referenceParameterHaving: [
+									{
+										groupHaving: {
+											attributeCodeEquals: "%s"
+										}
+									}
+								]
+							}
+						) {
+							recordPage(size: %d) {
+								totalRecordCount
+							}
+						}
+					}
+					""",
+				groupCode,
+				Integer.MAX_VALUE
+			)
+			.executeAndThen()
+			.statusCode(200)
+			.body(ERRORS_PATH, nullValue())
+			.body(
+				PRODUCT_QUERY_PATH + "." + ResponseDescriptor.RECORD_PAGE.name() + "." +
+					DataChunkDescriptor.TOTAL_RECORD_COUNT.name(),
+				equalTo(expectedCount)
+			);
+	}
+
+	@Test
+	@UseDataSet(GRAPHQL_THOUSAND_PRODUCTS)
 	@DisplayName("Should return error for reference summary with histogram statistics for non-bucketed reference for products")
 	void shouldReturnErrorForReferenceSummaryWithHistogramStatisticsForNonBucketedReferenceForProducts(Evita evita, GraphQLTester tester) {
 		tester.test(TEST_CATALOG)

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/CatalogRestQueryEntityQueryFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/rest/api/catalog/dataApi/CatalogRestQueryEntityQueryFunctionalTest.java
@@ -42,6 +42,7 @@ import io.evitadb.api.requestResponse.data.EntityContract;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
 import io.evitadb.api.requestResponse.data.PriceRangeForSale;
+import io.evitadb.api.requestResponse.data.ReferenceContract;
 import io.evitadb.api.requestResponse.data.SealedEntity;
 import io.evitadb.api.requestResponse.data.structure.EntityReference;
 import io.evitadb.api.requestResponse.extraResult.AttributeHistogram;
@@ -102,6 +103,7 @@ import static io.evitadb.utils.AssertionUtils.assertSortedResultEquals;
 import static io.evitadb.utils.MapBuilder.map;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.evitadb.test.TestTags.REST;
 import static io.evitadb.test.TestTags.EXTERNAL_API;
@@ -4906,6 +4908,90 @@ class CatalogRestQueryEntityQueryFunctionalTest extends CatalogRestDataEndpointF
 				resultPath(ResponseDescriptor.EXTRA_RESULTS, ExtraResultsDescriptor.REFERENCE_SUMMARY) +
 					".parameter.findAll { it.histogramStatistics?.priceIndex?.min != null }.size()",
 				greaterThan(0)
+			);
+	}
+
+	@Test
+	@UseDataSet(REST_THOUSAND_PRODUCTS)
+	@DisplayName("Should narrow results via groupHaving nested in the generic referenceParameterHaving container")
+	void shouldApplyGroupHavingInReferenceHaving(Evita evita, RestTester tester, List<SealedEntity> originalProductEntities) {
+		// Regression: the schema builder never generated the GROUP constraint slot for generic
+		// referenceXxxHaving/facetXxxHaving containers — only histogramHaving's own dedicated
+		// groupSelector slot worked. This exercises groupHaving nested in referenceParameterHaving.
+		final SealedEntity sampleProduct = originalProductEntities.stream()
+			.filter(it -> it.getReferences(Entities.PARAMETER).stream()
+				.anyMatch(reference -> reference.getGroup().isPresent()))
+			.findFirst()
+			.orElseThrow();
+		final ReferenceContract sampleParameterReference = sampleProduct.getReferences(Entities.PARAMETER)
+			.stream()
+			.filter(reference -> reference.getGroup().isPresent())
+			.findFirst()
+			.orElseThrow();
+		final int groupPk = sampleParameterReference.getGroup().orElseThrow().getPrimaryKey();
+		final String groupCode = evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				return session.getEntity(Entities.PARAMETER_GROUP, groupPk, attributeContent(ATTRIBUTE_CODE));
+			}
+		).orElseThrow().getAttribute(ATTRIBUTE_CODE);
+		assertNotNull(groupCode, "sampled parameter group must carry a code — fixture sanity check");
+
+		final EvitaResponse<EntityClassifier> baselineResponse = queryEntities(
+			evita,
+			query(
+				collection(Entities.PRODUCT),
+				filterBy(
+					referenceHaving(
+						Entities.PARAMETER,
+						groupHaving(attributeEquals(ATTRIBUTE_CODE, groupCode))
+					)
+				),
+				require(page(1, 1))
+			)
+		);
+		final int expectedCount = baselineResponse.getTotalRecordCount();
+		assertTrue(expectedCount > 0, "baseline query must match at least the sample product — fixture sanity check");
+
+		final EvitaResponse<EntityClassifier> catalogWideResponse = queryEntities(
+			evita,
+			query(collection(Entities.PRODUCT), require(page(1, 1)))
+		);
+		assertTrue(expectedCount < catalogWideResponse.getTotalRecordCount(),
+			"groupHaving must strictly narrow the result set (got " + expectedCount +
+				" with the group filter vs " + catalogWideResponse.getTotalRecordCount() + " catalog-wide)");
+
+		tester.test(TEST_CATALOG)
+			.urlPathSuffix("/PRODUCT/query")
+			.httpMethod(Request.METHOD_POST)
+			.requestBody(
+				"""
+					{
+						"filterBy": {
+							"referenceParameterHaving": [
+								{
+									"groupHaving": {
+										"attributeCodeEquals": "%s"
+									}
+								}
+							]
+						},
+						"require": {
+							"page": {
+								"number": 1,
+								"size": %d
+							}
+						}
+					}
+					""",
+				groupCode,
+				Integer.MAX_VALUE
+			)
+			.executeAndThen()
+			.statusCode(200)
+			.body(
+				resultPath(ResponseDescriptor.RECORD_PAGE) + ".totalRecordCount",
+				equalTo(expectedCount)
 			);
 	}
 


### PR DESCRIPTION
## Summary
- `ConstraintSchemaBuilder` (shared by the REST and GraphQL constraint-schema builders) never built `ConstraintPropertyType.GROUP` children, so `groupHaving` was silently absent from every generic `referenceXxxHaving`/`facetXxxHaving` filter container - even for references with a configured group type. It only worked inside `HistogramHaving`'s own dedicated child slot.
- Added `buildGroupChildren` mirroring the existing `buildEntityChildren`, and wired it into both `GraphQLConstraintSchemaBuilder.buildContainer` and `OpenApiConstraintSchemaBuilder.buildContainer`.
- Found while investigating a failing documentation example (`group-having.rest`/`group-having.graphql`) that used the constraint's pre-fix wire name `entityGroupHaving`; after correcting the docs to the current name `groupHaving` (separate docs commit on `dev`), the query still failed with "field not in FilterContainer", which led to this root cause.

## Test plan
- [x] `mvn compile` on `evita_external_api_core`, `evita_external_api_graphql`, `evita_external_api_rest` - builds clean
- [ ] Re-run the `group-having.rest`/`group-having.graphql` documentation examples once this ships to confirm they go green
- [x] Add a dedicated REST/GraphQL functional test asserting `groupHaving` appears in the filter schema for a group-typed reference