### PR TITLE
perf/fix: upsert allocation cuts + transactional-structure and gRPC-session hardening

### DIFF
--- a/documentation/user/cs/use/connectors/java.md
+++ b/documentation/user/cs/use/connectors/java.md
@@ -120,6 +120,30 @@ Nastavení spojení se konfiguruje přes
         <p>Identifikace portu serveru, na kterém běží system API evitaDB. System API slouží k automatickému nastavení klientského certifikátu pro mTLS nebo ke stažení self-signed certifikátu serveru.
         Viz [Konfigurace a principy TLS](../../operate/tls.md). System API není vyžadováno, pokud server používá důvěryhodný certifikát a mTLS je vypnuté, nebo pokud je privátní/veřejný klíč serveru/klienta distribuován „ručně“ s klientem.</p>
     </dd>
+    <dt>pingIntervalMillis</dt>
+    <dd>
+        <p>**Výchozí: `30000` (30 s)**</p>
+        <p>Interval HTTP/2 keep-alive PING v milisekundách. Pokud na spojení po tuto dobu neproběhne žádný provoz,
+        klient odešle PING; pokud ho protistrana ve stejném intervalu nepotvrdí, je spojení uzavřeno. Interval je
+        tedy *rozpočet na zaseknutí* — musí s rezervou překročit nejdelší tolerovatelnou pauzu způsobenou GC či
+        vytížením CPU, nikoli být frekvencí sondování, jinak může být pomalé, ale živé volání předčasně zabito.
+        Hodnota `0` PING klienta zcela vypne (spojení je pak uklizeno pouze na základě `idleTimeoutMillis`); jakákoli
+        jiná hodnota musí být alespoň `1000` ms. PING musí zůstat striktně pod hodnotou `idleTimeoutMillis`, jinak
+        ho podkladový HTTP klient tiše vypne — výchozí dvojice (`30000` PING, `300000` idle) tuto podmínku splňuje
+        a klient zaloguje varování, pokud ji vlastní dvojice poruší.</p>
+    </dd>
+    <dt>idleTimeoutMillis</dt>
+    <dd>
+        <p>**Výchozí: `300000` (300 s)**</p>
+        <p>Jak dlouho může spojení ze sdíleného poolu zůstat bez aplikačního provozu, než je uzavřeno. Tato hodnota
+        je záměrně **oddělena od časového limitu jednotlivého volání (`timeout`)**: krátký časový limit požadavku
+        nesmí vynutit zbourání a znovunavázání fyzického spojení mezi voláními. Výchozích 300 s leží s rezervou nad
+        30s PINGem, takže keep-alive hlídač zůstává aktivní a zdravá spojení jsou udržována „teplá“ — potvrzené PINGy
+        se počítají jako provoz, takže živé spojení nikdy nevyprší nečinností, zatímco mrtvá protistrana je odhalena
+        do jednoho intervalu PINGu. Hodnota `0` časový limit nečinnosti zcela vypne (spojení pak žije, dokud ho
+        neuzavře protistrana, selhání PINGu nebo pool spojení). Udržujte tuto hodnotu striktně nad
+        `pingIntervalMillis`.</p>
+    </dd>
 </dl>
 
 #### Možnosti TLS

--- a/documentation/user/en/use/connectors/java.md
+++ b/documentation/user/en/use/connectors/java.md
@@ -130,6 +130,30 @@ Connection settings are configured via
         a trusted certificate and mTLS is disabled, or the server / client's private/public key pair is distributed
         "manually" with the client.</p>
     </dd>
+    <dt>pingIntervalMillis</dt>
+    <dd>
+        <p>**Default: `30000` (30 s)**</p>
+        <p>The HTTP/2 keep-alive PING interval in milliseconds. When the connection sees no traffic for this long,
+        the client sends a PING; if the peer does not acknowledge it within the same interval, the connection is
+        closed. The interval is therefore the *stall budget* — it must comfortably exceed the worst tolerable
+        GC / CPU-starvation pause, not act as a probe frequency, otherwise a slow-but-alive call may be killed
+        mid-flight. Set `0` to disable the client ping entirely (the connection is then reaped by
+        `idleTimeoutMillis` alone); any other value must be at least `1000` ms. The ping must stay strictly below
+        `idleTimeoutMillis`, otherwise the underlying HTTP client silently disables it — the default pair
+        (`30000` ping, `300000` idle) satisfies this, and the client logs a warning if a custom pair does not.</p>
+    </dd>
+    <dt>idleTimeoutMillis</dt>
+    <dd>
+        <p>**Default: `300000` (300 s)**</p>
+        <p>How long a pooled connection may sit with no application traffic before it is closed. This is deliberately
+        **decoupled from the per-call `timeout`** (see [Timeout options](#timeout-options)): a short request deadline
+        must not force the physical connection to be torn down and re-established between calls. The default of
+        300 s sits comfortably above the 30 s ping, so the keep-alive watchdog stays active and healthy connections
+        are kept warm — acknowledged pings count as activity, so a live connection never idles out, while a dead
+        peer is detected within one ping interval. Set `0` to disable the idle timeout entirely (the connection then
+        lives until closed by the peer, a ping failure, or the connection pool). Keep this value strictly above
+        `pingIntervalMillis`.</p>
+    </dd>
 </dl>
 
 #### TLS options

--- a/evita_api/src/main/java/io/evitadb/api/configuration/ServerOptions.java
+++ b/evita_api/src/main/java/io/evitadb/api/configuration/ServerOptions.java
@@ -24,7 +24,6 @@
 package io.evitadb.api.configuration;
 
 import io.evitadb.api.EvitaSessionContract;
-import io.evitadb.api.requestResponse.data.DevelopmentConstants;
 import io.evitadb.api.requestResponse.data.EntityContract;
 import lombok.ToString;
 
@@ -55,10 +54,6 @@ import javax.annotation.Nullable;
  * @param readOnly                              Starts the database in full read-only mode, prohibiting write operations
  *                                              on `EntityContract` level and open read-write `EvitaSessionContract`.
  * @param quiet                                 If true, all output to the system console is suppressed.
- * @param directExecutor                        Undocumented internal option that allows to use direct executor for
- *                                              the request thread pool and scheduler. It avoids using asynchronous
- *                                              execution and instead runs tasks directly in the calling thread, which
- *                                              makes tests more predictable and easier to debug.
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public record ServerOptions(
@@ -71,15 +66,15 @@ public record ServerOptions(
 	@Nonnull ChangeDataCaptureOptions changeDataCapture,
 	@Nonnull TrafficRecordingOptions trafficRecording,
 	boolean readOnly,
-	boolean quiet,
-	boolean directExecutor
+	boolean quiet
 ) {
 	public static final long DEFAULT_QUERY_TIMEOUT_IN_MILLISECONDS = 5000L;
+	/** Default read-write transaction timeout: 5 minutes (`300 * 1000` ms). */
 	public static final long DEFAULT_TRANSACTION_TIMEOUT_IN_MILLISECONDS = 300 * 1000L;
+	/** Default idle-session auto-close threshold: 20 minutes (`60 * 20` seconds). */
 	public static final int DEFAULT_CLOSE_SESSIONS_AFTER_SECONDS_OF_INACTIVITY = 60 * 20;
 	public static final boolean DEFAULT_READ_ONLY = false;
 	public static final boolean DEFAULT_QUIET = false;
-	public static final boolean DEFAULT_DIRECT_EXECUTOR = DevelopmentConstants.isTestRun();
 
 	/**
 	 * Builder for the server options. Recommended to use to avoid binary compatibility problems in the future.
@@ -95,6 +90,11 @@ public record ServerOptions(
 		return new Builder(serverOptions);
 	}
 
+	/**
+	 * Canonical constructor that normalizes optional inputs: any `null` thread-pool, change-data-capture, or
+	 * traffic-recording component is replaced with its default build, so the resulting record never holds a
+	 * `null` component.
+	 */
 	public ServerOptions(
 		@Nullable ThreadPoolOptions requestThreadPool,
 		@Nullable ThreadPoolOptions transactionThreadPool,
@@ -105,8 +105,7 @@ public record ServerOptions(
 		@Nullable ChangeDataCaptureOptions changeDataCapture,
 		@Nullable TrafficRecordingOptions trafficRecording,
 		boolean readOnly,
-		boolean quiet,
-		boolean directExecutor
+		boolean quiet
 	) {
 		this.requestThreadPool = requestThreadPool == null ? ThreadPoolOptions.requestThreadPoolBuilder().build() : requestThreadPool;
 		this.transactionThreadPool = transactionThreadPool == null ? ThreadPoolOptions.transactionThreadPoolBuilder().build() : transactionThreadPool;
@@ -118,7 +117,6 @@ public record ServerOptions(
 		this.trafficRecording = trafficRecording == null ? TrafficRecordingOptions.builder().build() : trafficRecording;
 		this.readOnly = readOnly;
 		this.quiet = quiet;
-		this.directExecutor = directExecutor;
 	}
 
 	public ServerOptions() {
@@ -132,8 +130,7 @@ public record ServerOptions(
 			ChangeDataCaptureOptions.builder().build(),
 			TrafficRecordingOptions.builder().build(),
 			DEFAULT_READ_ONLY,
-			DEFAULT_QUIET,
-			DEFAULT_DIRECT_EXECUTOR
+			DEFAULT_QUIET
 		);
 	}
 
@@ -241,8 +238,7 @@ public record ServerOptions(
 				this.changeDataCapture,
 				this.trafficRecording,
 				this.readOnly,
-				this.quiet,
-				DEFAULT_DIRECT_EXECUTOR
+				this.quiet
 			);
 		}
 

--- a/evita_api/src/main/java/io/evitadb/api/exception/ConcurrentSessionAccessException.java
+++ b/evita_api/src/main/java/io/evitadb/api/exception/ConcurrentSessionAccessException.java
@@ -1,0 +1,81 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.exception;
+
+import io.evitadb.exception.EvitaInvalidUsageException;
+
+import javax.annotation.Nonnull;
+import java.io.Serial;
+import java.util.UUID;
+
+/**
+ * Exception thrown when a single evitaDB session is invoked concurrently from more than one thread.
+ *
+ * `EvitaSession` is `@NotThreadSafe` by contract — a session maintains mutable, unsynchronized
+ * state (open transaction, warm-up index trees, buffers) that a second thread entering while the
+ * first is still inside would corrupt silently. Rather than counting concurrent invocations and
+ * letting the data race proceed, evitaDB rejects the second thread's call immediately and loudly.
+ * This matches the defensive-design rule: an unexpected state must surface at runtime, never be
+ * silently absorbed.
+ *
+ * **Typical Causes:**
+ * - Sharing one session instance across multiple threads (e.g. issuing upserts from a thread pool
+ *   over a single warm-up session during a bulk reindex)
+ * - A driver- or application-level retry of a timed-out call that runs concurrently with the
+ *   still executing original call on the same session
+ *
+ * **Resolution:**
+ * - Use a separate session per thread — sessions are cheap to open and close
+ * - Serialize access to a shared session so that at most one call is in flight at any moment
+ * - Ensure a timed-out call has fully finished (or the session has been closed) before retrying it
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class ConcurrentSessionAccessException extends EvitaInvalidUsageException {
+	@Serial private static final long serialVersionUID = -3502787329552563863L;
+
+	/**
+	 * Creates a new exception indicating that a session was accessed concurrently from two threads.
+	 *
+	 * @param sessionId           the id of the session that was accessed concurrently
+	 * @param owningThreadName    the name of the thread that currently owns (is executing on) the
+	 *                            session
+	 * @param intrudingThreadName the name of the thread whose concurrent call was rejected
+	 */
+	public ConcurrentSessionAccessException(
+		@Nonnull UUID sessionId,
+		@Nonnull String owningThreadName,
+		@Nonnull String intrudingThreadName
+	) {
+		super(
+			"Session `" + sessionId + "` is being used concurrently by more than one thread: " +
+				"thread `" + intrudingThreadName + "` attempted a call while thread `" +
+				owningThreadName + "` is still executing on it. An evitaDB session is not " +
+				"thread-safe - use a separate session per thread, or serialize access so that at " +
+				"most one call is in flight at any moment. If this is a retry of a timed-out call, " +
+				"make sure the original call has finished (or close the session) before retrying."
+		);
+	}
+
+}

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/Attributes.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/Attributes.java
@@ -314,6 +314,24 @@ public abstract class Attributes<S extends AttributeSchemaContract> implements A
 	}
 
 	/**
+	 * Returns TRUE when an existing (non-dropped) attribute value is stored under the exact passed
+	 * key. This is an allocation-free membership probe performing a single map lookup: it is
+	 * equivalent to testing whether the key is contained in the set of existing attribute keys (see
+	 * the `exists()` filtering done when that key set is built), but without materializing that set -
+	 * which matters on the hot mutation path where mandatory / default-valued attributes are verified
+	 * per reference. Unlike {@link #getAttributeValue(AttributeKey)} this does not validate the
+	 * attribute against the schema (no lookup, no exception, no `Optional` allocation); the caller is
+	 * expected to probe keys derived from the schema itself.
+	 *
+	 * @param attributeKey the attribute key to test, must not be null
+	 * @return TRUE if an existing (non-dropped) attribute value is stored under the given key
+	 */
+	public boolean isAttributeValuePresentAndExists(@Nonnull AttributeKey attributeKey) {
+		final AttributeValue value = this.attributeValues.get(attributeKey);
+		return value != null && value.exists();
+	}
+
+	/**
 	 * Returns collection of all values present in this object.
 	 */
 	@Nonnull

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/Reference.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/structure/Reference.java
@@ -298,6 +298,21 @@ public class Reference implements ReferenceContract {
 		return this.referenceKey;
 	}
 
+	/**
+	 * Delegates to {@link Attributes#isAttributeValuePresentAndExists(AttributeKey)} - an
+	 * allocation-free probe for the presence of an existing (non-dropped) attribute value under the
+	 * given key on this reference. This is not part of the {@link AttributesContract} surface
+	 * delegated via Lombok, so it is declared explicitly here to guarantee the fast, set-free
+	 * membership test used when verifying mandatory / default-valued reference attributes.
+	 *
+	 * @param attributeKey the attribute key to test, must not be null
+	 * @return TRUE if an existing (non-dropped) attribute value is stored under the given key on
+	 * this reference
+	 */
+	public boolean isAttributeValuePresentAndExists(@Nonnull AttributeKey attributeKey) {
+		return this.attributes.isAttributeValuePresentAndExists(attributeKey);
+	}
+
 	@Nonnull
 	@Override
 	public Optional<SealedEntity> getReferencedEntity() {

--- a/evita_common/src/main/java/io/evitadb/comparator/CollationKeyCache.java
+++ b/evita_common/src/main/java/io/evitadb/comparator/CollationKeyCache.java
@@ -1,0 +1,191 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.comparator;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serial;
+import java.io.Serializable;
+import java.text.CollationKey;
+import java.text.Collator;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Bounded, process-wide cache of {@link CollationKey} byte forms, shared by all
+ * {@link LocalizedStringComparator} instances created for the same {@link Locale}.
+ *
+ * Rationale: `Collator.compare` re-runs the full collation-element machinery on both operands on
+ * every call (hundreds of nanoseconds to tens of microseconds plus kilobytes of allocation per
+ * comparison on realistic e-commerce corpora), while comparing two pre-computed collation-key byte
+ * arrays as unsigned bytes costs about ten nanoseconds, allocates nothing, and is guaranteed by the
+ * {@link CollationKey} contract to produce the identical total order. Index write paths
+ * compare the same probe and pivot values over and over (binary-search midpoints, B+ tree
+ * separators), so a small cache converts almost all collation work into plain byte comparisons.
+ *
+ * Design notes:
+ *
+ * - **per-locale static registry** - comparator instances are numerous (one per localized attribute
+ *   index), and the key form is a pure function of (locale rules, string): sharing one cache per
+ *   locale maximizes the hit rate, bounds total memory to `locales × slots` entries and makes
+ *   invalidation unnecessary (entries never become stale);
+ * - **2-way direct-mapped, replace-on-collision** - no LRU bookkeeping, no locks; the secondary
+ *   slot (derived from the upper hash bits) prevents two hot values that collide on the primary
+ *   slot from evicting each other on every access;
+ * - **immutable entries, benign races** - {@link CachedKey} is a record (all fields final), so a
+ *   racy read of a concurrently published entry is safe under the JMM final-field guarantee; the
+ *   worst outcome of a lost concurrent write is a redundant recomputation;
+ * - **per-thread collators** - `RuleBasedCollator.getCollationKey` is `synchronized`, therefore
+ *   each thread computes keys on its own {@link Collator} instance, keeping cache misses
+ *   monitor-free under concurrent indexing;
+ * - **memory bound** - `slots` entries per locale (default 8192, roughly 2 MB warm for typical
+ *   attribute value lengths), created lazily only for locales that actually collate; the system
+ *   property `evita.collationKeyCache.size` resizes the cache (values round down to a power of
+ *   two) and `0` disables it entirely, making comparators delegate straight to
+ *   {@link Collator#compare(String, String)}.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+final class CollationKeyCache implements Serializable {
+	@Serial private static final long serialVersionUID = 2359981769309770696L;
+
+	/**
+	 * Name of the system property controlling the per-locale slot count.
+	 */
+	static final String SIZE_PROPERTY = "evita.collationKeyCache.size";
+	/**
+	 * Registry of per-locale caches; populated lazily, never evicted (the locale count is bounded
+	 * by the catalog schemas).
+	 */
+	private static final ConcurrentHashMap<Locale, CollationKeyCache> INSTANCES = new ConcurrentHashMap<>(8);
+	/**
+	 * Number of slots per locale resolved once at class load; zero disables caching.
+	 */
+	private static final int SIZE = resolveSize();
+
+	/**
+	 * Cached entries; elements are written with plain stores (see the class javadoc on benign
+	 * races) and are either null or fully initialized immutable records.
+	 */
+	@Nonnull private final CachedKey[] slots;
+	/**
+	 * Bit mask selecting a slot index from a hash (`SIZE - 1`).
+	 */
+	private final int mask;
+	/**
+	 * Per-thread collator of this cache's locale used to compute keys on cache misses.
+	 */
+	@SuppressWarnings("TransientFieldNotInitialized")
+	@Nonnull private final transient ThreadLocal<Collator> collator;
+
+	/**
+	 * Returns the shared cache for `locale`, or null when caching is disabled by configuration.
+	 *
+	 * @param locale locale whose default collator order the cache serves
+	 * @return shared cache instance, or null when the cache is disabled
+	 */
+	@Nullable
+	static CollationKeyCache forLocale(@Nonnull Locale locale) {
+		return SIZE <= 0 ? null : INSTANCES.computeIfAbsent(locale, CollationKeyCache::new);
+	}
+
+	/**
+	 * Resolves the configured per-locale slot count, rounding down to a power of two so that slot
+	 * selection can use bit masking, and capping it to keep the worst-case footprint sane.
+	 *
+	 * @return slot count per locale; zero when caching is disabled
+	 */
+	private static int resolveSize() {
+		final int configured = Integer.getInteger(SIZE_PROPERTY, 8192);
+		return configured <= 0 ? 0 : Integer.highestOneBit(Math.min(configured, 1 << 20));
+	}
+
+	/**
+	 * Creates the cache for a single locale; invoked lazily through {@link #forLocale(Locale)}.
+	 *
+	 * @param locale locale whose default collator order this cache serves
+	 */
+	private CollationKeyCache(@Nonnull Locale locale) {
+		this.slots = new CachedKey[SIZE];
+		this.mask = SIZE - 1;
+		// Collator.getInstance returns a fresh clone per call, so each thread gets its own instance
+		this.collator = ThreadLocal.withInitial(() -> Collator.getInstance(locale));
+	}
+
+	/**
+	 * Returns the collation-key byte form of `value` under this cache's locale, computing and
+	 * caching it when absent. Unsigned lexicographic order of the returned arrays (i.e.
+	 * `Arrays.compareUnsigned`) equals {@link Collator#compare(String, String)} of the source
+	 * strings for the same locale.
+	 *
+	 * @param value string to resolve
+	 * @return collation-key bytes defining the value's position in the locale's total order
+	 */
+	@Nonnull
+	byte[] keyFor(@Nonnull String value) {
+		final int hash = value.hashCode();
+		final int primary = hash & this.mask;
+		final CachedKey primaryEntry = this.slots[primary];
+		// the `value == ...` reference check is a deliberate fast path, not dead code: on the
+		// common identity hit (the same probe/pivot String recurs across binary-search and B+ tree
+		// steps, see class javadoc) it returns without entering String.equals at all. IntelliJ
+		// reports it as an "unnecessary part of condition" because reference identity implies
+		// equals(), so the `==` operand cannot change the boolean result - but it is kept because
+		// it changes the cost.
+		//noinspection StringEquality,ConditionCoveredByFurtherCondition
+		if (primaryEntry != null && (primaryEntry.value == value || primaryEntry.value.equals(value))) {
+			return primaryEntry.key;
+		}
+		final int secondary = (hash >>> 16) & this.mask;
+		final CachedKey secondaryEntry = this.slots[secondary];
+		// intentional identity fast path (see the note on the primary slot above)
+		//noinspection StringEquality,ConditionCoveredByFurtherCondition
+		if (secondaryEntry != null && (secondaryEntry.value == value || secondaryEntry.value.equals(value))) {
+			return secondaryEntry.key;
+		}
+		final byte[] key = this.collator.get().getCollationKey(value).toByteArray();
+		// prefer filling an empty way; when both ways are occupied displace the primary slot - the
+		// secondary way then shields the displaced value's competitor from ping-pong eviction
+		if (primaryEntry == null || secondaryEntry != null) {
+			this.slots[primary] = new CachedKey(value, key);
+		} else {
+			this.slots[secondary] = new CachedKey(value, key);
+		}
+		return key;
+	}
+
+	/**
+	 * Immutable (value, collation key) pair; record finality guarantees safe publication even when
+	 * the {@link #slots} elements are written without synchronization.
+	 *
+	 * @param value the source string
+	 * @param key   its collation-key byte form
+	 */
+	private record CachedKey(
+		@Nonnull String value,
+		@Nonnull byte[] key
+	) implements Serializable {
+	}
+
+}

--- a/evita_common/src/main/java/io/evitadb/comparator/LocalizedStringComparator.java
+++ b/evita_common/src/main/java/io/evitadb/comparator/LocalizedStringComparator.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2025
+ *   Copyright (c) 2023-2026
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -23,32 +23,82 @@
 
 package io.evitadb.comparator;
 
-import lombok.RequiredArgsConstructor;
-
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.Serial;
 import java.io.Serializable;
+import java.text.CollationKey;
 import java.text.Collator;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Locale;
 
 /**
  * This comparator compares two strings with respect to national characters.
  *
+ * When constructed with a {@link Locale}, ordering decisions are served by the shared
+ * {@link CollationKeyCache}: both operands resolve to their {@link CollationKey} byte
+ * form (computed at most once per distinct hot value, then reused) and are compared as unsigned
+ * bytes, which yields exactly the same total order as {@link Collator#compare(String, String)} for
+ * that locale at a fraction of the CPU and allocation cost. This path dominates localized-attribute
+ * index maintenance, because both hot B+ tree implementations (the front-coded bucket columns and
+ * the sort index's order-statistic tree) funnel every ordering decision through this class.
+ *
+ * When constructed with an explicit {@link Collator} (custom strength, decomposition or rules), the
+ * comparator delegates directly to {@link Collator#compare(String, String)} - the shared cache
+ * holds keys computed under the locale's default configuration and must not serve an order defined
+ * by a different one.
+ *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2023
  */
-@RequiredArgsConstructor
 public class LocalizedStringComparator implements Comparator<String>, Serializable {
 	@Serial private static final long serialVersionUID = 8102561596057708303L;
+	/**
+	 * Collator defining the target order; used directly whenever {@link #cache} is null.
+	 */
 	@Nonnull private final Collator collator;
+	/**
+	 * Shared per-locale collation-key cache; null when the comparator was created with a custom
+	 * {@link Collator} or when the cache is disabled by configuration (see
+	 * {@link CollationKeyCache#forLocale(Locale)}). Resolved from a static registry and therefore
+	 * deliberately not serialized.
+	 */
+	@Nullable private final CollationKeyCache cache;
 
+	/**
+	 * Creates a comparator ordering strings by the default collation rules of `locale`, serving
+	 * comparisons from the shared collation-key cache when it is enabled.
+	 *
+	 * @param locale locale whose collation rules define the order
+	 */
 	public LocalizedStringComparator(@Nonnull Locale locale) {
 		this.collator = Collator.getInstance(locale);
+		this.cache = CollationKeyCache.forLocale(locale);
+	}
+
+	/**
+	 * Creates a comparator delegating every comparison to the given (possibly customized)
+	 * `collator`; the shared collation-key cache is bypassed on this path.
+	 *
+	 * @param collator collator defining the order
+	 */
+	public LocalizedStringComparator(@Nonnull Collator collator) {
+		this.collator = collator;
+		this.cache = null;
 	}
 
 	@Override
 	public int compare(String o1, String o2) {
-		return this.collator.compare(o1, o2);
+		//noinspection StringEquality
+		if (o1 == o2) {
+			// identity covers the frequent same-instance probe re-comparison in B+ tree descents
+			return 0;
+		}
+		final CollationKeyCache cache = this.cache;
+		if (cache == null) {
+			return this.collator.compare(o1, o2);
+		}
+		return Arrays.compareUnsigned(cache.keyFor(o1), cache.keyFor(o2));
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/Evita.java
+++ b/evita_engine/src/main/java/io/evitadb/core/Evita.java
@@ -49,6 +49,7 @@ import io.evitadb.api.requestResponse.cdc.ChangeCapturePublisher;
 import io.evitadb.api.requestResponse.cdc.ChangeSystemCapture;
 import io.evitadb.api.requestResponse.cdc.ChangeSystemCaptureRequest;
 import io.evitadb.api.requestResponse.cdc.HostSystemEvent;
+import io.evitadb.api.requestResponse.data.DevelopmentConstants;
 import io.evitadb.api.requestResponse.mutation.EngineMutation;
 import io.evitadb.api.requestResponse.progress.Progress;
 import io.evitadb.api.requestResponse.progress.ProgressingFuture;
@@ -357,11 +358,60 @@ public final class Evita implements EvitaContract {
 		);
 	}
 
+	/**
+	 * Constructs a new `Evita` instance with session lifecycle callbacks and explicit control over the
+	 * second phase of the boot sequence (see {@link #Evita(EvitaConfiguration, boolean)}). The executor kind
+	 * defaults to {@link DevelopmentConstants#isTestRun()} — an immediate (synchronous) executor during test
+	 * runs, real thread pools otherwise; use
+	 * {@link #Evita(EvitaConfiguration, boolean, Consumer, Consumer, boolean)} to choose it explicitly.
+	 *
+	 * @param configuration                evita configuration; never `null`
+	 * @param scheduleCatalogLoading       `true` schedules loading immediately; `false` defers it to an
+	 *                                     explicit {@link #scheduleInitialCatalogLoading()} call
+	 * @param onSessionCreationCallback    optional callback invoked when a session is created
+	 * @param onSessionTerminationCallback optional callback invoked when a session is terminated
+	 */
 	public Evita(
 		@Nonnull EvitaConfiguration configuration,
 		boolean scheduleCatalogLoading,
 		@Nullable Consumer<EvitaSessionContract> onSessionCreationCallback,
 		@Nullable Consumer<EvitaSessionContract> onSessionTerminationCallback
+	) {
+		this(
+			configuration,
+			scheduleCatalogLoading,
+			onSessionCreationCallback,
+			onSessionTerminationCallback,
+			// in test runs default to the immediate (synchronous) executor so embedded execution stays
+			// deterministic; networked / production callers pass an explicit value to the constructor below
+			DevelopmentConstants.isTestRun()
+		);
+	}
+
+	/**
+	 * Constructs a new `Evita` instance with explicit control over both the second phase of the boot
+	 * sequence and the executor kind used for the request pool and the scheduler.
+	 *
+	 * This is the full constructor all other overloads delegate to. Networked hosts (e.g.
+	 * `EvitaServer`) and any caller that needs real (asynchronous) thread pools pass
+	 * `directExecutor=false`; embedded callers that omit the flag get the {@link DevelopmentConstants#isTestRun()}
+	 * default, which collapses the request pool and scheduler into an immediate (synchronous) executor
+	 * during test runs to keep embedded execution deterministic.
+	 *
+	 * @param configuration                       evita configuration; never `null`
+	 * @param scheduleCatalogLoading              `true` schedules loading immediately; `false` defers it to
+	 *                                            an explicit {@link #scheduleInitialCatalogLoading()} call
+	 * @param onSessionCreationCallback           optional callback invoked when a session is created
+	 * @param onSessionTerminationCallback        optional callback invoked when a session is terminated
+	 * @param directExecutor                      `true` uses the immediate (synchronous) executor for the
+	 *                                            request pool and scheduler; `false` uses real thread pools
+	 */
+	public Evita(
+		@Nonnull EvitaConfiguration configuration,
+		boolean scheduleCatalogLoading,
+		@Nullable Consumer<EvitaSessionContract> onSessionCreationCallback,
+		@Nullable Consumer<EvitaSessionContract> onSessionTerminationCallback,
+		boolean directExecutor
 	) {
 		this.configuration = configuration;
 		this.onSessionCreationCallback = onSessionCreationCallback == null ?
@@ -369,14 +419,14 @@ public final class Evita implements EvitaContract {
 		this.onSessionTerminationCallback = onSessionTerminationCallback == null ?
 			Functions.noOpConsumer() : onSessionTerminationCallback;
 
-		this.serviceExecutor = configuration.server().directExecutor() ?
+		this.serviceExecutor = directExecutor ?
 			// in test environment we use immediate (synchronous) executor to avoid race conditions
 			new Scheduler(new ImmediateScheduledThreadPoolExecutor()) :
 			// in standard environment we use a scheduled thread pool executor
 			new Scheduler(configuration.server().serviceThreadPool());
 		this.requestExecutor = new ObservableThreadExecutor(
 			"request", configuration.server().requestThreadPool(),
-			configuration.server().directExecutor(),
+			directExecutor,
 			RequestThreadPoolStatisticsEvent::new
 		);
 		this.transactionExecutor = new ObservableThreadExecutor(

--- a/evita_engine/src/main/java/io/evitadb/core/exception/DataStructureCorruptedException.java
+++ b/evita_engine/src/main/java/io/evitadb/core/exception/DataStructureCorruptedException.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.exception;
+
+import io.evitadb.exception.GenericEvitaInternalError;
+
+import javax.annotation.Nonnull;
+import java.io.Serial;
+
+/**
+ * Thrown when a transactional data structure detects structural corruption during commit-time integrity
+ * validation — either the pre-commit pass (before the transaction reaches the shared write-ahead log) or the
+ * post-replay pass (after replayed mutations are merged, before the new catalog version propagates to the live
+ * view). Participants subclass this exception with structure-specific detail (e.g. the B+ tree variants). See
+ * {@link io.evitadb.core.transaction.memory.DirtyScopeValidator} for the validation protocol.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class DataStructureCorruptedException extends GenericEvitaInternalError {
+	@Serial private static final long serialVersionUID = -5478139672340815902L;
+
+	public DataStructureCorruptedException(@Nonnull String publicMessage) {
+		super(publicMessage);
+	}
+
+	public DataStructureCorruptedException(@Nonnull String privateMessage, @Nonnull String publicMessage) {
+		super(privateMessage, publicMessage);
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/session/EvitaSession.java
+++ b/evita_engine/src/main/java/io/evitadb/core/session/EvitaSession.java
@@ -1824,7 +1824,21 @@ public final class EvitaSession implements EvitaInternalSessionContract {
 						transaction == null,
 						"In warming-up mode no transaction is expected to be opened!"
 					);
-					final ProgressingFuture<Void> flushFuture = this.catalog.flush();
+					final ProgressingFuture<Void> flushFuture;
+					try {
+						// building the warm-up flush future pops the trapped changes SYNCHRONOUSLY
+						// (Catalog.flush -> EntityCollection.createFlushFuture -> popTrappedChanges); a throw
+						// here (e.g. a corrupted index serialized at close) must complete the close future
+						// EXCEPTIONALLY instead of escaping and leaving `commitProgress` / `closingSequenceFuture`
+						// pending forever, which would hang SessionRegistry.closeAllActiveSessionsAndSuspend and
+						// Evita.close()
+						flushFuture = this.catalog.flush();
+					} catch (Throwable ex) {
+						this.commitProgress.completeExceptionally(ex);
+						this.closedFuture = this.commitProgress.on(commitBehavior);
+						this.closingSequenceFuture.get().complete(this.closedFuture);
+						return this.commitProgress;
+					}
 					// register the completion callback BEFORE dispatching to the executor — otherwise a
 					// synchronous RejectedExecutionException (e.g. during evitaDB shutdown) would escape
 					// without the callback ever being attached, leaving `commitProgress` pending forever

--- a/evita_engine/src/main/java/io/evitadb/core/session/EvitaSessionProxy.java
+++ b/evita_engine/src/main/java/io/evitadb/core/session/EvitaSessionProxy.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.core.session;
 
+import io.evitadb.api.exception.ConcurrentSessionAccessException;
 import io.evitadb.api.exception.RollbackException;
 import io.evitadb.api.exception.TransactionException;
 import io.evitadb.api.observability.trace.RepresentsMutation;
@@ -93,6 +94,18 @@ final class EvitaSessionProxy implements InvocationHandler {
 	private final AtomicInteger insideInvocation = new AtomicInteger(0);
 	private final AtomicLong lastCall = new AtomicLong(System.currentTimeMillis());
 	private final AtomicReference<ClosingSequence> closeLambda = new AtomicReference<>(null);
+	/**
+	 * Thread that currently owns (is executing a business method on) this {@code @NotThreadSafe}
+	 * session, or {@code null} when no business method is in flight. A second thread that tries to
+	 * enter while another owns the session is rejected with a
+	 * {@link ConcurrentSessionAccessException} rather than being allowed to race the shared mutable
+	 * session state — the guard is thread-identity based so a legitimate re-entrant call on the very
+	 * same thread is permitted. Only guards the
+	 * delegated business-method path in {@link #invoke}; the housekeeping methods
+	 * {@link io.evitadb.core.session.task.SessionKiller} polls concurrently (e.g. `isActive`,
+	 * `isInactiveAndIdle`) are intentionally left unguarded.
+	 */
+	private final AtomicReference<Thread> owningThread = new AtomicReference<>(null);
 
 	/**
 	 * Resolves a method from {@link EvitaInternalSessionContract} by name and parameter types.
@@ -520,6 +533,21 @@ final class EvitaSessionProxy implements InvocationHandler {
 			});
 	}
 
+	/**
+	 * Dispatches a proxied session method call. Housekeeping methods polled by
+	 * {@link io.evitadb.core.session.task.SessionKiller} ({@code isActive}, {@code isInactiveAndIdle}
+	 * and friends) are handled directly and bypass the concurrency guard below since they must remain
+	 * safely callable from a different thread than the one currently executing a business method.
+	 * Every other (business) method is delegated to the wrapped {@link EvitaSession}, but only after
+	 * the calling thread claims exclusive ownership of {@link #owningThread} — see that field's
+	 * JavaDoc for why the session cannot tolerate two threads inside a business method at once.
+	 *
+	 * @param proxy  the proxy instance the method was invoked on (unused — calls are delegated to
+	 *               the wrapped {@link #evitaSession})
+	 * @param method the method that was invoked on the proxy
+	 * @param args   the arguments passed to the method invocation
+	 * @return the result of the delegated call, or a directly computed value for housekeeping methods
+	 */
 	@Nullable
 	@Override
 	public Object invoke(Object proxy, Method method, Object[] args) {
@@ -570,6 +598,20 @@ final class EvitaSessionProxy implements InvocationHandler {
 			}
 			return null;
 		} else {
+			// reject concurrent access from a second thread: an evitaDB session is @NotThreadSafe, so a
+			// racing call would silently corrupt the shared mutable session state (open transaction,
+			// warm-up index trees). The guard is thread-identity based, so a legitimate re-entrant call
+			// on the very same thread is allowed; only a genuinely different thread entering while this
+			// one owns the session fails.
+			final Thread currentThread = Thread.currentThread();
+			final Thread previousOwner = this.owningThread.compareAndExchange(null, currentThread);
+			if (previousOwner != null && previousOwner != currentThread) {
+				throw new ConcurrentSessionAccessException(
+					this.evitaSession.getId(), previousOwner.getName(), currentThread.getName()
+				);
+			}
+			// only the outermost invocation on the owning thread releases ownership when it unwinds
+			final boolean outermostInvocation = previousOwner == null;
 			try {
 				final ClosingSequence closingSequence = this.closeLambda.get();
 				// if there's a closing sequence in place
@@ -586,6 +628,9 @@ final class EvitaSessionProxy implements InvocationHandler {
 					return executeDelegateMethod(method, args);
 				}
 			} finally {
+				if (outermostInvocation) {
+					this.owningThread.set(null);
+				}
 				final ClosingSequence closingSequence = this.closeLambda.get();
 				// if there is newly registered close lambda and there is no other method being executed
 				if (this.insideInvocation.get() == 0 && closingSequence != null) {

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
@@ -77,6 +77,8 @@ import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.function.Functions;
 import io.evitadb.spi.store.catalog.shared.model.LogRecordReference;
 import io.evitadb.spi.store.catalog.wal.IsolatedWalPersistenceService;
+import io.evitadb.spi.store.engine.exception.WriteAheadLogCorruptedException;
+import io.evitadb.spi.store.engine.exception.WriteAheadLogCorruptedException.WalKind;
 import io.evitadb.utils.Assert;
 import io.evitadb.utils.IOUtils;
 import lombok.Getter;
@@ -97,9 +99,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.LongConsumer;
+import java.util.function.LongSupplier;
 import java.util.stream.Stream;
 
 import static java.util.Optional.empty;
@@ -116,6 +120,19 @@ import static java.util.Optional.ofNullable;
  */
 @Slf4j
 public class TransactionManager implements Closeable {
+	/**
+	 * Number of busy-spin attempts in
+	 * {@link #waitUntilVersionReaches(LongSupplier, long, long, String)} before the wait falls back
+	 * to parking. Catalog-version propagation to the live view normally lands within microseconds,
+	 * so the spin window keeps the hot path latency-free while a genuine stall stops burning a full
+	 * core.
+	 */
+	private static final int SPIN_ATTEMPTS_BEFORE_PARK = 4_096;
+	/**
+	 * Interval in nanoseconds the bounded wait parks for between live-version checks once the spin
+	 * window of {@link #SPIN_ATTEMPTS_BEFORE_PARK} attempts is exhausted.
+	 */
+	private static final long PARK_INTERVAL_NANOS = 100_000L;
 	/**
 	 * Reference to the evitaDB instance this transaction manager belongs to.
 	 */
@@ -1045,6 +1062,10 @@ public class TransactionManager implements Closeable {
 	 * @param waitForLock        Indicates whether to wait for the trunk incorporation lock.
 	 * @param progressCallback   A callback to report progress during transaction processing.
 	 * @return The processed transaction.
+	 * @throws WriteAheadLogCorruptedException when the mutation stream is empty but the finalized
+	 *                                          version has not yet reached {@code nextCatalogVersion}
+	 *                                          — i.e. a committed transaction was expected but could
+	 *                                          not be read from the WAL
 	 */
 	@Nonnull
 	public Optional<ProcessResult> processTransactions(
@@ -1090,8 +1111,24 @@ public class TransactionManager implements Closeable {
 					}
 					final Iterator<CatalogBoundMutation> mutationIterator = committedMutationStream.iterator();
 					if (!mutationIterator.hasNext()) {
-						// previous execution already processed all the mutations
-						return empty();
+						// an empty stream is only legitimately "already processed" when the finalized version
+						// has actually reached the version we were asked to process; if it has not, the WAL
+						// delivered nothing for a version we must reach — reporting "someone else did it"
+						// would silently finalize at a stale version and leave the commit-progress record
+						// (and any client awaiting it) hanging forever
+						if (lastFinalizedVersion >= nextCatalogVersion) {
+							// previous execution already processed all the mutations
+							return empty();
+						}
+						throw new WriteAheadLogCorruptedException(
+							WalKind.CATALOG,
+							"WAL mutation stream of catalog `" + getCatalogName() + "` went dry at finalized " +
+								"version " + lastFinalizedVersion + " without reaching requested version " +
+								nextCatalogVersion + " (last written version " +
+								this.lastWrittenCatalogVersion.get() + "). A committed transaction was not " +
+								"readable - refusing to report it as already processed.",
+							"Write-ahead log mutation stream ended before reaching a committed transaction."
+						);
 					} else {
 						long nextExpectedCatalogVersion = lastFinalizedVersion + 1;
 						// and process them
@@ -1246,15 +1283,74 @@ public class TransactionManager implements Closeable {
 	}
 
 	/**
-	 * Waits until the catalog version in the "live view" reaches the specified version.
+	 * Waits until the catalog version in the "live view" reaches the specified version. The wait is
+	 * bounded by {@link #safetyDeadlineMs()} — the same threshold the dangling-commit sweeper uses — so
+	 * it never fires under normal back-pressure, only on a genuine propagation stall. On expiry
+	 * a {@link TransactionTimedOutException} is thrown, which every caller translates into an
+	 * exceptional completion of the affected commit-progress record (or a watchdog reschedule)
+	 * instead of spinning a core forever.
 	 *
 	 * @param catalogVersion The catalog version to wait for in the "live view".
+	 * @throws TransactionTimedOutException when the live view does not reach the version in time
 	 */
 	public void waitUntilLiveVersionReaches(long catalogVersion) {
-		while (getLivingCatalog().getVersion() < catalogVersion) {
-			// wait until the catalog version is propagated to the "live view"
-			Thread.onSpinWait();
+		waitUntilVersionReaches(
+			() -> getLivingCatalog().getVersion(),
+			catalogVersion,
+			safetyDeadlineMs(),
+			getCatalogName()
+		);
+	}
+
+	/**
+	 * Bounded wait for a monotonically increasing version to reach the expected value. Busy-spins for
+	 * {@link #SPIN_ATTEMPTS_BEFORE_PARK} attempts (propagation normally lands within microseconds) and
+	 * then parks in {@link #PARK_INTERVAL_NANOS} intervals so a genuine stall does not burn a core.
+	 * Package-private so the bounded-wait contract can be unit-tested without a full manager instance.
+	 *
+	 * @param liveVersion    supplier of the currently visible version
+	 * @param catalogVersion the version that must be reached
+	 * @param deadlineMs     maximum time to wait in milliseconds
+	 * @param catalogName    name of the catalog used in the timeout message
+	 * @throws TransactionTimedOutException when the version does not reach the expected value in time
+	 */
+	static void waitUntilVersionReaches(
+		@Nonnull LongSupplier liveVersion,
+		long catalogVersion,
+		long deadlineMs,
+		@Nonnull String catalogName
+	) {
+		final long deadlineNanos = System.nanoTime() + deadlineMs * 1_000_000L;
+		int spins = 0;
+		long currentVersion;
+		while ((currentVersion = liveVersion.getAsLong()) < catalogVersion) {
+			// overflow-safe monotonic comparison mandated by the System.nanoTime() contract
+			if (System.nanoTime() - deadlineNanos >= 0) {
+				throw new TransactionTimedOutException(
+					"Live view of catalog `" + catalogName + "` did not reach version " + catalogVersion +
+						" within " + deadlineMs + " ms (stuck at version " + currentVersion +
+						"); refusing to wait indefinitely."
+				);
+			}
+			if (spins < SPIN_ATTEMPTS_BEFORE_PARK) {
+				Thread.onSpinWait();
+				spins++;
+			} else {
+				LockSupport.parkNanos(PARK_INTERVAL_NANOS);
+			}
 		}
+	}
+
+	/**
+	 * Returns the safety threshold in milliseconds after which a pipeline wait or a pending
+	 * commit-progress record is considered genuinely stalled. Five times the acceptance timeout gives
+	 * ample headroom for back-pressure spikes and executor queue drain times; a floor of 60s keeps the
+	 * threshold sensible on deployments that tune the acceptance timeout very low.
+	 *
+	 * @return the stall-detection deadline in milliseconds
+	 */
+	private long safetyDeadlineMs() {
+		return Math.max(60_000L, this.transactionAcceptanceTimeout * 5);
 	}
 
 	/**
@@ -1348,10 +1444,13 @@ public class TransactionManager implements Closeable {
 	}
 
 	/**
-	 * Sends the task simulating the WAL stage finalization with tasks that drains entire contents of the WAL in
-	 * the trunk incorporation stage. This should handle the situation when last transaction was not processed due
-	 * to queues being full. When no other transaction comes the WAL will forever contain more records than are
-	 * incorporated in the catalog.
+	 * Sends the task simulating the WAL stage finalization with tasks that drains entire contents of
+	 * the WAL in the trunk incorporation stage. This should handle the situation when last transaction
+	 * was not processed due to queues being full. When no other transaction comes the WAL will forever
+	 * contain more records than are incorporated in the catalog.
+	 *
+	 * @return `0` to reschedule immediately when a transient condition (busy lock or a momentarily
+	 * unreadable WAL tail) prevented draining, `-1` to pause the task once draining completed
 	 */
 	private long drainWal() {
 		try {
@@ -1362,8 +1461,13 @@ public class TransactionManager implements Closeable {
 				false, // we should not wait for the lock here - if its already running it will process the transactions
 				Functions.noOpLongConsumer()
 			);
-		} catch (TransactionTimedOutException ex) {
-			// reschedule again
+		} catch (TransactionTimedOutException | WriteAheadLogCorruptedException ex) {
+			// Best-effort background drainer: both conditions are transient here and get retried on the
+			// next tick. A busy trunk lock means another incorporation is already running; a WAL read that
+			// momentarily cannot see a just-appended version (same-JVM file-length visibility lag) clears on
+			// a later pass. A genuinely persistent inconsistency is surfaced loudly on the client commit
+			// path by the trunk-incorporation stage; the drainer owns no commit-progress record and must not
+			// let an uncaught throw permanently pause this task.
 			return 0;
 		}
 		// pause the task
@@ -1384,12 +1488,7 @@ public class TransactionManager implements Closeable {
 	 * pause when there is nothing left to watch over
 	 */
 	private long sweepDanglingCommitProgress() {
-		// five times the acceptance timeout gives ample headroom for back-pressure spikes and
-		// executor queue drain times; a floor of 60s keeps the threshold sensible on deployments
-		// that tune the acceptance timeout very low
-		final long acceptanceTimeoutMs = this.configuration.transaction().waitForTransactionAcceptanceInMillis();
-		final long maxAgeMs = Math.max(60_000L, acceptanceTimeoutMs * 5);
-		this.pendingCommitProgressRegistry.sweepRecordsOlderThan(Duration.ofMillis(maxAgeMs));
+		this.pendingCommitProgressRegistry.sweepRecordsOlderThan(Duration.ofMillis(safetyDeadlineMs()));
 		return this.pendingCommitProgressRegistry.size() > 0 ? 0L : -1L;
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionTrunkFinalizer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionTrunkFinalizer.java
@@ -26,6 +26,7 @@ package io.evitadb.core.transaction;
 import io.evitadb.api.requestResponse.mutation.Mutation;
 import io.evitadb.api.requestResponse.mutation.infrastructure.TransactionMutation;
 import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.exception.DataStructureCorruptedException;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.utils.Assert;
@@ -106,7 +107,19 @@ public class TransactionTrunkFinalizer implements TransactionHandler {
 		// now let's flush the catalog on the disk
 		this.catalogToUpdate.flush(catalogVersion, lastProcessedTransaction);
 		// init new catalog with the same collections as the previous one
-		final Catalog newCatalog = this.lastTransactionLayer.getStateCopyWithCommittedChanges(this.catalogToUpdate);
+		final Catalog newCatalog;
+		try {
+			// the merge runs the post-replay (merge-time) dirty-scope validation on every participant the replay
+			// touched, before this catalog version can propagate to the live view
+			newCatalog = this.lastTransactionLayer.getStateCopyWithCommittedChanges(this.catalogToUpdate);
+		} catch (DataStructureCorruptedException ex) {
+			// the corruption slipped past the isolated run's pre-commit pass: the transaction is already durable
+			// in the write-ahead log, and its corrupt state may already sit in the flushed data files because the
+			// flush above precedes this merge. A restart will replay the WAL and either re-trigger this failure or
+			// fail at load-time validation. Re-wrap the neutral structure-level error with the poison-pill
+			// remediation caveat before it completes the commit progress exceptionally.
+			throw wrapPostReplayCorruption(ex);
+		}
 		Assert.isPremiseValid(
 			newCatalog.getVersion() == catalogVersion,
 			"Catalog version mismatch!"
@@ -117,6 +130,32 @@ public class TransactionTrunkFinalizer implements TransactionHandler {
 		this.committedCatalog = newCatalog;
 		// and return created catalog
 		return this.committedCatalog;
+	}
+
+	/**
+	 * Wraps a neutral, structure-level {@link DataStructureCorruptedException} raised by the post-replay (merge-time)
+	 * dirty-scope validation into the trunk-path poison-pill error. Unlike the isolated pre-commit (pre-WAL)
+	 * rejection — which happens with the shared write-ahead log still clean — a post-replay failure fires while
+	 * incorporating an already-committed transaction: it is durable in the write-ahead log, and because the catalog
+	 * flush precedes the merge its corrupt state may already sit in the flushed data files. The message states both
+	 * so the operator does not understate the blast radius, and chains the neutral structure-level cause for the
+	 * structural detail. A restart will replay the write-ahead log and either re-trigger this failure or fail at
+	 * load-time validation — either way loudly. Extracted from the `commitCatalogChanges` catch so the poison-pill
+	 * wording stays under test.
+	 *
+	 * @param cause the neutral structure-level corruption error raised by the merge
+	 * @return the poison-pill error to complete the commit progress exceptionally with
+	 */
+	@Nonnull
+	public static GenericEvitaInternalError wrapPostReplayCorruption(@Nonnull DataStructureCorruptedException cause) {
+		return new GenericEvitaInternalError(
+			"A transactional data structure failed post-replay integrity validation while incorporating a " +
+				"transaction into the catalog trunk. The transaction is already durable in the write-ahead log " +
+				"(and its corrupt state may already be in the flushed data files), so a restart will replay it and " +
+				"either re-trigger this failure or fail at load-time validation. Remediation: restore the catalog " +
+				"from a backup, or fully rebuild / reindex it, and file a bug report.",
+			cause
+		);
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionWalFinalizer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionWalFinalizer.java
@@ -125,6 +125,34 @@ public class TransactionWalFinalizer implements TransactionHandler {
 	@Override
 	public void commit(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		try {
+			// pre-commit (pre-WAL): re-derive the invariants for every dirty scope this transaction registered, while
+			// the isolated diff layers are still live and BEFORE any mutation reaches the shared WAL. A rejection here
+			// leaves the shared WAL verifiably without this transaction, so the client can recover.
+			transactionalLayer.validateDirtyScopesBeforeCommit();
+		} catch (Throwable ex) {
+			// a raw throw would hang the commit future (nothing between here and the client completes it on an
+			// unexpected exception from commit) and leak the isolated WAL's off-heap region / temp file. Mirror
+			// rollback's resource discipline EXACTLY: close the transactional resources in the try, and release the
+			// isolated WAL + complete the commit progress exceptionally in the finally, so a throwing closeable can
+			// never prevent the WAL release or leave the commit future hanging.
+			try {
+				closeRegisteredCloseables();
+			} finally {
+				if (this.walPersistenceService != null) {
+					this.walPersistenceService.close();
+					this.walPersistenceService = null;
+				}
+				this.commitProgress.completeExceptionally(
+					new RollbackException(
+						"Transaction changes have been rolled back: a transactional data structure failed pre-commit " +
+							"integrity validation; the change was not written to the write-ahead log.",
+						ex
+					)
+				);
+			}
+			return;
+		}
+		try {
 			// here we close all registered closeables - i.e. transactional OffsetIndexes along with their data
 			// (i.e. OffHeapManager regions and temporary files) - we will not need them anymore, they were used only
 			// for the client's transaction that is being closed right now

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/DirtyScopeValidator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/DirtyScopeValidator.java
@@ -1,0 +1,71 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.transaction.memory;
+
+import io.evitadb.core.exception.DataStructureCorruptedException;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+/**
+ * Contract implemented by any transactional data structure that participates in commit-time structural integrity
+ * validation, in two phases:
+ *
+ * (a) A participant registers opaque *tokens* at its invariant-changing mutation seams via
+ * {@link TransactionalLayerMaintainer#registerDirtyScopeToken}. Tokens and participants are both compared by
+ * identity.
+ *
+ * (b) The receiver decides the view: the same {@link #validateDirtyScope(Collection)} method serves the pre-commit
+ * pass — called on the live baseline instance, so it validates through the transactional diff-layered view, before
+ * the mutations reach the shared write-ahead log — and the post-replay pass — called on the freshly merged copy, so
+ * it validates plain merged state, before that copy propagates to the live view.
+ *
+ * (c) Tokens are hints only, never validated in place — the participant must re-locate the current state they point
+ * at. A stale token (e.g. one pointing at a savepoint-reverted layer, or an element merged away since registration)
+ * at worst causes a redundant check; it can never cause a false positive.
+ *
+ * (d) Validation must be read-only with respect to transactional memory — it must not create new diff layers,
+ * because the post-replay pass runs with layer creation already disabled.
+ *
+ * (e) Two-phase responsibility split: the pre-commit pass is orchestrated centrally by
+ * {@link TransactionalLayerMaintainer#validateDirtyScopesBeforeCommit()}; the post-replay pass is self-service — a
+ * participant that registers tokens MUST pull its own {@link TransactionalLayerMaintainer#getDirtyScopeTokens} inside
+ * its {@code createCopyWithMergedTransactionalMemory} and validate the merged copy itself.
+ *
+ * (f) Violations surface as {@link DataStructureCorruptedException}.
+ */
+public interface DirtyScopeValidator {
+
+	/**
+	 * Validates this participant's dirty scope against the tokens it (or its predecessor, for the post-replay pass)
+	 * registered during the transaction. Each implementation defines what a token is and how it is relocated; see the
+	 * concrete overrides (e.g. the B+ tree variants) for structure-specific detail.
+	 *
+	 * @param dirtyScopeTokens the tokens registered for this participant; never validated in place, only used to
+	 *                         relocate the current state to check
+	 * @throws DataStructureCorruptedException when the relocated state violates the participant's invariants
+	 */
+	void validateDirtyScope(@Nonnull Collection<Object> dirtyScopeTokens);
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerMaintainer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerMaintainer.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.core.transaction.memory;
 
+import io.evitadb.core.exception.DataStructureCorruptedException;
 import io.evitadb.core.exception.StaleTransactionMemoryException;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.utils.Assert;
@@ -31,12 +32,15 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Closeable;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Optional.ofNullable;
@@ -85,12 +89,72 @@ public class TransactionalLayerMaintainer {
 	 * savepoint can be rolled back independently of the surrounding transaction.
 	 */
 	@Nullable private Savepoint currentSavepoint;
+	/**
+	 * Per-transaction dirty-scope registry feeding the pre-commit (pre-WAL) and post-replay (merge-time) structural
+	 * integrity validation. Maps each participant (a {@link DirtyScopeValidator}) to the identity set of opaque tokens
+	 * it registered at its invariant-changing mutation seams during this transaction. Both axes are identity-keyed and
+	 * the whole structure is lazily instantiated on first registration (a transaction that touches no participant
+	 * pays nothing). Registration feeds both the pre-commit and post-replay validation passes, which each run
+	 * unconditionally whenever at least one participant was dirtied.
+	 */
+	@Nullable private Map<DirtyScopeValidator, Set<Object>> dirtyScopes;
 
 	TransactionalLayerMaintainer(
 		@Nonnull TransactionalLayerMaintainerFinalizer finalizer
 	) {
 		this.finalizer = finalizer;
 		this.transactionalLayer = new HashMap<>(4096);
+	}
+
+	/**
+	 * Registers an opaque scope token as dirtied by the given participant during this transaction, so the pre-commit
+	 * (pre-WAL) and post-replay (merge-time) validation can re-derive its invariants at commit. Called unconditionally
+	 * from the participant's invariant-changing mutation seams; the registered object is used only as a scope token
+	 * (see {@link DirtyScopeValidator}).
+	 *
+	 * @param owner      the participant the token belongs to
+	 * @param scopeToken the dirtied scope token
+	 */
+	public void registerDirtyScopeToken(@Nonnull DirtyScopeValidator owner, @Nonnull Object scopeToken) {
+		if (this.dirtyScopes == null) {
+			this.dirtyScopes = new IdentityHashMap<>(64);
+		}
+		this.dirtyScopes
+			.computeIfAbsent(owner, it -> Collections.newSetFromMap(new IdentityHashMap<>(64)))
+			.add(scopeToken);
+	}
+
+	/**
+	 * Returns the scope tokens registered for the given participant during this transaction, or an empty set when it
+	 * dirtied none. Used by the participant's post-replay validation to relocate each token in the freshly merged
+	 * copy.
+	 *
+	 * @param owner the participant whose registered dirty scope tokens are requested
+	 * @return the registered scope tokens for the participant; never {@code null}
+	 */
+	@Nonnull
+	public Set<Object> getDirtyScopeTokens(@Nonnull DirtyScopeValidator owner) {
+		if (this.dirtyScopes == null) {
+			return Collections.emptySet();
+		}
+		final Set<Object> tokens = this.dirtyScopes.get(owner);
+		return tokens == null ? Collections.emptySet() : tokens;
+	}
+
+	/**
+	 * Runs the pre-commit (pre-WAL) dirty-scope validation: for every participant that dirtied at least one scope
+	 * token, re-derives its invariants over the registered scope against the still-live transactional view. Runs
+	 * unconditionally; a no-op only when no participant was touched. A violation surfaces as
+	 * {@link DataStructureCorruptedException}, which the caller must translate into an exceptional commit completion
+	 * so the shared WAL never receives the transaction.
+	 */
+	public void validateDirtyScopesBeforeCommit() {
+		if (this.dirtyScopes == null) {
+			return;
+		}
+		for (final Entry<DirtyScopeValidator, Set<Object>> entry : this.dirtyScopes.entrySet()) {
+			entry.getKey().validateDirtyScope(entry.getValue());
+		}
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/ChainIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/ChainIndex.java
@@ -26,6 +26,7 @@ package io.evitadb.index.attribute;
 import com.carrotsearch.hppc.IntArrayDeque;
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntHashSet;
+import com.carrotsearch.hppc.IntIntHashMap;
 import io.evitadb.api.requestResponse.data.structure.RepresentativeReferenceKey;
 import io.evitadb.core.buffer.TrappedChanges;
 import io.evitadb.core.catalog.Catalog;
@@ -35,6 +36,7 @@ import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.dataType.ChainableType;
+import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.dataType.ConsistencySensitiveDataStructure;
 import io.evitadb.dataType.ReferencedEntityPredecessor;
 import io.evitadb.index.AbstractReducedEntityIndex;
@@ -341,6 +343,11 @@ public class ChainIndex implements
 		@Nonnull List<ChainIndexLeafPagePart> pages,
 		int highWaterPageSequence
 	) {
+		// 0. a chain page is positional and carries no ordering invariant, so the stale leaf-page twin corruption
+		// manifests as duplicate record ids across pages; assert none exists before assembly (fails fast otherwise — the
+		// paged layout never shipped in a released version, so a duplicate is never a production catalog and is not
+		// silently repaired)
+		assertNoDuplicateChainRecords(pages, attributeIndexKey);
 		// 1. assemble the element array 1:1 from the pages (boundary-stable, one leaf per page, dirty=false)
 		final List<LeafPageInput> pageInputs = new ArrayList<>(pages.size());
 		for (final ChainIndexLeafPagePart page : pages) {
@@ -419,6 +426,60 @@ public class ChainIndex implements
 		return new ChainIndex(
 			referenceKey, attributeIndexKey, elements, descriptors, predecessorMap, inverseMap, pageStreamRegistry
 		);
+	}
+
+	/**
+	 * Asserts that no record id appears in more than one persisted chain-index leaf page. Unlike the key-ordered paged
+	 * indexes a chain page is positional and carries no ordering invariant to violate, so the stale leaf-page twin
+	 * corruption — a writer race persisting a frozen stale snapshot of a leaf page alongside the page that superseded it
+	 * — manifests instead as DUPLICATE record ids across pages. Because the paged persistence layout has never shipped
+	 * in a released version, no production catalog can carry such a twin; a duplicate is index corruption that is not
+	 * silently repaired but fails fast here with a {@link GenericEvitaInternalError} naming the record id, both
+	 * offending page sequences, the attribute identity and an operator remediation hint.
+	 *
+	 * @param pages             the persisted leaf pages in ascending logical order
+	 * @param attributeIndexKey the attribute identity of this index (diagnostics)
+	 * @throws GenericEvitaInternalError when a record id appears in more than one leaf page
+	 */
+	private static void assertNoDuplicateChainRecords(
+		@Nonnull List<ChainIndexLeafPagePart> pages,
+		@Nonnull AttributeIndexKey attributeIndexKey
+	) {
+		// fast path: scan every record id against one set; when no record id repeats there is no corruption — the
+		// overwhelmingly common case, O(N) over the ints
+		final IntHashSet seen = new IntHashSet();
+		boolean duplicateFound = false;
+		for (final ChainIndexLeafPagePart page : pages) {
+			for (final int recordId : page.getRecordIds()) {
+				if (!seen.add(recordId)) {
+					duplicateFound = true;
+					break;
+				}
+			}
+			if (duplicateFound) {
+				break;
+			}
+		}
+		if (!duplicateFound) {
+			return;
+		}
+		// a record id repeats across pages — re-scan to attribute the first duplicate to its two page sequences for a
+		// precise diagnostic, then fail fast
+		final IntIntHashMap firstPageOfRecord = new IntIntHashMap();
+		for (final ChainIndexLeafPagePart page : pages) {
+			final int pageSequence = page.getPageSequence();
+			for (final int recordId : page.getRecordIds()) {
+				if (firstPageOfRecord.containsKey(recordId)) {
+					throw new GenericEvitaInternalError(
+						"Corrupted persisted chain index for attribute " + attributeIndexKey + ": record id " + recordId +
+							" appears in more than one leaf page (sequences " + firstPageOfRecord.get(recordId) + " and " +
+							pageSequence + "). This is a stale leaf-page twin or other index corruption. Restore the " +
+							"catalog from a backup, or fully rebuild / reindex the affected catalog."
+					);
+				}
+				firstPageOfRecord.put(recordId, pageSequence);
+			}
+		}
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
@@ -302,7 +302,10 @@ public class GlobalUniqueIndex implements
 			pageTrees.add(pageTree);
 		}
 		final TransactionalBucketBPlusTree tree =
-			createEmptyTree(plainType, comparator).assembleFromSingleLeafTrees(pageTrees, orderedPageSequences);
+			createEmptyTree(plainType, comparator).assembleFromSingleLeafTrees(
+				pageTrees, orderedPageSequences,
+				"global unique index for attribute " + attributeKey + " in scope " + scope
+			);
 		final PageStreamRegistry pageStreamRegistry = PageStreamRegistry.restoredFrom(
 			UNIQUE_PAGE_STREAM, highWaterPageSequence, tree.leafPageHandles()
 		);

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
@@ -264,7 +264,10 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 			pageTrees.add(pageTree);
 		}
 		final TransactionalBucketBPlusTree tree =
-			createEmptyTree(plainType, comparator).assembleFromSingleLeafTrees(pageTrees, orderedPageSequences);
+			createEmptyTree(plainType, comparator).assembleFromSingleLeafTrees(
+				pageTrees, orderedPageSequences,
+				"owner unique index for attribute " + attributeIndexKey + " of entity `" + entityType + "`"
+			);
 		final PageStreamRegistry pageStreamRegistry = PageStreamRegistry.restoredFrom(
 			UNIQUE_PAGE_STREAM, highWaterPageSequence, tree.leafPageHandles()
 		);

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/AbstractTransactionalBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/AbstractTransactionalBPlusTree.java
@@ -23,7 +23,9 @@
 
 package io.evitadb.index.bPlusTree;
 
+import io.evitadb.core.exception.DataStructureCorruptedException;
 import io.evitadb.core.transaction.Transaction;
+import io.evitadb.core.transaction.memory.DirtyScopeValidator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
@@ -58,7 +60,7 @@ import java.util.Objects;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
-abstract class AbstractTransactionalBPlusTree implements Serializable {
+public abstract class AbstractTransactionalBPlusTree implements Serializable {
 	@Serial private static final long serialVersionUID = -941486965526807368L;
 	/**
 	 * Sentinel value of a leaf's {@link LeafBPlusTreeNode#getPageSequence()} before it has been assigned a persistence
@@ -389,6 +391,40 @@ abstract class AbstractTransactionalBPlusTree implements Serializable {
 	protected abstract BPlusTreeNode<?> newEmptyLeaf();
 
 	/**
+	 * Registers a leaf as dirtied for the current transaction's pre-commit / post-replay dirty-scope validation. A
+	 * no-op when no transaction is active — warm-up bulk load and other non-transactional mutations have neither a
+	 * registry nor a WAL, so the validation does not apply and pays nothing. The registered object is the leaf's write
+	 * LAYER when one exists (it holds the effective in-transaction keys and survives the layer discard the trunk merge
+	 * performs), otherwise the leaf itself (a split-born leaf holds its keys directly). Registered objects are key
+	 * sources only, so registering a not-strictly-current object cannot cause a false positive (see
+	 * {@link DirtyScopeValidator}).
+	 *
+	 * @param tree the owner tree the leaf belongs to
+	 * @param leaf the dirtied leaf node
+	 */
+	static void registerDirtyLeafInScope(@Nonnull DirtyScopeValidator tree, @Nonnull BPlusTreeNode<?> leaf) {
+		final TransactionalLayerMaintainer maintainer = Transaction.getTransactionalLayerMaintainer();
+		if (maintainer == null) {
+			return;
+		}
+		final Object writable = Transaction.getTransactionalMemoryLayerIfExists(leaf);
+		maintainer.registerDirtyScopeToken(tree, writable != null ? writable : leaf);
+	}
+
+	/**
+	 * Hook invoked by {@link #consolidate(Cursor)} for each leaf whose boundary keys a rebalance (steal / merge)
+	 * changed, so the concrete tree can register it in the transaction's dirty-scope validation. The default is a
+	 * no-op: the out-of-scope trees ({@code TransactionalObjectBPlusTree}, {@code TransactionalIntToLongBPlusTree}) do
+	 * not participate in the dirty-leaf validation. The in-scope paged trees override it to call
+	 * {@link #registerDirtyLeafInScope(DirtyScopeValidator, BPlusTreeNode)}.
+	 *
+	 * @param leaf the rebalanced leaf node
+	 */
+	protected void registerConsolidatedLeaf(@Nonnull BPlusTreeNode<?> leaf) {
+		// no-op by default; the in-scope paged trees override this to register the rebalanced leaf
+	}
+
+	/**
 	 * Recursively removes the transactional diff layers of the passed node, its descendants and - for leaf nodes whose
 	 * values are themselves {@link TransactionalLayerProducer}s - those values. Walks the current (transaction-aware)
 	 * view of the tree.
@@ -540,6 +576,12 @@ abstract class AbstractTransactionalBPlusTree implements Serializable {
 								Math.max(1, (previousNode.keyCount() - minBlock) / 2), previousNode);
 							// update parent keys
 							updateParentKeys(cursorWithLevel);
+							// both the receiver and the donor leaf had their boundary keys shifted — register them
+							// for the transaction's dirty-scope validation
+							if (!isInternal) {
+								registerConsolidatedLeaf(node);
+								registerConsolidatedLeaf(previousNode);
+							}
 							return;
 						}
 					}
@@ -558,6 +600,12 @@ abstract class AbstractTransactionalBPlusTree implements Serializable {
 							// update parent keys, but only if node was empty - which means first key was added
 							if (isInternal || nodeIsEmpty) {
 								updateParentKeys(cursorWithLevel);
+							}
+							// both the receiver and the donor leaf had their boundary keys shifted — register them
+							// for the transaction's dirty-scope validation
+							if (!isInternal) {
+								registerConsolidatedLeaf(node);
+								registerConsolidatedLeaf(nextNode);
 							}
 							return;
 						}
@@ -579,6 +627,12 @@ abstract class AbstractTransactionalBPlusTree implements Serializable {
 							}
 							// update parent keys, previous node has been removed
 							updateParentKeys(previousNodeCursor.withReplacedCurrentNode(node));
+							// the surviving merged leaf absorbed the left sibling — its first key lowered; register it
+							// for the transaction's dirty-scope validation (the merged-away node is gone and needs no
+							// registration)
+							if (!isInternal) {
+								registerConsolidatedLeaf(node);
+							}
 							// consolidate the parent node
 							cursorWithLevel = cursorWithLevel.toParentLevel();
 							// continue with parent level
@@ -602,6 +656,12 @@ abstract class AbstractTransactionalBPlusTree implements Serializable {
 							}
 							// update parent keys, next node has been removed
 							updateParentKeys(cursorWithLevel.withReplacedCurrentNode(node));
+							// the surviving merged leaf absorbed the right sibling — its last key rose; register it for
+							// the transaction's dirty-scope validation (the merged-away node is gone and needs no
+							// registration)
+							if (!isInternal) {
+								registerConsolidatedLeaf(node);
+							}
 							// consolidate the parent node
 							cursorWithLevel = cursorWithLevel.toParentLevel();
 						}
@@ -1303,6 +1363,29 @@ abstract class AbstractTransactionalBPlusTree implements Serializable {
 			}
 			this.hasNextElement = found;
 		}
+	}
+
+	/**
+	 * Raised when a transactional B+ tree is found to violate its cross-leaf ordering invariants — a leaf whose key range
+	 * overlaps an adjacent leaf (the "stale leaf-page twin" corruption class) or an internal separator that no longer
+	 * matches the live leaf it fronts.
+	 *
+	 * It is a dedicated {@link DataStructureCorruptedException} subtype so the transaction commit path can recognise a
+	 * tree-corruption rejection specifically — without catching unrelated internal errors. The pre-commit (pre-WAL)
+	 * validation rejects the commit with a still-clean write-ahead log; the post-replay (merge-time) validation catches
+	 * this exception after the transaction is already durable and re-wraps it with the poison-pill remediation caveat.
+	 * The message carried here is deliberately view-neutral (it fires on the isolated merge path too, where no WAL
+	 * exists), so the WAL / poison-pill wording lives only in the trunk wrapper.
+	 *
+	 * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+	 */
+	public static class BPlusTreeCorruptedException extends DataStructureCorruptedException {
+		@Serial private static final long serialVersionUID = 6748142835067359214L;
+
+		public BPlusTreeCorruptedException(@Nonnull String publicMessage) {
+			super(publicMessage);
+		}
+
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTree.java
@@ -25,6 +25,7 @@ package io.evitadb.index.bPlusTree;
 
 
 import io.evitadb.core.transaction.Transaction;
+import io.evitadb.core.transaction.memory.DirtyScopeValidator;
 import io.evitadb.core.transaction.memory.Snapshotable;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
@@ -46,6 +47,7 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
@@ -99,7 +101,8 @@ import static io.evitadb.utils.ArrayUtils.*;
 @NotThreadSafe
 public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 	IntRecordBucketTree<K>,
-	LongPayloadBucketTree<K>
+	LongPayloadBucketTree<K>,
+	DirtyScopeValidator
 {
 	@Serial private static final long serialVersionUID = -2030749900648110509L;
 	/**
@@ -856,6 +859,12 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 		final BPlusLeafTreeNode<K> leaf = cursor.leafNode();
 		if (leaf.addRecord(value, pk)) {
 			this.size.set(size() + 1);
+			// op-time boundary-mutation asserts run on the new-bucket branch before the (possible) split, while the
+			// cursor still reflects the pre-split spine — a mis-routed new bucket corrupts cross-leaf order with no
+			// structural op firing
+			assertInsertBoundaries(cursor, value);
+			// register the dirtied leaf as a dirty-scope token for this transaction
+			registerDirtyLeafInScope(leaf);
 		}
 		if (leaf.isFull()) {
 			splitLeafNode(leaf, cursor);
@@ -879,6 +888,11 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 		final BPlusLeafTreeNode<K> leaf = cursor.leafNode();
 		if (leaf.addRecords(value, pks)) {
 			this.size.set(size() + 1);
+			// op-time boundary-mutation asserts — see addRecord(K, int); the new-bucket branch validates cross-leaf
+			// order before the (possible) split
+			assertInsertBoundaries(cursor, value);
+			// register the dirtied leaf as a dirty-scope token for this transaction
+			registerDirtyLeafInScope(leaf);
 		}
 		if (leaf.isFull()) {
 			splitLeafNode(leaf, cursor);
@@ -905,6 +919,10 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 		final boolean headRemoved = leaf.size() > 1 && value.equals(leaf.keyAt(0));
 		if (leaf.removeRecords(value, pks)) {
 			this.size.set(size() - 1);
+			// register the dirtied leaf as a dirty-scope token for this transaction: a removal
+			// narrows the leaf's key range, but a later reverted layer could restore the wider pre-transaction range
+			// and overlap a neighbour that split during the transaction — so removals are validated too
+			registerDirtyLeafInScope(leaf);
 			// the head of the leaf may have been removed, update parent keys accordingly
 			if (headRemoved) {
 				updateParentKeys(cursor.toCursorWithLevel());
@@ -947,6 +965,11 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 		final BPlusLeafTreeNode<K> leaf = cursor.leafNode();
 		leaf.addLongRecord(value, payload);
 		this.size.set(size() + 1);
+		// op-time boundary-mutation asserts — a long-payload add always inserts a new bucket (or throws on a duplicate),
+		// so validate cross-leaf order unconditionally before the (possible) split
+		assertInsertBoundaries(cursor, value);
+		// register the dirtied leaf as a dirty-scope token for this transaction
+		registerDirtyLeafInScope(leaf);
 		if (leaf.isFull()) {
 			splitLeafNode(leaf, cursor);
 		}
@@ -987,6 +1010,10 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 		final boolean headRemoved = leaf.size() > 1 && value.equals(leaf.keyAt(0));
 		if (leaf.removeLongRecord(value)) {
 			this.size.set(size() - 1);
+			// register the dirtied leaf as a dirty-scope token for this transaction: a removal
+			// narrows the leaf's key range, but a later reverted layer could restore the wider pre-transaction range
+			// and overlap a neighbour that split during the transaction — so removals are validated too
+			registerDirtyLeafInScope(leaf);
 			// the head of the leaf may have been removed, update parent keys accordingly
 			if (headRemoved) {
 				updateParentKeys(cursor.toCursorWithLevel());
@@ -1126,10 +1153,11 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 		@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		final BPlusTreeNode<K, ?> theRoot = transactionalLayer.getStateCopyWithCommittedChanges(this.root)
 			.orElseThrow();
+		final TransactionalBucketBPlusTree<K> merged;
 		if (theRoot instanceof BPlusLeafTreeNode<?> leafNode) {
 			//noinspection unchecked
 			final BPlusLeafTreeNode<K> theLeafNode = (BPlusLeafTreeNode<K>) leafNode;
-			return new TransactionalBucketBPlusTree<>(
+			merged = new TransactionalBucketBPlusTree<>(
 				this.valueBlockSize, this.minValueBlockSize,
 				this.internalNodeBlockSize, this.minInternalNodeBlockSize,
 				this.keyType,
@@ -1141,7 +1169,7 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 			);
 		} else if (theRoot instanceof BPlusInternalTreeNode<?> internalNode) {
 			//noinspection unchecked
-			return new TransactionalBucketBPlusTree<>(
+			merged = new TransactionalBucketBPlusTree<>(
 				this.valueBlockSize, this.minValueBlockSize,
 				this.internalNodeBlockSize, this.minInternalNodeBlockSize,
 				this.keyType,
@@ -1154,6 +1182,15 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 		} else {
 			throw new GenericEvitaInternalError("Unknown node type: " + theRoot);
 		}
+		// post-replay (merge-time): before this merged version can propagate to the live view, re-derive the cross-leaf boundary
+		// invariants for every leaf this transaction dirtied — against the freshly merged structure (plain reads;
+		// the merged nodes are fresh or unchanged-and-layer-free, so the descent never consults a diff layer).
+		// Registered objects are key sources only; each is relocated by its current key in the merged tree.
+		final Set<Object> dirtyScope = transactionalLayer.getDirtyScopeTokens(this);
+		if (!dirtyScope.isEmpty()) {
+			merged.validateDirtyScope(dirtyScope);
+		}
+		return merged;
 	}
 
 	/**
@@ -1407,14 +1444,24 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 	 * into the assembled tree exactly as in {@link #assembleFromLeaves} — do not keep mutating the source trees
 	 * afterwards.
 	 *
+	 * The reassembled leaves are validated for strict cross-leaf key order BEFORE the spine is built: the last key of a
+	 * key-bearing leaf must sort strictly before the first key of the next key-bearing leaf (per the tree's comparator or
+	 * the keys' natural order). A violation means the persisted page list carries a stale leaf-page twin (a frozen
+	 * snapshot of a leaf persisted next to the page that superseded it) or other index corruption; it is not silently
+	 * repaired but reported via {@link #assertCrossLeafBoundaries} — see the defensive-design rationale there.
+	 *
 	 * @param orderedSingleLeafTrees the per-page single-leaf trees in ascending key order
-	 * @param pageSequences               the persisted page sequence for each tree, positionally aligned; same length
+	 * @param pageSequences          the persisted page sequence for each tree, positionally aligned; same length
+	 * @param structureDescription   a full identification of the index for diagnostics, reading like a noun phrase after
+	 *                               `persisted ` (e.g. `inverted index for type \`X\``)
 	 * @return a new tree whose leaves are exactly those of the supplied trees, each stamped with its page sequence
+	 * @throws GenericEvitaInternalError when the persisted leaf pages violate strict cross-leaf key order
 	 */
 	@Nonnull
 	public TransactionalBucketBPlusTree<K> assembleFromSingleLeafTrees(
 		@Nonnull List<TransactionalBucketBPlusTree<K>> orderedSingleLeafTrees,
-		@Nonnull int[] pageSequences
+		@Nonnull int[] pageSequences,
+		@Nonnull String structureDescription
 	) {
 		Assert.isPremiseValid(
 			orderedSingleLeafTrees.size() == pageSequences.length,
@@ -1432,7 +1479,338 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 			leaf.setPageSequence(pageSequences[i]);
 			leaves.add(leaf);
 		}
+		// validate cross-leaf key order BEFORE assembly, so the corruption diagnostic fires ahead of any left-boundary
+		// separator invariant the spine builder would otherwise trip on with a less actionable message
+		assertCrossLeafBoundaries(leaves, structureDescription);
 		return assembleFromLeaves(leaves);
+	}
+
+	/**
+	 * Validates that the supplied leaves are in strict cross-leaf key order: the last key of each key-bearing leaf must
+	 * sort strictly before the first key of the next key-bearing leaf (per the tree's comparator, or the keys' natural
+	 * order when no comparator is set). Empty leaves carry no key and impose no boundary constraint, so they are skipped
+	 * when locating the previous key-bearing leaf.
+	 *
+	 * A paged index persists one storage part per B+ tree leaf plus a root part listing the ordered leaf-page sequence;
+	 * the reload path re-assembles one in-memory leaf per persisted page. A writer race on a `@NotThreadSafe` warm-up
+	 * session can leave a frozen stale snapshot of a leaf reachable next to the page that superseded it, and a one-shot
+	 * flush persists BOTH — every subsequent reload then rebuilds a tree whose leaves overlap, silently serving corrupt
+	 * data until it crashes later with a confusing signature far from the cause. Because the paged persistence layout has
+	 * never shipped in a released version, no production catalog can carry such a twin; silently repairing one would
+	 * contradict the defensive-design rule, so any detected overlap fails fast here with full diagnostics and an operator
+	 * remediation hint.
+	 *
+	 * @param leaves               the reassembled leaves in persisted list order
+	 * @param structureDescription a full identification of the index for diagnostics (see
+	 *                             {@link #assembleFromSingleLeafTrees})
+	 * @throws GenericEvitaInternalError when a leaf's last key does not sort strictly before the next leaf's first key
+	 */
+	private void assertCrossLeafBoundaries(
+		@Nonnull List<BPlusLeafTreeNode<K>> leaves,
+		@Nonnull String structureDescription
+	) {
+		BPlusLeafTreeNode<K> previousKeyBearing = null;
+		for (final BPlusLeafTreeNode<K> leaf : leaves) {
+			final int peek = leaf.getPeek();
+			if (peek < 0) {
+				// empty leaf carries no key and cannot violate cross-leaf ordering
+				continue;
+			}
+			final K[] keys = leaf.getKeys();
+			// intra-leaf order: a serializer bug, truncated write or bit rot can leave a leaf whose interior keys
+			// are out of order, while the cross-leaf walk alone would pass it — binary search inside such a leaf
+			// then silently returns wrong answers. Assert each key sorts strictly after its predecessor within the
+			// leaf (one comparison per key, once per load).
+			for (int i = 1; i <= peek; i++) {
+				if (compareKeys(keys[i - 1], keys[i], this.comparator) >= 0) {
+					throw new GenericEvitaInternalError(
+						"Corrupted persisted " + structureDescription + ": leaf-page sequence " +
+							leaf.getPageSequence() + " has out-of-order keys — the key at position " + (i - 1) + " (" +
+							keys[i - 1] + ") does not sort before the key at position " + i + " (" + keys[i] + "). This " +
+							"is index corruption. Restore the catalog from a backup, or fully rebuild / reindex the " +
+							"affected catalog."
+					);
+				}
+			}
+			if (previousKeyBearing != null) {
+				final K previousLastKey = previousKeyBearing.getKeys()[previousKeyBearing.getPeek()];
+				final K currentFirstKey = keys[0];
+				if (compareKeys(previousLastKey, currentFirstKey, this.comparator) >= 0) {
+					throw new GenericEvitaInternalError(
+						"Corrupted persisted " + structureDescription + ": leaf-page sequence " +
+							previousKeyBearing.getPageSequence() + " overlaps its successor leaf-page sequence " +
+							leaf.getPageSequence() + " — its last key (" + previousLastKey + ") does not sort before the " +
+							"first key (" + currentFirstKey + ") of the next leaf page. This is a stale leaf-page twin or " +
+							"other index corruption. Restore the catalog from a backup, or fully rebuild / reindex the " +
+							"affected catalog."
+					);
+				}
+			}
+			previousKeyBearing = leaf;
+		}
+	}
+
+	/**
+	 * Compares two keys using the supplied comparator when present, otherwise the keys' natural [Comparable] order.
+	 * This is the single key-comparison mechanism every boundary / separator assert routes through (it mirrors the
+	 * ternary used inside {@link #assertCrossLeafBoundaries}), so the object-keyed tree never falls back to a raw
+	 * `>=` on object references.
+	 *
+	 * @param left       the left operand
+	 * @param right      the right operand
+	 * @param comparator the total order to use, or `null` for the keys' natural order
+	 * @param <M>        the key type
+	 * @return a negative, zero or positive int as `left` sorts before, equal to, or after `right`
+	 */
+	private static <M extends Comparable<M>> int compareKeys(
+		@Nonnull M left, @Nonnull M right, @Nullable Comparator<M> comparator) {
+		return comparator != null ? comparator.compare(left, right) : left.compareTo(right);
+	}
+
+	/**
+	 * Tail-boundary assert. On any leaf mutation that RAISES the leaf's last key (a new bucket inserted at the
+	 * tail, including the insert into an empty leaf), verifies the new last key still sorts strictly below the leaf's
+	 * upper fence. The fence is the separator at the nearest ancestor whose descent was not into the rightmost child —
+	 * which, by the separator-from-first-key invariant, equals the first key of the successor leaf, even when that
+	 * successor lives under a different parent, grandparent, etc. A rightmost descent at every level means the leaf is
+	 * the tree's last leaf and has no successor, so nothing is checked.
+	 *
+	 * A violation means a key was routed into a leaf whose successor should hold it (a search-path corruption); it would
+	 * overlap the successor's page on flush, so it fails fast here. Zero allocation and no cross-parent leaf navigation:
+	 * the fence is pure index arithmetic over the cursor arrays (the internal node's `getKeys()` returns its backing
+	 * separator array, not a copy). Sequential bulk append descends into the rightmost child at every level, so the walk
+	 * finds no fence and returns after a few comparisons.
+	 *
+	 * @param cursor     the descent path to the mutated leaf
+	 * @param newLastKey the leaf's new last key after the mutation
+	 * @throws GenericEvitaInternalError when the new last key does not sort strictly before the successor fence
+	 */
+	void assertTailBoundary(@Nonnull Cursor<K> cursor, @Nonnull K newLastKey) {
+		final List<CursorLevel<K>> path = cursor.path();
+		for (int level = path.size() - 1; level >= 1; level--) {
+			final CursorLevel<K> cursorLevel = path.get(level);
+			final int childIndex = cursorLevel.index();
+			if (childIndex < cursorLevel.peek()) {
+				// the ancestor whose children are this level's siblings holds the fence separator at childIndex
+				final CursorLevel<K> ancestorLevel = path.get(level - 1);
+				//noinspection unchecked
+				final BPlusInternalTreeNode<K> ancestor =
+					(BPlusInternalTreeNode<K>) ancestorLevel.siblings()[ancestorLevel.index()];
+				final K fence = ancestor.getKeys()[childIndex];
+				if (compareKeys(newLastKey, fence, this.comparator) >= 0) {
+					throw boundaryMutationError("tail", newLastKey, "before the successor leaf boundary", fence);
+				}
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Head-boundary assert. On any leaf mutation that LOWERS the leaf's first key (a new bucket inserted at the
+	 * head, including the insert into an empty leaf), verifies the new first key still sorts strictly above the
+	 * predecessor leaf's last key. In a sound tree a head insert can only land on the tree's leftmost leaf (the
+	 * separator-from-first-key invariant routes every key at-or-above the leaf's own first key), so this check passes
+	 * trivially; it fires only on a mis-routed insert that undercuts a real predecessor.
+	 *
+	 * The predecessor's last key is the only meaningful operand: checking the parent separator would be circular, as the
+	 * maintained invariant makes it equal the leaf's own first key.
+	 *
+	 * @param cursor      the descent path to the mutated leaf
+	 * @param newFirstKey the leaf's new first key after the mutation
+	 * @throws GenericEvitaInternalError when the new first key does not sort strictly after the predecessor boundary
+	 */
+	void assertHeadBoundary(@Nonnull Cursor<K> cursor, @Nonnull K newFirstKey) {
+		final BPlusLeafTreeNode<K> predecessor = predecessorLeaf(cursor);
+		if (predecessor == null) {
+			// leftmost leaf — no predecessor to violate
+			return;
+		}
+		final int predecessorPeek = predecessor.getPeek();
+		if (predecessorPeek < 0) {
+			// an empty predecessor carries no key (mirrors the load-time empty-leaf skip)
+			return;
+		}
+		final K predecessorLastKey = predecessor.keyAt(predecessorPeek);
+		if (compareKeys(predecessorLastKey, newFirstKey, this.comparator) >= 0) {
+			throw boundaryMutationError(
+				"head", newFirstKey, "after the predecessor leaf boundary", predecessorLastKey);
+		}
+	}
+
+	/**
+	 * Resolves the predecessor leaf of the cursor's leaf. Common case (`ci > 0`): the same-parent left sibling is the
+	 * predecessor, read in O(1) from the cursor's already-materialized sibling array. Rare case (`ci == 0`): walk up to
+	 * the nearest ancestor whose descent was into a non-leftmost child (the clamp ancestor), then follow that ancestor's
+	 * left-neighbour subtree down its right spine to the predecessor leaf. That rare branch is O(height) and is never
+	 * taken by sequential append (append never lowers a first key); only a random workload that undercuts a leaf minimum
+	 * at a parent edge reaches it.
+	 *
+	 * @param cursor the descent path to the leaf whose predecessor is sought
+	 * @return the predecessor leaf, or `null` when the cursor's leaf is the tree's leftmost leaf
+	 */
+	@Nullable
+	private BPlusLeafTreeNode<K> predecessorLeaf(@Nonnull Cursor<K> cursor) {
+		final List<CursorLevel<K>> path = cursor.path();
+		final CursorLevel<K> leafLevel = path.get(path.size() - 1);
+		final int leafIndex = leafLevel.index();
+		if (leafIndex > 0) {
+			//noinspection unchecked
+			return (BPlusLeafTreeNode<K>) leafLevel.siblings()[leafIndex - 1];
+		}
+		for (int level = path.size() - 1; level >= 1; level--) {
+			final CursorLevel<K> cursorLevel = path.get(level);
+			final int childIndex = cursorLevel.index();
+			if (childIndex > 0) {
+				BPlusTreeNode<K, ?> node = cursorLevel.siblings()[childIndex - 1];
+				while (node instanceof BPlusInternalTreeNode<?> internal) {
+					//noinspection unchecked
+					final BPlusInternalTreeNode<K> internalNode = (BPlusInternalTreeNode<K>) internal;
+					node = internalNode.getChildren()[internalNode.getPeek()];
+				}
+				//noinspection unchecked
+				return (BPlusLeafTreeNode<K>) node;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Builds the shared boundary-mutation corruption error (offending key, the neighbour boundary it collides
+	 * with, remediation hint).
+	 *
+	 * @param side        `tail` or `head` — which boundary the mutation changed
+	 * @param boundaryKey the leaf's new boundary key that violates cross-leaf order
+	 * @param relation    the ordering relation that was expected (e.g. `before the successor leaf boundary`)
+	 * @param neighborKey the adjacent leaf boundary that `boundaryKey` failed to sort against
+	 * @return the corruption error to throw
+	 */
+	@Nonnull
+	private AbstractTransactionalBPlusTree.BPlusTreeCorruptedException boundaryMutationError(
+		@Nonnull String side, @Nonnull K boundaryKey, @Nonnull String relation, @Nonnull K neighborKey) {
+		return new AbstractTransactionalBPlusTree.BPlusTreeCorruptedException(
+			"Corrupted in-memory B+ tree: a leaf's " + side + " boundary key " + boundaryKey + " does not sort " +
+				relation + " (" + neighborKey + "). This indicates cross-leaf key overlap (a mis-routed insertion, a " +
+				"reverted transactional layer, or a merge defect) that would overlap an adjacent leaf page on flush. " +
+				"Restore the catalog from a backup, or fully rebuild / reindex the affected catalog."
+		);
+	}
+
+	/**
+	 * Registers a dirtied leaf as a dirty-scope token for this transaction. This standalone tree does
+	 * not extend {@link AbstractTransactionalBPlusTree}, so it cannot reuse the base's static registration helper (whose
+	 * parameter is the base-package leaf type this tree's nested leaf does not implement); it inlines the same semantics
+	 * instead. A no-op when no transaction is active — warm-up bulk load and other non-transactional mutations have
+	 * neither a registry nor a WAL, so the pre-commit (pre-WAL) and post-replay (merge-time) validations do not apply and pay nothing. The registered object is the leaf's write
+	 * LAYER when one exists (it holds the effective in-transaction keys and survives the layer discard the trunk merge
+	 * performs), otherwise the leaf itself (a split-born leaf holds its keys directly). Registered objects are key
+	 * sources only, so registering a not-strictly-current object cannot cause a false positive.
+	 *
+	 * @param leaf the dirtied leaf node
+	 */
+	private void registerDirtyLeafInScope(@Nonnull BPlusLeafTreeNode<K> leaf) {
+		final TransactionalLayerMaintainer maintainer = Transaction.getTransactionalLayerMaintainer();
+		if (maintainer == null) {
+			return;
+		}
+		final Object writable = Transaction.getTransactionalMemoryLayerIfExists(leaf);
+		maintainer.registerDirtyScopeToken(this, writable != null ? writable : leaf);
+	}
+
+	/**
+	 * Dirty-scope validation for this tree. For each registered key source (a writable leaf
+	 * this transaction dirtied) it reads the current first key, descends from this tree's root to the leaf that key
+	 * routes to, and re-derives both cross-leaf half-invariants on the leaf the descent actually landed on — reusing
+	 * the op-time machinery with the leaf's ACTUAL boundary keys ({@link #assertTailBoundary} against the successor
+	 * fence, {@link #assertHeadBoundary} against the predecessor's last key). Empty key sources and descents that land
+	 * on an empty leaf are skipped (nothing to relocate by / assert). Called on the live baseline tree for the
+	 * pre-commit (pre-WAL) pass (the descent resolves diff layers) and on a freshly merged tree for the post-replay
+	 * (merge-time) pass (plain reads); both use read-path accessors only.
+	 *
+	 * @param registeredLeafKeySources the writable leaf objects registered for this tree; used only as key sources
+	 * @throws AbstractTransactionalBPlusTree.BPlusTreeCorruptedException when a relocated leaf overlaps an adjacent leaf
+	 */
+	@Override
+	public void validateDirtyScope(@Nonnull Collection<Object> registeredLeafKeySources) {
+		for (final Object keySource : registeredLeafKeySources) {
+			//noinspection unchecked
+			final BPlusLeafTreeNode<K> registered = (BPlusLeafTreeNode<K>) keySource;
+			if (registered.getPeek() < 0) {
+				// empty key source — nothing to relocate by (key-source-only rule)
+				continue;
+			}
+			final K probeKey = registered.keyAt(0);
+			final Cursor<K> cursor = createCursor(probeKey);
+			final BPlusLeafTreeNode<K> leaf = cursor.leafNode();
+			final int peek = leaf.getPeek();
+			if (peek < 0) {
+				// the descent landed on an empty leaf — validating it is sound and vacuous
+				continue;
+			}
+			assertTailBoundary(cursor, leaf.keyAt(peek));
+			assertHeadBoundary(cursor, leaf.keyAt(0));
+		}
+	}
+
+	/**
+	 * Separator-order belt. After a parent separator at `slot` is rewritten (head-key propagation), asserts strict
+	 * local order against its existing neighbours. This catches stale/aliased internal-node state — the historical
+	 * stale-leaf-page twin bugs were object aliasing, whose first symptom is a separator that no longer matches the live
+	 * leaf it fronts. It is a belt, not the head-side check: it cannot detect a mis-routed head insert that keeps the
+	 * separators individually ordered (that is what {@link #assertHeadBoundary} covers). The comparator is passed in
+	 * rather than read from `this` so the static belt can run inside the internal node's key-update path.
+	 *
+	 * @param keys       the internal node's live separator array
+	 * @param peek       the internal node's peek (separator count is `peek`, valid indices `0..peek-1`)
+	 * @param slot       the just-rewritten separator index
+	 * @param comparator the total order to use, or `null` for the keys' natural order
+	 * @param <M>        the key type
+	 * @throws GenericEvitaInternalError when the rewritten separator breaks strict local order
+	 */
+	static <M extends Comparable<M>> void assertSeparatorOrder(
+		@Nonnull M[] keys, int peek, int slot, @Nullable Comparator<M> comparator) {
+		if (slot > 0 && compareKeys(keys[slot - 1], keys[slot], comparator) >= 0) {
+			throw separatorOrderError(keys[slot - 1], keys[slot]);
+		}
+		if (slot < peek - 1 && compareKeys(keys[slot], keys[slot + 1], comparator) >= 0) {
+			throw separatorOrderError(keys[slot], keys[slot + 1]);
+		}
+	}
+
+	/**
+	 * Builds the separator-order corruption error.
+	 *
+	 * @param leftKey  the separator that should sort strictly before `rightKey`
+	 * @param rightKey the separator that `leftKey` collides with
+	 * @return the corruption error to throw
+	 */
+	@Nonnull
+	private static GenericEvitaInternalError separatorOrderError(@Nonnull Object leftKey, @Nonnull Object rightKey) {
+		return new GenericEvitaInternalError(
+			"Corrupted in-memory B+ tree: internal separator keys are out of order (" + leftKey + " does not sort " +
+				"before " + rightKey + "). This indicates stale/aliased internal-node state. Restore the catalog " +
+				"from a backup, or fully rebuild / reindex the affected catalog."
+		);
+	}
+
+	/**
+	 * Runs the op-time boundary-mutation asserts for a freshly inserted bucket key. A tail insert raises the leaf's last
+	 * key, a head insert lowers its first key, and the insert into an empty leaf (the 0→1 transition) does both; an
+	 * interior insert cannot violate cross-leaf order in a sound tree and is not checked. Called on the new-bucket branch
+	 * shared by warm-up bulk load, transactional ops and trunk replay. The leaf accessors are transaction-layer-aware, so
+	 * this reflects the post-insert state whether the mutation landed on the node or on its transactional layer.
+	 *
+	 * @param cursor the descent path to the mutated leaf
+	 * @param key    the bucket key just inserted
+	 */
+	void assertInsertBoundaries(@Nonnull Cursor<K> cursor, @Nonnull K key) {
+		final BPlusLeafTreeNode<K> leaf = cursor.leafNode();
+		final int peek = leaf.getPeek();
+		if (compareKeys(key, leaf.keyAt(peek), this.comparator) == 0) {
+			assertTailBoundary(cursor, key);
+		}
+		if (compareKeys(key, leaf.keyAt(0), this.comparator) == 0) {
+			assertHeadBoundary(cursor, key);
+		}
 	}
 
 	/**
@@ -1644,6 +2022,14 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 								previousNode
 							);
 							updateParentKeys(cursorWithLevel);
+							if (!isInternal) {
+								// a steal shifts both this leaf's and the donor's boundary keys — register both as
+								// dirty-scope tokens for this transaction
+								//noinspection unchecked
+								registerDirtyLeafInScope((BPlusLeafTreeNode<K>) node);
+								//noinspection unchecked
+								registerDirtyLeafInScope((BPlusLeafTreeNode<K>) previousNode);
+							}
 							return;
 						}
 					}
@@ -1659,6 +2045,14 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 							updateParentKeys(nextNodeCursor);
 							if (isInternal || nodeIsEmpty) {
 								updateParentKeys(cursorWithLevel);
+							}
+							if (!isInternal) {
+								// a steal shifts both this leaf's and the donor's boundary keys — register both as
+								// dirty-scope tokens for this transaction
+								//noinspection unchecked
+								registerDirtyLeafInScope((BPlusLeafTreeNode<K>) node);
+								//noinspection unchecked
+								registerDirtyLeafInScope((BPlusLeafTreeNode<K>) nextNode);
 							}
 							return;
 						}
@@ -1678,6 +2072,12 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 							updateParentKeys(
 								previousNodeCursor.withReplacedCurrentNode(node)
 							);
+							if (!isInternal) {
+								// a merge lowers this surviving leaf's head boundary — register it as a
+								// dirty-scope token for this transaction
+								//noinspection unchecked
+								registerDirtyLeafInScope((BPlusLeafTreeNode<K>) node);
+							}
 							cursorWithLevel = cursorWithLevel.toParentLevel();
 							continue;
 						}
@@ -1697,6 +2097,12 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 							updateParentKeys(
 								cursorWithLevel.withReplacedCurrentNode(node)
 							);
+							if (!isInternal) {
+								// a merge raises this surviving leaf's tail boundary — register it as a
+								// dirty-scope token for this transaction
+								//noinspection unchecked
+								registerDirtyLeafInScope((BPlusLeafTreeNode<K>) node);
+							}
 							cursorWithLevel = cursorWithLevel.toParentLevel();
 						}
 					}
@@ -1778,7 +2184,7 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 	 * @return a cursor to the leaf node responsible for storing the provided key
 	 */
 	@Nonnull
-	private Cursor<K> createCursor(@Nonnull K key) {
+	Cursor<K> createCursor(@Nonnull K key) {
 		final ArrayList<CursorLevel<K>> path = new ArrayList<>(this.size() == 0 ? 1 : (int) (Math.log(
 			this.size()) + 1));
 		final BPlusTreeNode<K, ?> theRoot = this.getRoot();
@@ -1807,6 +2213,21 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 		final ValueColumn<K> originKeys = leaf.getKeyColumn();
 		final RecordColumn originRecords = leaf.getRecords();
 		final TransactionalBitmap[] originOverflow = leaf.getOverflow();
+
+		// Structural assert: the split partitions a sorted leaf into a left half [0, mid) and a right half
+		// [mid, capacity); the left leaf's last key must sort strictly before the right leaf's first key, and the
+		// promoted separator is exactly that right first key. A violation means the leaf being split was already out of
+		// order — fail fast rather than persist two overlapping pages.
+		final K leftHalfLastKey = originKeys.keyAt(mid - 1);
+		final K rightHalfFirstKey = originKeys.keyAt(mid);
+		if (compareKeys(leftHalfLastKey, rightHalfFirstKey, this.comparator) >= 0) {
+			throw new GenericEvitaInternalError(
+				"Corrupted in-memory B+ tree: splitting a leaf produced overlapping halves — the left half's last " +
+					"key (" + leftHalfLastKey + ") does not sort before the right half's first key (" +
+					rightHalfFirstKey + "). The leaf being split was already out of order. Restore the catalog from a " +
+					"backup, or fully rebuild / reindex the affected catalog."
+			);
+		}
 
 		// Move half the buckets to fresh arrays of the left leaf node
 		final BPlusLeafTreeNode<K> leftLeaf = new BPlusLeafTreeNode<>(
@@ -1862,6 +2283,10 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 				cursor.toCursorWithLevel()
 			);
 		}
+		// a split creates a brand-new adjacent leaf pair with a fresh separator between them — register both halves
+		// as dirty-scope tokens for this transaction
+		registerDirtyLeafInScope(leftLeaf);
+		registerDirtyLeafInScope(rightLeaf);
 	}
 
 	/**
@@ -2798,6 +3223,8 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 					"Node to update key for must match the child node at the specified index!"
 				);
 				this.keys[index - 1] = node.getLeftBoundaryKey();
+				// separator-order belt: the rewritten separator must keep strict local order
+				assertSeparatorOrder(this.keys, this.peek, index - 1, this.comparator);
 			} else {
 				decoupleTransactionalArrays();
 				Assert.isPremiseValid(
@@ -2805,6 +3232,7 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 					"Node to update key for must match the child node at the specified index!"
 				);
 				layer.keys[index - 1] = node.getLeftBoundaryKey();
+				assertSeparatorOrder(layer.keys, layer.peek, index - 1, this.comparator);
 			}
 		}
 
@@ -4869,7 +5297,7 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 	 * @param path the path representing the sequence of nodes traversed to reach the leaf node
 	 * @param <M>  the type of key stored in the B+ tree nodes
 	 */
-	private record Cursor<M extends Comparable<M>>(
+	record Cursor<M extends Comparable<M>>(
 		@Nonnull List<CursorLevel<M>> path
 	) {
 

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTree.java
@@ -25,6 +25,7 @@ package io.evitadb.index.bPlusTree;
 
 
 import io.evitadb.core.transaction.Transaction;
+import io.evitadb.core.transaction.memory.DirtyScopeValidator;
 import io.evitadb.core.transaction.memory.Snapshotable;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
@@ -42,10 +43,12 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.PrimitiveIterator.OfInt;
+import java.util.Set;
 import java.util.function.ToIntFunction;
 
 import static io.evitadb.utils.ArrayUtils.insertRecordIntoSameArrayOnIndex;
@@ -79,6 +82,7 @@ import static io.evitadb.utils.ArrayUtils.removeRecordFromSameArrayOnIndex;
 @NotThreadSafe
 public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree implements
 	TransactionalLayerProducer<Void, TransactionalElementBPlusTree<E>>,
+	DirtyScopeValidator,
 	Serializable {
 	@Serial private static final long serialVersionUID = -5872551790204880972L;
 	private static final int DEFAULT_VALUE_BLOCK_SIZE = 64;
@@ -288,14 +292,24 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 	 * into the assembled tree exactly as in {@link #assembleFromLeaves} — do not keep mutating the source trees
 	 * afterwards.
 	 *
+	 * The reassembled leaves are validated for strict cross-leaf key order BEFORE the spine is built: the last key of a
+	 * key-bearing leaf must sort strictly before the first key of the next key-bearing leaf. A violation means the
+	 * persisted page list carries a stale leaf-page twin (a frozen snapshot of a leaf persisted next to the page that
+	 * superseded it) or other index corruption; it is not silently repaired but reported via
+	 * {@link #assertCrossLeafBoundaries} — see the defensive-design rationale there.
+	 *
 	 * @param orderedSingleLeafTrees the per-page single-leaf trees in ascending key order
 	 * @param pageSequences          the persisted page sequence for each tree, positionally aligned; same length
+	 * @param structureDescription   a full identification of the index for diagnostics, reading like a noun phrase after
+	 *                               `persisted ` (e.g. `price index for …`)
 	 * @return a new tree whose leaves are exactly those of the supplied trees, each stamped with its page sequence
+	 * @throws GenericEvitaInternalError when the persisted leaf pages violate strict cross-leaf key order
 	 */
 	@Nonnull
 	public TransactionalElementBPlusTree<E> assembleFromSingleLeafTrees(
 		@Nonnull List<TransactionalElementBPlusTree<E>> orderedSingleLeafTrees,
-		@Nonnull int[] pageSequences
+		@Nonnull int[] pageSequences,
+		@Nonnull String structureDescription
 	) {
 		Assert.isPremiseValid(
 			orderedSingleLeafTrees.size() == pageSequences.length,
@@ -313,7 +327,314 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 			leaf.setPageSequence(pageSequences[i]);
 			leaves.add(leaf);
 		}
+		// validate cross-leaf key order BEFORE assembly, so the corruption diagnostic fires ahead of any left-boundary
+		// separator invariant the spine builder would otherwise trip on with a less actionable message
+		assertCrossLeafBoundaries(leaves, structureDescription);
 		return assembleFromLeaves(leaves);
+	}
+
+	/**
+	 * Validates that the supplied leaves are in strict cross-leaf key order: the last key of each key-bearing leaf must
+	 * sort strictly before the first key of the next key-bearing leaf (the element order derived via the tree's key
+	 * extractor). Empty leaves carry no key and impose no boundary constraint, so they are skipped when locating the
+	 * previous key-bearing leaf.
+	 *
+	 * A paged index persists one storage part per B+ tree leaf plus a root part listing the ordered leaf-page sequence;
+	 * the reload path re-assembles one in-memory leaf per persisted page. A writer race on a `@NotThreadSafe` warm-up
+	 * session can leave a frozen stale snapshot of a leaf reachable next to the page that superseded it, and a one-shot
+	 * flush persists BOTH — every subsequent reload then rebuilds a tree whose leaves overlap, silently serving corrupt
+	 * data until it crashes later with a confusing signature far from the cause. Because the paged persistence layout has
+	 * never shipped in a released version, no production catalog can carry such a twin; silently repairing one would
+	 * contradict the defensive-design rule, so any detected overlap fails fast here with full diagnostics and an operator
+	 * remediation hint.
+	 *
+	 * @param leaves               the reassembled leaves in persisted list order
+	 * @param structureDescription a full identification of the index for diagnostics (see
+	 *                             {@link #assembleFromSingleLeafTrees})
+	 * @throws GenericEvitaInternalError when a leaf's last key does not sort strictly before the next leaf's first key
+	 */
+	private void assertCrossLeafBoundaries(
+		@Nonnull List<BPlusLeafTreeNode<E>> leaves,
+		@Nonnull String structureDescription
+	) {
+		BPlusLeafTreeNode<E> previousKeyBearing = null;
+		for (final BPlusLeafTreeNode<E> leaf : leaves) {
+			final int peek = leaf.getPeek();
+			if (peek < 0) {
+				// empty leaf carries no key and cannot violate cross-leaf ordering
+				continue;
+			}
+			final E[] values = leaf.getValues();
+			// intra-leaf order: a serializer bug, truncated write or bit rot can leave a leaf whose interior keys
+			// are out of order, while the cross-leaf walk alone would pass it — binary search inside such a leaf
+			// then silently returns wrong answers. Assert each key sorts strictly after its predecessor within the
+			// leaf (one comparison per key, once per load); keys are re-derived on demand via the key extractor.
+			int previousKey = this.keyExtractor.applyAsInt(values[0]);
+			for (int i = 1; i <= peek; i++) {
+				final int currentKey = this.keyExtractor.applyAsInt(values[i]);
+				if (previousKey >= currentKey) {
+					throw new GenericEvitaInternalError(
+						"Corrupted persisted " + structureDescription + ": leaf-page sequence " +
+							leaf.getPageSequence() + " has out-of-order keys — the key at position " + (i - 1) + " (" +
+							previousKey + ") does not sort before the key at position " + i + " (" + currentKey + "). This " +
+							"is index corruption. Restore the catalog from a backup, or fully rebuild / reindex the " +
+							"affected catalog."
+					);
+				}
+				previousKey = currentKey;
+			}
+			if (previousKeyBearing != null) {
+				final int previousLastKey = this.keyExtractor.applyAsInt(
+					previousKeyBearing.getValues()[previousKeyBearing.getPeek()]
+				);
+				final int currentFirstKey = leaf.getLeftBoundaryKey();
+				if (previousLastKey >= currentFirstKey) {
+					throw new GenericEvitaInternalError(
+						"Corrupted persisted " + structureDescription + ": leaf-page sequence " +
+							previousKeyBearing.getPageSequence() + " overlaps its successor leaf-page sequence " +
+							leaf.getPageSequence() + " — its last key (" + previousLastKey + ") does not sort before the " +
+							"first key (" + currentFirstKey + ") of the next leaf page. This is a stale leaf-page twin or " +
+							"other index corruption. Restore the catalog from a backup, or fully rebuild / reindex the " +
+							"affected catalog."
+					);
+				}
+			}
+			previousKeyBearing = leaf;
+		}
+	}
+
+	/**
+	 * Tail-boundary assert. On any leaf mutation that RAISES the leaf's last key (a tail insert, including
+	 * the insert into an empty leaf), verifies the new last key still sorts strictly below the leaf's upper fence.
+	 * The fence is the separator at the nearest ancestor whose descent was not into the rightmost child — which,
+	 * by the separator-from-first-key invariant, equals the first key of the successor leaf, even when that
+	 * successor lives under a different parent, grandparent, etc. A rightmost descent at every level means the
+	 * leaf is the tree's last leaf and has no successor, so nothing is checked.
+	 *
+	 * A violation means a key was routed into a leaf whose successor should hold it (a search-path corruption); it
+	 * would overlap the successor's page on flush, so it fails fast here. Zero allocation and no cross-parent leaf
+	 * navigation: the fence is pure index arithmetic over the cursor arrays. Sequential bulk append descends into
+	 * the rightmost child at every level, so the walk finds no fence and returns after a few comparisons.
+	 *
+	 * @param cursor     the descent path to the mutated leaf
+	 * @param newLastKey the leaf's new last key after the mutation
+	 * @throws GenericEvitaInternalError when the new last key does not sort strictly before the successor fence
+	 */
+	void assertTailBoundary(@Nonnull Cursor cursor, int newLastKey) {
+		final List<CursorLevel> path = cursor.path();
+		for (int level = path.size() - 1; level >= 1; level--) {
+			final CursorLevel cursorLevel = path.get(level);
+			final int childIndex = cursorLevel.index();
+			if (childIndex < cursorLevel.peek()) {
+				// the ancestor whose children are this level's siblings holds the fence separator at childIndex
+				final CursorLevel ancestorLevel = path.get(level - 1);
+				final BPlusInternalTreeNode ancestor =
+					(BPlusInternalTreeNode) ancestorLevel.siblings()[ancestorLevel.index()];
+				final int fence = ancestor.getKeys()[childIndex];
+				if (newLastKey >= fence) {
+					throw boundaryMutationError("tail", newLastKey, "before the successor leaf boundary", fence);
+				}
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Head-boundary assert. On any leaf mutation that LOWERS the leaf's first key (a head insert, including
+	 * the insert into an empty leaf), verifies the new first key still sorts strictly above the predecessor leaf's
+	 * last key. In a sound tree a head insert can only land on the tree's leftmost leaf (the separator-from-first-key
+	 * invariant routes every key at-or-above the leaf's own first key), so this check passes trivially; it fires only
+	 * on a mis-routed insert that undercuts a real predecessor.
+	 *
+	 * The predecessor's last key is the only meaningful operand: checking the parent separator would be circular,
+	 * as the maintained invariant makes it equal the leaf's own first key.
+	 *
+	 * @param cursor      the descent path to the mutated leaf
+	 * @param newFirstKey the leaf's new first key after the mutation
+	 * @throws GenericEvitaInternalError when the new first key does not sort strictly after the predecessor boundary
+	 */
+	void assertHeadBoundary(@Nonnull Cursor cursor, int newFirstKey) {
+		final BPlusLeafTreeNode<E> predecessor = predecessorLeaf(cursor);
+		if (predecessor == null) {
+			// leftmost leaf — no predecessor to violate
+			return;
+		}
+		final int predecessorPeek = predecessor.getPeek();
+		if (predecessorPeek < 0) {
+			// an empty predecessor carries no key (mirrors the load-time empty-leaf skip)
+			return;
+		}
+		final int predecessorLastKey = this.keyExtractor.applyAsInt(predecessor.getValues()[predecessorPeek]);
+		if (predecessorLastKey >= newFirstKey) {
+			throw boundaryMutationError(
+				"head", newFirstKey, "after the predecessor leaf boundary", predecessorLastKey);
+		}
+	}
+
+	/**
+	 * Resolves the predecessor leaf of the cursor's leaf. Common case ({@code ci > 0}): the same-parent left sibling
+	 * is the predecessor, read in O(1) from the cursor's already-materialized sibling array. Rare case
+	 * ({@code ci == 0}): walk up to the nearest ancestor whose descent was into a non-leftmost child (the clamp
+	 * ancestor), then follow that ancestor's left-neighbour subtree down its right spine to the predecessor leaf.
+	 * That rare branch is O(height) and, if transactional-layer child resolution allocates, allocation is accepted —
+	 * it is never taken by sequential append (append never lowers a first key) and only by a random workload that
+	 * undercuts a leaf minimum at a parent edge.
+	 *
+	 * @param cursor the descent path to the leaf whose predecessor is sought
+	 * @return the predecessor leaf, or {@code null} when the cursor's leaf is the tree's leftmost leaf
+	 */
+	@Nullable
+	private BPlusLeafTreeNode<E> predecessorLeaf(@Nonnull Cursor cursor) {
+		final List<CursorLevel> path = cursor.path();
+		final CursorLevel leafLevel = path.get(path.size() - 1);
+		final int leafIndex = leafLevel.index();
+		if (leafIndex > 0) {
+			//noinspection unchecked
+			return (BPlusLeafTreeNode<E>) leafLevel.siblings()[leafIndex - 1];
+		}
+		for (int level = path.size() - 1; level >= 1; level--) {
+			final CursorLevel cursorLevel = path.get(level);
+			final int childIndex = cursorLevel.index();
+			if (childIndex > 0) {
+				BPlusTreeNode<?> node = cursorLevel.siblings()[childIndex - 1];
+				while (node instanceof BPlusInternalTreeNode internalNode) {
+					node = internalNode.getChildren()[internalNode.getPeek()];
+				}
+				//noinspection unchecked
+				return (BPlusLeafTreeNode<E>) node;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Builds the shared boundary-mutation corruption error with the offending key, the neighbour boundary it
+	 * collides with and a remediation hint.
+	 *
+	 * @param side        {@code "tail"} or {@code "head"} — which boundary the mutation changed
+	 * @param boundaryKey the leaf's new boundary key that violates cross-leaf order
+	 * @param relation    the ordering relation that was expected (e.g. `before the successor leaf boundary`)
+	 * @param neighborKey the adjacent leaf boundary that {@code boundaryKey} failed to sort against
+	 * @return the corruption error to throw
+	 */
+	@Nonnull
+	private BPlusTreeCorruptedException boundaryMutationError(
+		@Nonnull String side, int boundaryKey, @Nonnull String relation, int neighborKey) {
+		return new BPlusTreeCorruptedException(
+			"Corrupted in-memory B+ tree: a leaf's " + side + " boundary key " + boundaryKey + " does not sort " +
+				relation + " (" + neighborKey + "). This indicates cross-leaf key overlap (a mis-routed insertion, a " +
+				"reverted transactional layer, or a merge defect) that would overlap an adjacent leaf page on flush. " +
+				"Restore the catalog from a backup, or fully rebuild / reindex the affected catalog."
+		);
+	}
+
+	/**
+	 * Registers a rebalanced leaf as a dirty-scope token for this transaction. Invoked by the base
+	 * {@link #consolidate(Cursor)} for each leaf whose boundary keys a steal / merge shifted.
+	 *
+	 * @param leaf the rebalanced leaf node
+	 */
+	@Override
+	protected void registerConsolidatedLeaf(@Nonnull BPlusTreeNode<?> leaf) {
+		registerDirtyLeafInScope(this, leaf);
+	}
+
+	/**
+	 * Dirty-scope validation for this tree. For each registered key source (a writable leaf
+	 * this transaction dirtied) it reads the current first key, descends from this tree's root to the leaf that key
+	 * routes to, and re-derives both cross-leaf half-invariants on the leaf the descent actually landed on — reusing
+	 * the op-time machinery with the leaf's ACTUAL boundary keys ({@link #assertTailBoundary} against the successor
+	 * fence, {@link #assertHeadBoundary} against the predecessor's last key). This tree keeps no parallel key array,
+	 * so the boundary keys are re-derived on demand: the first key via {@link BPlusLeafTreeNode#getLeftBoundaryKey()},
+	 * the last via the key extractor over the peek slot. Empty key sources and descents that land on an empty leaf are
+	 * skipped (nothing to relocate by / assert). Called on the live baseline tree for the pre-commit (pre-WAL) pass,
+	 * where the descent resolves diff layers, and on a freshly merged tree for the post-replay (merge-time) pass with
+	 * plain reads; both use read-path accessors only.
+	 *
+	 * @param registeredLeafKeySources the writable leaf objects registered for this tree; used only as key sources
+	 * @throws BPlusTreeCorruptedException when a relocated leaf overlaps an adjacent leaf
+	 */
+	@Override
+	public void validateDirtyScope(@Nonnull Collection<Object> registeredLeafKeySources) {
+		for (final Object keySource : registeredLeafKeySources) {
+			//noinspection unchecked
+			final BPlusLeafTreeNode<E> registered = (BPlusLeafTreeNode<E>) keySource;
+			if (registered.getPeek() < 0) {
+				// empty key source — nothing to relocate by (key-source-only rule)
+				continue;
+			}
+			final int probeKey = registered.getLeftBoundaryKey();
+			final Cursor cursor = createCursor(probeKey);
+			final BPlusLeafTreeNode<E> leaf = cursor.leafNode();
+			final int peek = leaf.getPeek();
+			if (peek < 0) {
+				// the descent landed on an empty leaf — validating it is sound and vacuous
+				continue;
+			}
+			final int firstKey = leaf.getLeftBoundaryKey();
+			final int lastKey = this.keyExtractor.applyAsInt(leaf.getValues()[peek]);
+			assertTailBoundary(cursor, lastKey);
+			assertHeadBoundary(cursor, firstKey);
+		}
+	}
+
+	/**
+	 * Separator-order belt. After a parent separator at {@code slot} is rewritten (head-key propagation),
+	 * asserts strict local order against its existing neighbours. This catches stale/aliased internal-node state —
+	 * the historical stale-leaf-page twin bugs were object aliasing, whose first symptom is a separator that no
+	 * longer matches the live leaf it fronts. It is a belt, not the head-side check: it cannot detect a mis-routed
+	 * head insert that keeps the separators individually ordered (that is what {@link #assertHeadBoundary} covers).
+	 *
+	 * @param keys the internal node's live separator array
+	 * @param peek the internal node's peek (separator count is {@code peek}, valid indices {@code 0..peek-1})
+	 * @param slot the just-rewritten separator index
+	 * @throws GenericEvitaInternalError when the rewritten separator breaks strict local order
+	 */
+	static void assertSeparatorOrder(@Nonnull int[] keys, int peek, int slot) {
+		if (slot > 0 && keys[slot - 1] >= keys[slot]) {
+			throw separatorOrderError(keys[slot - 1], keys[slot]);
+		}
+		if (slot < peek - 1 && keys[slot] >= keys[slot + 1]) {
+			throw separatorOrderError(keys[slot], keys[slot + 1]);
+		}
+	}
+
+	/**
+	 * Builds the separator-order corruption error.
+	 *
+	 * @param leftKey  the separator that should sort strictly before {@code rightKey}
+	 * @param rightKey the separator that {@code leftKey} collides with
+	 * @return the corruption error to throw
+	 */
+	@Nonnull
+	private static GenericEvitaInternalError separatorOrderError(int leftKey, int rightKey) {
+		return new GenericEvitaInternalError(
+			"Corrupted in-memory B+ tree: internal separator keys are out of order (" + leftKey + " does not sort " +
+				"before " + rightKey + "). This indicates stale/aliased internal-node state. Restore the catalog " +
+				"from a backup, or fully rebuild / reindex the affected catalog."
+		);
+	}
+
+	/**
+	 * Runs the op-time boundary-mutation asserts for a freshly inserted key. A tail insert raises the leaf's last
+	 * key, a head insert lowers its first key, and the insert into an empty leaf (the 0→1 transition) does both;
+	 * an interior insert cannot violate cross-leaf order in a sound tree and is not checked. Called on the leaf
+	 * mutation path shared by warm-up bulk load, transactional ops and trunk replay. The leaf's boundary keys are
+	 * re-derived on demand via the key extractor (this tree keeps no parallel key array).
+	 *
+	 * @param cursor the descent path to the mutated leaf
+	 * @param key    the key just inserted
+	 */
+	void assertInsertBoundaries(@Nonnull Cursor cursor, int key) {
+		final BPlusLeafTreeNode<E> leaf = cursor.leafNode();
+		final int firstKey = leaf.getLeftBoundaryKey();
+		final int lastKey = this.keyExtractor.applyAsInt(leaf.getValues()[leaf.getPeek()]);
+		if (key == lastKey) {
+			assertTailBoundary(cursor, key);
+		}
+		if (key == firstKey) {
+			assertHeadBoundary(cursor, key);
+		}
 	}
 
 	/**
@@ -385,6 +706,11 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 		final BPlusLeafTreeNode<E> leaf = cursor.leafNode();
 		if (leaf.insert(value)) {
 			this.size.set(size() + 1);
+			// op-time boundary-mutation asserts run before the (possible) split, while the cursor still reflects
+			// the pre-split spine — a mis-routed insert corrupts cross-leaf order without any structural op firing
+			assertInsertBoundaries(cursor, key);
+			// register the dirtied leaf as a dirty-scope token for this transaction
+			registerDirtyLeafInScope(this, leaf);
 		}
 
 		// Split the leaf node if it exceeds the block size
@@ -407,6 +733,10 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 		final boolean headRemoved = leaf.size() > 1 && key == leaf.getLeftBoundaryKey();
 		if (leaf.delete(key)) {
 			this.size.set(size() - 1);
+			// register the dirtied leaf as a dirty-scope token for this transaction: a removal
+			// narrows the leaf's key range, but a later reverted layer could restore the wider pre-transaction range
+			// and overlap a neighbour that split during the transaction — so removals are validated too
+			registerDirtyLeafInScope(this, leaf);
 		}
 
 		// if the head of the leaf has been removed, we need to update parent keys accordingly
@@ -572,8 +902,9 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 	public TransactionalElementBPlusTree<E> createCopyWithMergedTransactionalMemory(
 		@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		final BPlusTreeNode<?> theRoot = transactionalLayer.getStateCopyWithCommittedChanges(this.root).orElseThrow();
+		final TransactionalElementBPlusTree<E> merged;
 		if (theRoot instanceof BPlusLeafTreeNode || theRoot instanceof BPlusInternalTreeNode) {
-			return new TransactionalElementBPlusTree<>(
+			merged = new TransactionalElementBPlusTree<>(
 				this.valueBlockSize, this.minValueBlockSize,
 				this.internalNodeBlockSize, this.minInternalNodeBlockSize,
 				this.elementType,
@@ -584,6 +915,16 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 		} else {
 			throw new GenericEvitaInternalError("Unknown node type: " + theRoot);
 		}
+		// post-replay (merge-time): before this merged version can propagate to the live view, re-derive the
+		// cross-leaf boundary invariants for every leaf this transaction dirtied — against the freshly merged
+		// structure (plain reads; the merged nodes are fresh or unchanged-and-layer-free, so the descent never
+		// consults a diff layer). Registered objects are key sources only; each is relocated by its current key
+		// in the merged tree.
+		final Set<Object> dirtyScope = transactionalLayer.getDirtyScopeTokens(this);
+		if (!dirtyScope.isEmpty()) {
+			merged.validateDirtyScope(dirtyScope);
+		}
+		return merged;
 	}
 
 	/**
@@ -611,6 +952,21 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 	) {
 		final int mid = this.valueBlockSize / 2;
 		final E[] originValues = leaf.getValues();
+
+		// structural assert: the split partitions a sorted leaf into a left half [0, mid) and a right half
+		// [mid, length); the left leaf's last key must sort strictly before the right leaf's first key, and the
+		// promoted separator is exactly that right first key. A violation means the leaf being split was already
+		// out of order — fail fast rather than persist two overlapping pages.
+		final int leftLastKey = this.keyExtractor.applyAsInt(originValues[mid - 1]);
+		final int rightFirstKey = this.keyExtractor.applyAsInt(originValues[mid]);
+		if (leftLastKey >= rightFirstKey) {
+			throw new GenericEvitaInternalError(
+				"Corrupted in-memory B+ tree: splitting a leaf produced overlapping halves — the left half's last " +
+					"key (" + leftLastKey + ") does not sort before the right half's first key (" +
+					rightFirstKey + "). The leaf being split was already out of order. Restore the catalog from a " +
+					"backup, or fully rebuild / reindex the affected catalog."
+			);
+		}
 
 		// Move half the values into the new array of the left leaf node. Split offspring are transaction-aware (see
 		// splitNodesJoinTransactionalLayer): inside an active transaction they mutate in place, so the commit-merge
@@ -658,6 +1014,10 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 				cursor.toCursorWithLevel()
 			);
 		}
+		// a split creates a brand-new adjacent leaf pair with a fresh separator between them — register both halves
+		// as dirty-scope tokens for this transaction
+		registerDirtyLeafInScope(this, leftLeaf);
+		registerDirtyLeafInScope(this, rightLeaf);
 	}
 
 	/**
@@ -730,6 +1090,23 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 			boolean transactionalLayer
 		) {
 			return new BPlusInternalTreeNode(keys, children, peek, transactionalLayer);
+		}
+
+		/**
+		 * Rewrites the separator for the child at {@code index} (head-key propagation) and then runs the
+		 * separator-order belt over the just-written slot. The superclass writes into whichever separator array is
+		 * live — the committed {@code this.keys} when no transactional layer exists, or the decoupled {@code layer.keys}
+		 * otherwise — so reading the array back via {@link #getKeys()} / {@link #getPeek()} covers both branches with a
+		 * single zero-allocation check on the same array the write landed in.
+		 *
+		 * @param index the index in the keys array whose separator is rewritten (must be greater than 0)
+		 * @param node  the child node whose left boundary key becomes the new separator at {@code index}
+		 */
+		@Override
+		public void updateKeyForNode(int index, @Nonnull BPlusTreeNode<?> node) {
+			super.updateKeyForNode(index, node);
+			// separator-order belt: the rewritten separator must keep strict local order
+			assertSeparatorOrder(getKeys(), getPeek(), index - 1);
 		}
 
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTree.java
@@ -25,6 +25,7 @@ package io.evitadb.index.bPlusTree;
 
 
 import io.evitadb.core.transaction.Transaction;
+import io.evitadb.core.transaction.memory.DirtyScopeValidator;
 import io.evitadb.core.transaction.memory.Snapshotable;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
@@ -42,10 +43,12 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.PrimitiveIterator.OfLong;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
@@ -61,6 +64,7 @@ import static io.evitadb.utils.ArrayUtils.*;
 @NotThreadSafe
 public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTree implements
 	TransactionalLayerProducer<Void, TransactionalLongBPlusTree<V>>,
+	DirtyScopeValidator,
 	Serializable,
 	ConsistencySensitiveDataStructure {
 	@Serial private static final long serialVersionUID = 124088192205606247L;
@@ -398,14 +402,24 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 	 * into the assembled tree exactly as in {@link #assembleFromLeaves} — do not keep mutating the source trees
 	 * afterwards.
 	 *
+	 * The reassembled leaves are validated for strict cross-leaf key order BEFORE the spine is built: the last key of a
+	 * key-bearing leaf must sort strictly before the first key of the next key-bearing leaf. A violation means the
+	 * persisted page list carries a stale leaf-page twin (a frozen snapshot of a leaf persisted next to the page that
+	 * superseded it) or other index corruption; it is not silently repaired but reported via
+	 * {@link #assertCrossLeafBoundaries} — see the defensive-design rationale there.
+	 *
 	 * @param orderedSingleLeafTrees the per-page single-leaf trees in ascending key order
-	 * @param pageSequences               the persisted page sequence for each tree, positionally aligned; same length
+	 * @param pageSequences          the persisted page sequence for each tree, positionally aligned; same length
+	 * @param structureDescription   a full identification of the index for diagnostics, reading like a noun phrase after
+	 *                               `persisted ` (e.g. `range index for attribute …`)
 	 * @return a new tree whose leaves are exactly those of the supplied trees, each stamped with its page sequence
+	 * @throws GenericEvitaInternalError when the persisted leaf pages violate strict cross-leaf key order
 	 */
 	@Nonnull
 	public TransactionalLongBPlusTree<V> assembleFromSingleLeafTrees(
 		@Nonnull List<TransactionalLongBPlusTree<V>> orderedSingleLeafTrees,
-		@Nonnull int[] pageSequences
+		@Nonnull int[] pageSequences,
+		@Nonnull String structureDescription
 	) {
 		Assert.isPremiseValid(
 			orderedSingleLeafTrees.size() == pageSequences.length,
@@ -423,7 +437,286 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 			leaf.setPageSequence(pageSequences[i]);
 			leaves.add(leaf);
 		}
+		// validate cross-leaf key order BEFORE assembly, so the corruption diagnostic fires ahead of any left-boundary
+		// separator invariant the spine builder would otherwise trip on with a less actionable message
+		assertCrossLeafBoundaries(leaves, structureDescription);
 		return assembleFromLeaves(leaves);
+	}
+
+	/**
+	 * Validates that the supplied leaves are in strict cross-leaf key order: the last key of each key-bearing leaf must
+	 * sort strictly before the first key of the next key-bearing leaf (natural `long` order). Empty leaves carry no key
+	 * and impose no boundary constraint, so they are skipped when locating the previous key-bearing leaf.
+	 *
+	 * A paged index persists one storage part per B+ tree leaf plus a root part listing the ordered leaf-page sequence;
+	 * the reload path re-assembles one in-memory leaf per persisted page. A writer race on a `@NotThreadSafe` warm-up
+	 * session can leave a frozen stale snapshot of a leaf reachable next to the page that superseded it, and a one-shot
+	 * flush persists BOTH — every subsequent reload then rebuilds a tree whose leaves overlap, silently serving corrupt
+	 * data until it crashes later with a confusing signature far from the cause. Because the paged persistence layout has
+	 * never shipped in a released version, no production catalog can carry such a twin; silently repairing one would
+	 * contradict the defensive-design rule, so any detected overlap fails fast here with full diagnostics and an operator
+	 * remediation hint.
+	 *
+	 * @param leaves               the reassembled leaves in persisted list order
+	 * @param structureDescription a full identification of the index for diagnostics (see
+	 *                             {@link #assembleFromSingleLeafTrees})
+	 * @throws GenericEvitaInternalError when a leaf's last key does not sort strictly before the next leaf's first key
+	 */
+	private void assertCrossLeafBoundaries(
+		@Nonnull List<BPlusLeafTreeNode<V>> leaves,
+		@Nonnull String structureDescription
+	) {
+		BPlusLeafTreeNode<V> previousKeyBearing = null;
+		for (final BPlusLeafTreeNode<V> leaf : leaves) {
+			final int peek = leaf.getPeek();
+			if (peek < 0) {
+				// empty leaf carries no key and cannot violate cross-leaf ordering
+				continue;
+			}
+			final long[] keys = leaf.getKeys();
+			// intra-leaf order: a serializer bug, truncated write or bit rot can leave a leaf whose interior keys
+			// are out of order, while the cross-leaf walk alone would pass it — binary search inside such a leaf
+			// then silently returns wrong answers. Assert each key sorts strictly after its predecessor within the
+			// leaf (one comparison per key, once per load).
+			for (int i = 1; i <= peek; i++) {
+				if (keys[i - 1] >= keys[i]) {
+					throw new GenericEvitaInternalError(
+						"Corrupted persisted " + structureDescription + ": leaf-page sequence " +
+							leaf.getPageSequence() + " has out-of-order keys — the key at position " + (i - 1) + " (" +
+							keys[i - 1] + ") does not sort before the key at position " + i + " (" + keys[i] + "). This " +
+							"is index corruption. Restore the catalog from a backup, or fully rebuild / reindex the " +
+							"affected catalog."
+					);
+				}
+			}
+			if (previousKeyBearing != null) {
+				final long previousLastKey = previousKeyBearing.getKeys()[previousKeyBearing.getPeek()];
+				final long currentFirstKey = keys[0];
+				if (previousLastKey >= currentFirstKey) {
+					throw new GenericEvitaInternalError(
+						"Corrupted persisted " + structureDescription + ": leaf-page sequence " +
+							previousKeyBearing.getPageSequence() + " overlaps its successor leaf-page sequence " +
+							leaf.getPageSequence() + " — its last key (" + previousLastKey + ") does not sort before the " +
+							"first key (" + currentFirstKey + ") of the next leaf page. This is a stale leaf-page twin or " +
+							"other index corruption. Restore the catalog from a backup, or fully rebuild / reindex the " +
+							"affected catalog."
+					);
+				}
+			}
+			previousKeyBearing = leaf;
+		}
+	}
+
+	/**
+	 * Tail-boundary assert. On any leaf mutation that RAISES the leaf's last key (a tail insert, including
+	 * the insert into an empty leaf), verifies the new last key still sorts strictly below the leaf's upper fence.
+	 * The fence is the separator at the nearest ancestor whose descent was not into the rightmost child — which,
+	 * by the separator-from-first-key invariant, equals the first key of the successor leaf, even when that
+	 * successor lives under a different parent, grandparent, etc. A rightmost descent at every level means the
+	 * leaf is the tree's last leaf and has no successor, so nothing is checked.
+	 *
+	 * A violation means a key was routed into a leaf whose successor should hold it (a search-path corruption); it
+	 * would overlap the successor's page on flush, so it fails fast here. Zero allocation and no cross-parent leaf
+	 * navigation: the fence is pure index arithmetic over the cursor arrays. Sequential bulk append descends into
+	 * the rightmost child at every level, so the walk finds no fence and returns after a few comparisons.
+	 *
+	 * @param cursor     the descent path to the mutated leaf
+	 * @param newLastKey the leaf's new last key after the mutation
+	 * @throws GenericEvitaInternalError when the new last key does not sort strictly before the successor fence
+	 */
+	void assertTailBoundary(@Nonnull Cursor cursor, long newLastKey) {
+		final List<CursorLevel> path = cursor.path();
+		for (int level = path.size() - 1; level >= 1; level--) {
+			final CursorLevel cursorLevel = path.get(level);
+			final int childIndex = cursorLevel.index();
+			if (childIndex < cursorLevel.peek()) {
+				// the ancestor whose children are this level's siblings holds the fence separator at childIndex
+				final CursorLevel ancestorLevel = path.get(level - 1);
+				final BPlusInternalTreeNode ancestor =
+					(BPlusInternalTreeNode) ancestorLevel.siblings()[ancestorLevel.index()];
+				final long fence = ancestor.getKeys()[childIndex];
+				if (newLastKey >= fence) {
+					throw boundaryMutationError("tail", newLastKey, "before the successor leaf boundary", fence);
+				}
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Head-boundary assert. On any leaf mutation that LOWERS the leaf's first key (a head insert, including
+	 * the insert into an empty leaf), verifies the new first key still sorts strictly above the predecessor leaf's
+	 * last key. In a sound tree a head insert can only land on the tree's leftmost leaf (the separator-from-first-key
+	 * invariant routes every key at-or-above the leaf's own first key), so this check passes trivially; it fires only
+	 * on a mis-routed insert that undercuts a real predecessor.
+	 *
+	 * The predecessor's last key is the only meaningful operand: checking the parent separator would be circular,
+	 * as the maintained invariant makes it equal the leaf's own first key.
+	 *
+	 * @param cursor      the descent path to the mutated leaf
+	 * @param newFirstKey the leaf's new first key after the mutation
+	 * @throws GenericEvitaInternalError when the new first key does not sort strictly after the predecessor boundary
+	 */
+	void assertHeadBoundary(@Nonnull Cursor cursor, long newFirstKey) {
+		final BPlusLeafTreeNode<V> predecessor = predecessorLeaf(cursor);
+		if (predecessor == null) {
+			// leftmost leaf — no predecessor to violate
+			return;
+		}
+		final int predecessorPeek = predecessor.getPeek();
+		if (predecessorPeek < 0) {
+			// an empty predecessor carries no key (mirrors the load-time empty-leaf skip)
+			return;
+		}
+		final long predecessorLastKey = predecessor.getKeys()[predecessorPeek];
+		if (predecessorLastKey >= newFirstKey) {
+			throw boundaryMutationError(
+				"head", newFirstKey, "after the predecessor leaf boundary", predecessorLastKey);
+		}
+	}
+
+	/**
+	 * Resolves the predecessor leaf of the cursor's leaf. Common case ({@code ci > 0}): the same-parent left sibling
+	 * is the predecessor, read in O(1) from the cursor's already-materialized sibling array. Rare case
+	 * ({@code ci == 0}): walk up to the nearest ancestor whose descent was into a non-leftmost child (the clamp
+	 * ancestor), then follow that ancestor's left-neighbour subtree down its right spine to the predecessor leaf.
+	 * That rare branch is O(height) and, if transactional-layer child resolution allocates, allocation is accepted —
+	 * it is never taken by sequential append (append never lowers a first key) and only by a random workload that
+	 * undercuts a leaf minimum at a parent edge.
+	 *
+	 * @param cursor the descent path to the leaf whose predecessor is sought
+	 * @return the predecessor leaf, or {@code null} when the cursor's leaf is the tree's leftmost leaf
+	 */
+	@Nullable
+	private BPlusLeafTreeNode<V> predecessorLeaf(@Nonnull Cursor cursor) {
+		final List<CursorLevel> path = cursor.path();
+		final CursorLevel leafLevel = path.get(path.size() - 1);
+		final int leafIndex = leafLevel.index();
+		if (leafIndex > 0) {
+			//noinspection unchecked
+			return (BPlusLeafTreeNode<V>) leafLevel.siblings()[leafIndex - 1];
+		}
+		for (int level = path.size() - 1; level >= 1; level--) {
+			final CursorLevel cursorLevel = path.get(level);
+			final int childIndex = cursorLevel.index();
+			if (childIndex > 0) {
+				BPlusTreeNode<?> node = cursorLevel.siblings()[childIndex - 1];
+				while (node instanceof BPlusInternalTreeNode internalNode) {
+					node = internalNode.getChildren()[internalNode.getPeek()];
+				}
+				//noinspection unchecked
+				return (BPlusLeafTreeNode<V>) node;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Builds the shared cross-leaf boundary corruption error with the Phase 1 message style (offending boundary key,
+	 * the neighbour boundary it collides with, remediation hint). Shared by the op-time asserts and the
+	 * commit-time relocate-and-validate pass, so its wording is cause-neutral (a mis-routed insertion, a
+	 * reverted transactional layer or a merge defect could all produce the overlap) and view-neutral (no WAL /
+	 * poison-pill wording — the trunk-replay path adds that when it wraps the exception).
+	 *
+	 * @param side        {@code "tail"} or {@code "head"} — which leaf boundary is out of order
+	 * @param boundaryKey the leaf boundary key that violates cross-leaf order
+	 * @param relation    the ordering relation that was expected (e.g. `before the successor leaf boundary`)
+	 * @param neighborKey the adjacent leaf boundary that {@code boundaryKey} failed to sort against
+	 * @return the corruption error to throw
+	 */
+	@Nonnull
+	private BPlusTreeCorruptedException boundaryMutationError(
+		@Nonnull String side, long boundaryKey, @Nonnull String relation, long neighborKey) {
+		return new BPlusTreeCorruptedException(
+			"Corrupted in-memory B+ tree: a leaf's " + side + " boundary key " + boundaryKey + " does not sort " +
+				relation + " (" + neighborKey + "). This indicates cross-leaf key overlap (a mis-routed insertion, a " +
+				"reverted transactional layer, or a merge defect) that would overlap an adjacent leaf page on flush. " +
+				"Restore the catalog from a backup, or fully rebuild / reindex the affected catalog."
+		);
+	}
+
+	/**
+	 * Registers a rebalanced leaf as a dirty-scope token for this transaction.
+	 * Invoked by the base {@link #consolidate(Cursor)} for each leaf whose boundary keys a steal / merge shifted.
+	 *
+	 * @param leaf the rebalanced leaf node
+	 */
+	@Override
+	protected void registerConsolidatedLeaf(@Nonnull BPlusTreeNode<?> leaf) {
+		registerDirtyLeafInScope(this, leaf);
+	}
+
+	/**
+	 * Dirty-scope validation for this tree. For each registered key source (a writable leaf
+	 * this transaction dirtied) it reads the current first key, descends from this tree's root to the leaf that key
+	 * routes to, and re-derives both cross-leaf half-invariants on the leaf the descent actually landed on — reusing
+	 * the op-time machinery with the leaf's ACTUAL boundary keys ({@link #assertTailBoundary} against the successor
+	 * fence, {@link #assertHeadBoundary} against the predecessor's last key). Empty key sources and descents that land
+	 * on an empty leaf are skipped (nothing to relocate by / assert). Called on the live baseline tree for the
+	 * pre-commit (pre-WAL) pass (the descent resolves diff layers) and on a freshly merged tree for the post-replay
+	 * (merge-time) pass (plain reads); both use read-path accessors only.
+	 *
+	 * @param registeredLeafKeySources the writable leaf objects registered for this tree; used only as key sources
+	 * @throws BPlusTreeCorruptedException when a relocated leaf overlaps an adjacent leaf
+	 */
+	@Override
+	public void validateDirtyScope(@Nonnull Collection<Object> registeredLeafKeySources) {
+		for (final Object keySource : registeredLeafKeySources) {
+			//noinspection unchecked
+			final BPlusLeafTreeNode<V> registered = (BPlusLeafTreeNode<V>) keySource;
+			if (registered.getPeek() < 0) {
+				// empty key source — nothing to relocate by (key-source-only rule)
+				continue;
+			}
+			final long probeKey = registered.getKeys()[0];
+			final Cursor cursor = createCursor(probeKey);
+			final BPlusLeafTreeNode<V> leaf = cursor.leafNode();
+			final int peek = leaf.getPeek();
+			if (peek < 0) {
+				// the descent landed on an empty leaf — validating it is sound and vacuous
+				continue;
+			}
+			final long[] keys = leaf.getKeys();
+			assertTailBoundary(cursor, keys[peek]);
+			assertHeadBoundary(cursor, keys[0]);
+		}
+	}
+
+	/**
+	 * Separator-order belt. After a parent separator at {@code slot} is rewritten (head-key propagation),
+	 * asserts strict local order against its existing neighbours. This catches stale/aliased internal-node state —
+	 * the historical stale-leaf-page twin bugs were object aliasing, whose first symptom is a separator that no
+	 * longer matches the live leaf it fronts. It is a belt, not the head-side check: it cannot detect a mis-routed
+	 * head insert that keeps the separators individually ordered (that is what {@link #assertHeadBoundary} covers).
+	 *
+	 * @param keys the internal node's live separator array
+	 * @param peek the internal node's peek (separator count is {@code peek}, valid indices {@code 0..peek-1})
+	 * @param slot the just-rewritten separator index
+	 * @throws GenericEvitaInternalError when the rewritten separator breaks strict local order
+	 */
+	static void assertSeparatorOrder(@Nonnull long[] keys, int peek, int slot) {
+		if (slot > 0 && keys[slot - 1] >= keys[slot]) {
+			throw separatorOrderError(keys[slot - 1], keys[slot]);
+		}
+		if (slot < peek - 1 && keys[slot] >= keys[slot + 1]) {
+			throw separatorOrderError(keys[slot], keys[slot + 1]);
+		}
+	}
+
+	/**
+	 * Builds the separator-order corruption error.
+	 *
+	 * @param leftKey  the separator that should sort strictly before {@code rightKey}
+	 * @param rightKey the separator that {@code leftKey} collides with
+	 * @return the corruption error to throw
+	 */
+	@Nonnull
+	private static GenericEvitaInternalError separatorOrderError(long leftKey, long rightKey) {
+		return new GenericEvitaInternalError(
+			"Corrupted in-memory B+ tree: internal separator keys are out of order (" + leftKey + " does not sort " +
+				"before " + rightKey + "). This indicates stale/aliased internal-node state. Restore the catalog " +
+				"from a backup, or fully rebuild / reindex the affected catalog."
+		);
 	}
 
 	/**
@@ -494,11 +787,38 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 		final BPlusLeafTreeNode<V> leaf = cursor.leafNode();
 		if (leaf.insert(key, value)) {
 			this.size.set(size() + 1);
+			// op-time boundary-mutation asserts run before the (possible) split, while the cursor still reflects
+			// the pre-split spine — a mis-routed insert corrupts cross-leaf order without any structural op firing
+			assertInsertBoundaries(cursor, key);
+			// register the dirtied leaf as a dirty-scope token for this transaction
+			registerDirtyLeafInScope(this, leaf);
 		}
 
 		// Split the leaf node if it exceeds the block size
 		if (leaf.isFull()) {
 			splitLeafNode(leaf, cursor);
+		}
+	}
+
+	/**
+	 * Runs the op-time boundary-mutation asserts for a freshly inserted key. A tail insert raises the leaf's last
+	 * key, a head insert lowers its first key, and the insert into an empty leaf (the 0→1 transition) does both;
+	 * an interior insert cannot violate cross-leaf order in a sound tree and is not checked. Called on the leaf
+	 * mutation path shared by warm-up bulk load, transactional ops and trunk replay.
+	 *
+	 * @param cursor the descent path to the mutated leaf
+	 * @param leaf   the mutated leaf
+	 * @param key    the key just inserted
+	 */
+	void assertInsertBoundaries(@Nonnull Cursor cursor, long key) {
+		final BPlusLeafTreeNode<V> leaf = cursor.leafNode();
+		final long[] keys = leaf.getKeys();
+		final int peek = leaf.getPeek();
+		if (key == keys[peek]) {
+			assertTailBoundary(cursor, key);
+		}
+		if (key == keys[0]) {
+			assertHeadBoundary(cursor, key);
 		}
 	}
 
@@ -518,7 +838,9 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 		final int existingIndex = leaf.getValueIndex(key);
 		if (existingIndex >= 0) {
 			// updating an existing value's slot mutates this leaf's page (the value object is replaced or mutated in
-			// place by the updater) — flag the leaf so the granular write path re-emits its page
+			// place by the updater) — flag the leaf so the granular write path re-emits its page. This branch does NOT
+			// register the leaf for dirty-scope validation: it replaces a value at an existing key, so no key boundary
+			// moves and no reverted layer could create cross-leaf overlap — validating it would be pure cost.
 			leaf.markDirty();
 			// update the value on specified index
 			leaf.decoupleTransactionalArrays();
@@ -536,6 +858,10 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 			// insert the new value
 			if (leaf.insert(key, updater.apply(null))) {
 				this.size.set(size() + 1);
+				// op-time boundary-mutation asserts — see insert(long, V)
+				assertInsertBoundaries(cursor, key);
+				// register the dirtied leaf as a dirty-scope token for this transaction
+				registerDirtyLeafInScope(this, leaf);
 			}
 
 			// Split the leaf node if it exceeds the block size
@@ -560,6 +886,11 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 		final boolean headRemoved = leaf.size() > 1 && key == leaf.getKeys()[0];
 		if (leaf.delete(key)) {
 			this.size.set(size() - 1);
+			// register the dirtied leaf as a dirty-scope token for this transaction: a
+			// removal narrows the leaf's key range, but a later reverted layer could restore the wider
+			// pre-transaction range and overlap a neighbour that split during the transaction — so removals are
+			// validated too
+			registerDirtyLeafInScope(this, leaf);
 		}
 
 		// if the head of the leaf has been removed, we need to update parent keys accordingly
@@ -596,6 +927,8 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 		final Cursor cursor = createCursor(key);
 		final BPlusLeafTreeNode<V> leaf = cursor.leafNode();
 		if (leaf.getValueIndex(key) >= 0) {
+			// flags an out-of-band value-content change; no key boundary moves, so this is not registered for the
+			// transaction's dirty scope (see the in-place branch of upsert)
 			leaf.markDirty();
 		}
 	}
@@ -769,10 +1102,11 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 	public TransactionalLongBPlusTree<V> createCopyWithMergedTransactionalMemory(
 		@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		final BPlusTreeNode<?> theRoot = transactionalLayer.getStateCopyWithCommittedChanges(this.root).orElseThrow();
+		final TransactionalLongBPlusTree<V> merged;
 		if (theRoot instanceof BPlusLeafTreeNode<?> leafNode) {
 			//noinspection unchecked
 			final BPlusLeafTreeNode<V> theLeafNode = (BPlusLeafTreeNode<V>) leafNode;
-			return new TransactionalLongBPlusTree<>(
+			merged = new TransactionalLongBPlusTree<>(
 				this.valueBlockSize, this.minValueBlockSize,
 				this.internalNodeBlockSize, this.minInternalNodeBlockSize,
 				this.valueType,
@@ -781,7 +1115,7 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 				transactionalLayer.getStateCopyWithCommittedChanges(this.size).orElseThrow()
 			);
 		} else if (theRoot instanceof BPlusInternalTreeNode internalNode) {
-			return new TransactionalLongBPlusTree<>(
+			merged = new TransactionalLongBPlusTree<>(
 				this.valueBlockSize, this.minValueBlockSize,
 				this.internalNodeBlockSize, this.minInternalNodeBlockSize,
 				this.valueType,
@@ -792,6 +1126,16 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 		} else {
 			throw new GenericEvitaInternalError("Unknown node type: " + theRoot);
 		}
+		// post-replay (merge-time): before this merged version can propagate to the live view, re-derive the
+		// cross-leaf boundary invariants for every leaf this transaction dirtied — against the freshly merged
+		// structure (plain reads; the merged nodes are fresh or unchanged-and-layer-free, so the descent never
+		// consults a diff layer).
+		// Registered objects are key sources only; each is relocated by its current key in the merged tree.
+		final Set<Object> dirtyScope = transactionalLayer.getDirtyScopeTokens(this);
+		if (!dirtyScope.isEmpty()) {
+			merged.validateDirtyScope(dirtyScope);
+		}
+		return merged;
 	}
 
 	@Nonnull
@@ -825,7 +1169,7 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 	 * note that the leaf may not actually contain the key - but it is the correct leaf node for accommodating it
 	 */
 	@Nonnull
-	private Cursor createCursor(long key) {
+	Cursor createCursor(long key) {
 		final ArrayList<CursorLevel> path = new ArrayList<>(this.size() == 0 ? 1 : (int) (Math.log(this.size()) + 1));
 		final BPlusTreeNode<?> theRoot = this.getRoot();
 		final BPlusTreeNode<?>[] rootSiblings = new BPlusTreeNode<?>[]{theRoot};
@@ -852,6 +1196,19 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 		final int mid = this.valueBlockSize / 2;
 		final long[] originKeys = leaf.getKeys();
 		final V[] originValues = leaf.getValues();
+
+		// structural assert: the split partitions a sorted leaf into a left half [0, mid) and a right half
+		// [mid, length); the left leaf's last key must sort strictly before the right leaf's first key, and the
+		// promoted separator is exactly that right first key. A violation means the leaf being split was already
+		// out of order — fail fast rather than persist two overlapping pages.
+		if (originKeys[mid - 1] >= originKeys[mid]) {
+			throw new GenericEvitaInternalError(
+				"Corrupted in-memory B+ tree: splitting a leaf produced overlapping halves — the left half's last " +
+					"key (" + originKeys[mid - 1] + ") does not sort before the right half's first key (" +
+					originKeys[mid] + "). The leaf being split was already out of order. Restore the catalog from a " +
+					"backup, or fully rebuild / reindex the affected catalog."
+			);
+		}
 
 		// Move half the keys to the new arrays of the left leaf node
 		//noinspection unchecked
@@ -908,6 +1265,10 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 				cursor.toCursorWithLevel()
 			);
 		}
+		// a split creates a brand-new adjacent leaf pair with a fresh separator between them — register both halves
+		// as dirty-scope tokens for this transaction
+		registerDirtyLeafInScope(this, leftLeaf);
+		registerDirtyLeafInScope(this, rightLeaf);
 	}
 
 	/**
@@ -1666,6 +2027,8 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 					"Node to update key for must match the child node at the specified index!"
 				);
 				this.keys[index - 1] = leftBoundaryKeyOf(node);
+				// separator-order belt: the rewritten separator must keep strict local order
+				assertSeparatorOrder(this.keys, this.peek, index - 1);
 			} else {
 				decoupleTransactionalArrays();
 				Assert.isPremiseValid(
@@ -1673,6 +2036,7 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 					"Node to update key for must match the child node at the specified index!"
 				);
 				layer.keys[index - 1] = leftBoundaryKeyOf(node);
+				assertSeparatorOrder(layer.keys, layer.peek, index - 1);
 			}
 		}
 

--- a/evita_engine/src/main/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndex.java
@@ -172,6 +172,7 @@ public class ReferenceTypeCardinalityIndex
 	 * (high-water + live set) is restored, so the first post-restart commit rewrites only genuinely-changed leaves rather
 	 * than re-paginating the whole index.
 	 *
+	 * @param indexDescription       a full identification of this index for corruption diagnostics (e.g. the reference)
 	 * @param orderedPageSequences   the persisted leaf-page sequences in ascending key order
 	 * @param perPageKeys            the composed `long` keys of each leaf page, positionally aligned with `orderedPageSequences`
 	 * @param perPagePayloads        the counts of each leaf page, positionally aligned with `perPageKeys`
@@ -181,6 +182,7 @@ public class ReferenceTypeCardinalityIndex
 	 */
 	@Nonnull
 	public static ReferenceTypeCardinalityIndex fromPersistedPages(
+		@Nonnull String indexDescription,
 		@Nonnull int[] orderedPageSequences,
 		@Nonnull long[][] perPageKeys,
 		@Nonnull long[][] perPagePayloads,
@@ -204,7 +206,7 @@ public class ReferenceTypeCardinalityIndex
 			pageTrees.add(pageTree);
 		}
 		final TransactionalBucketBPlusTree tree =
-			createEmptyTree().assembleFromSingleLeafTrees(pageTrees, orderedPageSequences);
+			createEmptyTree().assembleFromSingleLeafTrees(pageTrees, orderedPageSequences, "cardinality index for " + indexDescription);
 		final PageStreamRegistry registry = PageStreamRegistry.restoredFrom(
 			CARDINALITY_PAGE_STREAM, highWaterPageSequence, tree.leafPageHandles()
 		);

--- a/evita_engine/src/main/java/io/evitadb/index/component/loader/AttributeIndexLoader.java
+++ b/evita_engine/src/main/java/io/evitadb/index/component/loader/AttributeIndexLoader.java
@@ -438,7 +438,7 @@ public final class AttributeIndexLoader implements ComponentLoader {
 			perPagePoints[i] = leafPage.getPoints();
 		}
 		return RangeIndex.fromPersistedPages(
-			rangePageSequences, perPagePoints, part.getRangeHighWaterPageSequence()
+			"attribute " + attributeIndexKey, rangePageSequences, perPagePoints, part.getRangeHighWaterPageSequence()
 		);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/component/loader/HistogramIndexMapLoader.java
+++ b/evita_engine/src/main/java/io/evitadb/index/component/loader/HistogramIndexMapLoader.java
@@ -262,7 +262,8 @@ public final class HistogramIndexMapLoader implements ComponentLoader {
 				perPagePoints[i] = leafPage.getPoints();
 			}
 			rangeIndex = RangeIndex.fromPersistedPages(
-				rangePageSequences, perPagePoints, part.getRangeHighWaterPageSequence()
+				"histogram '" + histogramName + "'", rangePageSequences, perPagePoints,
+				part.getRangeHighWaterPageSequence()
 			);
 		}
 

--- a/evita_engine/src/main/java/io/evitadb/index/component/loader/ReferenceTypeCardinalityLoader.java
+++ b/evita_engine/src/main/java/io/evitadb/index/component/loader/ReferenceTypeCardinalityLoader.java
@@ -91,7 +91,7 @@ public final class ReferenceTypeCardinalityLoader implements ComponentLoader {
 				perPagePayloads[i] = leaf.getPayloads();
 			}
 			index = ReferenceTypeCardinalityIndex.fromPersistedPages(
-				orderedPageSequences, perPageKeys, perPagePayloads,
+				"reference `" + referenceName + "`", orderedPageSequences, perPageKeys, perPagePayloads,
 				part.getHighWaterPageSequence(), part.getReferencedPrimaryKeysIndex()
 			);
 		} else {

--- a/evita_engine/src/main/java/io/evitadb/index/invertedIndex/InvertedIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/invertedIndex/InvertedIndex.java
@@ -35,6 +35,7 @@ import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer;
 import io.evitadb.dataType.ConsistencySensitiveDataStructure;
 import io.evitadb.dataType.array.CompositeObjectArray;
+import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.IndexDataStructure;
 import io.evitadb.index.bPlusTree.IntRecordBucketTree;
 import io.evitadb.index.bPlusTree.TransactionalBucketBPlusTree;
@@ -52,6 +53,7 @@ import io.evitadb.roaringbitmap.PersistentRoaringBitmap;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -106,6 +108,7 @@ import java.util.function.Predicate;
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 @ThreadSafe
+@Slf4j
 public class InvertedIndex implements
 	IndexDataStructure,
 	ConsistencySensitiveDataStructure,
@@ -526,7 +529,9 @@ public class InvertedIndex implements
 		}
 		// assemble the spine over the per-page leaves, preserving boundaries and stamping each leaf's page sequence
 		final TransactionalBucketBPlusTree tree =
-			createEmptyTree(plainType, comparator).assembleFromSingleLeafTrees(pageTrees, orderedPageSequences);
+			createEmptyTree(plainType, comparator).assembleFromSingleLeafTrees(
+				pageTrees, orderedPageSequences, "inverted index for type `" + plainType.getName() + "`"
+			);
 		final PageStreamRegistry pageStreamRegistry = PageStreamRegistry.restoredFrom(
 			BUCKET_PAGE_STREAM, highWaterPageSequence, tree.leafPageHandles()
 		);

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
@@ -234,37 +234,22 @@ public final class ContainerizedLocalMutationExecutor
 	}
 
 	/**
-	 * Retrieves all attribute keys specified in the passed {@link ReferenceContract}.
-	 */
-	@Nonnull
-	private static Set<AttributeKey> collectAttributeKeys(@Nonnull ReferenceContract referenceContract) {
-		final Collection<AttributeValue> attributeValues = referenceContract.getAttributeValues();
-		if (attributeValues.isEmpty()) {
-			return Collections.emptySet();
-		}
-		// allocation-optimized loop (avoids stream pipeline on this hot mutation path);
-		// pre-sized for the worst case where every attribute exists
-		final Set<AttributeKey> result = CollectionUtils.createHashSet(attributeValues.size());
-		for (final AttributeValue attributeValue : attributeValues) {
-			if (attributeValue.exists()) {
-				result.add(attributeValue.key());
-			}
-		}
-		return result;
-	}
-
-	/**
-	 * Processes reference attributes with default values.
+	 * Processes reference attributes with default values. For every mandatory / default-valued attribute declared by
+	 * the reference schema this checks - via an allocation-free membership probe on the reference itself
+	 * ({@link Reference#isAttributeValuePresentAndExists(AttributeKey)}) - whether the corresponding value is already
+	 * present; if not, the handler is invoked to either register the missing mandatory attribute or emit the
+	 * default-value mutation. Probing the (usually few) schema attributes directly avoids materializing the full key
+	 * set of the reference (a HashSet per reference) on this hot mutation path.
 	 *
 	 * @param referenceSchema         The reference schema, expected to be non-null.
 	 * @param entityLocales           The set of locales applicable to the entity, expected to be non-null.
-	 * @param availableAttributes     The set of available attribute keys, expected to be non-null.
-	 * @param missingAttributeHandler The handler for missing attributes, can be null if no handling is required.
+	 * @param reference               The reference whose existing attribute values are probed, expected to be non-null.
+	 * @param missingAttributeHandler The handler for missing attributes, expected to be non-null.
 	 */
 	private static void processReferenceAttributesWithDefaultValue(
 		@Nonnull ReferenceSchema referenceSchema,
 		@Nonnull Set<Locale> entityLocales,
-		@Nonnull Set<AttributeKey> availableAttributes,
+		@Nonnull Reference reference,
 		@Nonnull MissingAttributeHandler missingAttributeHandler
 	) {
 		for (final AttributeSchemaContract attributeSchema : referenceSchema.getNonNullableOrDefaultValueAttributes().values()) {
@@ -273,13 +258,13 @@ public final class ContainerizedLocalMutationExecutor
 			if (attributeSchema.isLocalized()) {
 				for (final Locale locale : entityLocales) {
 					final AttributeKey attributeKey = new AttributeKey(attributeSchema.getName(), locale);
-					if (!availableAttributes.contains(attributeKey)) {
+					if (!reference.isAttributeValuePresentAndExists(attributeKey)) {
 						missingAttributeHandler.accept(defaultValue, nullable, attributeKey);
 					}
 				}
 			} else {
 				final AttributeKey attributeKey = new AttributeKey(attributeSchema.getName());
-				if (!availableAttributes.contains(attributeKey)) {
+				if (!reference.isAttributeValuePresentAndExists(attributeKey)) {
 					missingAttributeHandler.accept(defaultValue, nullable, attributeKey);
 				}
 			}
@@ -2477,6 +2462,24 @@ public final class ContainerizedLocalMutationExecutor
 
 		final Set<Locale> entityLocales = entityStorageContainer.getLocales();
 		final List<AttributeKey> missingReferenceMandatedAttribute = new LinkedList<>();
+		// the only per-reference state the handler needs is the reference key; carrying it through a single-element
+		// holder lets the handler (and its captured context) be allocated once per call instead of once per reference
+		final ReferenceKey[] currentReferenceKey = new ReferenceKey[1];
+		final MissingAttributeHandler missingAttributeHandler = (defaultValue, nullable, attributeKey) -> {
+			Assert.isPremiseValid(attributeKey != null, "Attribute key must not be null!");
+			if (defaultValue == null) {
+				if (!nullable) {
+					missingReferenceMandatedAttribute.add(attributeKey);
+				}
+			} else {
+				mutationCollector.addLocalMutation(
+					new ReferenceAttributeMutation(
+						currentReferenceKey[0],
+						new UpsertAttributeMutation(attributeKey, defaultValue)
+					)
+				);
+			}
+		};
 		ReferenceSchema referenceSchema = null;
 		for (Reference reference : referencesStoragePart.getReferences()) {
 			if (reference.exists()) {
@@ -2485,31 +2488,19 @@ public final class ContainerizedLocalMutationExecutor
 					referenceSchema = entitySchema.getReferenceOrThrowException(reference.getReferenceName());
 				}
 				// skip references whose schema declares no mandatory / default-valued attributes -
-				// there is nothing to verify or default here, so we avoid collecting the reference
-				// attribute keys and allocating the per-reference handler for the common case
+				// there is nothing to verify or default here, so we avoid probing the reference attributes
+				// for the common case
 				if (referenceSchema.getNonNullableOrDefaultValueAttributes().isEmpty()) {
 					continue;
 				}
 				missingReferenceMandatedAttribute.clear();
-				final Set<AttributeKey> availableAttributes = collectAttributeKeys(reference);
-				final MissingAttributeHandler missingAttributeHandler = (defaultValue, nullable, attributeKey) -> {
-					Assert.isPremiseValid(attributeKey != null, "Attribute key must not be null!");
-					if (defaultValue == null) {
-						if (!nullable) {
-							missingReferenceMandatedAttribute.add(attributeKey);
-						}
-					} else {
-						mutationCollector.addLocalMutation(
-							new ReferenceAttributeMutation(
-								reference.getReferenceKey(),
-								new UpsertAttributeMutation(attributeKey, defaultValue)
-							)
-						);
-					}
-				};
+				// point the shared handler at the reference currently being verified
+				currentReferenceKey[0] = reference.getReferenceKey();
 
+				// probe the reference directly for each mandatory / default-valued schema attribute instead of
+				// materializing the full key set of the reference (a HashSet per reference on the hot path)
 				processReferenceAttributesWithDefaultValue(
-					referenceSchema, entityLocales, availableAttributes, missingAttributeHandler
+					referenceSchema, entityLocales, reference, missingAttributeHandler
 				);
 
 				if (!missingReferenceMandatedAttribute.isEmpty()) {

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndex.java
@@ -179,7 +179,9 @@ public class PriceListAndCurrencyPriceSuperIndex
 		}
 		// assemble the spine over the per-page leaves, preserving boundaries and stamping each leaf's page sequence
 		final TransactionalElementBPlusTree<PriceRecordContract> tree =
-			newPriceRecordTree().assembleFromSingleLeafTrees(pageTrees, orderedPageSequences);
+			newPriceRecordTree().assembleFromSingleLeafTrees(
+				pageTrees, orderedPageSequences, "super price index for price list " + priceIndexKey
+			);
 		final PageStreamRegistry pageStreamRegistry = PageStreamRegistry.restoredFrom(
 			PRICE_PAGE_STREAM, highWaterPageSequence, tree.<PriceRecordContract>leafPageHandles()
 		);

--- a/evita_engine/src/main/java/io/evitadb/index/range/RangeIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/range/RangeIndex.java
@@ -782,6 +782,8 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 	 * re-paginating the whole index. The border sentinels (`Long.MIN_VALUE` / `Long.MAX_VALUE`) live in the first / last
 	 * pages, so the reassembled tree carries them.
 	 *
+	 * @param indexDescription      a full identification of the owning index for corruption diagnostics (e.g. the
+	 *                              attribute or histogram the range companion belongs to)
 	 * @param orderedPageSequences  the persisted leaf-page sequences in ascending threshold order (the root's leaf list)
 	 * @param perPagePoints    the range points of each leaf page, positionally aligned with `orderedPageSequences`
 	 * @param highWaterPageSequence the persisted stream high-water (largest page sequence ever allocated)
@@ -789,6 +791,7 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 	 */
 	@Nonnull
 	public static RangeIndex fromPersistedPages(
+		@Nonnull String indexDescription,
 		@Nonnull int[] orderedPageSequences,
 		@Nonnull TransactionalRangePoint[][] perPagePoints,
 		int highWaterPageSequence
@@ -810,7 +813,7 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 		}
 		// assemble the spine over the per-page leaves, preserving boundaries and stamping each leaf's page sequence
 		final TransactionalLongBPlusTree<TransactionalRangePoint> tree =
-			createBareTree().assembleFromSingleLeafTrees(pageTrees, orderedPageSequences);
+			createBareTree().assembleFromSingleLeafTrees(pageTrees, orderedPageSequences, "range index for " + indexDescription);
 		final PageStreamRegistry pageStreamRegistry = PageStreamRegistry.restoredFrom(
 			RANGE_PAGE_STREAM, highWaterPageSequence, tree.<TransactionalRangePoint>leafPageHandles()
 		);

--- a/evita_engine/src/main/java/module-info.java
+++ b/evita_engine/src/main/java/module-info.java
@@ -39,6 +39,7 @@ module evita.engine {
 	exports io.evitadb.core.expression.proxy.reference;
 	exports io.evitadb.core.expression.trigger;
 	exports io.evitadb.core.engine;
+	exports io.evitadb.core.exception;
 	exports io.evitadb.core.executor;
 	exports io.evitadb.core.management;
 	exports io.evitadb.core.metric.event;

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/builder/constraint/ConstraintSchemaBuilder.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/builder/constraint/ConstraintSchemaBuilder.java
@@ -358,6 +358,45 @@ public abstract class ConstraintSchemaBuilder<CTX extends ConstraintSchemaBuildi
 
 	/**
 	 * Builds fields representing children of constraint container from constraint descriptors of these children.
+	 * This is shortcut method for building all children of {@link ConstraintPropertyType#GROUP} property type.
+	 * Unlike {@link #buildEntityChildren}, there's no root-level fallback: a GROUP-typed constraint only makes
+	 * sense when nested in a reference/facet scope whose reference schema actually declares a group type.
+	 */
+	@Nonnull
+	protected List<OBJECT_FIELD> buildGroupChildren(@Nonnull ConstraintBuildContext buildContext,
+	                                                @Nonnull AllowedConstraintPredicate allowedChildrenPredicate) {
+		final DataLocator parentDataLocator = buildContext.dataLocator();
+		if (!(parentDataLocator instanceof final DataLocatorWithReference dataLocatorWithReference)) {
+			return List.of();
+		}
+		final String referenceName = dataLocatorWithReference.referenceName();
+		if (referenceName == null) {
+			return List.of();
+		}
+
+		final ReferenceSchemaContract referenceSchema = this.sharedContext.getEntitySchemaOrThrowException(parentDataLocator.entityType())
+			.getReferenceOrThrowException(referenceName);
+		final String referencedGroupType = referenceSchema.getReferencedGroupType();
+		if (referencedGroupType == null) {
+			// the reference has no group type configured, so there's no group entity to filter/order/require by
+			return List.of();
+		}
+
+		final DataLocator childDataLocator = new EntityDataLocator(
+			referenceSchema.isReferencedGroupTypeManaged()
+				? new ManagedEntityTypePointer(referencedGroupType)
+				: new ExternalEntityTypePointer(referencedGroupType)
+		);
+
+		return buildBasicChildren(
+			buildContext.switchToChildContext(childDataLocator),
+			allowedChildrenPredicate,
+			ConstraintPropertyType.GROUP
+		);
+	}
+
+	/**
+	 * Builds fields representing children of constraint container from constraint descriptors of these children.
 	 * This is shortcut method for building all children of {@link ConstraintPropertyType#ATTRIBUTE} property type.
 	 */
 	@Nonnull

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/configuration/ApiOptions.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/configuration/ApiOptions.java
@@ -60,8 +60,8 @@ import static java.util.Optional.ofNullable;
  *                               connections with a request in progress). The interval therefore IS the stall budget. Defaults to
  *                               `0`, which DISABLES the server-side ping — quiet connections are reaped by the idle timeout and
  *                               orphaned sessions by the session killer instead, matching the convention that keep-alive pinging is
- *                               the client's responsibility while the server polices and reaps. Any non-zero value must be at least
- *                               `1000` ms (the minimum Armeria permits).
+ *                               the client's responsibility while the server polices and reaps. A negative value falls back to the
+ *                               default; any positive value below `1000` ms (the minimum Armeria permits) is raised to that floor.
  * @param maxEntitySizeInBytes   The default maximum size of a request entity. If entity body is larger than this limit then a
  *                               java.io.IOException will be thrown at some point when reading the request (on the first read for fixed
  *                               length requests, when too much data has been read for chunked requests).
@@ -114,8 +114,11 @@ public record ApiOptions(
 		this.workerGroupThreads = ofNullable(workerGroupThreads).orElse(DEFAULT_WORKER_GROUP_THREADS);
 		this.idleTimeoutInMillis = idleTimeoutInMillis <= 0 ? DEFAULT_IDLE_TIMEOUT : idleTimeoutInMillis;
 		this.requestTimeoutInMillis = requestTimeoutInMillis <= 0 ? DEFAULT_REQUEST_TIMEOUT : requestTimeoutInMillis;
-		// 0 is a meaningful value here (disables the server ping); only a negative value falls back to the default
-		this.pingIntervalMillis = pingIntervalMillis < 0 ? DEFAULT_PING_INTERVAL : pingIntervalMillis;
+		// 0 disables the server ping and a negative value falls back to the default; any positive value below
+		// Armeria's 1000 ms minimum is raised to that floor to honour the documented pingIntervalMillis contract
+		this.pingIntervalMillis = pingIntervalMillis < 0
+			? DEFAULT_PING_INTERVAL
+			: pingIntervalMillis == 0 ? 0 : Math.max(pingIntervalMillis, 1000);
 		this.maxEntitySizeInBytes = maxEntitySizeInBytes <= 0 ? DEFAULT_MAX_ENTITY_SIZE : maxEntitySizeInBytes;
 		this.accessLog = accessLog;
 		this.headers = headers;

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/configuration/ApiOptions.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/configuration/ApiOptions.java
@@ -54,6 +54,14 @@ import static java.util.Optional.ofNullable;
  *                               grained approach, and small values will cause problems for requests with a long processing time.
  * @param requestTimeoutInMillis The amount of time a connection can sit idle without processing a request, before it is closed by
  *                               the server.
+ * @param pingIntervalMillis     The HTTP/2 keep-alive PING interval in milliseconds. When neither a read nor a write happens on a
+ *                               connection for this long, the server sends a PING; if the peer does not acknowledge it within the
+ *                               same interval, the connection is closed unconditionally (unlike the idle timeout, which skips
+ *                               connections with a request in progress). The interval therefore IS the stall budget. Defaults to
+ *                               `0`, which DISABLES the server-side ping — quiet connections are reaped by the idle timeout and
+ *                               orphaned sessions by the session killer instead, matching the convention that keep-alive pinging is
+ *                               the client's responsibility while the server polices and reaps. Any non-zero value must be at least
+ *                               `1000` ms (the minimum Armeria permits).
  * @param maxEntitySizeInBytes   The default maximum size of a request entity. If entity body is larger than this limit then a
  *                               java.io.IOException will be thrown at some point when reading the request (on the first read for fixed
  *                               length requests, when too much data has been read for chunked requests).
@@ -63,6 +71,7 @@ public record ApiOptions(
 	@Nullable Integer workerGroupThreads,
 	int idleTimeoutInMillis,
 	int requestTimeoutInMillis,
+	int pingIntervalMillis,
 	long maxEntitySizeInBytes,
 	boolean accessLog,
 	@Nonnull HeaderOptions headers,
@@ -72,6 +81,7 @@ public record ApiOptions(
 	public static final int DEFAULT_WORKER_GROUP_THREADS = Runtime.getRuntime().availableProcessors();
 	public static final int DEFAULT_IDLE_TIMEOUT = 20 * 1000;
 	public static final int DEFAULT_REQUEST_TIMEOUT = 1000;
+	public static final int DEFAULT_PING_INTERVAL = 0;
 	public static final long DEFAULT_MAX_ENTITY_SIZE = 2_097_152L;
 
 	/**
@@ -95,7 +105,7 @@ public record ApiOptions(
 
 	public ApiOptions(
 		@Nullable Integer workerGroupThreads,
-		int idleTimeoutInMillis, int requestTimeoutInMillis,
+		int idleTimeoutInMillis, int requestTimeoutInMillis, int pingIntervalMillis,
 		long maxEntitySizeInBytes, boolean accessLog,
 		@Nonnull HeaderOptions headers,
 		@Nonnull CertificateOptions certificate,
@@ -104,6 +114,8 @@ public record ApiOptions(
 		this.workerGroupThreads = ofNullable(workerGroupThreads).orElse(DEFAULT_WORKER_GROUP_THREADS);
 		this.idleTimeoutInMillis = idleTimeoutInMillis <= 0 ? DEFAULT_IDLE_TIMEOUT : idleTimeoutInMillis;
 		this.requestTimeoutInMillis = requestTimeoutInMillis <= 0 ? DEFAULT_REQUEST_TIMEOUT : requestTimeoutInMillis;
+		// 0 is a meaningful value here (disables the server ping); only a negative value falls back to the default
+		this.pingIntervalMillis = pingIntervalMillis < 0 ? DEFAULT_PING_INTERVAL : pingIntervalMillis;
 		this.maxEntitySizeInBytes = maxEntitySizeInBytes <= 0 ? DEFAULT_MAX_ENTITY_SIZE : maxEntitySizeInBytes;
 		this.accessLog = accessLog;
 		this.headers = headers;
@@ -113,7 +125,7 @@ public record ApiOptions(
 
 	public ApiOptions() {
 		this(
-			DEFAULT_WORKER_GROUP_THREADS, DEFAULT_IDLE_TIMEOUT, DEFAULT_REQUEST_TIMEOUT,
+			DEFAULT_WORKER_GROUP_THREADS, DEFAULT_IDLE_TIMEOUT, DEFAULT_REQUEST_TIMEOUT, DEFAULT_PING_INTERVAL,
 			DEFAULT_MAX_ENTITY_SIZE, false,
 			new HeaderOptions(), new CertificateOptions(), new HashMap<>(8)
 		);
@@ -208,6 +220,7 @@ public record ApiOptions(
 		private final Map<String, AbstractApiOptions> enabledProviders;
 		private int idleTimeoutInMillis = DEFAULT_IDLE_TIMEOUT;
 		private int requestTimeoutInMillis = DEFAULT_REQUEST_TIMEOUT;
+		private int pingIntervalMillis = DEFAULT_PING_INTERVAL;
 		private long maxEntitySizeInBytes = DEFAULT_MAX_ENTITY_SIZE;
 		private HeaderOptions headers;
 		private CertificateOptions certificate;
@@ -244,6 +257,7 @@ public record ApiOptions(
 			this.workerGroupThreads = source.workerGroupThreadsAsInt();
 			this.idleTimeoutInMillis = source.idleTimeoutInMillis();
 			this.requestTimeoutInMillis = source.requestTimeoutInMillis();
+			this.pingIntervalMillis = source.pingIntervalMillis();
 			this.maxEntitySizeInBytes = source.maxEntitySizeInBytes();
 			this.accessLog = source.accessLog();
 			this.headers = source.headers();
@@ -265,6 +279,20 @@ public record ApiOptions(
 		@Nonnull
 		public ApiOptions.Builder requestTimeoutInMillis(int requestTimeoutInMillis) {
 			this.requestTimeoutInMillis = requestTimeoutInMillis;
+			return this;
+		}
+
+		/**
+		 * Sets the HTTP/2 keep-alive PING interval in milliseconds. See
+		 * {@link ApiOptions#pingIntervalMillis()} for the semantics (`0` disables the server ping, otherwise
+		 * the value must be `>= 1000`).
+		 *
+		 * @param pingIntervalMillis the keep-alive ping interval in milliseconds
+		 * @return this builder for chaining
+		 */
+		@Nonnull
+		public ApiOptions.Builder pingIntervalMillis(int pingIntervalMillis) {
+			this.pingIntervalMillis = pingIntervalMillis;
 			return this;
 		}
 
@@ -326,7 +354,7 @@ public record ApiOptions(
 		public ApiOptions build() {
 			return new ApiOptions(
 				this.workerGroupThreads,
-				this.idleTimeoutInMillis, this.requestTimeoutInMillis,
+				this.idleTimeoutInMillis, this.requestTimeoutInMillis, this.pingIntervalMillis,
 				this.maxEntitySizeInBytes,
 				this.accessLog,
 				this.headers,

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiServer.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/http/ExternalApiServer.java
@@ -596,7 +596,7 @@ public class ExternalApiServer implements AutoCloseable {
 			.gracefulShutdownTimeout(gracefulShutdown ? Duration.ofSeconds(1) : Duration.ZERO, gracefulShutdown ? Duration.ofSeconds(1) : Duration.ZERO)
 			.idleTimeoutMillis(apiOptions.idleTimeoutInMillis())
 			.requestTimeoutMillis(apiOptions.requestTimeoutInMillis())
-			.pingIntervalMillis(1000)
+			.pingIntervalMillis(apiOptions.pingIntervalMillis())
 			.serviceWorkerGroup(workerGroup, true)
 			.maxRequestLength(apiOptions.maxEntitySizeInBytes())
 			.workerGroup(workerGroup, true)

--- a/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/constraint/GraphQLConstraintSchemaBuilder.java
+++ b/evita_external_api/evita_external_api_graphql/src/main/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/builder/constraint/GraphQLConstraintSchemaBuilder.java
@@ -101,6 +101,7 @@ public abstract class GraphQLConstraintSchemaBuilder extends ConstraintSchemaBui
 		final List<GraphQLInputObjectField> children = new LinkedList<>();
 		children.addAll(buildGenericChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildEntityChildren(buildContext, allowedChildrenPredicate));
+		children.addAll(buildGroupChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildAttributeChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildAssociatedDataChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildPriceChildren(buildContext, allowedChildrenPredicate));

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
@@ -32,8 +32,10 @@ import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
 import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.client.retry.RetryRule;
 import com.linecorp.armeria.client.retry.RetryingClient;
+import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.common.util.TimeoutMode;
 import io.evitadb.api.CatalogState;
@@ -272,6 +274,38 @@ public class EvitaClient implements EvitaContract {
 		}
 	}
 
+	/**
+	 * Classifies a throwable as a TRANSPORT-level failure — one where the gRPC connection did not deliver the
+	 * call's outcome, as opposed to a business error the server deliberately returned over a healthy connection.
+	 * A transport failure is any of: a {@link StatusRuntimeException} with status {@link Code#CANCELLED},
+	 * {@link Code#UNAVAILABLE} or {@link Code#DEADLINE_EXCEEDED}, or a cause chain carrying Armeria's
+	 * {@link ClosedSessionException} / {@link ClosedStreamException}. The whole cause chain is inspected because
+	 * the transport signal is frequently wrapped (e.g. a {@link StatusRuntimeException} caused by a
+	 * {@link ClosedSessionException}).
+	 *
+	 * When a session call fails this way the server-side invocation is orphaned and the outcome is indeterminate
+	 * for the client, which is why the caller must treat the session as lost rather than retrying blindly.
+	 *
+	 * @param throwable the throwable to classify (typically unwrapped from an {@link ExecutionException})
+	 * @return true if the failure happened at the transport level
+	 */
+	public static boolean isTransportFailure(@Nonnull Throwable throwable) {
+		Throwable current = throwable;
+		while (current != null) {
+			if (current instanceof final StatusRuntimeException statusRuntimeException) {
+				final Code code = statusRuntimeException.getStatus().getCode();
+				if (code == Code.CANCELLED || code == Code.UNAVAILABLE || code == Code.DEADLINE_EXCEEDED) {
+					return true;
+				}
+			}
+			if (current instanceof ClosedStreamException) {
+				return true;
+			}
+			current = current.getCause();
+		}
+		return false;
+	}
+
 	@Nonnull
 	private static ClientTracingContext getClientTracingContext(@Nonnull EvitaClientConfiguration configuration) {
 		final ClientTracingContext context = ClientTracingContextProvider.getContext();
@@ -379,16 +413,33 @@ public class EvitaClient implements EvitaContract {
 				.build();
 		}
 
+		// The connection idle timeout is a dedicated knob, deliberately decoupled from the per-call timeout:
+		// a short request deadline must not tear down the pooled HTTP/2 connection between calls.
+		final int idleTimeoutMillis = configuration.connection().idleTimeoutMillis();
+		final int pingIntervalMillis = configuration.connection().pingIntervalMillis();
+		// Armeria silently disables the keep-alive ping when the (floored) ping interval is not strictly below
+		// a positive connection idle timeout (see ClientFactoryBuilder ping/idle reconciliation: the ping is
+		// dropped when idle > 0 && ping > 0 && max(ping, 1000) >= idle; 1000 ms is Armeria's minimum ping). An
+		// idle timeout of 0 means "never idle out" and keeps the ping active. Warn loudly so an operator who
+		// configured a ping expecting a watchdog is not left with a silently inert one.
+		if (idleTimeoutMillis > 0 && pingIntervalMillis > 0
+			&& Math.max(pingIntervalMillis, 1000) >= idleTimeoutMillis) {
+			log.warn(
+				"Client keep-alive ping ({} ms) is not below the connection idle timeout ({} ms); Armeria will " +
+					"disable the ping. Lower the ping interval (ClientConnectionOptions.pingIntervalMillis) or " +
+					"raise the connection idle timeout (ClientConnectionOptions.idleTimeoutMillis) to keep the " +
+					"ping active.",
+				pingIntervalMillis, idleTimeoutMillis
+			);
+		}
+		// keepAliveOnPing = true makes acknowledged keep-alive pings count as connection activity, so a healthy
+		// connection is never reaped by the idle timeout — set explicitly rather than riding Armeria's global
+		// Flags.defaultClientKeepAliveOnPing (false by default, and flippable by a system property).
 		ClientFactoryBuilder clientFactoryBuilder = ClientFactory
 			.builder()
 			.workerGroup(workerGroup, true)
-			.idleTimeoutMillis(
-				TimeUnit.MILLISECONDS.convert(
-					clientTimeouts.timeout(),
-					clientTimeouts.timeoutUnit()
-				)
-			)
-			.pingIntervalMillis(1000);
+			.idleTimeoutMillis(idleTimeoutMillis, true)
+			.pingIntervalMillis(pingIntervalMillis);
 
 		final String uriScheme;
 		final ClientTlsOptions tlsOptions = configuration.tls();

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClient.java
@@ -298,6 +298,8 @@ public class EvitaClient implements EvitaContract {
 					return true;
 				}
 			}
+			// ClosedSessionException (a connection-level close) is a final subclass of ClosedStreamException,
+			// so this single check classifies both stream- and session-level Armeria closures as transport failures
 			if (current instanceof ClosedStreamException) {
 				return true;
 			}

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientSession.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/EvitaClientSession.java
@@ -102,6 +102,7 @@ import io.evitadb.driver.config.ClientTimeoutOptions;
 import io.evitadb.driver.config.EvitaClientConfiguration;
 import io.evitadb.driver.exception.EvitaClientServerCallException;
 import io.evitadb.driver.exception.EvitaClientTimedOutException;
+import io.evitadb.driver.exception.TransportException;
 import io.evitadb.driver.interceptor.ClientSessionInterceptor.SessionIdHolder;
 import io.evitadb.driver.requestResponse.schema.ClientCatalogSchemaDecorator;
 import io.evitadb.exception.EvitaInvalidUsageException;
@@ -2361,6 +2362,20 @@ public class EvitaClientSession implements EvitaSessionContract {
 			return Objects.requireNonNull(result);
 		} catch (ExecutionException e) {
 			final Throwable theException = e.getCause() == null ? e : e.getCause();
+			if (EvitaClient.isTransportFailure(theException)) {
+				// The connection died mid-call: the server-side invocation is orphaned and the outcome is
+				// indeterminate for us. Mark the session dead locally (terminateLocally() completes the close
+				// future without a server round-trip and flips isActive() to false) so the try-with-resources
+				// close becomes a local no-op instead of racing the orphan with a remote close — the source of
+				// the ConcurrentSessionAccessException cascade. The server's SessionKiller reaps the orphaned
+				// session on inactivity.
+				terminateLocally();
+				throw new TransportException(
+					"Connection to the evitaDB server was lost while executing a session call; the session has " +
+						"been closed locally and the outcome of the call is indeterminate.",
+					theException
+				);
+			}
 			throw EvitaClient.transformException(
 				theException,
 				() -> {
@@ -2412,6 +2427,20 @@ public class EvitaClientSession implements EvitaSessionContract {
 			return lambda.apply(this.evitaSessionServiceStub.withDeadlineAfter(this.streamingTimeout));
 		} catch (ExecutionException e) {
 			final Throwable theException = e.getCause() == null ? e : e.getCause();
+			if (EvitaClient.isTransportFailure(theException)) {
+				// The connection died mid-call: the server-side invocation is orphaned and the outcome is
+				// indeterminate for us. Mark the session dead locally (terminateLocally() completes the close
+				// future without a server round-trip and flips isActive() to false) so the try-with-resources
+				// close becomes a local no-op instead of racing the orphan with a remote close — the source of
+				// the ConcurrentSessionAccessException cascade. The server's SessionKiller reaps the orphaned
+				// session on inactivity.
+				terminateLocally();
+				throw new TransportException(
+					"Connection to the evitaDB server was lost while executing a session call; the session has " +
+						"been closed locally and the outcome of the call is indeterminate.",
+					theException
+				);
+			}
 			throw EvitaClient.transformException(
 				theException,
 				() -> {

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCapturePublisher.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCapturePublisher.java
@@ -145,8 +145,15 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 	 * on a synchronous init failure, `onNext` dereferencing the subscription
 	 * field) must already be in place when it does.
 	 *
+	 * This call is **blocking**: it returns only once the server has acknowledged the
+	 * subscription, so a subsequent call issued by the same thread on the same session is
+	 * guaranteed to run after the server-side subscription is established. See
+	 * {@link ClientChangeCaptureSubscriber#awaitAcknowledgement()} for the races this closes.
+	 *
 	 * @param subscriber the subscriber to register
 	 * @throws IllegalStateException if the publisher has been closed
+	 * @throws io.evitadb.exception.GenericEvitaInternalError if the server does not acknowledge the
+	 *         subscription within the streaming timeout or the stream fails during setup
 	 */
 	@Override
 	public void subscribe(Subscriber<? super C> subscriber) {
@@ -192,6 +199,20 @@ public abstract class ClientChangeCapturePublisher<C extends ChangeCapture, REQ,
 		}
 		// notify the delegate that it has a subscription it can drive
 		internalSubscriber.onSubscribe(subscription);
+		// block until the server acknowledges the subscription so that a subsequent call issued on
+		// the same session runs strictly after the server-side subscription is established —
+		// otherwise it would race the still-pending registration offloaded onto the server request
+		// pool (concurrent session access), or fire a mutation before this subscriber is wired into
+		// the change observer (a missed event). See ClientChangeCaptureSubscriber#awaitAcknowledgement.
+		try {
+			internalSubscriber.awaitAcknowledgement();
+		} catch (RuntimeException ex) {
+			// the server never confirmed the subscription within the streaming timeout, or the
+			// stream failed during setup — tear the half-open subscription down (which removes it
+			// from `subscriptions` and cancels the gRPC stream) before rethrowing to the caller
+			subscription.cancel();
+			throw ex;
+		}
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCaptureSubscriber.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/cdc/ClientChangeCaptureSubscriber.java
@@ -44,8 +44,11 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscription;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
@@ -116,6 +119,15 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	 * This is used to differentiate between client-initiated and server-initiated closures.
 	 */
 	private final AtomicBoolean serverSideClosed = new AtomicBoolean(false);
+
+	/**
+	 * Completed when the server acknowledges the subscription (the first {@link #onNext} carrying the
+	 * ACKNOWLEDGEMENT), or completed exceptionally if the stream fails before that acknowledgement
+	 * arrives. {@link ClientChangeCapturePublisher#subscribe} blocks on this future via
+	 * {@link #awaitAcknowledgement()} so it returns only once the server-side subscription is
+	 * established — see that method for the ordering guarantees this provides.
+	 */
+	private final CompletableFuture<Void> acknowledged = new CompletableFuture<>();
 
 	/**
 	 * The gRPC observer that sends requests to and receives responses from the server.
@@ -194,7 +206,7 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	 * @throws GenericEvitaInternalError if the subscriber has already been started
 	 */
 	@Override
-	public void beforeStart(@Nonnull ClientCallStreamObserver<REQ> observer) {
+	public void beforeStart(ClientCallStreamObserver<REQ> observer) {
 		Assert.isPremiseValid(
 			this.serverObserver == null,
 			"ClientChangeCaptureSubscriber can only be started once. It is already started."
@@ -232,8 +244,59 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	 * @param subscription the subscription created by the publisher
 	 */
 	@Override
-	public void onSubscribe(@Nonnull Subscription subscription) {
+	public void onSubscribe(Subscription subscription) {
 		this.delegate.onSubscribe(subscription);
+	}
+
+	/**
+	 * Blocks the calling thread until the server acknowledges the subscription — the first
+	 * {@link #onNext} carrying the ACKNOWLEDGEMENT response — or until the stream fails or the
+	 * streaming timeout elapses during setup.
+	 *
+	 * Gating {@link ClientChangeCapturePublisher#subscribe} on this acknowledgement makes the
+	 * client-side `subscribe` return only once the server-side subscription is established. This
+	 * closes two races that only surface when the caller immediately issues another call on the
+	 * same session (the offloaded server-side registration otherwise runs on the request pool
+	 * after `subscribe` has already returned):
+	 *
+	 * 1. a concurrent same-session call racing the still-pending registration on the server
+	 *    request pool (rejected with a concurrent-session-access error), and
+	 * 2. a mutation firing before this subscriber is wired into the change observer, so its event
+	 *    is never delivered.
+	 *
+	 * The acknowledgement is delivered on the gRPC inbound thread — never on the caller thread that
+	 * runs `subscribe` — so this wait cannot deadlock the delivery of the acknowledgement it awaits.
+	 *
+	 * @throws GenericEvitaInternalError if the server does not acknowledge the subscription within
+	 *         the streaming timeout, the stream fails before the acknowledgement arrives, or the
+	 *         waiting thread is interrupted
+	 */
+	void awaitAcknowledgement() {
+		try {
+			this.acknowledged.get(this.streamingTimeout.toMillis(), TimeUnit.MILLISECONDS);
+		} catch (java.util.concurrent.TimeoutException ex) {
+			throw new GenericEvitaInternalError(
+				"The evitaDB server did not acknowledge the change data capture subscription within " +
+					this.streamingTimeout.toMillis() + " ms.",
+				"The evitaDB server did not acknowledge the change data capture subscription in time.",
+				ex
+			);
+		} catch (ExecutionException ex) {
+			final Throwable cause = ex.getCause() == null ? ex : ex.getCause();
+			throw new GenericEvitaInternalError(
+				"The change data capture subscription failed before it was acknowledged by the server: " +
+					cause.getMessage(),
+				"The change data capture subscription failed before it was acknowledged by the server.",
+				cause
+			);
+		} catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			throw new GenericEvitaInternalError(
+				"Interrupted while waiting for the change data capture subscription acknowledgement.",
+				"Interrupted while waiting for the change data capture subscription acknowledgement.",
+				ex
+			);
+		}
 	}
 
 	/**
@@ -294,20 +357,27 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 				}
 			});
 		if (activeSubscription.getSubscriptionId() == null) {
-			// the very first message MUST be the acknowledgement — otherwise the
-			// protocol is being violated and the heartbeat field is still null;
-			// `isPremiseValid` is the project's idiomatic precondition check and
-			// surfaces the violation as `GenericEvitaInternalError` with the descriptive message
-			Assert.isPremiseValid(
-				this.lastHeartBeat != null,
-				"Expected ACKNOWLEDGEMENT as first message but got something else."
-			);
-			// IDE-friendly capture: the assert above already proved non-null, so this
+			// the very first message MUST be the acknowledgement — otherwise the protocol is being
+			// violated and the heartbeat field is still null. Fail the acknowledgement future so a
+			// caller blocked in `awaitAcknowledgement` is released immediately instead of waiting out
+			// the streaming timeout, and surface the same descriptive `GenericEvitaInternalError` on
+			// the gRPC delivery thread as before.
+			if (this.lastHeartBeat == null) {
+				final GenericEvitaInternalError protocolViolation = new GenericEvitaInternalError(
+					"Expected ACKNOWLEDGEMENT as first message but got something else."
+				);
+				this.acknowledged.completeExceptionally(protocolViolation);
+				throw protocolViolation;
+			}
+			// IDE-friendly capture: the null-check above already proved non-null, so this
 			// `requireNonNull` is a no-op at runtime but tells static analyzers the dereference is safe
 			final HeartBeat acknowledgement = Objects.requireNonNull(this.lastHeartBeat);
 			activeSubscription.setSubscriptionId(acknowledgement.subscriptionId());
 			// ACK consumed: open the full window so the server may start streaming captures
 			observer.request(this.flowControlWindow);
+			// release any caller blocked in `awaitAcknowledgement` — the server-side subscription
+			// is now established, so a subsequent same-session call is safe to issue
+			this.acknowledged.complete(null);
 		} else {
 			final Optional<C> capture = this.deserializeCaptureResponse.apply(itemResponse);
 			if (capture.isPresent()) {
@@ -329,8 +399,9 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	 * draining the queue after the stream has been torn down cannot resurrect the channel.
 	 */
 	void requestOneMore() {
-		if (this.serverObserver != null && !this.closed.get() && !this.serverSideClosed.get()) {
-			this.serverObserver.request(1);
+		final ClientCallStreamObserver<REQ> theServerRequest = this.serverObserver;
+		if (theServerRequest != null && !this.closed.get() && !this.serverSideClosed.get()) {
+			theServerRequest.request(1);
 		}
 	}
 
@@ -350,6 +421,10 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	public void onError(Throwable throwable) {
 		this.serverSideClosed.set(true);
 		final Throwable rootCause = ExceptionUtils.getRootCause(throwable);
+		// unblock a caller still waiting in `awaitAcknowledgement`: the stream failed before the
+		// server acknowledged the subscription, so the subscribe() call must fail rather than wait
+		// out the full streaming timeout (no-op once the ACK has already completed the future)
+		this.acknowledged.completeExceptionally(rootCause);
 		if (rootCause instanceof PublisherClosedByClientException) {
 			// this is expected, we closed the publisher manually
 			// apparently, gRPC server doesn't know if cancellation was initiated by the client or by some network error
@@ -393,6 +468,8 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	 * @param cause exception describing the client-internal failure
 	 */
 	void notifyClientFailureAndClose(@Nonnull Throwable cause) {
+		// unblock a caller still waiting in `awaitAcknowledgement` (no-op once the ACK completed it)
+		this.acknowledged.completeExceptionally(cause);
 		if (!this.closed.get()) {
 			log.error("Client-side change capture subscription failed.", cause);
 			// invoked from `ClientSubscription.consume`, which can only exist once the
@@ -420,6 +497,12 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	@Override
 	public void onComplete() {
 		this.serverSideClosed.set(true);
+		// unblock a caller still waiting in `awaitAcknowledgement`: the stream completed before the
+		// server acknowledged the subscription, which is abnormal — fail the subscribe() rather than
+		// wait out the streaming timeout (no-op once the ACK has already completed the future)
+		this.acknowledged.completeExceptionally(
+			new GenericEvitaInternalError("The change data capture stream completed before it was acknowledged.")
+		);
 		if (!this.closed.get()) {
 			// gRPC calls `onComplete` only after `beforeStart` returned, by which point
 			// the publisher has already attached the subscription
@@ -467,9 +550,13 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 	 */
 	@Override
 	public void close() {
+		// unblock a caller still waiting in `awaitAcknowledgement` if the subscriber is torn down
+		// before the server acknowledged the subscription (no-op once the ACK completed the future)
+		this.acknowledged.completeExceptionally(new PublisherClosedByClientException());
 		// cancel the subscription if not already cancelled - this will call this close method again
-		if (this.subscription != null && !this.subscription.isCanceled()) {
-			this.subscription.cancel();
+		final ClientSubscription<C, REQ, RES> theSubscription = this.subscription;
+		if (theSubscription != null && !theSubscription.isCanceled()) {
+			theSubscription.cancel();
 		} else if (this.closed.compareAndSet(false, true)) {
 			// `close()` can legitimately fire before `beforeStart` (user-initiated abort during
 			// stream setup), so the observer and the subscription may both still be null here.
@@ -489,9 +576,10 @@ public class ClientChangeCaptureSubscriber<C extends ChangeCapture, REQ, RES>
 
 	@Override
 	public String toString() {
-		return this.subscription == null || this.subscription.getSubscriptionId() == null ?
+		final ClientSubscription<C, REQ, RES> theSubscription = this.subscription;
+		return theSubscription == null || theSubscription.getSubscriptionId() == null ?
 			"Change capture not yet started or acknowledged." :
-			"Change capture: " + this.subscription.getSubscriptionId();
+			"Change capture: " + theSubscription.getSubscriptionId();
 	}
 
 }

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/config/ClientConnectionOptions.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/config/ClientConnectionOptions.java
@@ -32,29 +32,61 @@ import java.net.UnknownHostException;
 /**
  * Record contains connection-related settings for the evitaDB Java client.
  *
- * @param clientId      The identification of the client used in logs and troubleshooting.
- *                      Defaults to `gRPC client at hostname`.
- * @param host          The IP address or host name where the gRPC server listens. Defaults to `localhost`.
- * @param port          The port the gRPC server listens on. Defaults to `5555`.
- * @param systemApiPort The port the system API server listens on. Used for automatic certificate management.
- *                      Defaults to `5555`.
+ * @param clientId          The identification of the client used in logs and troubleshooting.
+ *                          Defaults to `gRPC client at hostname`.
+ * @param host              The IP address or host name where the gRPC server listens. Defaults to `localhost`.
+ * @param port              The port the gRPC server listens on. Defaults to `5555`.
+ * @param systemApiPort     The port the system API server listens on. Used for automatic certificate management.
+ *                          Defaults to `5555`.
+ * @param pingIntervalMillis The HTTP/2 keep-alive PING interval in milliseconds. When neither a read nor a write
+ *                          happens on the connection for this long, a PING is sent; if the peer does not acknowledge
+ *                          it within the same interval, the connection is closed. The interval therefore IS the stall
+ *                          budget — it must exceed the worst tolerable GC / CPU-starvation pause, not act as a probe
+ *                          frequency, otherwise a slow-but-alive call can be killed mid-flight. Defaults to
+ *                          `30000` (30 s). `0` disables the client ping entirely (the connection is then reaped by the
+ *                          idle timeout alone); any other value must be at least `1000` ms (the minimum Armeria
+ *                          permits).
+ *
+ *                          **Precondition — the ping must stay strictly below {@link #idleTimeoutMillis()}.** Armeria
+ *                          **silently disables** the ping (no error, no log) whenever `max(pingIntervalMillis, 1000)`
+ *                          is greater than or equal to a positive connection idle timeout. The default pair
+ *                          (`30000` ms ping, `300000` ms idle) satisfies this, so the watchdog is active out of the
+ *                          box; `EvitaClient` logs a warning if a custom pair violates it. Also keep the interval below
+ *                          any load-balancer / NAT idle window on the network path.
+ * @param idleTimeoutMillis The connection idle timeout in milliseconds — how long a pooled HTTP/2 connection may sit
+ *                          with no application traffic before Armeria closes it. This is deliberately **decoupled from
+ *                          the per-call {@link ClientTimeoutOptions#timeout()}**: a short request deadline must not
+ *                          force the physical connection to be torn down and re-established between calls. Defaults to
+ *                          `300000` (300 s), comfortably above the `30000` ms ping so the keep-alive watchdog stays
+ *                          active and healthy connections are kept warm — the client counts keep-alive pings as
+ *                          activity (`keepAliveOnPing = true`), so a connection whose pings are acknowledged never
+ *                          idles out. `0` disables the idle timeout entirely (the connection then lives until closed
+ *                          by the peer, a ping failure or the pool). Must be `>= 0`; keep it strictly above
+ *                          {@link #pingIntervalMillis()} to preserve the watchdog.
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public record ClientConnectionOptions(
 	@Nonnull String clientId,
 	@Nonnull String host,
 	int port,
-	int systemApiPort
+	int systemApiPort,
+	int pingIntervalMillis,
+	int idleTimeoutMillis
 ) {
 	public static final String DEFAULT_HOST = "localhost";
 	public static final int DEFAULT_PORT = 5555;
 	public static final int DEFAULT_SYSTEM_API_PORT = 5555;
+	public static final int DEFAULT_PING_INTERVAL_MILLIS = 30_000;
+	public static final int DEFAULT_IDLE_TIMEOUT_MILLIS = 300_000;
 
 	/**
 	 * Creates a new instance with all default values.
 	 */
 	public ClientConnectionOptions() {
-		this(resolveDefaultClientId(), DEFAULT_HOST, DEFAULT_PORT, DEFAULT_SYSTEM_API_PORT);
+		this(
+			resolveDefaultClientId(), DEFAULT_HOST, DEFAULT_PORT, DEFAULT_SYSTEM_API_PORT,
+			DEFAULT_PING_INTERVAL_MILLIS, DEFAULT_IDLE_TIMEOUT_MILLIS
+		);
 	}
 
 	/**
@@ -95,6 +127,8 @@ public record ClientConnectionOptions(
 		private String host = DEFAULT_HOST;
 		private int port = DEFAULT_PORT;
 		private int systemApiPort = DEFAULT_SYSTEM_API_PORT;
+		private int pingIntervalMillis = DEFAULT_PING_INTERVAL_MILLIS;
+		private int idleTimeoutMillis = DEFAULT_IDLE_TIMEOUT_MILLIS;
 
 		Builder() {
 			this.clientId = resolveDefaultClientId();
@@ -105,6 +139,8 @@ public record ClientConnectionOptions(
 			this.host = connectionOptions.host();
 			this.port = connectionOptions.port();
 			this.systemApiPort = connectionOptions.systemApiPort();
+			this.pingIntervalMillis = connectionOptions.pingIntervalMillis();
+			this.idleTimeoutMillis = connectionOptions.idleTimeoutMillis();
 		}
 
 		@Nonnull
@@ -131,9 +167,40 @@ public record ClientConnectionOptions(
 			return this;
 		}
 
+		/**
+		 * Sets the HTTP/2 keep-alive PING interval in milliseconds. See
+		 * {@link ClientConnectionOptions#pingIntervalMillis()} for the semantics and the accepted range
+		 * (`0` to disable, otherwise `>= 1000`).
+		 *
+		 * @param pingIntervalMillis the keep-alive ping interval in milliseconds
+		 * @return this builder for chaining
+		 */
+		@Nonnull
+		public ClientConnectionOptions.Builder pingIntervalMillis(int pingIntervalMillis) {
+			this.pingIntervalMillis = pingIntervalMillis;
+			return this;
+		}
+
+		/**
+		 * Sets the connection idle timeout in milliseconds. See
+		 * {@link ClientConnectionOptions#idleTimeoutMillis()} for the semantics and the accepted range
+		 * (`0` disables the idle timeout, otherwise `>= 0` and ideally above the ping interval).
+		 *
+		 * @param idleTimeoutMillis the connection idle timeout in milliseconds
+		 * @return this builder for chaining
+		 */
+		@Nonnull
+		public ClientConnectionOptions.Builder idleTimeoutMillis(int idleTimeoutMillis) {
+			this.idleTimeoutMillis = idleTimeoutMillis;
+			return this;
+		}
+
 		@Nonnull
 		public ClientConnectionOptions build() {
-			return new ClientConnectionOptions(this.clientId, this.host, this.port, this.systemApiPort);
+			return new ClientConnectionOptions(
+				this.clientId, this.host, this.port, this.systemApiPort,
+				this.pingIntervalMillis, this.idleTimeoutMillis
+			);
 		}
 	}
 }

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/config/ClientConnectionOptions.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/config/ClientConnectionOptions.java
@@ -44,8 +44,8 @@ import java.net.UnknownHostException;
  *                          budget — it must exceed the worst tolerable GC / CPU-starvation pause, not act as a probe
  *                          frequency, otherwise a slow-but-alive call can be killed mid-flight. Defaults to
  *                          `30000` (30 s). `0` disables the client ping entirely (the connection is then reaped by the
- *                          idle timeout alone); any other value must be at least `1000` ms (the minimum Armeria
- *                          permits).
+ *                          idle timeout alone); a negative value falls back to the default, and any positive value below
+ *                          `1000` ms (the minimum Armeria permits) is raised to that floor.
  *
  *                          **Precondition — the ping must stay strictly below {@link #idleTimeoutMillis()}.** Armeria
  *                          **silently disables** the ping (no error, no log) whenever `max(pingIntervalMillis, 1000)`
@@ -61,8 +61,8 @@ import java.net.UnknownHostException;
  *                          active and healthy connections are kept warm — the client counts keep-alive pings as
  *                          activity (`keepAliveOnPing = true`), so a connection whose pings are acknowledged never
  *                          idles out. `0` disables the idle timeout entirely (the connection then lives until closed
- *                          by the peer, a ping failure or the pool). Must be `>= 0`; keep it strictly above
- *                          {@link #pingIntervalMillis()} to preserve the watchdog.
+ *                          by the peer, a ping failure or the pool). A negative value falls back to the default; keep it
+ *                          strictly above {@link #pingIntervalMillis()} to preserve the watchdog.
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public record ClientConnectionOptions(
@@ -78,6 +78,18 @@ public record ClientConnectionOptions(
 	public static final int DEFAULT_SYSTEM_API_PORT = 5555;
 	public static final int DEFAULT_PING_INTERVAL_MILLIS = 30_000;
 	public static final int DEFAULT_IDLE_TIMEOUT_MILLIS = 300_000;
+
+	/**
+	 * Normalizes the keep-alive settings to honour their documented contracts: a negative ping interval falls back
+	 * to the default, `0` disables the ping, and any positive value below Armeria's `1000` ms minimum is raised to
+	 * that floor; a negative idle timeout falls back to the default while `0` disables it.
+	 */
+	public ClientConnectionOptions {
+		pingIntervalMillis = pingIntervalMillis < 0
+			? DEFAULT_PING_INTERVAL_MILLIS
+			: pingIntervalMillis == 0 ? 0 : Math.max(pingIntervalMillis, 1000);
+		idleTimeoutMillis = idleTimeoutMillis < 0 ? DEFAULT_IDLE_TIMEOUT_MILLIS : idleTimeoutMillis;
+	}
 
 	/**
 	 * Creates a new instance with all default values.

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/config/EvitaClientConfiguration.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/config/EvitaClientConfiguration.java
@@ -144,6 +144,28 @@ public record EvitaClientConfiguration(
 		return this.connection.systemApiPort();
 	}
 
+	/**
+	 * Returns the HTTP/2 keep-alive PING interval in milliseconds.
+	 *
+	 * Delegates to {@link ClientConnectionOptions#pingIntervalMillis()}.
+	 *
+	 * @return the keep-alive ping interval in milliseconds
+	 */
+	public int pingIntervalMillis() {
+		return this.connection.pingIntervalMillis();
+	}
+
+	/**
+	 * Returns the connection idle timeout in milliseconds.
+	 *
+	 * Delegates to {@link ClientConnectionOptions#idleTimeoutMillis()}.
+	 *
+	 * @return the connection idle timeout in milliseconds
+	 */
+	public int idleTimeoutMillis() {
+		return this.connection.idleTimeoutMillis();
+	}
+
 	// ============================================================================================
 	// Deprecated delegate accessor methods for backward compatibility
 	// ============================================================================================
@@ -415,6 +437,34 @@ public record EvitaClientConfiguration(
 		@Nonnull
 		public EvitaClientConfiguration.Builder systemApiPort(int systemApiPort) {
 			this.connectionBuilder.systemApiPort(systemApiPort);
+			return this;
+		}
+
+		/**
+		 * Sets the HTTP/2 keep-alive PING interval in milliseconds.
+		 *
+		 * Delegates to {@link ClientConnectionOptions.Builder#pingIntervalMillis(int)}.
+		 *
+		 * @param pingIntervalMillis the keep-alive ping interval in milliseconds (`0` disables, otherwise `>= 1000`)
+		 * @return this builder for chaining
+		 */
+		@Nonnull
+		public EvitaClientConfiguration.Builder pingIntervalMillis(int pingIntervalMillis) {
+			this.connectionBuilder.pingIntervalMillis(pingIntervalMillis);
+			return this;
+		}
+
+		/**
+		 * Sets the connection idle timeout in milliseconds.
+		 *
+		 * Delegates to {@link ClientConnectionOptions.Builder#idleTimeoutMillis(int)}.
+		 *
+		 * @param idleTimeoutMillis the connection idle timeout in milliseconds (`0` disables the idle timeout)
+		 * @return this builder for chaining
+		 */
+		@Nonnull
+		public EvitaClientConfiguration.Builder idleTimeoutMillis(int idleTimeoutMillis) {
+			this.connectionBuilder.idleTimeoutMillis(idleTimeoutMillis);
 			return this;
 		}
 

--- a/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/exception/TransportException.java
+++ b/evita_external_api/evita_external_api_grpc/client/src/main/java/io/evitadb/driver/exception/TransportException.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.driver.exception;
+
+import javax.annotation.Nonnull;
+import java.io.Serial;
+
+/**
+ * Signals that a client-to-server call failed at the **transport** level — the underlying gRPC
+ * connection was closed, cancelled, became unavailable, or the call deadline elapsed — rather than
+ * the server rejecting the request with a business error. This is distinct from
+ * {@link EvitaClientServerCallException} (an unexpected server-side error surfaced over a healthy
+ * connection): here the connection itself did not deliver the outcome.
+ *
+ * When this exception is raised for a session call, the originating client session is marked
+ * inactive locally and no further RPC is issued for it; the server-side session killer reaps the
+ * now-orphaned session on inactivity.
+ *
+ * **Outcome ambiguity (at-most-once vs. at-least-once).** Because the failure happened in transit,
+ * the outcome of the call is **indeterminate** for the client. A mutation that triggered this
+ * exception MAY still have been applied on the server — or may complete shortly after the client
+ * observed the failure, since the server-side invocation is not interrupted. Callers that require
+ * exactly-once semantics must reconcile against server state before retrying; a blind retry can
+ * duplicate an already-applied change.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class TransportException extends EvitaClientServerCallException {
+	@Serial private static final long serialVersionUID = -6829977889216969455L;
+
+	public TransportException(@Nonnull String publicMessage, @Nonnull Throwable cause) {
+		super(publicMessage, cause);
+	}
+
+}

--- a/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/builder/constraint/OpenApiConstraintSchemaBuilder.java
+++ b/evita_external_api/evita_external_api_rest/src/main/java/io/evitadb/externalApi/rest/api/catalog/dataApi/builder/constraint/OpenApiConstraintSchemaBuilder.java
@@ -103,6 +103,7 @@ public abstract class OpenApiConstraintSchemaBuilder
 		final List<OpenApiProperty> children = new LinkedList<>();
 		children.addAll(buildGenericChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildEntityChildren(buildContext, allowedChildrenPredicate));
+		children.addAll(buildGroupChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildAttributeChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildAssociatedDataChildren(buildContext, allowedChildrenPredicate));
 		children.addAll(buildPriceChildren(buildContext, allowedChildrenPredicate));

--- a/evita_server/src/main/java/io/evitadb/server/EvitaServer.java
+++ b/evita_server/src/main/java/io/evitadb/server/EvitaServer.java
@@ -646,7 +646,7 @@ public class EvitaServer {
 	 */
 	public void run() {
 		if (this.evita == null) {
-			this.evita = new Evita(this.evitaConfiguration, false);
+			this.evita = new Evita(this.evitaConfiguration, false, null, null, false);
 		}
 		this.externalApiServer = new ExternalApiServer(
 			this.evita, this.evitaServerConfiguration.api(), this.externalApiProviders

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/supplier/AbstractMutationSupplier.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/supplier/AbstractMutationSupplier.java
@@ -171,6 +171,23 @@ abstract sealed class AbstractMutationSupplier<T extends Mutation> implements Su
 	}
 
 	/**
+	 * Returns the file position the given transaction must reach on disk to be considered readable at the current
+	 * position: the full record end (including the trailing cumulative checksum) for a greedy read, or the content
+	 * end (checksum excluded) in {@link #avoidPartiallyFilledBuffer} mode, where the trailing checksum of a
+	 * known-written requested transaction may momentarily lag the reader's file-length view.
+	 *
+	 * @param startPosition                   the byte position where the transaction begins in the WAL file
+	 * @param transactionMutationWithLocation the transaction whose required end position is being computed
+	 * @return the byte position that must be present in the file for the transaction to be delivered
+	 */
+	private long requiredEndPosition(
+		long startPosition, @Nonnull TransactionMutationWithLocation transactionMutationWithLocation
+	) {
+		final long fullEnd = calculateNextTransactionStartPosition(startPosition, transactionMutationWithLocation);
+		return this.avoidPartiallyFilledBuffer ? fullEnd - CUMULATIVE_CRC32_SIZE : fullEnd;
+	}
+
+	/**
 	 * Creates a new AbstractMutationSupplier for reading transactions from a WAL file.
 	 *
 	 * @param version                        the starting version to read from
@@ -258,10 +275,12 @@ abstract sealed class AbstractMutationSupplier<T extends Mutation> implements Su
 						this.cumulativeChecksum.reset(actualCumulativeChecksum);
 						this.cumulativeChecksum.update(actualCumulativeChecksum);
 						initialTransactionMutation = readAndRecordTransactionMutation(this.filePosition, walFileLength);
-						// verify the file has enough room for the complete transaction
+						// verify the file has enough room for the required portion of the transaction — the full
+						// record (incl. trailing checksum) for a greedy read, only the content in
+						// avoidPartiallyFilledBuffer mode where the checksum of a known-written tail may still be pending
 						if (
 							initialTransactionMutation
-								.map(it -> walFileLength < calculateNextTransactionStartPosition(this.filePosition, it))
+								.map(it -> walFileLength < requiredEndPosition(this.filePosition, it))
 								.orElse(true)
 						) {
 							initialTransactionMutation = empty();
@@ -432,9 +451,19 @@ abstract sealed class AbstractMutationSupplier<T extends Mutation> implements Su
 
 		// full record = 4 (length prefix) + content + 8 (trailing cumulative CRC32C)
 		final int fullRecordLength = 4 + contentLength + CUMULATIVE_CRC32_SIZE;
+		// content = 4 (length prefix) + leading TransactionMutation + individual mutations (no trailing checksum)
+		final int contentRecordLength = 4 + contentLength;
 
-		if (startPosition + fullRecordLength > fileSize) {
-			// file is truncated — not enough room for content + trailing checksum
+		// In avoidPartiallyFilledBuffer mode the caller guarantees the requested transaction is durably
+		// written, so a transaction whose CONTENT is fully on disk may be read even when its trailing
+		// cumulative checksum has not yet landed in the reader's (possibly lagging) file-length view: the
+		// writer flushes the length prefix and content before the trailing checksum, and a same-JVM reader's
+		// cached file length can observe that intermediate state. A greedy read (recovery/replay) treats a
+		// transaction as complete only once its trailing checksum is present too, so a genuinely torn tail
+		// is not delivered prematurely.
+		final int requiredRecordLength = this.avoidPartiallyFilledBuffer ? contentRecordLength : fullRecordLength;
+		if (startPosition + requiredRecordLength > fileSize) {
+			// file is truncated — not enough room for the required portion of the record
 			return empty();
 		}
 

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/supplier/MutationSupplier.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/supplier/MutationSupplier.java
@@ -59,6 +59,15 @@ import java.util.function.IntFunction;
  * Reading stops when there are no more complete transactions available, or when the
  * {@link #requestedCatalogVersion} is reached (if {@code avoidPartiallyFilledBuffer} is enabled).
  *
+ * **End-of-stream vs. failure.** When {@code avoidPartiallyFilledBuffer} is enabled, the caller is asserting
+ * that {@link #requestedCatalogVersion} has already been durably written and may only lag in what the
+ * reader's cached file-length view can currently observe. Until that version has actually been delivered,
+ * any inability to advance — a truncated read, a not-yet-visible next record, or running out of WAL files —
+ * is surfaced as a {@link WriteAheadLogCorruptedException} rather than
+ * a silent {@code null}, so such a caller cannot mistake "not visible yet" for "nothing left to process".
+ * Once the requested version has been delivered, or when no target version is enforced (a greedy read), the
+ * same conditions are treated as a normal, graceful end of the stream.
+ *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
 public final class MutationSupplier<T extends Mutation> extends AbstractMutationSupplier<T> {
@@ -120,6 +129,9 @@ public final class MutationSupplier<T extends Mutation> extends AbstractMutation
 	 *
 	 * @return the next mutation in forward order, or {@code null} if all transactions have been exhausted
 	 *         or the file is incomplete
+	 * @throws WriteAheadLogCorruptedException if the trailing cumulative checksum does not match the computed
+	 *         one, or if — in {@code avoidPartiallyFilledBuffer} mode — the stream cannot advance to the next
+	 *         transaction before {@link #requestedCatalogVersion} has been delivered
 	 */
 	@Nullable
 	@Override
@@ -138,31 +150,53 @@ public final class MutationSupplier<T extends Mutation> extends AbstractMutation
 				//noinspection unchecked
 				return (T) readMutation();
 			} else {
-				// Phase 3: all mutations read — validate checksum and advance to next transaction
-				final long readCumulativeChecksum = getObservableInput().simpleLongRead();
-				final Checksum checksum = Objects.requireNonNull(this.cumulativeChecksum);
-				Assert.isPremiseValid(
-					checksum.equalsTo(readCumulativeChecksum),
-					() -> new WriteAheadLogCorruptedException(
-						this.walKind,
-						this.walFile.toPath(),
-						this.transactionMutation.getTransactionSpan().endPosition(),
-						checksum.getValue(),
-						readCumulativeChecksum
-					)
-				);
-				this.transactionMutation.withCumulativeChecksum(readCumulativeChecksum);
-				// feed the validated checksum back into cumulative — it is part of the WAL format
-				// and participates in the cumulative computation for the next transaction
-				checksum.update(readCumulativeChecksum);
-
-				this.filePosition = this.transactionMutation.getTransactionSpan().endPosition();
+				// Phase 3: all mutations read — validate the trailing cumulative checksum and advance to the
+				// next transaction. A read failure here (a missing trailing checksum, or a genuinely
+				// underflowing next transaction) is a legitimate end-of-stream ONLY when we have already
+				// delivered the caller's requested version, or when reading greedily; before that point a
+				// requested version could not be read and MUST surface. Swallowing it into a silent "no more
+				// data" is what makes the trunk-incorporation stage misread a durably-written transaction as
+				// "already processed", hang, and spin forever.
+				final long lastDeliveredVersion = this.transactionMutation.getVersion();
+				final boolean mayEndGracefully = !this.avoidPartiallyFilledBuffer
+					|| lastDeliveredVersion >= this.requestedCatalogVersion;
 				try {
+					final long readCumulativeChecksum = getObservableInput().simpleLongRead();
+					final Checksum checksum = Objects.requireNonNull(this.cumulativeChecksum);
+					Assert.isPremiseValid(
+						checksum.equalsTo(readCumulativeChecksum),
+						() -> new WriteAheadLogCorruptedException(
+							this.walKind,
+							this.walFile.toPath(),
+							this.transactionMutation.getTransactionSpan().endPosition(),
+							checksum.getValue(),
+							readCumulativeChecksum
+						)
+					);
+					this.transactionMutation.withCumulativeChecksum(readCumulativeChecksum);
+					// feed the validated checksum back into cumulative — it is part of the WAL format
+					// and participates in the cumulative computation for the next transaction
+					checksum.update(readCumulativeChecksum);
+
+					this.filePosition = this.transactionMutation.getTransactionSpan().endPosition();
 					final long currentFileLength = this.walFile.length();
 					// check if there is enough room for another transaction (content + WAL tail marker)
 					if (currentFileLength <= this.filePosition + AbstractMutationLog.WAL_TAIL_LENGTH) {
 						if (!moveToNextWalFile(1)) {
-							return null;
+							if (mayEndGracefully) {
+								return null;
+							}
+							// the current WAL ends without room for another transaction before the caller's
+							// requested version was reached, and there is no next file — the requested
+							// transaction is missing or truncated, surface it instead of ending silently
+							throw new WriteAheadLogCorruptedException(
+								this.walKind,
+								"Reached the end of " + this.walKind.fileLabel + " `" + this.walFile.getName() +
+									"` at position " + this.filePosition + " before the requested catalog version " +
+									this.requestedCatalogVersion + " was read (last delivered version " +
+									lastDeliveredVersion + ").",
+								this.walKind.corruptedLabel + ": requested version missing before end of file"
+							);
 						}
 					}
 					this.transactionMutation = readAndRecordTransactionMutation(
@@ -174,30 +208,63 @@ public final class MutationSupplier<T extends Mutation> extends AbstractMutation
 					// buffer, concurrent writes can cause pointer misalignment. This check ensures
 					// we only proceed when sufficient data is available.
 					if (this.transactionMutation == null) {
-						return null;
-					} else {
-						final long requiredLength = this.transactionMutation.getTransactionSpan().endPosition();
-						final boolean canProceed;
-						if (this.avoidPartiallyFilledBuffer) {
-							// conservative mode: only proceed if the version is within the requested
-							// range AND the full transaction data is available on disk
-							canProceed = this.transactionMutation.getVersion() <= this.requestedCatalogVersion
-								&& currentFileLength >= requiredLength;
-						} else {
-							// standard mode: proceed as long as the full transaction is written
-							canProceed = currentFileLength >= requiredLength;
-						}
-						if (canProceed) {
-							this.transactionMutationRead = 1;
-							//noinspection unchecked
-							return (T) this.transactionMutation;
-						} else {
+						if (mayEndGracefully) {
+							// greedy/recovery read, or the caller's requested version has already been
+							// delivered — a truncated or not-yet-durable next record is a legitimate end
 							return null;
 						}
+						// the next transaction on the way to the caller's requested version is not (yet)
+						// sufficiently on disk; ending the stream silently here would be indistinguishable
+						// from "nothing left to process" to a caller that already believes this version was
+						// durably written, causing it to finalize prematurely at a stale version instead of
+						// retrying — surface it loudly, exactly like the sibling end-of-data branches above
+						throw new WriteAheadLogCorruptedException(
+							this.walKind,
+							"Reached a truncated or unreadable transaction record in " + this.walKind.fileLabel +
+								" `" + this.walFile.getName() + "` at position " + this.filePosition +
+								" before the requested catalog version " + this.requestedCatalogVersion +
+								" was read (last delivered version " + lastDeliveredVersion + ").",
+							this.walKind.corruptedLabel + ": requested version not fully on disk before end of data"
+						);
 					}
+					final long requiredEndPosition = this.transactionMutation.getTransactionSpan().endPosition();
+					final boolean canProceed;
+					if (this.avoidPartiallyFilledBuffer) {
+						// the caller guarantees the requested transaction is written: proceed once its version is
+						// within the requested range AND its CONTENT is on disk (the trailing checksum of a
+						// just-written tail may still be lagging the reader's file-length view)
+						canProceed = this.transactionMutation.getVersion() <= this.requestedCatalogVersion
+							&& currentFileLength >= requiredEndPosition - AbstractMutationLog.CUMULATIVE_CRC32_SIZE;
+					} else {
+						// standard mode: proceed as long as the full transaction (incl. checksum) is written
+						canProceed = currentFileLength >= requiredEndPosition;
+					}
+					if (canProceed) {
+						this.transactionMutationRead = 1;
+						//noinspection unchecked
+						return (T) this.transactionMutation;
+					} else {
+						return null;
+					}
+				} catch (WriteAheadLogCorruptedException ex) {
+					// a cumulative-checksum mismatch is a hard corruption regardless of position — never swallow it
+					throw ex;
 				} catch (Exception ex) {
-					// EOF or incomplete transaction write — stop iteration gracefully
-					return null;
+					if (mayEndGracefully) {
+						// everything the caller requested has been delivered (or we are reading greedily): a torn
+						// or not-yet-durable tail is a legitimate graceful end-of-stream
+						return null;
+					}
+					// a transaction the caller explicitly requested could not be read — surface it loudly instead
+					// of reporting an exhausted stream that the caller would misread as "nothing left to process"
+					throw new WriteAheadLogCorruptedException(
+						this.walKind,
+						"Failed to read " + this.walKind.fileLabel + " `" + this.walFile.getName() +
+							"` while advancing towards requested catalog version " + this.requestedCatalogVersion +
+							" (last delivered version " + lastDeliveredVersion + ") at position " + this.filePosition + ".",
+						this.walKind.corruptedLabel + ": read failed before the requested version was reached",
+						ex
+					);
 				}
 			}
 		}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/configuration/ServerOptionsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/configuration/ServerOptionsTest.java
@@ -135,7 +135,7 @@ class ServerOptionsTest {
 				ServerOptions
 					.DEFAULT_CLOSE_SESSIONS_AFTER_SECONDS_OF_INACTIVITY,
 				null, null,
-				false, false, false
+				false, false
 			);
 
 			assertNotNull(options.requestThreadPool());
@@ -158,7 +158,7 @@ class ServerOptionsTest {
 				ServerOptions
 					.DEFAULT_CLOSE_SESSIONS_AFTER_SECONDS_OF_INACTIVITY,
 				null, null,
-				false, false, false
+				false, false
 			);
 
 			assertNotNull(options.changeDataCapture());

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/storage/StaleLeafPageTwinWriterReproductionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/storage/StaleLeafPageTwinWriterReproductionTest.java
@@ -1,0 +1,1280 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.storage;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.TransactionContract.CommitBehavior;
+import io.evitadb.api.exception.ConcurrentSessionAccessException;
+import io.evitadb.api.exception.MandatoryAttributesNotProvidedException;
+import io.evitadb.api.requestResponse.data.EntityEditor.EntityBuilder;
+import io.evitadb.api.requestResponse.data.EntityReferenceContract;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
+import io.evitadb.api.requestResponse.data.structure.RepresentativeReferenceKey;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.core.Evita;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.EntityIndexType;
+import io.evitadb.index.attribute.FilterIndex;
+import io.evitadb.index.bPlusTree.BucketBPlusTree;
+import io.evitadb.index.bPlusTree.PagedLeafHandle;
+import io.evitadb.index.invertedIndex.InvertedIndex;
+import io.evitadb.index.invertedIndex.ValueToRecord;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
+import static io.evitadb.api.query.QueryConstraints.attributeEquals;
+import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.filterBy;
+import static io.evitadb.api.query.QueryConstraints.referenceContentAll;
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.FILTER;
+import static io.evitadb.test.TestTags.INDEXING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Writer-side reproduction harness for a stale leaf-page twin corruption: two on-disk leaf pages of a persisted
+ * `PAGED` {@link io.evitadb.index.invertedIndex.InvertedIndex} bucket tree end up covering overlapping key
+ * ranges because a frozen snapshot of a leaf is left reachable in the persisted leaf-page list right next to
+ * the page that superseded it (see {@link io.evitadb.index.attribute.StaleLeafPageTwinReproductionTest} for the
+ * load-side half of the reproduction and the production failure signatures the corruption causes downstream).
+ *
+ * CHECKSUM-ESTABLISHED FACTS the recipes below are aimed at, from the production incident that first surfaced
+ * this corruption: the corrupted dataset was byte-identical to the backup taken right after a full reindex — a
+ * fresh catalog populated in ONE `WARM_UP` session and then flipped ALIVE. The twin was therefore written by
+ * the single warm-up flush at `goLiveAndClose`; transactional commits and savepoints are exonerated. The
+ * in-memory bucket tree already contained BOTH twin leaves at flush time: a frozen 128-bucket leaf (exactly a
+ * split half captured at the split moment) and, adjacent to it, a 190-bucket leaf whose first 128 buckets are
+ * identical — two DISTINCT node instances (the persisted page list is strictly distinct). The insert stream
+ * was NEAR-monotonic `OffsetDateTime`s with jitter (the observed leaf sizes 127/128/186/190/235 prove
+ * middle-leaf splits and borrows, i.e. out-of-order inserts and removals, not pure appends).
+ *
+ * The primary recipes therefore drive the NON-TRANSACTIONAL (warm-up) mutation path of the
+ * {@link io.evitadb.index.bPlusTree.TransactionalBucketBPlusTree}:
+ *
+ * 1. a deterministic single-threaded warm-up stream (jittered near-monotonic values, re-publishes =
+ *    remove+insert, deletions = leaf borrows/merges) swept across several seeds, with the IN-MEMORY tree
+ *    scanned periodically and right before `goLive` — the corruption exists in memory before the flush,
+ * 2. the top race hypothesis: SEVERAL THREADS upserting concurrently over ONE shared warm-up session
+ *    (the session is only contractually non-thread-safe; nothing serializes the invocation path, so a
+ *    racing leaf split can leave a stale clone of a split half reachable in the spine — the exact twin
+ *    anatomy). Monotonic values concentrate every thread on the rightmost leaf to maximize the odds of
+ *    two threads splitting the same full leaf.
+ *
+ * One transactional skip-on-fail churn variant is kept as a CONTROL only (that path is exonerated).
+ *
+ * The oracle asserts, in memory before the flush and on the reloaded catalog after it, the fundamental
+ * invariant whose violation IS the corruption: bucket keys iterate strictly ascending and match a
+ * reference model exactly (a stale twin surfaces as a duplicated key run), no two live leaves share a
+ * persistence page sequence, and (post-reload) every model value resolves via a real query. Checked on
+ * the GLOBAL index and the REDUCED index (the production twin lived in a reduced index, which receives a
+ * filtered subsequence of the stream).
+ *
+ * While these tests pass, the corruption is NOT reproduced by the exercised recipes; a failure of any
+ * assertion here is a reproduction of the writer-side incident and must be preserved verbatim.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@Tag(FILTER)
+@DisplayName("Stale leaf-page twin writer-side reproduction harness")
+class StaleLeafPageTwinWriterReproductionTest implements EvitaTestSupport {
+
+	private static final String ATTRIBUTE_PUBLISHED = "published";
+	private static final String ATTRIBUTE_NAME = "name";
+	private static final String REFERENCE_CATEGORIES = "categories";
+	/** The category ~60% of entities reference — its REDUCED index receives a filtered subsequence. */
+	private static final int CATEGORY_PK = 1;
+	/** Deterministic base seed; the single-threaded warm-up recipe sweeps SEED..SEED+2. */
+	private static final long SEED = 20260714L;
+	/** Base timestamp of the `published` value stream (concrete value irrelevant). */
+	private static final OffsetDateTime BASE =
+		OffsetDateTime.of(2026, 7, 13, 11, 52, 31, 0, ZoneOffset.UTC);
+
+	private TestPaths paths;
+	private Evita evita;
+	/** Reference model: live entity primary key → its current `published` value (values MAY collide). */
+	private final TreeMap<Integer, OffsetDateTime> publishedByPk = new TreeMap<>();
+	/** Reference model: primary keys referencing the category (⊆ {@link #publishedByPk} keys). */
+	private final Set<Integer> pksInCategory = new HashSet<>();
+	/** Next primary key to assign. */
+	private int nextPk = 1;
+	/** Monotonic position of the value stream (thread-safe for the concurrent recipe). */
+	private final AtomicLong streamPosition = new AtomicLong(0);
+
+	@BeforeEach
+	void setUp() {
+		this.paths = createTestPaths("StaleLeafPageTwinWriter");
+		this.evita = new Evita(newTestEvitaConfigurationBuilder(this.paths).build());
+	}
+
+	@AfterEach
+	@Timeout(value = 90, unit = TimeUnit.SECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
+	void tearDown() {
+		if (this.evita != null && this.evita.isActive()) {
+			this.evita.close();
+		}
+		cleanupTestPaths(this.paths);
+	}
+
+	/*
+		PRIMARY RECIPE 1 — deterministic single warm-up session: jittered stream, re-publishes, deletions
+	 */
+
+	@Test
+	@DisplayName("a single warm-up session with a jittered re-publish stream writes a sound PAGED index")
+	void shouldSurviveSingleWarmUpSessionWithJitteredRepublishStream() {
+		for (long seed = SEED; seed < SEED + 3; seed++) {
+			resetForNextRun();
+			final Random random = new Random(seed);
+			final String seedPhase = "warm-up seed " + seed;
+			this.evita.defineCatalog(TEST_CATALOG);
+			this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					defineSchema(session);
+					// ~7000 ops in ONE warm-up session: jittered near-monotonic inserts (middle-leaf splits),
+					// re-publishes (remove+insert — the production stream's shape), deletions (borrows/merges;
+					// the observed 127-bucket leaf proves removals ran during warm-up). All mutations hit the
+					// direct (non-transactional) B+ tree branches; the flush happens once, at goLiveAndClose.
+					for (int op = 1; op <= 7_000; op++) {
+						final int dice = random.nextInt(100);
+						if (dice < 78 || this.publishedByPk.size() < 300) {
+							upsertNewEntity(session, jitteredValue(random), random.nextInt(100) < 60);
+						} else if (dice < 93) {
+							republishEntity(session, pickRandomPk(random), jitteredValue(random));
+						} else {
+							deleteEntity(session, pickRandomPk(random));
+						}
+						if (op % 1_000 == 0) {
+							// the corruption exists IN MEMORY before the flush — scan the live tree mid-stream
+							assertIndexesSound(seedPhase + ", in-memory after op " + op);
+						}
+					}
+					// the decisive scan: the in-memory tree right before the one-and-only flush
+					assertIndexesSound(seedPhase + ", in-memory right before goLive");
+					session.goLiveAndClose();
+				}
+			);
+			assertIndexesSound(seedPhase + ", after goLive flush");
+			assertTrue(
+				publishedFilterIndex(globalIndexKey()).getInvertedIndex().isPaged(),
+				seedInfo(seedPhase) + " the global `published` index is not PAGED — the recipe missed its target!"
+			);
+			reopenEvita();
+			assertIndexesSound(seedPhase + ", after cold reload");
+			assertModelResolvesViaQueries(seedPhase);
+		}
+	}
+
+	/*
+		PRIMARY RECIPE 2 — the race hypothesis: concurrent upserts over ONE shared warm-up session
+	 */
+
+	@Test
+	@Timeout(value = 300, unit = TimeUnit.SECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
+	@DisplayName("concurrent upserts over one shared warm-up session write a sound PAGED index")
+	void shouldSurviveConcurrentUpsertsOnSingleWarmUpSession() {
+		final int threadCount = 8;
+		final int upsertsPerThread = 1_500;
+		final int attempts = 3;
+		for (int attempt = 1; attempt <= attempts; attempt++) {
+			resetForNextRun();
+			final String attemptPhase = "concurrent warm-up attempt " + attempt;
+			final AtomicInteger raceExceptions = new AtomicInteger(0);
+			final List<Throwable> sampleExceptions = Collections.synchronizedList(new ArrayList<>());
+			final List<TreeMap<Integer, OffsetDateTime>> threadModels =
+				Collections.synchronizedList(new ArrayList<>());
+			final List<Set<Integer>> threadCategoryPks = Collections.synchronizedList(new ArrayList<>());
+			// primary keys whose upsert THREW: warm-up documents a failed entity as partially applied, so
+			// buckets carrying (only) these records are tolerated noise — the fatal signals stay ordering
+			// violations, duplicated page sequences and silently LOST successful upserts
+			final Set<Integer> toleratedPks = Collections.synchronizedSet(new HashSet<>());
+			this.evita.defineCatalog(TEST_CATALOG);
+			// a RAW long-lived read-write session (production full-reindex shape): a per-upsert failure on a
+			// worker thread must not poison the session close the way the updateCatalog future join does
+			final EvitaSessionContract session = this.evita.createReadWriteSession(TEST_CATALOG);
+			boolean wentLive = false;
+			try {
+				defineSchema(session);
+				// N threads share THE SAME warm-up session — the production full-reindex shape under
+				// suspicion. Values are globally monotonic with a jittered minority, so every thread
+				// hammers the rightmost leaf and two threads splitting the same full leaf is likely.
+				final List<Thread> threads = new ArrayList<>(threadCount);
+				for (int t = 0; t < threadCount; t++) {
+					final Thread thread = new Thread(
+						warmUpWriter(
+							session, t, upsertsPerThread, 0L,
+							raceExceptions, sampleExceptions, threadModels, threadCategoryPks, toleratedPks
+						),
+						"twin-warmup-" + t
+					);
+					threads.add(thread);
+					thread.start();
+				}
+				for (final Thread thread : threads) {
+					try {
+						thread.join(180_000);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						fail(seedInfo(attemptPhase) + " interrupted while joining upsert threads");
+					}
+					assertTrue(
+						!thread.isAlive(),
+						seedInfo(attemptPhase) + " thread " + thread.getName() + " hung!"
+					);
+				}
+				for (final TreeMap<Integer, OffsetDateTime> localModel : threadModels) {
+					this.publishedByPk.putAll(localModel);
+				}
+				for (final Set<Integer> localCategoryPks : threadCategoryPks) {
+					this.pksInCategory.addAll(localCategoryPks);
+				}
+				// post-fix oracle: every racing call must have been rejected LOUDLY with a
+				// ConcurrentSessionAccessException — the concurrency guard never lets a second thread silently
+				// race the shared session state. Any other exception would signal a corruption leak.
+				assertConcurrentAccessRejectedLoudly(sampleExceptions, attemptPhase);
+				// the decisive scan: the in-memory tree right before the one-and-only flush
+				assertIndexesSound(
+					attemptPhase + ", in-memory right before goLive (raceExceptions=" +
+						raceExceptions.get() + firstSample(sampleExceptions) + ")",
+					toleratedPks
+				);
+				try {
+					session.goLiveAndClose();
+					wentLive = true;
+				} catch (RuntimeException goLiveFailure) {
+					// the go-live flush choked on race residue — a loud (not silent) outcome; the in-memory
+					// oracle above already ruled on the twin, so record and continue with the next attempt
+					raceExceptions.incrementAndGet();
+					if (sampleExceptions.size() < 5) {
+						sampleExceptions.add(goLiveFailure);
+					}
+				}
+			} finally {
+				if (session.isActive()) {
+					try {
+						session.close();
+					} catch (RuntimeException closeFailure) {
+						// the close-time warm-up flush choked on race residue (e.g. a SortIndex whose sorted
+						// array diverged from its value structures) — a loud, non-twin outcome; sample it and
+						// let the next attempt run on a freshly dropped catalog
+						raceExceptions.incrementAndGet();
+						if (sampleExceptions.size() < 5) {
+							sampleExceptions.add(closeFailure);
+						}
+					}
+				}
+			}
+			if (wentLive) {
+				assertIndexesSound(attemptPhase + ", after goLive flush", toleratedPks);
+				reopenEvita();
+				assertIndexesSound(
+					attemptPhase + ", after cold reload (raceExceptions=" + raceExceptions.get() +
+						firstSample(sampleExceptions) + ")",
+					toleratedPks
+				);
+				assertModelResolvesViaQueries(attemptPhase, toleratedPks);
+			}
+		}
+	}
+
+	/*
+		PRIMARY RECIPE 3 — production-shaped RARE overlap: one main writer + an occasional interferer
+	 */
+
+	@Test
+	@Timeout(value = 300, unit = TimeUnit.SECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
+	@DisplayName("split-aimed overlapping upserts over one shared warm-up session write a sound PAGED index")
+	void shouldSurviveSplitAimedOverlappingUpsertsOnSingleWarmUpSession() {
+		// The full-contention variant degrades into a loud cascade almost immediately — but the production
+		// reindex COMPLETED, so its overlap (if any) must have been rare AND lucky. This variant spends its
+		// overlap budget exclusively on the event that can mint the twin: an interferer SNIPES the split window
+		// — it polls the rightmost-leaf fill and fires a single racing monotonic insert only when the leaf is
+		// about to split (fill ≥ 254), so two threads execute splitLeafNode/adaptToLeafSplit on the same full
+		// leaf. A stale clone of a split half left reachable in the spine is exactly the twin anatomy this
+		// harness targets.
+		final int attempts = 3;
+		for (int attempt = 1; attempt <= attempts; attempt++) {
+			resetForNextRun();
+			final String attemptPhase = "split-aimed overlap warm-up attempt " + attempt;
+			final AtomicInteger raceExceptions = new AtomicInteger(0);
+			final List<Throwable> sampleExceptions = Collections.synchronizedList(new ArrayList<>());
+			final List<TreeMap<Integer, OffsetDateTime>> threadModels =
+				Collections.synchronizedList(new ArrayList<>());
+			final List<Set<Integer>> threadCategoryPks = Collections.synchronizedList(new ArrayList<>());
+			final Set<Integer> toleratedPks = Collections.synchronizedSet(new HashSet<>());
+			this.evita.defineCatalog(TEST_CATALOG);
+			final EvitaSessionContract session = this.evita.createReadWriteSession(TEST_CATALOG);
+			boolean wentLive = false;
+			try {
+				defineSchema(session, false);
+				final java.util.concurrent.atomic.AtomicBoolean writerRunning =
+					new java.util.concurrent.atomic.AtomicBoolean(true);
+				final Runnable writerLoop = warmUpWriter(
+					session, 0, 12_000, 0L,
+					raceExceptions, sampleExceptions, threadModels, threadCategoryPks, toleratedPks
+				);
+				final Thread writer = new Thread(
+					() -> {
+						try {
+							writerLoop.run();
+						} finally {
+							writerRunning.set(false);
+						}
+					},
+					"twin-warmup-writer"
+				);
+				final Thread interferer = new Thread(
+					splitSniper(
+						session, writerRunning,
+						raceExceptions, sampleExceptions, threadModels, threadCategoryPks, toleratedPks
+					),
+					"twin-warmup-split-sniper"
+				);
+				writer.start();
+				interferer.start();
+				for (final Thread thread : List.of(writer, interferer)) {
+					try {
+						thread.join(180_000);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						fail(seedInfo(attemptPhase) + " interrupted while joining upsert threads");
+					}
+					assertTrue(
+						!thread.isAlive(),
+						seedInfo(attemptPhase) + " thread " + thread.getName() + " hung!"
+					);
+				}
+				for (final TreeMap<Integer, OffsetDateTime> localModel : threadModels) {
+					this.publishedByPk.putAll(localModel);
+				}
+				for (final Set<Integer> localCategoryPks : threadCategoryPks) {
+					this.pksInCategory.addAll(localCategoryPks);
+				}
+				// post-fix oracle: every racing call must have been rejected LOUDLY with a
+				// ConcurrentSessionAccessException — the concurrency guard never lets a second thread silently
+				// race the shared session state. Any other exception would signal a corruption leak.
+				assertConcurrentAccessRejectedLoudly(sampleExceptions, attemptPhase);
+				// the decisive scan: the in-memory tree right before the one-and-only flush
+				assertIndexesSound(
+					attemptPhase + ", in-memory right before goLive (raceExceptions=" +
+						raceExceptions.get() + firstSample(sampleExceptions) + ")",
+					toleratedPks
+				);
+				try {
+					session.goLiveAndClose();
+					wentLive = true;
+				} catch (RuntimeException goLiveFailure) {
+					raceExceptions.incrementAndGet();
+					if (sampleExceptions.size() < 5) {
+						sampleExceptions.add(goLiveFailure);
+					}
+				}
+			} finally {
+				if (session.isActive()) {
+					try {
+						session.close();
+					} catch (RuntimeException closeFailure) {
+						raceExceptions.incrementAndGet();
+						if (sampleExceptions.size() < 5) {
+							sampleExceptions.add(closeFailure);
+						}
+					}
+				}
+			}
+			if (wentLive) {
+				assertIndexesSound(attemptPhase + ", after goLive flush", toleratedPks);
+				reopenEvita();
+				assertIndexesSound(
+					attemptPhase + ", after cold reload (raceExceptions=" + raceExceptions.get() +
+						firstSample(sampleExceptions) + ")",
+					toleratedPks
+				);
+				assertModelResolvesViaQueries(attemptPhase, toleratedPks);
+			}
+		}
+	}
+
+	/**
+	 * Builds the split-window sniper for the split-aimed overlap recipe: it polls the GLOBAL tree's
+	 * rightmost-leaf fill (tolerating torn reads of the racing tree) and fires ONE racing monotonic insert
+	 * whenever the leaf is about to split, so both threads run the split machinery on the same full leaf.
+	 *
+	 * @param session          the SHARED warm-up session
+	 * @param writerRunning    cleared by the main writer when it finishes (stops the sniper)
+	 * @param raceExceptions   shared counter of throwing upserts
+	 * @param sampleExceptions shared sample of the first few thrown exceptions
+	 * @param modelsOut        sink for the sniper's pk → value model
+	 * @param categoryPksOut   sink for the sniper's category-referencing pks
+	 * @param toleratedPks     shared sink for pks of throwing upserts
+	 * @return the sniper loop
+	 */
+	@Nonnull
+	private Runnable splitSniper(
+		@Nonnull EvitaSessionContract session,
+		@Nonnull java.util.concurrent.atomic.AtomicBoolean writerRunning,
+		@Nonnull AtomicInteger raceExceptions,
+		@Nonnull List<Throwable> sampleExceptions,
+		@Nonnull List<TreeMap<Integer, OffsetDateTime>> modelsOut,
+		@Nonnull List<Set<Integer>> categoryPksOut,
+		@Nonnull Set<Integer> toleratedPks
+	) {
+		return () -> {
+			final TreeMap<Integer, OffsetDateTime> localModel = new TreeMap<>();
+			final Set<Integer> localCategoryPks = new HashSet<>();
+			int pkCursor = 2_000_000;
+			int fired = 0;
+			final long deadline = System.nanoTime() + 60_000_000_000L;
+			while (fired < 60 && writerRunning.get() && System.nanoTime() < deadline) {
+				final int fill = probeRightmostLeafFillQuietly();
+				if (fill >= 254) {
+					final int pk = pkCursor++;
+					final OffsetDateTime value = monotonicValue();
+					try {
+						upsertConcurrently(session, pk, value, true);
+						localModel.put(pk, value);
+						localCategoryPks.add(pk);
+					} catch (RuntimeException raceCasualty) {
+						raceExceptions.incrementAndGet();
+						toleratedPks.add(pk);
+						if (sampleExceptions.size() < 5) {
+							sampleExceptions.add(raceCasualty);
+						}
+					}
+					fired++;
+				} else {
+					Thread.onSpinWait();
+				}
+			}
+			modelsOut.add(localModel);
+			categoryPksOut.add(localCategoryPks);
+		};
+	}
+
+	/**
+	 * Concurrent-safe wrapper around the rightmost-leaf fill probe: the sniper reads the tree WHILE the writer
+	 * mutates it, so any exception from the torn read is swallowed and reported as "unknown".
+	 *
+	 * @return the rightmost-leaf bucket count, or `-1` when unreadable
+	 */
+	private int probeRightmostLeafFillQuietly() {
+		try {
+			final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+			final EntityCollection collection =
+				(EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+			final EntityIndex index = collection.getIndexByKeyIfExists(globalIndexKey());
+			if (index == null) {
+				return -1;
+			}
+			final FilterIndex filterIndex =
+				index.getFilterIndex(new AttributeIndexKey(null, ATTRIBUTE_PUBLISHED, null));
+			if (filterIndex == null) {
+				return -1;
+			}
+			final List<? extends PagedLeafHandle> handles = leafHandles(filterIndex.getInvertedIndex());
+			if (handles == null || handles.isEmpty()) {
+				return -1;
+			}
+			final PagedLeafHandle last = handles.get(handles.size() - 1);
+			if (!(last instanceof io.evitadb.index.bPlusTree.TransactionalBucketBPlusTree.LeafPageHandle<?> leafHandle)) {
+				return -1;
+			}
+			int count = 0;
+			final io.evitadb.index.bPlusTree.TransactionalBucketBPlusTree.BucketCursor<?> cursor =
+				leafHandle.cursor();
+			while (cursor.next()) {
+				count++;
+			}
+			return count;
+		} catch (RuntimeException | Error tornRead) {
+			return -1;
+		}
+	}
+
+	/**
+	 * Builds one warm-up upsert loop for the concurrent recipes: `upserts` inserts over the SHARED session with
+	 * a thread-private pk range and the shared globally monotonic (30% jittered) value stream, optionally paced
+	 * by a sleep between operations. Successful upserts land in a thread-local model (merged by the caller
+	 * after joining); throwing upserts are counted, sampled and their pks marked tolerated (warm-up documents a
+	 * failed entity as partially applied).
+	 *
+	 * @param session          the SHARED warm-up session
+	 * @param threadNo         the thread ordinal (selects the pk range and the random seed)
+	 * @param upserts          the number of upserts to issue
+	 * @param sleepMillis      the pause between operations (0 = full speed)
+	 * @param raceExceptions   shared counter of throwing upserts
+	 * @param sampleExceptions shared sample of the first few thrown exceptions
+	 * @param modelsOut        sink for the thread-local pk → value model
+	 * @param categoryPksOut   sink for the thread-local category-referencing pks
+	 * @param toleratedPks     shared sink for pks of throwing upserts
+	 * @return the upsert loop
+	 */
+	@Nonnull
+	private Runnable warmUpWriter(
+		@Nonnull EvitaSessionContract session,
+		int threadNo,
+		int upserts,
+		long sleepMillis,
+		@Nonnull AtomicInteger raceExceptions,
+		@Nonnull List<Throwable> sampleExceptions,
+		@Nonnull List<TreeMap<Integer, OffsetDateTime>> modelsOut,
+		@Nonnull List<Set<Integer>> categoryPksOut,
+		@Nonnull Set<Integer> toleratedPks
+	) {
+		return () -> {
+			final Random random = new Random(SEED + threadNo);
+			final TreeMap<Integer, OffsetDateTime> localModel = new TreeMap<>();
+			final Set<Integer> localCategoryPks = new HashSet<>();
+			// disjoint per-thread pk ranges; the CONTENTION is on the shared index trees
+			int pkCursor = 1_000_000 * (threadNo + 1);
+			for (int op = 1; op <= upserts; op++) {
+				final int pk = pkCursor++;
+				final OffsetDateTime value = random.nextInt(100) < 70
+					? monotonicValue()
+					: jitteredValue(random);
+				final boolean inCategory = random.nextInt(100) < 60;
+				try {
+					upsertConcurrently(session, pk, value, inCategory);
+					localModel.put(pk, value);
+					if (inCategory) {
+						localCategoryPks.add(pk);
+					}
+				} catch (RuntimeException raceCasualty) {
+					// an exception here is itself evidence of the unsynchronized-session race; it is counted
+					// and sampled, but the reproduction target is the SILENT twin — the oracle decides
+					raceExceptions.incrementAndGet();
+					toleratedPks.add(pk);
+					if (sampleExceptions.size() < 5) {
+						sampleExceptions.add(raceCasualty);
+					}
+				}
+				if (sleepMillis > 0) {
+					try {
+						Thread.sleep(sleepMillis);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						return;
+					}
+				}
+			}
+			modelsOut.add(localModel);
+			categoryPksOut.add(localCategoryPks);
+		};
+	}
+
+	/*
+		CONTROL — transactional skip-on-fail churn (exonerated path, kept to guard the trunk replay)
+	 */
+
+	@Test
+	@DisplayName("control: transactional skip-on-fail churn keeps every bucket tree sound")
+	void shouldSurviveTransactionalSkipOnFailChurnControl() {
+		resetForNextRun();
+		final Random random = new Random(SEED);
+		this.evita.defineCatalog(TEST_CATALOG);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				defineSchema(session);
+				for (int i = 0; i < 400; i++) {
+					upsertNewEntity(session, monotonicValue(), true);
+				}
+				session.goLiveAndClose();
+			}
+		);
+		assertIndexesSound("control warm-up");
+		for (int commit = 1; commit <= 15; commit++) {
+			this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					for (int op = 1; op <= 50; op++) {
+						final int dice = random.nextInt(100);
+						if (dice < 8) {
+							failingInsert(session, monotonicValue());
+						} else if (dice < 60) {
+							upsertNewEntity(session, jitteredValue(random), true);
+						} else {
+							republishEntity(session, pickRandomPk(random), monotonicValue());
+						}
+					}
+				},
+				CommitBehavior.WAIT_FOR_CHANGES_VISIBLE
+			);
+			assertIndexesSound("control commit " + commit);
+		}
+		reopenEvita();
+		assertIndexesSound("control final reopen");
+		assertModelResolvesViaQueries("control");
+	}
+
+	/*
+		SCHEMA + RUN RESET
+	 */
+
+	/**
+	 * Defines the production-shaped schema: both-flagged `published` OffsetDateTime attribute, mandatory
+	 * `name`, indexed `categories` reference (⇒ a reduced index partitioned by the referenced category).
+	 *
+	 * @param session the open read-write session
+	 */
+	private void defineSchema(@Nonnull EvitaSessionContract session) {
+		defineSchema(session, true);
+	}
+
+	/**
+	 * Variant of {@link #defineSchema(EvitaSessionContract)} with a switchable `sortable` flag on `published`.
+	 * The split-aimed concurrent recipe drops it: the SortIndex crashes loudly (insert- and flush-time) under
+	 * races, drowning and blocking the SILENT twin this harness hunts; the twin lives in the (filterable)
+	 * bucket tree either way.
+	 *
+	 * @param session           the open read-write session
+	 * @param sortablePublished whether `published` is also sortable (the production attribute was both-flagged)
+	 */
+	private void defineSchema(@Nonnull EvitaSessionContract session, boolean sortablePublished) {
+		session.defineEntitySchema(Entities.CATEGORY)
+			.withoutGeneratedPrimaryKey()
+			.updateVia(session);
+		session.defineEntitySchema(Entities.PRODUCT)
+			.withoutGeneratedPrimaryKey()
+			// both-flagged, exactly like the production `published` attribute (the split-aimed recipe drops
+			// `sortable`)
+			.withAttribute(
+				ATTRIBUTE_PUBLISHED, OffsetDateTime.class,
+				whichIs -> {
+					whichIs.filterable();
+					if (sortablePublished) {
+						whichIs.sortable();
+					}
+				}
+			)
+			// mandatory (non-nullable is the default) — the control variant omits it to force savepoint failures
+			.withAttribute(ATTRIBUTE_NAME, String.class)
+			.withReferenceToEntity(
+				REFERENCE_CATEGORIES, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
+				whichIs -> whichIs.indexedForFilteringAndPartitioning()
+			)
+			.updateVia(session);
+		session.upsertEntity(session.createNewEntity(Entities.CATEGORY, CATEGORY_PK));
+	}
+
+	/**
+	 * Clears the reference model and drops a possibly existing catalog so each seed / attempt starts from a
+	 * genuinely fresh catalog (dropped through the API, never on disk).
+	 */
+	private void resetForNextRun() {
+		this.publishedByPk.clear();
+		this.pksInCategory.clear();
+		this.nextPk = 1;
+		this.streamPosition.set(0);
+		this.evita.deleteCatalogIfExists(TEST_CATALOG);
+	}
+
+	/*
+		VALUE ALLOCATION
+	 */
+
+	/**
+	 * Returns the next strictly monotonic `published` value: {@link #BASE} + 50·position milliseconds.
+	 *
+	 * @return the next monotonic value
+	 */
+	@Nonnull
+	private OffsetDateTime monotonicValue() {
+		return BASE.plusNanos(50_000_000L * this.streamPosition.getAndIncrement());
+	}
+
+	/**
+	 * Returns the next NEAR-monotonic value: the monotonic 50 ms grid step plus a ±2000 ms jitter — the
+	 * production stream's shape. The jitter throws a minority of inserts back into already-built leaves
+	 * (middle-leaf splits) and lets distinct entities collide on the same value (multi-record buckets).
+	 *
+	 * @param random the deterministic random source
+	 * @return the next jittered value
+	 */
+	@Nonnull
+	private OffsetDateTime jitteredValue(@Nonnull Random random) {
+		final long position = this.streamPosition.getAndIncrement();
+		final long jitterMillis = random.nextLong(4_001L) - 2_000L;
+		return BASE.plusNanos(50_000_000L * position + 1_000_000L * jitterMillis);
+	}
+
+	/**
+	 * Picks a random live primary key from the reference model.
+	 *
+	 * @param random the deterministic random source
+	 * @return a live primary key
+	 */
+	private int pickRandomPk(@Nonnull Random random) {
+		final int index = random.nextInt(this.publishedByPk.size());
+		final Iterator<Integer> it = this.publishedByPk.keySet().iterator();
+		for (int i = 0; i < index; i++) {
+			it.next();
+		}
+		return it.next();
+	}
+
+	/*
+		OPERATIONS
+	 */
+
+	/**
+	 * Inserts a brand-new entity carrying the passed `published` value and the mandatory name; entities
+	 * referencing the category feed the reduced index with a filtered subsequence. Updates the model.
+	 *
+	 * @param session    the open read-write session
+	 * @param value      the `published` value to index
+	 * @param inCategory whether the entity references the category
+	 */
+	private void upsertNewEntity(
+		@Nonnull EvitaSessionContract session, @Nonnull OffsetDateTime value, boolean inCategory
+	) {
+		final int pk = this.nextPk++;
+		final EntityBuilder builder = session.createNewEntity(Entities.PRODUCT, pk)
+			.setAttribute(ATTRIBUTE_PUBLISHED, value)
+			.setAttribute(ATTRIBUTE_NAME, "Product " + pk);
+		if (inCategory) {
+			builder.setReference(REFERENCE_CATEGORIES, CATEGORY_PK);
+		}
+		session.upsertEntity(builder);
+		this.publishedByPk.put(pk, value);
+		if (inCategory) {
+			this.pksInCategory.add(pk);
+		}
+	}
+
+	/**
+	 * Concurrent-recipe insert: explicit primary key (thread-local cursor), NO shared-model mutation — the
+	 * threads merge their local models after joining.
+	 *
+	 * @param session    the SHARED warm-up session
+	 * @param pk         the thread-local primary key
+	 * @param value      the `published` value to index
+	 * @param inCategory whether the entity references the category
+	 */
+	private static void upsertConcurrently(
+		@Nonnull EvitaSessionContract session, int pk, @Nonnull OffsetDateTime value, boolean inCategory
+	) {
+		final EntityBuilder builder = session.createNewEntity(Entities.PRODUCT, pk)
+			.setAttribute(ATTRIBUTE_PUBLISHED, value)
+			.setAttribute(ATTRIBUTE_NAME, "Product " + pk);
+		if (inCategory) {
+			builder.setReference(REFERENCE_CATEGORIES, CATEGORY_PK);
+		}
+		session.upsertEntity(builder);
+	}
+
+	/**
+	 * Re-publishes an existing entity: its `published` value changes to the passed one (index-wise a bucket
+	 * removal + a bucket insert — the production re-publish shape); updates the model.
+	 *
+	 * @param session the open read-write session
+	 * @param pk      the primary key of the entity to re-publish
+	 * @param value   the new `published` value
+	 */
+	private void republishEntity(@Nonnull EvitaSessionContract session, int pk, @Nonnull OffsetDateTime value) {
+		final SealedEntity entity = session
+			.getEntity(Entities.PRODUCT, pk, attributeContentAll(), referenceContentAll())
+			.orElseThrow(() -> new AssertionError("Model entity " + pk + " unexpectedly missing!"));
+		session.upsertEntity(
+			entity.openForWrite().setAttribute(ATTRIBUTE_PUBLISHED, value)
+		);
+		this.publishedByPk.put(pk, value);
+	}
+
+	/**
+	 * Deletes an existing entity (bucket removal ⇒ leaf underflow ⇒ borrow/merge); updates the model.
+	 *
+	 * @param session the open read-write session
+	 * @param pk      the primary key of the entity to delete
+	 */
+	private void deleteEntity(@Nonnull EvitaSessionContract session, int pk) {
+		session.deleteEntity(Entities.PRODUCT, pk);
+		this.publishedByPk.remove(pk);
+		this.pksInCategory.remove(pk);
+	}
+
+	/**
+	 * Control-variant DELIBERATELY FAILING insert: omits the mandatory name so the validation throws AFTER the
+	 * `published` index write and the per-entity savepoint rolls the entity back (skip-on-fail). Only used in
+	 * the transactional control — during warm-up a failed entity is documented to stay partially applied, which
+	 * would drown the twin signal in expected phantom keys.
+	 *
+	 * @param session the open read-write session
+	 * @param value   the `published` value the failing entity briefly indexes
+	 */
+	private void failingInsert(@Nonnull EvitaSessionContract session, @Nonnull OffsetDateTime value) {
+		final int pk = this.nextPk++;
+		try {
+			session.upsertEntity(
+				session.createNewEntity(Entities.PRODUCT, pk)
+					.setAttribute(ATTRIBUTE_PUBLISHED, value)
+					.setReference(REFERENCE_CATEGORIES, CATEGORY_PK)
+			);
+			fail(seedInfo("control") + " failing insert of pk " + pk + " unexpectedly succeeded!");
+		} catch (MandatoryAttributesNotProvidedException expected) {
+			// the per-entity savepoint rolled the entity back — the batch continues (skip-on-fail)
+		} catch (RuntimeException unexpected) {
+			fail(
+				seedInfo("control") + " failing insert of pk " + pk + " threw an unexpected exception — " +
+					"a likely corruption signature: " + unexpected,
+				unexpected
+			);
+		}
+	}
+
+	/*
+		ORACLE
+	 */
+
+	/**
+	 * The heart of the oracle: for the GLOBAL index and the REDUCED index, walks the live `published` bucket
+	 * tree and asserts it matches the reference model bucket-for-bucket (strictly ascending distinct keys,
+	 * exact record-id sets) and that no two live leaves share a persistence page sequence. Works both on the
+	 * warm-up in-memory tree (page sequences still unassigned) and on the committed / reloaded tree.
+	 *
+	 * @param phase a human-readable description of the current phase (failure diagnostics)
+	 */
+	private void assertIndexesSound(@Nonnull String phase) {
+		assertIndexesSound(phase, Collections.emptySet());
+	}
+
+	/**
+	 * Tolerance-aware variant of {@link #assertIndexesSound(String)}: primary keys of upserts that visibly
+	 * FAILED may linger partially applied (documented warm-up behavior), so buckets carrying only such records
+	 * are tolerated. Ordering violations, duplicated page sequences and lost SUCCESSFUL upserts stay fatal.
+	 *
+	 * @param phase        a human-readable description of the current phase (failure diagnostics)
+	 * @param toleratedPks primary keys whose partial index residue is tolerated
+	 */
+	private void assertIndexesSound(@Nonnull String phase, @Nonnull Set<Integer> toleratedPks) {
+		assertIndexSound(globalIndexKey(), this.publishedByPk.keySet(), toleratedPks, "GLOBAL", phase);
+		assertIndexSound(
+			reducedIndexKey(), this.pksInCategory, toleratedPks,
+			"REDUCED categories:" + CATEGORY_PK, phase
+		);
+	}
+
+	/**
+	 * Asserts a single entity index's `published` bucket tree matches the reference model restricted to the
+	 * passed primary keys. A missing index (or filter index) is tolerated only while the restriction is empty.
+	 *
+	 * @param indexKey     the entity index key to check
+	 * @param modelPks     the primary keys expected in this index (each contributes its model `published` value)
+	 * @param toleratedPks primary keys whose partial index residue is tolerated (failed upserts)
+	 * @param indexName    the index description (failure diagnostics)
+	 * @param phase        the phase description (failure diagnostics)
+	 */
+	private void assertIndexSound(
+		@Nonnull EntityIndexKey indexKey,
+		@Nonnull Set<Integer> modelPks,
+		@Nonnull Set<Integer> toleratedPks,
+		@Nonnull String indexName,
+		@Nonnull String phase
+	) {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection =
+			(EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		final EntityIndex index = collection.getIndexByKeyIfExists(indexKey);
+		if (index == null) {
+			assertTrue(
+				modelPks.isEmpty(),
+				seedInfo(phase) + " index " + indexName + " missing although the model expects " +
+					modelPks.size() + " value(s)!"
+			);
+			return;
+		}
+		final FilterIndex filterIndex =
+			index.getFilterIndex(new AttributeIndexKey(null, ATTRIBUTE_PUBLISHED, null));
+		if (filterIndex == null) {
+			assertTrue(
+				modelPks.isEmpty(),
+				seedInfo(phase) + " filter index for `published` missing in " + indexName +
+					" although the model expects " + modelPks.size() + " value(s)!"
+			);
+			return;
+		}
+		final InvertedIndex invertedIndex = filterIndex.getInvertedIndex();
+
+		// build the expected bucket sequence: normalized key (Instant) → ascending record ids; values may
+		// legitimately collide across entities, so a bucket may hold several records
+		final TreeMap<Instant, List<Integer>> expected = new TreeMap<>();
+		for (final Integer pk : modelPks) {
+			final OffsetDateTime value = this.publishedByPk.get(pk);
+			assertNotNull(value, seedInfo(phase) + " model inconsistency: pk " + pk + " has no value!");
+			expected.computeIfAbsent(value.toInstant(), key -> new ArrayList<>(1)).add(pk);
+		}
+		for (final List<Integer> records : expected.values()) {
+			Collections.sort(records);
+		}
+
+		// 1) merge-walk: live buckets vs. the reference model — strictly ascending keys (fatal on violation:
+		//    the stale-twin signature), no phantom bucket beyond the tolerated partial residue, no lost key of
+		//    a successful upsert, record-id sets matching up to tolerated extras
+		final Iterator<ValueToRecord> actual = invertedIndex.getValueIterator();
+		final Iterator<Entry<Instant, List<Integer>>> expectedIt = expected.entrySet().iterator();
+		Entry<Instant, List<Integer>> pendingExpected = expectedIt.hasNext() ? expectedIt.next() : null;
+		Serializable previousKey = null;
+		int position = 0;
+		while (actual.hasNext()) {
+			final ValueToRecord bucket = actual.next();
+			final Serializable bucketKey = bucket.getValue();
+			if (previousKey != null && compareKeys(previousKey, bucketKey) >= 0) {
+				fail(
+					seedInfo(phase) + " " + indexName + ": bucket[" + position + "]=" + bucketKey +
+						" does not sort after bucket[" + (position - 1) + "]=" + previousKey +
+						" — cross-bucket ordering violated (stale-twin signature)!"
+				);
+			}
+			// an expected key the tree skipped over is fatal — a successful upsert was silently lost
+			if (pendingExpected != null && compareKeys(pendingExpected.getKey(), bucketKey) < 0) {
+				fail(
+					seedInfo(phase) + " " + indexName + ": model value " + pendingExpected.getKey() +
+						" of records " + pendingExpected.getValue() +
+						" is MISSING from the index (silently lost upsert)!"
+				);
+			}
+			if (pendingExpected == null || compareKeys(pendingExpected.getKey(), bucketKey) > 0) {
+				// a bucket the model does not know: tolerated only when every record belongs to a failed
+				// (partially applied) upsert
+				assertOnlyToleratedRecords(bucket, toleratedPks, indexName, phase, position);
+			} else {
+				// matching key: every expected record must be present; extras must be tolerated residue
+				final int[] actualRecords = bucket.getRecordIds().getArray();
+				final List<Integer> expectedRecords = pendingExpected.getValue();
+				int expectedIdx = 0;
+				for (final int actualRecord : actualRecords) {
+					if (expectedIdx < expectedRecords.size() && expectedRecords.get(expectedIdx) == actualRecord) {
+						expectedIdx++;
+					} else {
+						assertTrue(
+							toleratedPks.contains(actualRecord),
+							seedInfo(phase) + " " + indexName + ": bucket[" + position + "]=" + bucketKey +
+								" holds unexpected record " + actualRecord + " (bucket=" +
+								bucket.getRecordIds() + ", expected=" + expectedRecords + ")"
+						);
+					}
+				}
+				assertTrue(
+					expectedIdx == expectedRecords.size(),
+					seedInfo(phase) + " " + indexName + ": bucket[" + position + "]=" + bucketKey +
+						" lost expected record(s): holds " + bucket.getRecordIds() + ", expected " +
+						expectedRecords
+				);
+				pendingExpected = expectedIt.hasNext() ? expectedIt.next() : null;
+			}
+			previousKey = bucketKey;
+			position++;
+		}
+		if (pendingExpected != null) {
+			fail(
+				seedInfo(phase) + " " + indexName + ": model value " + pendingExpected.getKey() +
+					" of records " + pendingExpected.getValue() +
+					" (and possibly more) is MISSING from the index (silently lost upsert)!"
+			);
+		}
+
+		// 2) page-sequence uniqueness over the live leaves — two leaves sharing a page sequence is the direct
+		//    write-side twin signature (unassigned sequences of a not-yet-flushed warm-up tree are skipped)
+		final List<? extends PagedLeafHandle> handles = leafHandles(invertedIndex);
+		if (handles != null) {
+			final Set<Integer> seen = new HashSet<>(handles.size());
+			for (final PagedLeafHandle handle : handles) {
+				final int pageSequence = handle.getPageSequence();
+				if (pageSequence != PagedLeafHandle.UNASSIGNED_PAGE_SEQUENCE && !seen.add(pageSequence)) {
+					fail(
+						seedInfo(phase) + " " + indexName + ": two live leaves share page sequence " +
+							pageSequence + " — stale leaf-page twin in the live tree!"
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Fails unless every record of the model-unknown bucket belongs to a tolerated (visibly failed, partially
+	 * applied) upsert.
+	 *
+	 * @param bucket       the phantom bucket
+	 * @param toleratedPks primary keys whose partial index residue is tolerated
+	 * @param indexName    the index description (failure diagnostics)
+	 * @param phase        the phase description (failure diagnostics)
+	 * @param position     the bucket position (failure diagnostics)
+	 */
+	private static void assertOnlyToleratedRecords(
+		@Nonnull ValueToRecord bucket,
+		@Nonnull Set<Integer> toleratedPks,
+		@Nonnull String indexName,
+		@Nonnull String phase,
+		int position
+	) {
+		for (final int record : bucket.getRecordIds().getArray()) {
+			assertTrue(
+				toleratedPks.contains(record),
+				seedInfo(phase) + " " + indexName + ": phantom bucket[" + position + "]=" + bucket.getValue() +
+					" holds record " + record + " that belongs to NO failed upsert — a rolled-in ghost " +
+					"(bucket=" + bucket.getRecordIds() + ")!"
+			);
+		}
+	}
+
+	/**
+	 * Compares two bucket keys of the same runtime type.
+	 *
+	 * @param a the first key
+	 * @param b the second key
+	 * @return negative / zero / positive per {@link Comparable} contract
+	 */
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	private static int compareKeys(@Nonnull Serializable a, @Nonnull Serializable b) {
+		return ((Comparable) a).compareTo(b);
+	}
+
+	/**
+	 * Full end-to-end resolution check (run on the reloaded catalog): every distinct model value must resolve
+	 * through a real `attributeEquals` query to exactly the entities carrying it.
+	 *
+	 * @param phase the phase description (failure diagnostics)
+	 */
+	private void assertModelResolvesViaQueries(@Nonnull String phase) {
+		assertModelResolvesViaQueries(phase, Collections.emptySet());
+	}
+
+	/**
+	 * Tolerance-aware variant of {@link #assertModelResolvesViaQueries(String)}: extra matches belonging to a
+	 * visibly failed (partially applied) upsert are tolerated; a lost or wrongly resolved successful upsert is
+	 * fatal.
+	 *
+	 * @param phase        the phase description (failure diagnostics)
+	 * @param toleratedPks primary keys whose partial index residue is tolerated
+	 */
+	private void assertModelResolvesViaQueries(@Nonnull String phase, @Nonnull Set<Integer> toleratedPks) {
+		final TreeMap<OffsetDateTime, List<Integer>> byValue = new TreeMap<>();
+		for (final Entry<Integer, OffsetDateTime> entry : this.publishedByPk.entrySet()) {
+			byValue.computeIfAbsent(entry.getValue(), key -> new ArrayList<>(1)).add(entry.getKey());
+		}
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				for (final Entry<OffsetDateTime, List<Integer>> entry : byValue.entrySet()) {
+					final List<EntityReferenceContract> matches = session.queryListOfEntityReferences(
+						query(
+							collection(Entities.PRODUCT),
+							filterBy(attributeEquals(ATTRIBUTE_PUBLISHED, entry.getKey()))
+						)
+					);
+					final List<Integer> matchedPks = new ArrayList<>(matches.size());
+					for (final EntityReferenceContract match : matches) {
+						final int matchedPk = match.getPrimaryKey();
+						if (!toleratedPks.contains(matchedPk)) {
+							matchedPks.add(matchedPk);
+						}
+					}
+					Collections.sort(matchedPks);
+					assertEquals(
+						entry.getValue(), matchedPks,
+						seedInfo(phase) + " value " + entry.getKey() + " resolved to wrong entities"
+					);
+				}
+				return null;
+			}
+		);
+	}
+
+	/*
+		INTROSPECTION HELPERS
+	 */
+
+	/**
+	 * Returns the key of the GLOBAL entity index.
+	 *
+	 * @return the global index key
+	 */
+	@Nonnull
+	private static EntityIndexKey globalIndexKey() {
+		return new EntityIndexKey(EntityIndexType.GLOBAL);
+	}
+
+	/**
+	 * Returns the key of the REDUCED entity index partitioned by the category.
+	 *
+	 * @return the reduced index key
+	 */
+	@Nonnull
+	private static EntityIndexKey reducedIndexKey() {
+		return new EntityIndexKey(
+			EntityIndexType.REFERENCED_ENTITY,
+			Scope.LIVE,
+			new RepresentativeReferenceKey(new ReferenceKey(REFERENCE_CATEGORIES, CATEGORY_PK))
+		);
+	}
+
+	/**
+	 * Navigates to the live `published` {@link FilterIndex} of the passed entity index.
+	 *
+	 * @param indexKey the entity index key
+	 * @return the filter index; never null (asserts on absence)
+	 */
+	@Nonnull
+	private FilterIndex publishedFilterIndex(@Nonnull EntityIndexKey indexKey) {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection =
+			(EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		final EntityIndex index = collection.getIndexByKeyIfExists(indexKey);
+		assertNotNull(index, "Entity index " + indexKey + " unexpectedly missing!");
+		final FilterIndex filterIndex =
+			index.getFilterIndex(new AttributeIndexKey(null, ATTRIBUTE_PUBLISHED, null));
+		assertNotNull(filterIndex, "Filter index for `published` unexpectedly missing in " + indexKey + "!");
+		return filterIndex;
+	}
+
+	/**
+	 * Returns the live leaf-page handles of the passed inverted index's bucket tree, or `null` when the tree is
+	 * not reachable (single private-field reflection; the handles themselves are public API).
+	 *
+	 * @param invertedIndex the inverted index to introspect
+	 * @return the leaf handles in ascending key order, or `null` when unreachable
+	 */
+	@Nullable
+	private static List<? extends PagedLeafHandle> leafHandles(@Nonnull InvertedIndex invertedIndex) {
+		try {
+			final Field bucketsField = InvertedIndex.class.getDeclaredField("buckets");
+			bucketsField.setAccessible(true);
+			final Object tree = bucketsField.get(invertedIndex);
+			if (tree instanceof BucketBPlusTree<?> bucketTree) {
+				return bucketTree.leafPageHandles();
+			}
+			return null;
+		} catch (ReflectiveOperationException | RuntimeException e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Closes the whole Evita instance and reopens it over the same directories — a full cold restart forcing
+	 * the PAGED leaf pages to be reloaded from disk.
+	 */
+	private void reopenEvita() {
+		this.evita.close();
+		this.evita = new Evita(newTestEvitaConfigurationBuilder(this.paths).build());
+		this.evita.waitUntilFullyInitialized();
+	}
+
+	/**
+	 * Renders the first sampled race exception (if any) for failure diagnostics.
+	 *
+	 * @param sampleExceptions the sampled exceptions
+	 * @return a short rendering, or an empty string
+	 */
+	@Nonnull
+	private static String firstSample(@Nonnull List<Throwable> sampleExceptions) {
+		return sampleExceptions.isEmpty() ? "" : ", first: " + sampleExceptions.get(0);
+	}
+
+	/**
+	 * Post-fix oracle for the concurrency guard: every sampled exception a racing worker hit must be a
+	 * {@link ConcurrentSessionAccessException} — the loud rejection of a second thread entering the
+	 * `@NotThreadSafe` session. Any other exception means the guard failed to fence off the concurrent access and
+	 * corruption leaked into the shared trees, which is exactly what this harness must never see silently swallowed.
+	 *
+	 * @param sampleExceptions the sampled race exceptions collected across all worker threads
+	 * @param phase            the phase description (failure diagnostics)
+	 */
+	private static void assertConcurrentAccessRejectedLoudly(
+		@Nonnull List<Throwable> sampleExceptions, @Nonnull String phase
+	) {
+		for (final Throwable sample : sampleExceptions) {
+			assertTrue(
+				isConcurrentAccessRejection(sample),
+				seedInfo(phase) + " a racing call failed with something other than a loud " +
+					"ConcurrentSessionAccessException, so the concurrency guard did not cleanly reject the " +
+					"concurrent access (a likely corruption leak): " + sample
+			);
+		}
+	}
+
+	/**
+	 * Returns true when the passed throwable is, or is caused by, a {@link ConcurrentSessionAccessException}.
+	 *
+	 * @param throwable the throwable to inspect (may be null)
+	 * @return true if a {@link ConcurrentSessionAccessException} is found in the cause chain
+	 */
+	private static boolean isConcurrentAccessRejection(@Nullable Throwable throwable) {
+		for (Throwable current = throwable; current != null; current = current.getCause()) {
+			if (current instanceof ConcurrentSessionAccessException) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Prefixes failure diagnostics with the deterministic seed and phase info.
+	 *
+	 * @param phase the phase description
+	 * @return the diagnostics prefix
+	 */
+	@Nonnull
+	private static String seedInfo(@Nonnull String phase) {
+		return "[seed=" + SEED + ", " + phase + "]";
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/storage/WarmUpFlushFailureCloseTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/storage/WarmUpFlushFailureCloseTest.java
@@ -1,0 +1,161 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.storage;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.TransactionContract.CommitBehavior;
+import io.evitadb.core.Evita;
+import io.evitadb.core.buffer.DataStoreMemoryBuffer;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
+
+import javax.annotation.Nonnull;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.TimeUnit;
+
+import static io.evitadb.test.TestTags.SESSION;
+import static io.evitadb.test.TestTags.STORAGE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Reproduction of a close-time flush hang triggered by a throwing `WARM_UP` session flush.
+ *
+ * When a `WARM_UP` session's close-time flush throws, the flush future is built and popped SYNCHRONOUSLY inside
+ * {@link Catalog#flush()} (via {@link EntityCollection#createFlushFuture()} →
+ * {@code dataStoreBuffer.popTrappedChanges()}). The throw therefore escapes {@code EvitaSession.closeInternal}
+ * before it can complete `commitProgress` / `closingSequenceFuture`, leaving them pending forever. A subsequent
+ * close (e.g. {@code Evita.close()} → {@code SessionRegistry.closeAllActiveSessionsAndSuspend}, whose
+ * {@code allOf().join()} and {@code .exceptionally(ex -> null)} guard can only help futures that COMPLETE) then
+ * hangs the whole engine.
+ *
+ * The fix must complete the session close future EXCEPTIONALLY on any close-time flush throw so the close
+ * terminates in bounded time. This test injects a plain {@link RuntimeException} into the collection flush (no
+ * index corruption needed) and asserts the close surfaces the failure and {@code Evita.close()} still returns.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(STORAGE)
+@Tag(SESSION)
+@DisplayName("Warm-up close-time flush failure must not hang the session close")
+class WarmUpFlushFailureCloseTest implements EvitaTestSupport {
+
+	private static final String ATTRIBUTE_CODE = "code";
+
+	private TestPaths paths;
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() {
+		this.paths = createTestPaths("WarmUpFlushFailureClose");
+		this.evita = new Evita(newTestEvitaConfigurationBuilder(this.paths).build());
+	}
+
+	@AfterEach
+	@Timeout(value = 60, unit = TimeUnit.SECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
+	void tearDown() {
+		if (this.evita != null && this.evita.isActive()) {
+			this.evita.close();
+		}
+		cleanupTestPaths(this.paths);
+	}
+
+	@Test
+	@Timeout(value = 60, unit = TimeUnit.SECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
+	@DisplayName("a warm-up session whose close-time flush throws fails the close and never hangs Evita.close()")
+	void shouldFailCloseAndNotHangWhenWarmUpFlushThrows() {
+		this.evita.defineCatalog(TEST_CATALOG);
+		final EvitaSessionContract session = this.evita.createReadWriteSession(TEST_CATALOG);
+		session.defineEntitySchema(Entities.PRODUCT)
+			.withoutGeneratedPrimaryKey()
+			.withAttribute(ATTRIBUTE_CODE, String.class)
+			.updateVia(session);
+		session.upsertEntity(
+			session.createNewEntity(Entities.PRODUCT, 1).setAttribute(ATTRIBUTE_CODE, "the-product")
+		);
+
+		// make the close-time warm-up flush of the PRODUCT collection throw a plain RuntimeException at the exact
+		// point the production incident threw: synchronously, inside popTrappedChanges
+		injectFlushFailure(Entities.PRODUCT);
+
+		// the close-time flush throws: the close MUST surface the failure (an exceptionally-completed close
+		// future or a synchronous throw - both bounded), NEVER leave commitProgress / closingSequenceFuture
+		// pending forever
+		assertThrows(
+			RuntimeException.class,
+			() -> session.closeNow(CommitBehavior.WAIT_FOR_CHANGES_VISIBLE).toCompletableFuture().join(),
+			"Closing the warm-up session whose flush throws must surface the failure, not swallow it"
+		);
+
+		// the decisive assertion: the whole engine must still shut down in bounded time. Before the fix the
+		// never-completed close future hangs SessionRegistry.closeAllActiveSessionsAndSuspend -> Evita.close()
+		// forever (this method returning under the @Timeout is the pass condition)
+		this.evita.close();
+	}
+
+	/**
+	 * Replaces the {@link DataStoreMemoryBuffer} of the given entity collection with a proxy that throws a plain
+	 * {@link RuntimeException} from {@code popTrappedChanges()} — the synchronous step {@link Catalog#flush()}
+	 * runs while building the close-time flush future — and delegates every other call to the real buffer.
+	 *
+	 * @param entityType the entity collection whose flush should be made to throw
+	 */
+	private void injectFlushFailure(@Nonnull String entityType) {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection =
+			(EntityCollection) catalog.getCollectionForEntity(entityType).orElseThrow();
+		try {
+			final Field field = EntityCollection.class.getDeclaredField("dataStoreBuffer");
+			field.setAccessible(true);
+			final DataStoreMemoryBuffer real = (DataStoreMemoryBuffer) field.get(collection);
+			final DataStoreMemoryBuffer poisoned = (DataStoreMemoryBuffer) Proxy.newProxyInstance(
+				DataStoreMemoryBuffer.class.getClassLoader(),
+				new Class<?>[]{DataStoreMemoryBuffer.class},
+				(proxy, method, args) -> {
+					if ("popTrappedChanges".equals(method.getName())) {
+						throw new IllegalStateException("Injected warm-up flush failure (close-time flush hang)");
+					}
+					try {
+						return method.invoke(real, args);
+					} catch (InvocationTargetException ex) {
+						throw ex.getCause();
+					}
+				}
+			);
+			field.set(collection, poisoned);
+		} catch (ReflectiveOperationException ex) {
+			throw new IllegalStateException("Failed to inject the flush failure for `" + entityType + "`", ex);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/progress/ProgressRecordTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/progress/ProgressRecordTest.java
@@ -29,41 +29,42 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntConsumer;
-import org.junit.jupiter.api.Tag;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static io.evitadb.test.TestTags.CONTRACT;
 import static io.evitadb.test.TestTags.TASK;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Comprehensive test suite for {@link ProgressRecord}
- * verifying progress tracking, completion, observer
- * notification, and integration with
- * {@link ProgressingFuture}.
+ * Comprehensive test suite for {@link ProgressRecord} verifying progress tracking, completion, observer
+ * notification, and integration with {@link ProgressingFuture}.
  *
- * Tests cover factory methods, initial state,
- * progress tracking with boundary validation,
- * successful and exceptional completion,
- * listener management, and ProgressingFuture
- * integration. A dedicated section documents
- * known limitations in the current implementation.
+ * Tests cover factory methods, initial state, progress tracking with boundary validation, successful and
+ * exceptional completion, and listener management.
+ *
+ * ## Determinism note
+ *
+ * All semantic tests run the task with the synchronous `Runnable::run` executor, which executes the task
+ * inline inside the {@link ProgressRecord} constructor. This exercises the IDENTICAL wiring as a real thread
+ * pool — the constructor registers the `whenComplete` handler and the progress consumer BEFORE it calls
+ * {@link ProgressingFuture#execute(java.util.concurrent.Executor)} as its last statement — but with zero
+ * concurrency, so there are no latches, timeouts or thread hand-offs to starve under a CPU-saturated
+ * `parallel=all` run. The single genuinely cross-thread scenario lives in
+ * {@link RealExecutorIntegrationTest}, which owns its own pool and uses generous (≥ 60 s) budgets per the
+ * house rule for explicitly-async tests.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
  */
@@ -72,50 +73,20 @@ import static io.evitadb.test.TestTags.TASK;
 @Tag(TASK)
 class ProgressRecordTest implements EvitaTestSupport {
 
-	private Executor executor;
-
-	/**
-	 * Sets up a thread pool executor for tests
-	 * requiring asynchronous execution.
-	 */
-	@BeforeEach
-	void setUp() {
-		this.executor = Executors.newFixedThreadPool(4);
-	}
-
-	/**
-	 * Tears down the executor after each test to
-	 * release thread pool resources.
-	 */
-	@AfterEach
-	void tearDown() {
-		if (this.executor instanceof AutoCloseable) {
-			try {
-				((AutoCloseable) this.executor).close();
-			} catch (Exception e) {
-				// ignore
-			}
-		}
-	}
-
 	@Nested
 	@DisplayName("Factory methods")
 	class FactoryMethodsTest {
 
 		/**
-		 * Verifies that the static `completed` factory
-		 * creates a fully completed progress with the
-		 * given non-null result.
+		 * Verifies that the static `completed` factory creates a fully completed progress with the given
+		 * non-null result. The record is already completed on return, so its completion value is read with the
+		 * non-blocking `getNow`.
 		 */
 		@Test
 		@DisplayName(
 			"Should create completed progress with result"
 		)
-		void shouldCreateCompletedProgressWithResult()
-			throws ExecutionException,
-			InterruptedException,
-			TimeoutException {
-
+		void shouldCreateCompletedProgressWithResult() {
 			final Progress<String> progress =
 				ProgressRecord.completed("op", "value");
 
@@ -125,25 +96,18 @@ class ProgressRecordTest implements EvitaTestSupport {
 
 			final CompletionStage<String> stage =
 				progress.onCompletion();
-			final String result =
-				stage.toCompletableFuture()
-					.get(1, TimeUnit.SECONDS);
-			assertEquals("value", result);
+			assertEquals("value", stage.toCompletableFuture().getNow(null));
 		}
 
 		/**
-		 * Verifies that the static `completed` factory
-		 * works correctly with a null result.
+		 * Verifies that the static `completed` factory works correctly with a null result. The record is already
+		 * completed on return, so its completion value is read with the non-blocking `getNow`.
 		 */
 		@Test
 		@DisplayName(
 			"Should create completed progress with null"
 		)
-		void shouldCreateCompletedProgressWithNullResult()
-			throws ExecutionException,
-			InterruptedException,
-			TimeoutException {
-
+		void shouldCreateCompletedProgressWithNullResult() {
 			final Progress<String> progress =
 				ProgressRecord.completed("op", null);
 
@@ -151,11 +115,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 			assertTrue(progress.isCompletedSuccessfully());
 			assertFalse(progress.isCompletedExceptionally());
 
-			final String result =
-				progress.onCompletion()
-					.toCompletableFuture()
-					.get(1, TimeUnit.SECONDS);
-			assertNull(result);
+			assertNull(progress.onCompletion().toCompletableFuture().getNow(null));
 		}
 	}
 
@@ -164,10 +124,8 @@ class ProgressRecordTest implements EvitaTestSupport {
 	class InitialStateTest {
 
 		/**
-		 * Verifies that a newly constructed ProgressRecord
-		 * reports zero percent completed (the internal
-		 * value is -1 but `percentCompleted()` floors it
-		 * to 0 via `Math.max`).
+		 * Verifies that a newly constructed ProgressRecord reports zero percent completed (the internal value is
+		 * -1 but `percentCompleted()` floors it to 0 via `Math.max`).
 		 */
 		@Test
 		@DisplayName(
@@ -182,9 +140,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that a newly constructed ProgressRecord
-		 * is neither successfully nor exceptionally
-		 * completed.
+		 * Verifies that a newly constructed ProgressRecord is neither successfully nor exceptionally completed.
 		 */
 		@Test
 		@DisplayName(
@@ -199,24 +155,17 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that the ProgressingFuture-based
-		 * constructor calls `updatePercentCompleted(0)`
-		 * during construction, and the observer receives
-		 * the initial 0% notification.
+		 * Verifies that the ProgressingFuture-based constructor calls `updatePercentCompleted(0)` during
+		 * construction, and the observer receives the initial 0% notification. The synchronous `Runnable::run`
+		 * executor runs the task inline in the constructor, so the observation is fully settled on return.
 		 */
 		@Test
 		@DisplayName(
 			"Should start with zero percent"
 			+ " when constructed with ProgressingFuture"
 		)
-		void shouldStartWithZeroPercentWhenConstructedWithProgressingFuture()
-			throws ExecutionException,
-			InterruptedException,
-			TimeoutException {
-
-			final List<Integer> observed =
-				new CopyOnWriteArrayList<>();
-			final IntConsumer observer = observed::add;
+		void shouldStartWithZeroPercentWhenConstructedWithProgressingFuture() {
+			final List<Integer> observed = new ArrayList<>();
 
 			final ProgressingFuture<String> future =
 				new ProgressingFuture<>(
@@ -224,16 +173,12 @@ class ProgressRecordTest implements EvitaTestSupport {
 					theFuture -> "result"
 				);
 
-			final ProgressRecord<String> record =
-				new ProgressRecord<>(
-					"op", observer, future, executor
-				);
+			new ProgressRecord<>(
+				"op", observed::add, future, Runnable::run
+			);
 
-			// wait for the future to complete
-			future.get(2, TimeUnit.SECONDS);
-
-			// observer should have received the
-			// initial 0% notification
+			assertEquals("result", future.getNow(null));
+			// observer should have received the initial 0% notification first
 			assertTrue(
 				observed.contains(0),
 				"Observer should receive initial 0%"
@@ -247,8 +192,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 	class ProgressTrackingTest {
 
 		/**
-		 * Verifies that `updatePercentCompleted` sets the
-		 * percentage and `percentCompleted()` returns it.
+		 * Verifies that `updatePercentCompleted` sets the percentage and `percentCompleted()` returns it.
 		 */
 		@Test
 		@DisplayName(
@@ -264,8 +208,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that a negative percentage throws
-		 * IllegalArgumentException.
+		 * Verifies that a negative percentage throws {@link GenericEvitaInternalError}.
 		 */
 		@Test
 		@DisplayName(
@@ -288,8 +231,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that a percentage above 100 throws
-		 * IllegalArgumentException.
+		 * Verifies that a percentage above 100 throws {@link GenericEvitaInternalError}.
 		 */
 		@Test
 		@DisplayName(
@@ -312,8 +254,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that both boundary values 0 and 100
-		 * are accepted without error.
+		 * Verifies that both boundary values 0 and 100 are accepted without error.
 		 */
 		@Test
 		@DisplayName(
@@ -332,8 +273,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that setting the same percentage twice
-		 * does not invoke the observer a second time.
+		 * Verifies that setting the same percentage twice does not invoke the observer a second time.
 		 */
 		@Test
 		@DisplayName(
@@ -359,8 +299,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that all registered observers receive
-		 * progress notifications.
+		 * Verifies that all registered observers receive progress notifications.
 		 */
 		@Test
 		@DisplayName(
@@ -400,19 +339,15 @@ class ProgressRecordTest implements EvitaTestSupport {
 	class SuccessfulCompletionTest {
 
 		/**
-		 * Verifies that `complete()` marks the record
-		 * as successfully completed with percent at 100
-		 * and the result accessible via `onCompletion()`.
+		 * Verifies that `complete()` marks the record as successfully completed with percent at 100 and the
+		 * result accessible via `onCompletion()`. The record is completed synchronously, so the value is read
+		 * with the non-blocking `getNow`.
 		 */
 		@Test
 		@DisplayName(
 			"Should complete with result"
 		)
-		void shouldCompleteWithResult()
-			throws ExecutionException,
-			InterruptedException,
-			TimeoutException {
-
+		void shouldCompleteWithResult() {
 			final ProgressRecord<String> record =
 				new ProgressRecord<>("op", null);
 
@@ -424,26 +359,20 @@ class ProgressRecordTest implements EvitaTestSupport {
 				100, record.percentCompleted()
 			);
 
-			final String result =
-				record.onCompletion()
-					.toCompletableFuture()
-					.get(1, TimeUnit.SECONDS);
-			assertEquals("result", result);
+			assertEquals(
+				"result",
+				record.onCompletion().toCompletableFuture().getNow(null)
+			);
 		}
 
 		/**
-		 * Verifies that `complete(null)` works properly
-		 * and results in a null completion value.
+		 * Verifies that `complete(null)` works properly and results in a null completion value.
 		 */
 		@Test
 		@DisplayName(
 			"Should complete with null result"
 		)
-		void shouldCompleteWithNullResult()
-			throws ExecutionException,
-			InterruptedException,
-			TimeoutException {
-
+		void shouldCompleteWithNullResult() {
 			final ProgressRecord<String> record =
 				new ProgressRecord<>("op", null);
 
@@ -451,16 +380,13 @@ class ProgressRecordTest implements EvitaTestSupport {
 
 			assertTrue(record.isCompletedSuccessfully());
 
-			final String result =
-				record.onCompletion()
-					.toCompletableFuture()
-					.get(1, TimeUnit.SECONDS);
-			assertNull(result);
+			assertNull(
+				record.onCompletion().toCompletableFuture().getNow(null)
+			);
 		}
 
 		/**
-		 * Verifies that `complete()` updates percent
-		 * to 100 even when it was previously at 50.
+		 * Verifies that `complete()` updates percent to 100 even when it was previously at 50.
 		 */
 		@Test
 		@DisplayName(
@@ -479,30 +405,22 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that a second call to `complete()` is
-		 * ignored and the first result is preserved.
+		 * Verifies that a second call to `complete()` is ignored and the first result is preserved.
 		 */
 		@Test
 		@DisplayName(
 			"Should ignore subsequent complete calls"
 		)
-		void shouldIgnoreSubsequentCompleteCalls()
-			throws ExecutionException,
-			InterruptedException,
-			TimeoutException {
-
+		void shouldIgnoreSubsequentCompleteCalls() {
 			final ProgressRecord<String> record =
 				new ProgressRecord<>("op", null);
 
 			record.complete("first");
 			record.complete("second");
 
-			final String result =
-				record.onCompletion()
-					.toCompletableFuture()
-					.get(1, TimeUnit.SECONDS);
 			assertEquals(
-				"first", result,
+				"first",
+				record.onCompletion().toCompletableFuture().getNow(null),
 				"First completion value should win"
 			);
 		}
@@ -513,9 +431,8 @@ class ProgressRecordTest implements EvitaTestSupport {
 	class ExceptionalCompletionTest {
 
 		/**
-		 * Verifies that `completeExceptionally()` marks
-		 * the record as exceptionally completed and
-		 * the exception is retrievable.
+		 * Verifies that `completeExceptionally()` marks the record as exceptionally completed and the exception
+		 * is retrievable. The record is completed synchronously, so the unbounded `get()` returns immediately.
 		 */
 		@Test
 		@DisplayName(
@@ -536,14 +453,13 @@ class ProgressRecordTest implements EvitaTestSupport {
 				ExecutionException.class,
 				() -> record.onCompletion()
 					.toCompletableFuture()
-					.get(1, TimeUnit.SECONDS)
+					.get()
 			);
 			assertSame(cause, ex.getCause());
 		}
 
 		/**
-		 * Verifies that observers are notified with 100
-		 * when the record completes exceptionally.
+		 * Verifies that observers are notified with 100 when the record completes exceptionally.
 		 */
 		@Test
 		@DisplayName(
@@ -569,8 +485,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that calling `completeExceptionally()`
-		 * twice is idempotent -- the first exception wins.
+		 * Verifies that calling `completeExceptionally()` twice is idempotent -- the first exception wins.
 		 */
 		@Test
 		@DisplayName(
@@ -592,7 +507,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 				ExecutionException.class,
 				() -> record.onCompletion()
 					.toCompletableFuture()
-					.get(1, TimeUnit.SECONDS)
+					.get()
 			);
 			assertSame(
 				first, ex.getCause(),
@@ -601,8 +516,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that calling `complete()` after
-		 * `completeExceptionally()` is a no-op.
+		 * Verifies that calling `complete()` after `completeExceptionally()` is a no-op.
 		 */
 		@Test
 		@DisplayName(
@@ -628,8 +542,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 	class ProgressListenersTest {
 
 		/**
-		 * Verifies that a dynamically added listener
-		 * receives progress notifications.
+		 * Verifies that a dynamically added listener receives progress notifications.
 		 */
 		@Test
 		@DisplayName(
@@ -648,8 +561,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that a removed listener no longer
-		 * receives notifications.
+		 * Verifies that a removed listener no longer receives notifications.
 		 */
 		@Test
 		@DisplayName(
@@ -674,10 +586,8 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that an exception thrown by one
-		 * listener does not prevent other listeners
-		 * from being notified and does not propagate
-		 * to the caller.
+		 * Verifies that an exception thrown by one listener does not prevent other listeners from being notified
+		 * and does not propagate to the caller.
 		 */
 		@Test
 		@DisplayName(
@@ -709,8 +619,7 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that removing a listener that was
-		 * never added does not cause errors.
+		 * Verifies that removing a listener that was never added does not cause errors.
 		 */
 		@Test
 		@DisplayName(
@@ -733,72 +642,36 @@ class ProgressRecordTest implements EvitaTestSupport {
 	class ProgressingFutureIntegrationTest {
 
 		/**
-		 * Verifies that a ProgressRecord constructed
-		 * with a ProgressingFuture correctly tracks
-		 * percentage updates computed from step
-		 * progress.
+		 * Verifies that a ProgressRecord constructed with a ProgressingFuture correctly tracks percentage
+		 * updates computed from step progress. The task reaches the future through its own lambda parameter
+		 * (`lambda.apply(this)`), so no external hand-off is needed; the synchronous `Runnable::run` executor
+		 * runs it inline inside the constructor, which — because the constructor wires the progress consumer and
+		 * `whenComplete` BEFORE calling `execute` — exercises the identical wiring with zero concurrency. A
+		 * future reordering of the constructor that publishes progress after execution would break this test
+		 * loudly (the observer would miss the mid-flight 50%).
 		 */
 		@Test
 		@DisplayName(
 			"Should track progress"
 			+ " from ProgressingFuture"
 		)
-		void shouldTrackProgressFromProgressingFuture()
-			throws ExecutionException,
-			InterruptedException,
-			TimeoutException {
-
-			final List<Integer> observed =
-				new CopyOnWriteArrayList<>();
-			final CountDownLatch started =
-				new CountDownLatch(1);
-			final CountDownLatch proceed =
-				new CountDownLatch(1);
-			final AtomicReference<ProgressingFuture<String>>
-				futureRef = new AtomicReference<>();
-
+		void shouldTrackProgressFromProgressingFuture() {
+			final List<Integer> observed = new ArrayList<>();
 			final ProgressingFuture<String> future =
 				new ProgressingFuture<>(
 					9,
 					theFuture -> {
-						started.countDown();
-						try {
-							proceed.await(
-								2, TimeUnit.SECONDS
-							);
-						} catch (InterruptedException e) {
-							Thread.currentThread()
-								.interrupt();
-						}
-						final ProgressingFuture<String> f =
-							futureRef.get();
-						if (f != null) {
-							// 5 of 10 steps = 50%
-							f.updateProgress(5);
-						}
+						// 5 of 10 steps (actionSteps + 1) = 50%
+						theFuture.updateProgress(5);
 						return "done";
 					}
 				);
-			futureRef.set(future);
 
-			final ProgressRecord<String> record =
-				new ProgressRecord<>(
-					"op", observed::add,
-					future, executor
-				);
-
-			assertTrue(
-				started.await(2, TimeUnit.SECONDS),
-				"Task should start"
+			new ProgressRecord<>(
+				"op", observed::add, future, Runnable::run
 			);
-			proceed.countDown();
 
-			final String result =
-				future.get(2, TimeUnit.SECONDS);
-			assertEquals("done", result);
-
-			// observer should have received 0
-			// (initial) and 50 (5/10 * 100)
+			assertEquals("done", future.getNow(null));
 			assertTrue(
 				observed.contains(0),
 				"Should receive initial 0%"
@@ -810,20 +683,16 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 
 		/**
-		 * Verifies that the ProgressRecord is marked
-		 * as successfully completed when the underlying
-		 * ProgressingFuture completes normally.
+		 * Verifies that the ProgressRecord is marked as successfully completed when the underlying
+		 * ProgressingFuture completes normally, and that its `onCompletion` propagates the original result. The
+		 * task runs inline via `Runnable::run`, so completion is settled on constructor return.
 		 */
 		@Test
 		@DisplayName(
 			"Should complete when"
 			+ " ProgressingFuture completes"
 		)
-		void shouldCompleteWhenProgressingFutureCompletes()
-			throws ExecutionException,
-			InterruptedException,
-			TimeoutException {
-
+		void shouldCompleteWhenProgressingFutureCompletes() {
 			final ProgressingFuture<String> future =
 				new ProgressingFuture<>(
 					5,
@@ -832,36 +701,27 @@ class ProgressRecordTest implements EvitaTestSupport {
 
 			final ProgressRecord<String> record =
 				new ProgressRecord<>(
-					"op", null, future, executor
+					"op", null, future, Runnable::run
 				);
 
-			// wait for the progressing future
-			future.get(2, TimeUnit.SECONDS);
-
-			// the ProgressRecord's onCompletion is
-			// derived from the future's whenComplete,
-			// which propagates the original result
-			final String result =
-				record.onCompletion()
-					.toCompletableFuture()
-					.get(2, TimeUnit.SECONDS);
-			assertEquals("hello", result);
+			assertTrue(record.isCompletedSuccessfully());
+			// the ProgressRecord's onCompletion is derived from the future's whenComplete, which propagates
+			// the original result
+			assertEquals(
+				"hello",
+				record.onCompletion().toCompletableFuture().getNow(null)
+			);
 		}
 
 		/**
-		 * Verifies that the `onProgressExecution`
-		 * consumer is invoked during construction of
-		 * the full constructor variant.
+		 * Verifies that the `onProgressExecution` consumer is invoked during construction of the full
+		 * constructor variant, before the task executes.
 		 */
 		@Test
 		@DisplayName(
 			"Should call onProgressExecution consumer"
 		)
-		void shouldCallOnProgressExecutionConsumer()
-			throws ExecutionException,
-			InterruptedException,
-			TimeoutException {
-
+		void shouldCallOnProgressExecutionConsumer() {
 			final AtomicBoolean executionCalled =
 				new AtomicBoolean(false);
 
@@ -871,43 +731,36 @@ class ProgressRecordTest implements EvitaTestSupport {
 					theFuture -> "result"
 				);
 
-			final ProgressRecord<String> record =
-				new ProgressRecord<>(
-					"op",
-					null,
-					future,
-					pr -> executionCalled.set(true),
-					pr -> {},
-					executor
-				);
+			new ProgressRecord<>(
+				"op",
+				null,
+				future,
+				pr -> executionCalled.set(true),
+				pr -> {},
+				Runnable::run
+			);
 
-			// the callback is invoked during
-			// construction, before execute()
+			// the callback is invoked during construction, before execute()
 			assertTrue(
 				executionCalled.get(),
 				"onProgressExecution should be called"
 				+ " during construction"
 			);
-
-			future.get(2, TimeUnit.SECONDS);
+			assertEquals("result", future.getNow(null));
 		}
 
 		/**
-		 * Verifies that the `onProgressCompletion`
-		 * consumer is invoked when the underlying
-		 * ProgressingFuture completes.
+		 * Verifies that the `onProgressCompletion` consumer is invoked when the underlying ProgressingFuture
+		 * completes. Because the task runs inline via `Runnable::run`, completion — and therefore the
+		 * `whenComplete`-driven callback — happens synchronously inside the constructor.
 		 */
 		@Test
 		@DisplayName(
 			"Should call onProgressCompletion consumer"
 		)
-		void shouldCallOnProgressCompletionConsumer()
-			throws ExecutionException,
-			InterruptedException,
-			TimeoutException {
-
-			final CountDownLatch completionLatch =
-				new CountDownLatch(1);
+		void shouldCallOnProgressCompletionConsumer() {
+			final AtomicBoolean completionCalled =
+				new AtomicBoolean(false);
 
 			final ProgressingFuture<String> future =
 				new ProgressingFuture<>(
@@ -915,25 +768,21 @@ class ProgressRecordTest implements EvitaTestSupport {
 					theFuture -> "result"
 				);
 
-			final ProgressRecord<String> record =
-				new ProgressRecord<>(
-					"op",
-					null,
-					future,
-					pr -> {},
-					pr -> completionLatch.countDown(),
-					executor
-				);
-
-			future.get(2, TimeUnit.SECONDS);
+			new ProgressRecord<>(
+				"op",
+				null,
+				future,
+				pr -> {},
+				pr -> completionCalled.set(true),
+				Runnable::run
+			);
 
 			assertTrue(
-				completionLatch.await(
-					2, TimeUnit.SECONDS
-				),
+				completionCalled.get(),
 				"onProgressCompletion should be called"
 				+ " when the future completes"
 			);
+			assertEquals("result", future.getNow(null));
 		}
 	}
 
@@ -942,9 +791,8 @@ class ProgressRecordTest implements EvitaTestSupport {
 	class CompletionPercentConsistencyTest {
 
 		/**
-		 * Verifies that `completeExceptionally()` updates
-		 * `percentCompleted()` to 100, matching the
-		 * behavior of `complete()`.
+		 * Verifies that `completeExceptionally()` updates `percentCompleted()` to 100 (matching the behaviour of
+		 * `complete()`) even when it was previously at an intermediate value, and that the observer receives 100.
 		 */
 		@Test
 		@DisplayName(
@@ -978,23 +826,67 @@ class ProgressRecordTest implements EvitaTestSupport {
 		}
 	}
 
-	// -------------------------------------------------------------------------
-	// Helper methods
-	// -------------------------------------------------------------------------
+	@Nested
+	@DisplayName("Real-executor integration")
+	class RealExecutorIntegrationTest {
 
-	/**
-	 * Creates a simple ProgressRecord with the given
-	 * operation name and a null observer.
-	 *
-	 * @param operationName the name of the operation
-	 * @return a new ProgressRecord instance
-	 */
-	@Nonnull
-	private static <T> ProgressRecord<T> createRecord(
-		@Nonnull String operationName
-	) {
-		return new ProgressRecord<>(
-			operationName, null
-		);
+		private ExecutorService executor;
+
+		/**
+		 * Creates a real thread pool for the genuinely cross-thread scenario in this nested class.
+		 */
+		@BeforeEach
+		void setUp() {
+			this.executor = Executors.newFixedThreadPool(4);
+		}
+
+		/**
+		 * Shuts the pool down after each test via the explicit `shutdownNow()`. `ExecutorService` implements
+		 * `AutoCloseable` only since JDK 19; evitaDB builds on OpenJDK 17, so an `instanceof AutoCloseable` guard
+		 * (as an earlier revision of this class used) would silently never fire and leak the pool.
+		 */
+		@AfterEach
+		void tearDown() {
+			if (this.executor != null) {
+				this.executor.shutdownNow();
+			}
+		}
+
+		/**
+		 * Exercises the real cross-thread execution path: the task runs on a separate pool thread via
+		 * {@link ProgressingFuture#execute(java.util.concurrent.Executor)} and the record completes with the
+		 * task's result. This is the one scenario whose asserted property IS the cross-thread behaviour, so it
+		 * keeps a real executor; per the house rule for explicitly-async tests it uses a generous 60 s budget
+		 * (never the flake-prone small budgets) as a backstop against a genuine deadlock.
+		 */
+		@Test
+		@DisplayName(
+			"Should complete via a real executor thread"
+		)
+		void shouldCompleteViaRealExecutorThread()
+			throws ExecutionException,
+			InterruptedException,
+			TimeoutException {
+
+			final ProgressingFuture<String> future =
+				new ProgressingFuture<>(
+					5,
+					theFuture -> "hello"
+				);
+
+			final ProgressRecord<String> record =
+				new ProgressRecord<>(
+					"op", null, future, this.executor
+				);
+
+			assertEquals("hello", future.get(60, TimeUnit.SECONDS));
+			assertEquals(
+				"hello",
+				record.onCompletion()
+					.toCompletableFuture()
+					.get(60, TimeUnit.SECONDS)
+			);
+			assertTrue(record.isCompletedSuccessfully());
+		}
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/comparator/LocalizedStringComparatorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/comparator/LocalizedStringComparatorTest.java
@@ -25,18 +25,26 @@ package io.evitadb.comparator;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nonnull;
 import java.text.Collator;
+import java.text.Normalizer;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
-import org.junit.jupiter.api.Tag;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.COMPARATOR;
+import static io.evitadb.test.TestTags.ENGINE;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link LocalizedStringComparator} verifying
@@ -253,6 +261,224 @@ class LocalizedStringComparatorTest {
 			Arrays.sort(array, comparator);
 
 			assertArrayEquals(new String[]{"solo"}, array);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cached path order equivalence with Collator")
+	class CachedPathOrderEquivalenceTest {
+
+		private final Locale[] testedLocales = {
+			new Locale("cs"), Locale.ENGLISH, Locale.GERMAN
+		};
+
+		/**
+		 * Builds a corpus of national-character strings in **both** canonical forms (NFC and NFD),
+		 * with Czech `ch` digraph cases, case variants, combining-mark edge cases and the empty
+		 * string - the inputs most likely to expose a divergence between the collation-key byte
+		 * order served by the cache and the `Collator.compare` order it must replicate.
+		 *
+		 * @return corpus of strings for all-pairs order verification
+		 */
+		@Nonnull
+		private static List<String> nationalCorpus() {
+			final String[] base = {
+				"", "a", "A", "z", "Z", "0", "9",
+				"čaj", "Čaj", "čajník", "cukr", "Cukr", "cibule",
+				"chata", "Chata", "chalupa", "cesta", "hata", "Hrnek", "hrnek",
+				"háček", "hacek", "Háček", "říčka", "ricka", "Řeka", "reka",
+				"žárovka", "zarovka", "Žárovka", "šroub", "sroub", "Šroubovák",
+				"příliš", "žluťoučký", "kůň", "úpěl", "ďábelské", "ódy",
+				"Müller", "Mueller", "Muller", "Größe", "Grosse", "straße", "strasse",
+				"école", "ecole", "École", "élève", "cliché", "cœur", "coeur",
+				"Šroubovák aku 12V", "Šroubovák aku 18V",
+				"Žárovka LED E27 8W", "Žárovka LED E27 10W", "Žárovka LED E14 8W",
+				"ệ", "ắ", "ṩ"
+			};
+			final List<String> corpus = new ArrayList<>(base.length * 2);
+			for (final String value : base) {
+				corpus.add(Normalizer.normalize(value, Normalizer.Form.NFD));
+				corpus.add(Normalizer.normalize(value, Normalizer.Form.NFC));
+			}
+			return corpus;
+		}
+
+		@Test
+		@DisplayName(
+			"should order all corpus pairs exactly as Collator.compare in cs, en and de"
+		)
+		void shouldMatchCollatorSignOnAllPairs() {
+			for (final Locale locale : this.testedLocales) {
+				final LocalizedStringComparator cachedComparator =
+					new LocalizedStringComparator(locale);
+				final Collator reference = Collator.getInstance(locale);
+				final List<String> corpus = nationalCorpus();
+				for (final String left : corpus) {
+					for (final String right : corpus) {
+						assertEquals(
+							Integer.signum(reference.compare(left, right)),
+							Integer.signum(cachedComparator.compare(left, right)),
+							() -> "locale " + locale + ": '" + left + "' vs '" + right + "'"
+						);
+					}
+				}
+			}
+		}
+
+		@Test
+		@DisplayName(
+			"should sort a shuffled corpus into the same total order as Collator"
+		)
+		void shouldSortShuffledCorpusIdenticallyToCollator() {
+			for (final Locale locale : this.testedLocales) {
+				final Collator reference = Collator.getInstance(locale);
+				final List<String> corpus = nationalCorpus();
+				final String[] expected = corpus.toArray(String[]::new);
+				final String[] actual = corpus.toArray(String[]::new);
+				Collections.shuffle(Arrays.asList(actual), new Random(42));
+
+				Arrays.sort(expected, reference::compare);
+				Arrays.sort(actual, new LocalizedStringComparator(locale));
+
+				// distinct strings may compare equal (NFC vs NFD forms), so positions of ties may
+				// legally differ after shuffling - assert order equivalence, not array identity
+				for (int i = 0; i < expected.length; i++) {
+					final int index = i;
+					assertEquals(
+						0, reference.compare(expected[i], actual[i]),
+						() -> "locale " + locale + ": position " + index +
+							" expected '" + expected[index] + "' but got '" + actual[index] + "'"
+					);
+				}
+			}
+		}
+
+		@Test
+		@DisplayName(
+			"should treat NFC and NFD forms of the same text as equal"
+		)
+		void shouldTreatCanonicallyEquivalentFormsAsEqual() {
+			final LocalizedStringComparator comparator =
+				new LocalizedStringComparator(new Locale("cs"));
+			final String nfc = Normalizer.normalize("žluťoučký kůň", Normalizer.Form.NFC);
+			final String nfd = Normalizer.normalize("žluťoučký kůň", Normalizer.Form.NFD);
+
+			// the two forms differ as Java strings, yet must collate as equal
+			assertNotEquals(nfc, nfd);
+			assertEquals(0, comparator.compare(nfc, nfd));
+			assertEquals(0, comparator.compare(nfd, nfc));
+		}
+	}
+
+	@Nested
+	@DisplayName("Cached path robustness")
+	class CachedPathRobustnessTest {
+
+		@Test
+		@DisplayName(
+			"should keep Collator order under cache eviction pressure"
+		)
+		void shouldKeepCollatorOrderUnderCacheEvictionPressure() {
+			final Locale locale = new Locale("cs");
+			final LocalizedStringComparator cachedComparator =
+				new LocalizedStringComparator(locale);
+			final Collator reference = Collator.getInstance(locale);
+
+			// far more distinct values than the cache has slots, sharing long prefixes and
+			// recurring diacritic suffixes - forces constant slot collisions and evictions
+			final String[] suffixes = {"černá", "bílá", "žlutá", "červená", "modrá"};
+			final int valueCount = 20_000;
+			final String[] values = new String[valueCount];
+			for (int i = 0; i < valueCount; i++) {
+				values[i] = "Výrobek řady č. " + (i % 977) + " " +
+					suffixes[i % suffixes.length] + " " + i;
+			}
+
+			final Random rnd = new Random(42);
+			for (int i = 0; i < 100_000; i++) {
+				final String left = values[rnd.nextInt(valueCount)];
+				final String right = values[rnd.nextInt(valueCount)];
+				assertEquals(
+					Integer.signum(reference.compare(left, right)),
+					Integer.signum(cachedComparator.compare(left, right)),
+					() -> "'" + left + "' vs '" + right + "'"
+				);
+			}
+		}
+
+		@Test
+		@DisplayName(
+			"should stay consistent when hammered from multiple threads"
+		)
+		void shouldStayConsistentUnderConcurrentComparisons() throws Exception {
+			final Locale locale = new Locale("cs");
+			final LocalizedStringComparator cachedComparator =
+				new LocalizedStringComparator(locale);
+			final Collator reference = Collator.getInstance(locale);
+
+			final int valueCount = 512;
+			final String[] values = new String[valueCount];
+			for (int i = 0; i < valueCount; i++) {
+				values[i] = "Židle čalouněná řada " + (i % 61) + " model " + i;
+			}
+			// precompute reference signs single-threaded (Collator.compare is synchronized)
+			final int[][] expectedSigns = new int[valueCount][valueCount];
+			for (int a = 0; a < valueCount; a++) {
+				for (int b = 0; b < valueCount; b++) {
+					expectedSigns[a][b] = Integer.signum(reference.compare(values[a], values[b]));
+				}
+			}
+
+			final int threadCount = 8;
+			final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+			try {
+				final List<Future<Boolean>> futures = new ArrayList<>(threadCount);
+				for (int t = 0; t < threadCount; t++) {
+					final long seed = 1_000L + t;
+					futures.add(
+						executor.submit(() -> {
+							final Random rnd = new Random(seed);
+							for (int i = 0; i < 200_000; i++) {
+								final int a = rnd.nextInt(valueCount);
+								final int b = rnd.nextInt(valueCount);
+								final int actual = Integer.signum(
+									cachedComparator.compare(values[a], values[b])
+								);
+								if (actual != expectedSigns[a][b]) {
+									return false;
+								}
+							}
+							return true;
+						})
+					);
+				}
+				for (final Future<Boolean> future : futures) {
+					assertTrue(
+						future.get(60, TimeUnit.SECONDS),
+						"concurrent comparison diverged from Collator order"
+					);
+				}
+			} finally {
+				executor.shutdownNow();
+			}
+		}
+
+		@Test
+		@DisplayName(
+			"should follow custom Collator configuration and bypass the cache"
+		)
+		void shouldFollowCustomCollatorConfiguration() {
+			final Collator primaryStrength = Collator.getInstance(new Locale("cs"));
+			primaryStrength.setStrength(Collator.PRIMARY);
+			final LocalizedStringComparator customComparator =
+				new LocalizedStringComparator(primaryStrength);
+			final LocalizedStringComparator defaultComparator =
+				new LocalizedStringComparator(new Locale("cs"));
+
+			// PRIMARY strength ignores the accent difference; the default TERTIARY must not -
+			// proving the custom-collator constructor is not served from the locale-default cache
+			assertEquals(0, customComparator.compare("a", "á"));
+			assertTrue(defaultComparator.compare("a", "á") != 0);
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/EvitaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/EvitaTest.java
@@ -5372,14 +5372,17 @@ class EvitaTest implements EvitaTestSupport {
 					formerServerOptions.changeDataCapture(),
 					formerServerOptions.trafficRecording(),
 					formerServerOptions.readOnly(),
-					formerServerOptions.quiet(),
-					false
+					formerServerOptions.quiet()
 				),
 				formerConfiguration.storage(),
 				formerConfiguration.transaction(),
 				formerConfiguration.cache(),
 				formerConfiguration.export()
-			)
+			),
+			true,
+			null,
+			null,
+			false
 		);
 		reinstantiatedEvita.waitUntilFullyInitialized();
 		return reinstantiatedEvita;

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/TransactionManagerBoundedWaitTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/TransactionManagerBoundedWaitTest.java
@@ -1,0 +1,117 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.transaction;
+
+import io.evitadb.api.exception.TransactionTimedOutException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the bounded live-version wait in
+ * {@link TransactionManager#waitUntilVersionReaches}.
+ *
+ * The wait used to be an unbounded `Thread.onSpinWait()` loop: when catalog-version propagation to
+ * the live view stalled, the trunk-incorporation thread burned a full core forever and the affected
+ * commit-progress record was never completed, leaving the client awaiting that commit stuck
+ * indefinitely. The contract under test here is that the wait is **bounded**: it returns promptly
+ * once the version is reached and throws {@link TransactionTimedOutException} — which every
+ * caller translates into an exceptional completion of the commit-progress record or a watchdog
+ * reschedule — once the deadline expires.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("TransactionManager — bounded wait for live-version propagation")
+@Tag(ENGINE)
+@Tag(TRANSACTION)
+class TransactionManagerBoundedWaitTest {
+
+	@Test
+	@Timeout(10)
+	@DisplayName("should throw TransactionTimedOutException instead of waiting forever when the live version never reaches the target")
+	void shouldThrowTransactionTimedOutWhenLiveVersionNeverReachesTarget() {
+		final TransactionTimedOutException exception = assertThrows(
+			TransactionTimedOutException.class,
+			() -> TransactionManager.waitUntilVersionReaches(
+				() -> 1L,
+				2L,
+				50L,
+				"testCatalog"
+			),
+			"A live version that never reaches the target must end in a timeout, not an endless spin."
+		);
+		assertTrue(
+			exception.getMessage().contains("did not reach version 2"),
+			"Timeout message should name the unreached version: " + exception.getMessage()
+		);
+		assertTrue(
+			exception.getMessage().contains("stuck at version 1"),
+			"Timeout message should name the stuck version: " + exception.getMessage()
+		);
+	}
+
+	@Test
+	@Timeout(10)
+	@DisplayName("should return immediately when the live version already reached the target")
+	void shouldReturnImmediatelyWhenVersionAlreadyReached() {
+		assertDoesNotThrow(
+			() -> TransactionManager.waitUntilVersionReaches(
+				() -> 5L,
+				5L,
+				50L,
+				"testCatalog"
+			)
+		);
+	}
+
+	@Test
+	@Timeout(10)
+	@DisplayName("should return without exception when the live version reaches the target before the deadline")
+	void shouldReturnWhenVersionReachesTargetBeforeDeadline() {
+		// the supplier advances by one on every poll, so the target is reached after a few
+		// spin iterations - far inside both the spin window and the generous deadline
+		final AtomicLong liveVersion = new AtomicLong(0L);
+		assertDoesNotThrow(
+			() -> TransactionManager.waitUntilVersionReaches(
+				liveVersion::incrementAndGet,
+				10L,
+				60_000L,
+				"testCatalog"
+			)
+		);
+		assertTrue(
+			liveVersion.get() >= 10L,
+			"Supplier must have been polled until the target version was observed."
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/TransactionTrunkFinalizerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/TransactionTrunkFinalizerTest.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE.md
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.transaction;
+
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.index.bPlusTree.AbstractTransactionalBPlusTree.BPlusTreeCorruptedException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Focused test of the post-replay poison-pill wrapping in {@link TransactionTrunkFinalizer}.
+ *
+ * A post-replay B+ tree boundary failure is raised as a NEUTRAL, tree-level {@link BPlusTreeCorruptedException}
+ * (the same merge code fires on the isolated-finalizer path where write-ahead-log wording would be false). The trunk
+ * incorporation path re-wraps it with the poison-pill remediation caveat — durable in the write-ahead log AND possibly
+ * already in the flushed data files, because the catalog flush precedes the merge. That wrapping is exercised in
+ * production only when a real merge throws, which the tree-level unit tests never reach (they observe the raw neutral
+ * error); this test pins the operator-facing wording of {@link TransactionTrunkFinalizer#wrapPostReplayCorruption}
+ * directly, and that it chains the neutral cause.
+ */
+@Tag(INDEXING)
+@Tag(TRANSACTION)
+@DisplayName("Trunk finalizer post-replay corruption poison-pill wrapping")
+class TransactionTrunkFinalizerTest {
+
+	@Test
+	@DisplayName("wraps a neutral post-replay corruption error with the poison-pill flushed-data caveat and chains the cause")
+	void shouldWrapPostReplayCorruptionWithPoisonPillCaveat() {
+		final BPlusTreeCorruptedException cause = new BPlusTreeCorruptedException(
+			"neutral tree-level cross-leaf boundary message"
+		);
+		final GenericEvitaInternalError wrapped = TransactionTrunkFinalizer.wrapPostReplayCorruption(cause);
+		final String message = wrapped.getMessage();
+		// the poison-pill caveat must not understate the blast radius: durable in the WAL AND possibly already flushed
+		assertTrue(
+			message.contains("write-ahead log"),
+			"the poison-pill message must state the transaction is durable in the write-ahead log; got: " + message
+		);
+		assertTrue(
+			message.contains("flushed data files"),
+			"the poison-pill message must warn corrupt pages may already be in the flushed data files; got: " + message
+		);
+		assertTrue(
+			message.contains("restore") || message.contains("rebuild"),
+			"the poison-pill message must offer restore/rebuild remediation; got: " + message
+		);
+		// the neutral tree-level error is chained for the structural detail
+		assertSame(cause, wrapped.getCause(), "the neutral tree-level corruption must be chained as the cause");
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/TransactionWalFinalizerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/TransactionWalFinalizerTest.java
@@ -1,0 +1,217 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE.md
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.transaction;
+
+import io.evitadb.api.CommitProgressRecord;
+import io.evitadb.api.exception.RollbackException;
+import io.evitadb.api.requestResponse.mutation.Mutation;
+import io.evitadb.api.requestResponse.mutation.conflict.ConflictKey;
+import io.evitadb.api.requestResponse.transaction.TransactionMutation;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
+import io.evitadb.index.bPlusTree.AbstractTransactionalBPlusTree.BPlusTreeCorruptedException;
+import io.evitadb.spi.store.catalog.shared.model.LogRecordReference;
+import io.evitadb.spi.store.catalog.wal.IsolatedWalPersistenceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Direct coverage of the pre-commit (pre-WAL) rejection path in {@link TransactionWalFinalizer#commit}. The tree unit
+ * tests drive the DETECTION pipeline ({@code validateDirtyScopesBeforeCommit()} through isolated transactions); this
+ * test exercises the finalizer's own catch block — the seam whose entire purpose is behaving well when the pre-commit
+ * pass rejects. No production corruption-injection hook is needed: the maintainer is stubbed to throw the same
+ * {@link BPlusTreeCorruptedException} a real corrupt scope produces, and a recording isolated-WAL stub proves the WAL
+ * is released.
+ */
+@Tag(INDEXING)
+@Tag(TRANSACTION)
+@DisplayName("pre-commit rejection path in the transaction WAL finalizer")
+class TransactionWalFinalizerTest {
+
+	/**
+	 * Recording {@link IsolatedWalPersistenceService} stub — the only behaviour under test is that {@link #close()} is
+	 * invoked on a rejection, releasing the isolated WAL's off-heap region / temp file.
+	 */
+	private static final class RecordingWalService implements IsolatedWalPersistenceService {
+		private final UUID transactionId;
+		private final AtomicBoolean closed = new AtomicBoolean(false);
+
+		RecordingWalService(@Nonnull UUID transactionId) {
+			this.transactionId = transactionId;
+		}
+
+		@Nonnull
+		@Override
+		public UUID getTransactionId() {
+			return this.transactionId;
+		}
+
+		@Override
+		public int getMutationCount() {
+			return 0;
+		}
+
+		@Override
+		public long getMutationSizeInBytes() {
+			return 0L;
+		}
+
+		@Override
+		public void write(long catalogVersion, @Nonnull Mutation mutation) {
+			// no-op: the test only needs the service to exist so its close() can be asserted
+		}
+
+		@Override
+		public LogRecordReference getWalReference() {
+			return null;
+		}
+
+		@Nonnull
+		@Override
+		public Set<ConflictKey> getConflictKeys() {
+			return Collections.emptySet();
+		}
+
+		@Override
+		public void close() {
+			this.closed.set(true);
+		}
+
+		boolean isClosed() {
+			return this.closed.get();
+		}
+	}
+
+	/**
+	 * An {@link Error} thrown from a registered closeable. Errors escape {@code closeRegisteredCloseables}' own
+	 * {@code catch (Exception)}, reproducing the failure mode Finding 1 addresses.
+	 */
+	private static final class CloseFailure extends Error {
+		CloseFailure() {
+			super("simulated closeable failure during a pre-commit rejection");
+		}
+	}
+
+	@Nonnull
+	private static Catalog mockCatalog() {
+		final Catalog catalog = mock(Catalog.class, RETURNS_DEEP_STUBS);
+		when(catalog.getVersion()).thenReturn(1L);
+		return catalog;
+	}
+
+	@Nonnull
+	private static TransactionalLayerMaintainer maintainerRejectingPreCommit() {
+		final TransactionalLayerMaintainer maintainer = mock(TransactionalLayerMaintainer.class);
+		doThrow(new BPlusTreeCorruptedException("a B+ tree leaf overlaps its successor leaf boundary"))
+			.when(maintainer).validateDirtyScopesBeforeCommit();
+		return maintainer;
+	}
+
+	@Nonnull
+	private static Mutation liveWalMutation(@Nonnull UUID transactionId) {
+		// registering any mutation makes the lazily-created isolated WAL service live so its close() can be asserted;
+		// Mutation is a sealed interface (not mockable), so a real TransactionMutation stands in
+		return new TransactionMutation(transactionId, 1L, 1, 0L, OffsetDateTime.now());
+	}
+
+	@Test
+	@DisplayName("a pre-commit rejection releases the isolated WAL, closes registered closeables, and completes the commit exceptionally")
+	void shouldRejectCleanlyOnPreCommitValidationFailure() {
+		final UUID transactionId = UUID.randomUUID();
+		final RecordingWalService wal = new RecordingWalService(transactionId);
+		final CommitProgressRecord commitProgress = new CommitProgressRecord();
+		final TransactionWalFinalizer finalizer = new TransactionWalFinalizer(
+			mockCatalog(), transactionId, id -> wal, commitProgress
+		);
+		final AtomicBoolean closeableClosed = new AtomicBoolean(false);
+		finalizer.registerCloseable(() -> closeableClosed.set(true));
+		// the isolated WAL service is created lazily on the first registered mutation
+		finalizer.registerMutation(liveWalMutation(transactionId));
+
+		// (a) the rejection must not escape commit(...) — a raw throw would hang the commit future
+		assertDoesNotThrow(() -> finalizer.commit(maintainerRejectingPreCommit()));
+		// (b) the isolated WAL is released so its off-heap region / temp file cannot leak
+		assertTrue(wal.isClosed(), "the isolated WAL must be closed on a pre-commit rejection");
+		// (c) registered transactional resources are closed
+		assertTrue(closeableClosed.get(), "registered closeables must be closed on a pre-commit rejection");
+		// (d) the commit future completes exceptionally with RollbackException chaining BPlusTreeCorruptedException
+		final CompletableFuture<?> future = commitProgress.onWalAppended().toCompletableFuture();
+		assertTrue(future.isCompletedExceptionally(), "the commit future must complete exceptionally");
+		final ExecutionException executionException = assertThrows(ExecutionException.class, future::get);
+		final Throwable rollback = executionException.getCause();
+		assertInstanceOf(RollbackException.class, rollback, "the commit must fail with a RollbackException");
+		assertInstanceOf(
+			BPlusTreeCorruptedException.class, rollback.getCause(),
+			"the RollbackException must chain the tree-level corruption as its cause"
+		);
+	}
+
+	@Test
+	@DisplayName("a closeable throwing during a pre-commit rejection still releases the WAL and completes the commit (Finding 1)")
+	void shouldReleaseWalEvenWhenCloseableThrowsDuringRejection() {
+		final UUID transactionId = UUID.randomUUID();
+		final RecordingWalService wal = new RecordingWalService(transactionId);
+		final CommitProgressRecord commitProgress = new CommitProgressRecord();
+		final TransactionWalFinalizer finalizer = new TransactionWalFinalizer(
+			mockCatalog(), transactionId, id -> wal, commitProgress
+		);
+		// a closeable that throws an Error — Errors escape closeRegisteredCloseables' own catch(Exception), so without
+		// the try/finally the WAL close + commit completion would be skipped (the exact Finding-1 hazard)
+		finalizer.registerCloseable(() -> {
+			throw new CloseFailure();
+		});
+		finalizer.registerMutation(liveWalMutation(transactionId));
+
+		// the closeable's Error still propagates (as it does out of rollback too) — but ONLY after the finally has
+		// released the WAL and completed the commit future, so neither the hang nor the leak can occur
+		assertThrows(CloseFailure.class, () -> finalizer.commit(maintainerRejectingPreCommit()));
+		assertTrue(wal.isClosed(), "the isolated WAL must be released even when a closeable throws");
+		assertTrue(
+			commitProgress.onWalAppended().toCompletableFuture().isCompletedExceptionally(),
+			"the commit future must complete exceptionally even when a closeable throws"
+		);
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/ClientSessionCancellationCascadeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/ClientSessionCancellationCascadeTest.java
@@ -1,0 +1,275 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.driver;
+
+import com.linecorp.armeria.client.grpc.GrpcClientBuilder;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.driver.config.ClientConnectionOptions;
+import io.evitadb.driver.config.ClientTimeoutOptions;
+import io.evitadb.driver.config.ClientTlsOptions;
+import io.evitadb.driver.config.EvitaClientConfiguration;
+import io.evitadb.driver.exception.TransportException;
+import io.evitadb.externalApi.configuration.ApiOptions;
+import io.evitadb.externalApi.configuration.HostDefinition;
+import io.evitadb.externalApi.grpc.GrpcProvider;
+import io.evitadb.externalApi.system.SystemProvider;
+import io.evitadb.server.EvitaServer;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import io.evitadb.test.TestConstants;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import io.evitadb.utils.CertificateUtils;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.entityFetch;
+import static io.evitadb.api.query.QueryConstraints.entityPrimaryKeyInSet;
+import static io.evitadb.api.query.QueryConstraints.filterBy;
+import static io.evitadb.api.query.QueryConstraints.require;
+import static io.evitadb.test.TestConstants.TEST_CATALOG;
+import static io.evitadb.test.TestTags.DRIVER;
+import static io.evitadb.test.TestTags.GRPC;
+import static io.evitadb.test.TestTags.SESSION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the driver's handling of the client-session cancellation cascade: when a session call dies at the
+ * transport level (a dropped / cancelled connection), the driver must treat the session as lost locally and
+ * must NOT issue a remote close that would race the orphaned server-side invocation and trigger a
+ * `ConcurrentSessionAccessException`.
+ *
+ * The transport failure is injected deterministically with a client-side {@link ClientInterceptor} that fails
+ * a chosen unary call with {@link Status#CANCELLED} — simulating a mid-call connection drop — without touching
+ * the wire, and counts any further RPC the driver attempts on the dead session.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Client session cancellation cascade")
+@Tag(DRIVER)
+@Tag(GRPC)
+@Tag(SESSION)
+@ExtendWith(EvitaParameterResolver.class)
+class ClientSessionCancellationCascadeTest implements TestConstants, EvitaTestSupport {
+	private static final String DATA_SET_CANCELLATION_CASCADE = "clientSessionCancellationCascade";
+
+	/**
+	 * Builds a minimal catalog with two products reachable by primary key and keeps the setup client open for the
+	 * lifetime of the dataset. The catalog stays in the WARM_UP state — queries by primary key work there and the
+	 * read path needs no transaction, keeping the reproduction focused on the transport-failure handling.
+	 */
+	@DataSet(value = DATA_SET_CANCELLATION_CASCADE, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE}, readOnly = false, destroyAfterClass = true)
+	static EvitaClient initDataSet(EvitaServer evitaServer) {
+		final EvitaClient setupClient = new EvitaClient(
+			clientConfiguration(evitaServer, ClientConnectionOptions.DEFAULT_PING_INTERVAL_MILLIS)
+		);
+		setupClient.defineCatalog(TEST_CATALOG);
+		setupClient.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.createNewEntity(Entities.PRODUCT, 1).upsertVia(session);
+				session.createNewEntity(Entities.PRODUCT, 2).upsertVia(session);
+			}
+		);
+		return setupClient;
+	}
+
+	@Test
+	@UseDataSet(DATA_SET_CANCELLATION_CASCADE)
+	@DisplayName("should treat a mid-call transport failure as session loss and skip the remote close")
+	void shouldTreatMidCallTransportFailureAsSessionLoss(EvitaServer evitaServer) {
+		final FaultInjectingInterceptor faultInjector = new FaultInjectingInterceptor("QueryOne");
+		final AtomicReference<EvitaClientSession> capturedSession = new AtomicReference<>();
+
+		try (final EvitaClient client = new EvitaClient(
+			clientConfiguration(evitaServer, ClientConnectionOptions.DEFAULT_PING_INTERVAL_MILLIS),
+			(Consumer<GrpcClientBuilder>) builder -> builder.intercept(faultInjector)
+		)) {
+			// (a) the transport failure is surfaced as a dedicated TransportException, not the CANCELLED-mapped
+			// GenericEvitaInternalError, and the original transport cause is preserved
+			final TransportException transportException = assertThrows(
+				TransportException.class,
+				() -> client.queryCatalog(
+					TEST_CATALOG,
+					session -> {
+						capturedSession.set((EvitaClientSession) session);
+						faultInjector.arm();
+						return session.queryOne(
+							query(
+								collection(Entities.PRODUCT),
+								filterBy(entityPrimaryKeyInSet(1)),
+								require(entityFetch())
+							),
+							SealedEntity.class
+						);
+					}
+				)
+			);
+			assertNotNull(transportException.getCause(), "the original transport exception must be preserved as the cause");
+
+			// (b) the session is marked inactive locally, without a server round-trip
+			assertFalse(
+				capturedSession.get().isActive(),
+				"the session must be marked inactive locally after a transport failure"
+			);
+		}
+
+		// the fault must actually have been injected — otherwise the test proves nothing
+		assertTrue(faultInjector.wasFaultTriggered(), "the simulated transport failure was never injected");
+		// (c) no further RPC for that session after the fault — in particular no remote close, the source of the
+		// ConcurrentSessionAccessException cascade
+		assertEquals(
+			0,
+			faultInjector.remoteCloseCallsAfterFault(),
+			"the driver must not send a remote close (nor any further RPC) on a transport-failed session"
+		);
+	}
+
+	/**
+	 * Builds an {@link EvitaClientConfiguration} pointing at the running server's gRPC endpoint, with the client
+	 * keep-alive ping pinned to the requested interval.
+	 */
+	private static EvitaClientConfiguration clientConfiguration(EvitaServer evitaServer, int pingIntervalMillis) {
+		final ApiOptions apiOptions = evitaServer.getExternalApiServer().getApiOptions();
+		final HostDefinition grpcHost = apiOptions.getEndpointConfiguration(GrpcProvider.CODE).getHost()[0];
+		final HostDefinition systemHost = apiOptions.getEndpointConfiguration(SystemProvider.CODE).getHost()[0];
+
+		final String serverCertificates = apiOptions.certificate().getFolderPath().toString();
+		final int lastDash = serverCertificates.lastIndexOf('-');
+		final Path clientCertificates = Path.of(serverCertificates.substring(0, lastDash) + "-client");
+
+		return EvitaClientConfiguration
+			.builder()
+			.host(grpcHost.hostAddress())
+			.port(grpcHost.port())
+			.systemApiPort(systemHost.port())
+			.pingIntervalMillis(pingIntervalMillis)
+			.tls(
+				ClientTlsOptions.builder()
+					.mtlsEnabled(false)
+					.certificateFolderPath(clientCertificates)
+					.certificateFileName(Path.of(CertificateUtils.getGeneratedClientCertificateFileName()))
+					.certificateKeyFileName(Path.of(CertificateUtils.getGeneratedClientCertificatePrivateKeyFileName()))
+					.build()
+			)
+			.timeouts(
+				ClientTimeoutOptions.builder()
+					.timeout(10, TimeUnit.MINUTES)
+					.build()
+			)
+			.build();
+	}
+
+	/**
+	 * gRPC {@link ClientInterceptor} that, once {@link #arm() armed}, fails the next call whose method name contains
+	 * {@link #targetMethodSubstring} with {@link Status#CANCELLED} — simulating a mid-call connection drop without
+	 * touching the wire. After the fault it counts any close-family RPC the driver attempts, which would betray a
+	 * remote close on a session that should have been terminated locally.
+	 */
+	private static final class FaultInjectingInterceptor implements ClientInterceptor {
+		private final String targetMethodSubstring;
+		private final AtomicBoolean armed = new AtomicBoolean(false);
+		private final AtomicBoolean faultTriggered = new AtomicBoolean(false);
+		private final AtomicInteger remoteCloseCallsAfterFault = new AtomicInteger(0);
+
+		FaultInjectingInterceptor(String targetMethodSubstring) {
+			this.targetMethodSubstring = targetMethodSubstring;
+		}
+
+		void arm() {
+			this.armed.set(true);
+		}
+
+		boolean wasFaultTriggered() {
+			return this.faultTriggered.get();
+		}
+
+		int remoteCloseCallsAfterFault() {
+			return this.remoteCloseCallsAfterFault.get();
+		}
+
+		@Override
+		public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+			MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next
+		) {
+			final String methodName = method.getFullMethodName();
+			// after a fault has been injected, any close-family RPC means the driver went remote on a dead session
+			if (this.faultTriggered.get() && methodName.contains("Close")) {
+				this.remoteCloseCallsAfterFault.incrementAndGet();
+			}
+			if (methodName.contains(this.targetMethodSubstring) && this.armed.compareAndSet(true, false)) {
+				this.faultTriggered.set(true);
+				return new ClientCall<>() {
+					@Override
+					public void start(Listener<RespT> responseListener, Metadata headers) {
+						responseListener.onClose(
+							Status.CANCELLED.withDescription("simulated mid-call connection drop"), new Metadata()
+						);
+					}
+
+					@Override
+					public void request(int numMessages) {
+					}
+
+					@Override
+					public void cancel(@Nullable String message, @Nullable Throwable cause) {
+					}
+
+					@Override
+					public void halfClose() {
+					}
+
+					@Override
+					public void sendMessage(ReqT message) {
+					}
+				};
+			}
+			return next.newCall(method, callOptions);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadOnlyTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadOnlyTest.java
@@ -55,6 +55,7 @@ import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
 import io.evitadb.api.requestResponse.schema.Cardinality;
 import io.evitadb.api.requestResponse.schema.CatalogSchemaContract;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaEditor;
 import io.evitadb.api.requestResponse.system.MaterializedVersionBlock;
 import io.evitadb.api.requestResponse.system.SystemStatus;
 import io.evitadb.dataType.PaginatedList;
@@ -164,7 +165,7 @@ class EvitaClientReadOnlyTest implements TestConstants, EvitaTestSupport {
 	 * @return DataCarrier containing the configured EvitaClient and test data
 	 */
 	@DataSet(value = EVITA_CLIENT_DATA_SET, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE},
-		destroyAfterClass = true)
+		destroyAfterClass = true, useRealThreadPools = true)
 	static DataCarrier initDataSet(EvitaServer evitaServer) {
 		final DataGenerator dataGenerator = new DataGenerator.Builder()
 			.registerValueGenerator(
@@ -225,7 +226,7 @@ class EvitaClientReadOnlyTest implements TestConstants, EvitaTestSupport {
 					// Add global unique code attribute to catalog schema
 					session.getCatalogSchema()
 						.openForWrite()
-						.withAttribute(ATTRIBUTE_CODE, String.class, thatIs -> thatIs.uniqueGlobally())
+						.withAttribute(ATTRIBUTE_CODE, String.class, GlobalAttributeSchemaEditor::uniqueGlobally)
 						.updateVia(session);
 
 					// Generate brand entities (5 entities)

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadWriteTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadWriteTest.java
@@ -207,7 +207,7 @@ class EvitaClientReadWriteTest implements TestConstants, EvitaTestSupport {
 	private static final int PRODUCT_COUNT = 10;
 	private static DataGenerator DATA_GENERATOR;
 
-	@DataSet(value = EVITA_CLIENT_DATA_SET, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE}, readOnly = false, destroyAfterClass = true)
+	@DataSet(value = EVITA_CLIENT_DATA_SET, openWebApi = {GrpcProvider.CODE, SystemProvider.CODE}, readOnly = false, destroyAfterClass = true, useRealThreadPools = true)
 	static DataCarrier initDataSet(EvitaServer evitaServer) {
 		DATA_GENERATOR = new DataGenerator.Builder()
 			.registerValueGenerator(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/cdc/ClientChangeCapturePublisherTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/cdc/ClientChangeCapturePublisherTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
@@ -200,6 +201,8 @@ class ClientChangeCapturePublisherTest implements TestConstants {
 			// must already have its subscription field wired so `onNext` does not NPE.
 			final TestHarness harness = new TestHarness(0L, true);
 			harness.start();
+			// the ACK was delivered during init, so subscribe() has already returned on its thread
+			harness.joinSubscribe();
 
 			// the ACK was consumed during init — the subscription must have been assigned
 			// its server-side id and the flow window must have been primed
@@ -227,6 +230,14 @@ class ClientChangeCapturePublisherTest implements TestConstants {
 			assertEquals(
 				"Expected ACKNOWLEDGEMENT as first message but got something else.",
 				thrown.getPrivateMessage()
+			);
+			// the same protocol violation must release the blocked subscribe() rather than let it
+			// wait out the streaming timeout
+			harness.joinSubscribe();
+			assertInstanceOf(
+				GenericEvitaInternalError.class,
+				harness.subscribeError.get(),
+				"subscribe() must fail fast with the protocol-violation error"
 			);
 		}
 
@@ -376,8 +387,14 @@ class ClientChangeCapturePublisherTest implements TestConstants {
 
 	/**
 	 * Wires the publisher, a mock gRPC observer and a recording delegate together so each
-	 * test reads cleanly. `start()` performs `subscribe`, which synchronously triggers
-	 * the supplied stream initializer.
+	 * test reads cleanly.
+	 *
+	 * `subscribe()` now blocks until the server acknowledges the subscription, so `start()` runs it
+	 * on a background thread — mirroring production, where the acknowledgement arrives on a gRPC
+	 * inbound thread distinct from the caller — and returns once the stream initializer has run so
+	 * the test can assert against the primed subscriber and deliver the remaining messages (ACK,
+	 * heartbeats, captures) from the main thread. `deliverAck()` joins the subscribe thread so the
+	 * follow-up assertions run single-threaded once the acknowledgement gate has been released.
 	 */
 	private static final class TestHarness {
 		final ClientCallStreamObserver<Object> observer;
@@ -385,6 +402,18 @@ class ClientChangeCapturePublisherTest implements TestConstants {
 		private final SystemCapturePublisher publisher;
 		private final AtomicReference<ClientResponseObserver<Object, Object>> subscriberRef =
 			new AtomicReference<>();
+		/**
+		 * Counted down by the stream initializer once the subscriber is wired (`beforeStart` done and,
+		 * for the ack-during-init case, the ACK consumed), so `start()` can return with a fully primed
+		 * subscriber even though `subscribe()` is still blocked on the acknowledgement.
+		 */
+		private final CountDownLatch initialized = new CountDownLatch(1);
+		/**
+		 * Captures any throwable the background `subscribe()` call surfaces (e.g. a protocol violation
+		 * or an acknowledgement timeout) instead of letting it escape uncaught on the daemon thread.
+		 */
+		private final AtomicReference<Throwable> subscribeError = new AtomicReference<>();
+		private volatile Thread subscribeThread;
 
 		TestHarness() {
 			this(0L);
@@ -414,17 +443,43 @@ class ClientChangeCapturePublisherTest implements TestConstants {
 						// fire the ACK from the initializer itself — must NOT NPE
 						subscriber.onNext(buildHeartbeat(0));
 					}
+					// signal that the subscriber is fully wired so start() can return; subscribe()
+					// keeps blocking on the acknowledgement on this background thread
+					this.initialized.countDown();
 				}
 			);
 		}
 
 		void start() {
-			this.publisher.subscribe(this.delegate);
+			this.subscribeThread = new Thread(
+				() -> {
+					try {
+						this.publisher.subscribe(this.delegate);
+					} catch (Throwable t) {
+						this.subscribeError.set(t);
+					}
+				},
+				"test-cdc-subscribe"
+			);
+			this.subscribeThread.setDaemon(true);
+			this.subscribeThread.start();
+			try {
+				assertTrue(
+					this.initialized.await(5, TimeUnit.SECONDS),
+					"stream initializer did not run in time"
+				);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new AssertionError("interrupted while waiting for stream initialization", e);
+			}
 		}
 
 		void deliverAck() {
-			// first message: ACKNOWLEDGEMENT — its presence sets the subscription id
+			// first message: ACKNOWLEDGEMENT — its presence sets the subscription id and releases the
+			// acknowledgement gate; join the subscribe thread so it has fully returned before the test
+			// makes its (from here on single-threaded) assertions and further deliveries
 			this.subscriberRef.get().onNext(buildHeartbeat(0));
+			joinSubscribe();
 		}
 
 		void deliverHeartbeat(long index) {
@@ -435,6 +490,23 @@ class ClientChangeCapturePublisherTest implements TestConstants {
 			this.subscriberRef.get().onNext(
 				new ChangeSystemCapture(payload, payload, FIXED_TS, Operation.UPSERT, null)
 			);
+		}
+
+		/**
+		 * Waits for the background `subscribe()` call to return so the test's remaining work runs
+		 * without racing it.
+		 */
+		void joinSubscribe() {
+			final Thread thread = this.subscribeThread;
+			if (thread != null) {
+				try {
+					thread.join(TimeUnit.SECONDS.toMillis(5));
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new AssertionError("interrupted while joining the subscribe thread", e);
+				}
+				assertFalse(thread.isAlive(), "the subscribe thread did not return in time");
+			}
 		}
 
 		private static HeartBeat buildHeartbeat(long index) {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/config/ClientConnectionOptionsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/config/ClientConnectionOptionsTest.java
@@ -55,6 +55,10 @@ class ClientConnectionOptionsTest {
 		assertEquals(ClientConnectionOptions.DEFAULT_HOST, options.host());
 		assertEquals(ClientConnectionOptions.DEFAULT_PORT, options.port());
 		assertEquals(ClientConnectionOptions.DEFAULT_SYSTEM_API_PORT, options.systemApiPort());
+		assertEquals(ClientConnectionOptions.DEFAULT_PING_INTERVAL_MILLIS, options.pingIntervalMillis());
+		assertEquals(30_000, options.pingIntervalMillis());
+		assertEquals(ClientConnectionOptions.DEFAULT_IDLE_TIMEOUT_MILLIS, options.idleTimeoutMillis());
+		assertEquals(300_000, options.idleTimeoutMillis());
 	}
 
 	@Test
@@ -66,6 +70,8 @@ class ClientConnectionOptionsTest {
 		assertEquals("localhost", options.host());
 		assertEquals(5555, options.port());
 		assertEquals(5555, options.systemApiPort());
+		assertEquals(30_000, options.pingIntervalMillis());
+		assertEquals(300_000, options.idleTimeoutMillis());
 	}
 
 	@Nested
@@ -115,6 +121,50 @@ class ClientConnectionOptionsTest {
 
 			assertEquals("my-custom-client", options.clientId());
 		}
+
+		@Test
+		@DisplayName("should set custom ping interval via builder")
+		void shouldSetCustomPingInterval() {
+			final ClientConnectionOptions options =
+				ClientConnectionOptions.builder()
+					.pingIntervalMillis(1000)
+					.build();
+
+			assertEquals(1000, options.pingIntervalMillis());
+		}
+
+		@Test
+		@DisplayName("should allow disabling the ping via a zero interval")
+		void shouldAllowDisablingPing() {
+			final ClientConnectionOptions options =
+				ClientConnectionOptions.builder()
+					.pingIntervalMillis(0)
+					.build();
+
+			assertEquals(0, options.pingIntervalMillis());
+		}
+
+		@Test
+		@DisplayName("should set custom idle timeout via builder")
+		void shouldSetCustomIdleTimeout() {
+			final ClientConnectionOptions options =
+				ClientConnectionOptions.builder()
+					.idleTimeoutMillis(120_000)
+					.build();
+
+			assertEquals(120_000, options.idleTimeoutMillis());
+		}
+
+		@Test
+		@DisplayName("should allow disabling the idle timeout via a zero value")
+		void shouldAllowDisablingIdleTimeout() {
+			final ClientConnectionOptions options =
+				ClientConnectionOptions.builder()
+					.idleTimeoutMillis(0)
+					.build();
+
+			assertEquals(0, options.idleTimeoutMillis());
+		}
 	}
 
 	@Nested
@@ -130,6 +180,8 @@ class ClientConnectionOptionsTest {
 					.host("remotehost")
 					.port(1234)
 					.systemApiPort(5678)
+					.pingIntervalMillis(2500)
+					.idleTimeoutMillis(90_000)
 					.build();
 
 			final ClientConnectionOptions copy = ClientConnectionOptions.builder(source).build();
@@ -138,6 +190,8 @@ class ClientConnectionOptionsTest {
 			assertEquals("remotehost", copy.host());
 			assertEquals(1234, copy.port());
 			assertEquals(5678, copy.systemApiPort());
+			assertEquals(2500, copy.pingIntervalMillis());
+			assertEquals(90_000, copy.idleTimeoutMillis());
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/config/ClientConnectionOptionsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/config/ClientConnectionOptionsTest.java
@@ -145,6 +145,33 @@ class ClientConnectionOptionsTest {
 		}
 
 		@Test
+		@DisplayName("should raise a positive ping interval below the Armeria minimum to the 1000 ms floor")
+		void shouldClampSubMinimumPingIntervalToArmeriaFloor() {
+			assertEquals(
+				1000,
+				ClientConnectionOptions.builder().pingIntervalMillis(500).build().pingIntervalMillis()
+			);
+		}
+
+		@Test
+		@DisplayName("should fall back to the default for a negative ping interval")
+		void shouldFallBackToDefaultForNegativePingInterval() {
+			assertEquals(
+				ClientConnectionOptions.DEFAULT_PING_INTERVAL_MILLIS,
+				ClientConnectionOptions.builder().pingIntervalMillis(-1).build().pingIntervalMillis()
+			);
+		}
+
+		@Test
+		@DisplayName("should fall back to the default for a negative idle timeout")
+		void shouldFallBackToDefaultForNegativeIdleTimeout() {
+			assertEquals(
+				ClientConnectionOptions.DEFAULT_IDLE_TIMEOUT_MILLIS,
+				ClientConnectionOptions.builder().idleTimeoutMillis(-1).build().idleTimeoutMillis()
+			);
+		}
+
+		@Test
 		@DisplayName("should set custom idle timeout via builder")
 		void shouldSetCustomIdleTimeout() {
 			final ClientConnectionOptions options =

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/config/EvitaClientConfigurationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/config/EvitaClientConfigurationTest.java
@@ -283,6 +283,28 @@ class EvitaClientConfigurationTest {
 
 			assertEquals("custom-client", config.connection().clientId());
 		}
+
+		@Test
+		@DisplayName("should set ping interval via top-level builder setter")
+		void shouldSetPingIntervalViaBuilder() {
+			final EvitaClientConfiguration config =
+				EvitaClientConfiguration.builder()
+					.pingIntervalMillis(15_000)
+					.build();
+
+			assertEquals(15_000, config.connection().pingIntervalMillis());
+		}
+
+		@Test
+		@DisplayName("should set idle timeout via top-level builder setter")
+		void shouldSetIdleTimeoutViaBuilder() {
+			final EvitaClientConfiguration config =
+				EvitaClientConfiguration.builder()
+					.idleTimeoutMillis(150_000)
+					.build();
+
+			assertEquals(150_000, config.connection().idleTimeoutMillis());
+		}
 	}
 
 	@Nested
@@ -404,6 +426,30 @@ class EvitaClientConfigurationTest {
 					.build();
 
 			assertEquals(config.connection().systemApiPort(), config.systemApiPort());
+		}
+
+		@Test
+		@DisplayName("should delegate pingIntervalMillis() to connection().pingIntervalMillis()")
+		void shouldDelegatePingIntervalToConnectionPingInterval() {
+			final EvitaClientConfiguration config =
+				EvitaClientConfiguration.builder()
+					.connection(ClientConnectionOptions.builder().pingIntervalMillis(5000).build())
+					.build();
+
+			assertEquals(5000, config.pingIntervalMillis());
+			assertEquals(config.connection().pingIntervalMillis(), config.pingIntervalMillis());
+		}
+
+		@Test
+		@DisplayName("should delegate idleTimeoutMillis() to connection().idleTimeoutMillis()")
+		void shouldDelegateIdleTimeoutToConnectionIdleTimeout() {
+			final EvitaClientConfiguration config =
+				EvitaClientConfiguration.builder()
+					.connection(ClientConnectionOptions.builder().idleTimeoutMillis(120_000).build())
+					.build();
+
+			assertEquals(120_000, config.idleTimeoutMillis());
+			assertEquals(config.connection().idleTimeoutMillis(), config.idleTimeoutMillis());
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/configuration/ApiOptionsPingIntervalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/configuration/ApiOptionsPingIntervalTest.java
@@ -36,7 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * {@link io.evitadb.driver.config.ClientConnectionOptions} coverage. The ping interval is the stall budget that
  * governs when Armeria closes an unacknowledged connection; `0` disables the server ping entirely (the default,
  * matching gRPC's convention that keep-alive is the client's responsibility) and any negative value falls back to
- * that default. A positive value is passed through verbatim.
+ * that default. A positive value at or above Armeria's `1000` ms minimum is passed through verbatim, while a
+ * positive value below it is raised to that floor.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
@@ -62,6 +63,13 @@ class ApiOptionsPingIntervalTest {
 	@DisplayName("Passes a positive ping interval through verbatim")
 	void shouldSetCustomPingInterval() {
 		assertEquals(1000, ApiOptions.builder().pingIntervalMillis(1000).build().pingIntervalMillis());
+	}
+
+	@Test
+	@DisplayName("Raises a positive ping interval below the Armeria minimum to the 1000 ms floor")
+	void shouldClampSubMinimumPingIntervalToArmeriaFloor() {
+		assertEquals(1000, ApiOptions.builder().pingIntervalMillis(500).build().pingIntervalMillis());
+		assertEquals(1000, ApiOptions.builder().pingIntervalMillis(1).build().pingIntervalMillis());
 	}
 
 	@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/configuration/ApiOptionsPingIntervalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/configuration/ApiOptionsPingIntervalTest.java
@@ -1,0 +1,89 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.configuration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.MANAGEMENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies the server-side keep-alive ping configuration of {@link ApiOptions} — the counterpart of the client-side
+ * {@link io.evitadb.driver.config.ClientConnectionOptions} coverage. The ping interval is the stall budget that
+ * governs when Armeria closes an unacknowledged connection; `0` disables the server ping entirely (the default,
+ * matching gRPC's convention that keep-alive is the client's responsibility) and any negative value falls back to
+ * that default. A positive value is passed through verbatim.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("ApiOptions keep-alive ping interval")
+@Tag(EXTERNAL_API)
+@Tag(MANAGEMENT)
+class ApiOptionsPingIntervalTest {
+
+	@Test
+	@DisplayName("Defaults the server ping to disabled (0) via the no-arg constructor")
+	void shouldDefaultPingIntervalToDisabledViaNoArgConstructor() {
+		assertEquals(ApiOptions.DEFAULT_PING_INTERVAL, new ApiOptions().pingIntervalMillis());
+		assertEquals(0, new ApiOptions().pingIntervalMillis());
+	}
+
+	@Test
+	@DisplayName("Defaults the server ping to disabled (0) via the builder")
+	void shouldDefaultPingIntervalToDisabledViaBuilder() {
+		assertEquals(0, ApiOptions.builder().build().pingIntervalMillis());
+	}
+
+	@Test
+	@DisplayName("Passes a positive ping interval through verbatim")
+	void shouldSetCustomPingInterval() {
+		assertEquals(1000, ApiOptions.builder().pingIntervalMillis(1000).build().pingIntervalMillis());
+	}
+
+	@Test
+	@DisplayName("Keeps an explicit zero (disabled) ping interval")
+	void shouldKeepExplicitDisabledPingInterval() {
+		assertEquals(0, ApiOptions.builder().pingIntervalMillis(0).build().pingIntervalMillis());
+	}
+
+	@Test
+	@DisplayName("Falls back to the default for a negative ping interval")
+	void shouldClampNegativePingIntervalToDefault() {
+		// 0 is meaningful (disables the ping); only a negative value is invalid and falls back to the default
+		assertEquals(
+			ApiOptions.DEFAULT_PING_INTERVAL,
+			ApiOptions.builder().pingIntervalMillis(-1).build().pingIntervalMillis()
+		);
+	}
+
+	@Test
+	@DisplayName("Preserves the ping interval through the copy builder")
+	void shouldPreservePingIntervalInCopyBuilder() {
+		final ApiOptions source = ApiOptions.builder().pingIntervalMillis(2500).build();
+		assertEquals(2500, ApiOptions.builder(source).build().pingIntervalMillis());
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ChainIndexStaleLeafPageTwinTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ChainIndexStaleLeafPageTwinTest.java
@@ -1,0 +1,187 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.attribute;
+
+import io.evitadb.dataType.ChainableType;
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.ChainIndexLeafPagePart;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Extends the senesi stale-leaf-page-twin reproduction (`specifications/senesi-upsert-index-corruption/`) to the
+ * {@link ChainIndex} paged restore path. Unlike the key-ordered paged indexes, a chain-index element page is positional
+ * (an `UnorderedLookupTree` leaf), so there is no ordering invariant to violate — the twin manifests instead as
+ * DUPLICATE record ids across pages: `UnorderedLookupTree.assembleFromLeafPages` copies pages verbatim, so a twin's
+ * duplicated record ids silently overwrite the value index while the physical array keeps both copies (wrong chain
+ * lengths, later "Position N not found!").
+ *
+ * The reload no longer attempts any healing: a duplicate record id across chain leaf pages is unconditionally fatal.
+ * `ChainIndex.fromPersistedPages` calls `assertNoDuplicateChainRecords`, which fails fast with a
+ * {@link GenericEvitaInternalError} naming the offending record id and both leaf-page sequences. Even a shape that a
+ * previous revision would have "healed" — a page whose record ids are a strict prefix of its immediate successor's,
+ * regardless of any head-mark divergence over the shared prefix — must now throw.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@DisplayName("Stale leaf-page twin fails fast on the ChainIndex reload path")
+class ChainIndexStaleLeafPageTwinTest {
+
+	private static final AttributeIndexKey ORDER_KEY = new AttributeIndexKey(null, "orderInChain", null);
+
+	/**
+	 * Builds a read-path chain leaf page.
+	 *
+	 * @param pageSequence  the page sequence
+	 * @param recordIds     the leaf's record ids in tree order
+	 * @param headPositions the positions (into `recordIds`) that are chain heads, ascending
+	 * @return the leaf page
+	 */
+	@Nonnull
+	private static ChainIndexLeafPagePart page(int pageSequence, @Nonnull int[] recordIds, @Nonnull int[] headPositions) {
+		final long[] headWords = new long[(recordIds.length + 63) >>> 6];
+		final int[] headPredecessors = new int[headPositions.length];
+		for (int k = 0; k < headPositions.length; k++) {
+			final int position = headPositions[k];
+			headWords[position >>> 6] |= 1L << (position & 63);
+			// every head in these fixtures is a true chain head (its predecessor is the HEAD_PK sentinel)
+			headPredecessors[k] = ChainableType.HEAD_PK;
+		}
+		return new ChainIndexLeafPagePart(0, pageSequence, recordIds, headWords, headPredecessors, (long) (pageSequence + 1));
+	}
+
+	/**
+	 * Loads a {@link ChainIndex} from the passed persisted pages the way the catalog-open path does (see
+	 * `AttributeIndexLoader.fetchChain`): the global index (no reference key), high-water = last page sequence.
+	 *
+	 * @param pages the persisted leaf pages in ascending logical order
+	 * @return the rebuilt index
+	 */
+	@Nonnull
+	private static ChainIndex loadFromPersistedPages(@Nonnull ChainIndexLeafPagePart... pages) {
+		return ChainIndex.fromPersistedPages(null, ORDER_KEY, List.of(pages), pages.length - 1);
+	}
+
+	@Nested
+	@DisplayName("Any duplicate-record twin fails fast")
+	class FailFastTest {
+
+		@Test
+		@DisplayName("should fail fast on a stale strict-prefix record-id twin")
+		void shouldThrowOnStrictPrefixTwin() {
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					// a healthy predecessor chain 100 -> 101
+					page(0, new int[]{100, 101}, new int[]{0}),
+					// the frozen STALE twin of the next chain leaf (page sequence 1): 200 -> 201 -> 202
+					page(1, new int[]{200, 201, 202}, new int[]{0}),
+					// the leaf that superseded it (page sequence 2): same 3 records plus 203, 204 the chain gained afterwards
+					page(2, new int[]{200, 201, 202, 203, 204}, new int[]{0})
+				),
+				"A duplicate-record chain twin must fail fast on reload — a strict-prefix twin is no longer healed."
+			);
+			assertTrue(
+				ex.getMessage().contains("appears in more than one leaf page"),
+				"The failure must be the duplicate-record corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("should fail fast on a duplicate even when head marks diverge over the shared prefix")
+		void shouldThrowOnHeadMarkDivergentDuplicate() {
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					page(0, new int[]{100, 101}, new int[]{0}),
+					// the twin marks 201 ALSO as a head — a head-state divergence over the shared prefix
+					page(1, new int[]{200, 201, 202}, new int[]{0, 1}),
+					// the superseder marks only 200 as a head; the divergence must NOT prevent the throw
+					page(2, new int[]{200, 201, 202, 203, 204}, new int[]{0})
+				),
+				"A duplicate-record chain twin must fail fast on reload even when the head marks diverge over the shared prefix."
+			);
+			assertTrue(
+				ex.getMessage().contains("appears in more than one leaf page"),
+				"The failure must be the duplicate-record corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Unhealable overlap fails fast")
+	class HardFailureTest {
+
+		@Test
+		@DisplayName("should throw on a partial-overlap duplicate that is not a strict record-id prefix")
+		void shouldRefusePartialOverlapDuplicate() {
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					page(0, new int[]{100, 101}, new int[]{0}),
+					// shares 200, 201 with its successor but position 2 diverges (202 vs 999) => not a strict prefix
+					page(1, new int[]{200, 201, 202}, new int[]{0}),
+					page(2, new int[]{200, 201, 999, 203, 204}, new int[]{0})
+				),
+				"A partial-overlap duplicate is an unknown corruption shape and must fail fast."
+			);
+			assertTrue(
+				ex.getMessage().contains("appears in more than one leaf page"),
+				"The failure must be the duplicate-record corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("should throw on a non-adjacent duplicate record id")
+		void shouldRefuseNonAdjacentDuplicate() {
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					page(0, new int[]{100, 101}, new int[]{0}),
+					page(1, new int[]{200, 201}, new int[]{0}),
+					// record 100 reappears far from its first page and is not part of any strict-prefix twin
+					page(2, new int[]{300, 100}, new int[]{0})
+				),
+				"A non-adjacent duplicate record id is an unknown corruption shape and must fail fast."
+			);
+			assertTrue(
+				ex.getMessage().contains("appears in more than one leaf page"),
+				"The failure must be the duplicate-record corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexStaleLeafPageTwinTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexStaleLeafPageTwinTest.java
@@ -1,0 +1,184 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.attribute;
+
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.dataType.Scope;
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.utils.NumberUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.Map;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Extends the senesi stale-leaf-page-twin reproduction (`specifications/senesi-upsert-index-corruption/`) to the
+ * catalog-level {@link GlobalUniqueIndex} paged restore path. The value → packed-`(entityType, pk, locale)` map is a
+ * UNIQUE bucket tree persisted per leaf page; a frozen stale leaf referenced alongside the page that superseded it
+ * (the twin) breaks the strict ascending cross-leaf key order the {@code fromPersistedPages} spine builder now
+ * enforces — a corruption whose catalog-wide blast radius (e.g. globally-unique `url` routing lookups miss) used to
+ * load silently before the assembler validated leaf order.
+ *
+ * The reload must reject any twin with {@link GenericEvitaInternalError}: the B+ tree assembler validates strict
+ * cross-leaf key order, so any detected twin — a provable strict-prefix twin or any other overlap shape (e.g. a
+ * same-value twin pointing at a different packed payload) — fails fast at `GlobalUniqueIndex.fromPersistedPages`.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@DisplayName("Stale leaf-page twin fail-fast rejection on the GlobalUniqueIndex reload path")
+class GlobalUniqueIndexStaleLeafPageTwinTest {
+
+	private static final AttributeKey URL_KEY = new AttributeKey("url");
+	private static final int TWIN_PREFIX_SIZE = 128;
+	private static final int GROWN_PAGE_SIZE = 190;
+
+	/**
+	 * Returns the `i`-th unique attribute value (distinct ascending integers).
+	 */
+	private static Integer value(int i) {
+		return i;
+	}
+
+	/**
+	 * Returns the packed `long` payload owning the `i`-th value: entity type id 0, entity primary key `700000+i`, and the
+	 * `NO_LOCALE` sentinel — the same `high16 | mid16 | low32` layout `GlobalUniqueIndex.packTuple` produces.
+	 */
+	private static long payload(int i) {
+		// high16 == 0 encodes the NO_LOCALE(-1) sentinel (biased to 0), mid16 == 0 the entity type id, low32 the pk
+		return NumberUtils.pack(0, 0, 700_000 + i);
+	}
+
+	/**
+	 * Builds the value column of a page for the ordinals `[from, to)`.
+	 */
+	@Nonnull
+	private static Serializable[] valuePage(int from, int to) {
+		final Serializable[] values = new Serializable[to - from];
+		for (int i = from; i < to; i++) {
+			values[i - from] = value(i);
+		}
+		return values;
+	}
+
+	/**
+	 * Builds the packed-payload column of a page for the ordinals `[from, to)`.
+	 */
+	@Nonnull
+	private static long[] payloadPage(int from, int to) {
+		final long[] payloads = new long[to - from];
+		for (int i = from; i < to; i++) {
+			payloads[i - from] = payload(i);
+		}
+		return payloads;
+	}
+
+	/**
+	 * Loads a {@link GlobalUniqueIndex} from the passed persisted pages the way the catalog-open path does (see
+	 * `DefaultCatalogPersistenceService`): page sequences `0..n-1`, an `Integer` attribute type, no locales.
+	 *
+	 * @param valuePages   the per-page value columns
+	 * @param payloadPages the per-page packed-payload columns, positionally aligned with `valuePages`
+	 * @return the rebuilt index
+	 */
+	@Nonnull
+	private static GlobalUniqueIndex loadFromPersistedPages(@Nonnull Serializable[][] valuePages, @Nonnull long[][] payloadPages) {
+		final int[] pageSequences = new int[valuePages.length];
+		for (int i = 0; i < valuePages.length; i++) {
+			pageSequences[i] = i;
+		}
+		return GlobalUniqueIndex.fromPersistedPages(
+			Scope.LIVE, URL_KEY, Integer.class, pageSequences, valuePages, payloadPages, valuePages.length - 1, Map.of()
+		);
+	}
+
+	@Nested
+	@DisplayName("Strict-prefix twin fails fast")
+	class FailFastTest {
+
+		@Test
+		@DisplayName("should reject a stale strict-prefix twin page with GenericEvitaInternalError on reload")
+		void shouldThrowOnStrictPrefixTwin() {
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					new Serializable[][]{
+						valuePage(0, TWIN_PREFIX_SIZE),
+						valuePage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						valuePage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE)
+					},
+					new long[][]{
+						payloadPage(0, TWIN_PREFIX_SIZE),
+						payloadPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						payloadPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE)
+					}
+				),
+				"A stale strict-prefix leaf-page twin must fail fast on reload."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Unhealable overlap fails fast")
+	class HardFailureTest {
+
+		@Test
+		@DisplayName("should throw on a same-value twin pointing at a different packed payload than its superseder")
+		void shouldRefuseDivergedPayloadTwin() {
+			final long[] divergedPayloads = payloadPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE);
+			// same value as the twin's first value, but a different owning entity primary key => not a strict prefix
+			divergedPayloads[0] = NumberUtils.pack(0, 0, 987_654);
+			assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					new Serializable[][]{
+						valuePage(0, TWIN_PREFIX_SIZE),
+						valuePage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						valuePage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE)
+					},
+					new long[][]{
+						payloadPage(0, TWIN_PREFIX_SIZE),
+						payloadPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						divergedPayloads
+					}
+				),
+				"A same-value twin pointing at a different packed payload is an unknown corruption shape and must fail fast."
+			);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/OwnerUniqueIndexStaleLeafPageTwinTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/OwnerUniqueIndexStaleLeafPageTwinTest.java
@@ -1,0 +1,178 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.attribute;
+
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Extends the senesi stale-leaf-page-twin reproduction (`specifications/senesi-upsert-index-corruption/`) to the
+ * {@link OwnerUniqueIndex} paged restore path. The value → owning-record-id map is a UNIQUE bucket tree persisted per
+ * leaf page; a frozen stale leaf referenced alongside the page that superseded it (the twin) duplicates a value run in a
+ * UNIQUE tree and misroutes equality probes once the twins diverge. Its {@code assembleFromSingleLeafTrees} spine
+ * builder validates strict cross-leaf key order, so any such twin is detected at reassembly.
+ *
+ * The reload must reject any twin with {@link GenericEvitaInternalError} — there is no healing path; every detected
+ * overlap shape fails fast at {@link OwnerUniqueIndex#fromPersistedPages}.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@DisplayName("Stale leaf-page twin fails fast on the OwnerUniqueIndex reload path")
+class OwnerUniqueIndexStaleLeafPageTwinTest {
+
+	private static final String ENTITY_TYPE = "product";
+	private static final AttributeIndexKey CODE_KEY = new AttributeIndexKey(null, "code", null);
+	private static final int TWIN_PREFIX_SIZE = 128;
+	private static final int GROWN_PAGE_SIZE = 190;
+
+	/**
+	 * Returns the `i`-th unique attribute value (distinct ascending integers).
+	 */
+	private static Integer value(int i) {
+		return i;
+	}
+
+	/**
+	 * Returns the record id owning the `i`-th value (stable 1:1 mapping).
+	 */
+	private static int record(int i) {
+		return 500_000 + i;
+	}
+
+	/**
+	 * Builds the value column of a page for the ordinals `[from, to)`.
+	 */
+	@Nonnull
+	private static Serializable[] valuePage(int from, int to) {
+		final Serializable[] values = new Serializable[to - from];
+		for (int i = from; i < to; i++) {
+			values[i - from] = value(i);
+		}
+		return values;
+	}
+
+	/**
+	 * Builds the record-id column of a page for the ordinals `[from, to)`.
+	 */
+	@Nonnull
+	private static int[] recordPage(int from, int to) {
+		final int[] records = new int[to - from];
+		for (int i = from; i < to; i++) {
+			records[i - from] = record(i);
+		}
+		return records;
+	}
+
+	/**
+	 * Loads an {@link OwnerUniqueIndex} from the passed persisted pages the way the catalog-open path does
+	 * (see `AttributeIndexLoader`): page sequences `0..n-1`, an `Integer` attribute type.
+	 *
+	 * @param valuePages  the per-page value columns
+	 * @param recordPages the per-page record-id columns, positionally aligned with `valuePages`
+	 * @return the rebuilt index
+	 */
+	@Nonnull
+	private static OwnerUniqueIndex loadFromPersistedPages(@Nonnull Serializable[][] valuePages, @Nonnull int[][] recordPages) {
+		final int[] pageSequences = new int[valuePages.length];
+		for (int i = 0; i < valuePages.length; i++) {
+			pageSequences[i] = i;
+		}
+		return OwnerUniqueIndex.fromPersistedPages(
+			ENTITY_TYPE, CODE_KEY, Integer.class, pageSequences, valuePages, recordPages, valuePages.length - 1
+		);
+	}
+
+	@Nested
+	@DisplayName("Strict-prefix twin fails fast")
+	class FailFastTest {
+
+		@Test
+		@DisplayName("should throw when a stale strict-prefix twin page is present on reload")
+		void shouldThrowOnStrictPrefixTwin() {
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					new Serializable[][]{
+						valuePage(0, TWIN_PREFIX_SIZE),
+						valuePage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						valuePage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE)
+					},
+					new int[][]{
+						recordPage(0, TWIN_PREFIX_SIZE),
+						recordPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						recordPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE)
+					}
+				),
+				"A stale leaf-page twin must fail fast on reload instead of loading silently."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Unhealable overlap fails fast")
+	class HardFailureTest {
+
+		@Test
+		@DisplayName("should throw on a same-value twin pointing at a different record id than its superseder")
+		void shouldRefuseDivergedRecordTwin() {
+			final int[] divergedRecords = recordPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE);
+			// same value as the twin's first value, but a different owning record id => not a provable strict prefix
+			divergedRecords[0] = record(TWIN_PREFIX_SIZE) + 987_654;
+			assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					new Serializable[][]{
+						valuePage(0, TWIN_PREFIX_SIZE),
+						valuePage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						valuePage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE)
+					},
+					new int[][]{
+						recordPage(0, TWIN_PREFIX_SIZE),
+						recordPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						divergedRecords
+					}
+				),
+				"A same-value twin pointing at a different record id is an unknown corruption shape and must fail fast."
+			);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/StaleLeafPageTwinReproductionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/StaleLeafPageTwinReproductionTest.java
@@ -1,0 +1,270 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.attribute;
+
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.index.invertedIndex.InvertedIndex;
+import io.evitadb.index.invertedIndex.ValueToRecord;
+import io.evitadb.index.invertedIndex.ValueToRecordPrimitive;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.FILTER;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.ORDER;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduction of a stale leaf-page twin corruption: a persisted `PAGED` {@link InvertedIndex} whose leaf-page
+ * list references a STALE leaf page alongside the page that superseded it — two on-disk pages covering
+ * overlapping key ranges.
+ *
+ * Anatomy observed live on a production catalog (a reduced index for a `published` attribute, bucket keys are
+ * `Instant`s produced by the `OffsetDateTime -> Instant` filter normalizer):
+ *
+ * - persisted page seq=29 held 128 buckets `[A .. B]` — a frozen snapshot of a leaf,
+ * - persisted page seq=30 held 190 buckets whose first 128 buckets were IDENTICAL to page 29 (same keys,
+ *   same record ids) followed by 62 later keys — the same leaf after it kept growing,
+ * - the persisted leaf-page list referenced BOTH, so every reload of the catalog assembled a bucket tree
+ *   containing the 128-key run twice.
+ *
+ * {@link InvertedIndex#fromPersistedPages} now validates strict ascending key order both WITHIN each page and
+ * ACROSS page boundaries while re-assembling the bucket tree. Any leaf page whose last key does not sort
+ * strictly before the first key of its successor page fails fast at load with a
+ * {@link GenericEvitaInternalError} whose message contains `overlaps its successor leaf-page sequence`. Because
+ * the paged persistence layout has never shipped in a released version, no production catalog can carry such a
+ * twin, and the defensive-design rule forbids silently repairing one — so EVERY twin shape fails fast at load
+ * rather than assembling a corrupt bucket tree that would violate the index's fundamental invariant (strictly
+ * ascending distinct bucket keys) and later crash with a confusing signature far from the cause.
+ *
+ * The tests below feed the real loader the exact overlapping leaf-page shapes seen (and adjacent boundary
+ * shapes) and assert the fail-fast corruption diagnostic is raised at load time:
+ *
+ * - {@link LoadInvariantTest} — a stale strict-prefix twin next to its superseder,
+ * - {@link InterleavedTwinTest} — a post-churn interleaved (non-monotonic cross-page) twin,
+ * - {@link BoundaryTwinShapeTest} — boundary twin shapes (equal-content, twin-after-superseder) that must
+ *   fail fast just the same.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@Tag(FILTER)
+@Tag(ORDER)
+@DisplayName("Stale leaf-page twin corruption reproduction")
+class StaleLeafPageTwinReproductionTest {
+
+	private static final AttributeIndexKey PUBLISHED_KEY = new AttributeIndexKey(null, "published", null);
+	/**
+	 * Base timestamp of the generated key space; the concrete value is irrelevant, monotonic spacing matters.
+	 */
+	private static final Instant BASE = Instant.parse("2026-07-13T11:52:31.000000000Z");
+	/**
+	 * Number of buckets in the frozen (stale) twin page — mirrors the 128-bucket page size observed in the
+	 * production incident this reproduces.
+	 */
+	private static final int TWIN_PREFIX_SIZE = 128;
+	/**
+	 * Number of buckets the superseding page grew to before it was persisted — mirrors the 190-bucket page size
+	 * the same production leaf grew to.
+	 */
+	private static final int GROWN_PAGE_SIZE = 190;
+
+	/**
+	 * Returns the `i`-th generated bucket key: {@link #BASE} shifted by `i` milliseconds. Keys are `Instant`s —
+	 * the very form the `OffsetDateTime -> Instant` filter normalizer stores in the shared value tree.
+	 *
+	 * @param i the key ordinal
+	 * @return the generated bucket key
+	 */
+	@Nonnull
+	private static Instant key(int i) {
+		return BASE.plusMillis(i);
+	}
+
+	/**
+	 * Returns the record id associated with the `i`-th generated key (stable 1:1 mapping).
+	 *
+	 * @param i the key ordinal
+	 * @return the record id
+	 */
+	private static int record(int i) {
+		return 1_000_000 + i;
+	}
+
+	/**
+	 * Builds a page of single-record buckets for the key ordinals `[from, to)`.
+	 *
+	 * @param from the first key ordinal (inclusive)
+	 * @param to   the last key ordinal (exclusive)
+	 * @return the page buckets in ascending key order
+	 */
+	@Nonnull
+	private static ValueToRecord[] page(int from, int to) {
+		final ValueToRecord[] buckets = new ValueToRecord[to - from];
+		for (int i = from; i < to; i++) {
+			buckets[i - from] = new ValueToRecordPrimitive(key(i), record(i));
+		}
+		return buckets;
+	}
+
+	/**
+	 * Loads an {@link InvertedIndex} from the passed persisted pages exactly the way the catalog-open path does
+	 * (see `AttributeIndexLoader.loadInvertedIndex` for the `PAGED` shape): page sequences `0..n-1`, the very
+	 * normalizer / comparator the production loader re-derives for an `OffsetDateTime` attribute.
+	 *
+	 * @param pages the persisted leaf pages in list order
+	 * @return the rebuilt index
+	 */
+	@Nonnull
+	@SuppressWarnings("unchecked")
+	private static InvertedIndex loadFromPersistedPages(@Nonnull ValueToRecord[]... pages) {
+		final int[] pageSequences = new int[pages.length];
+		for (int i = 0; i < pages.length; i++) {
+			pageSequences[i] = i;
+		}
+		return InvertedIndex.fromPersistedPages(
+			OffsetDateTime.class,
+			pageSequences,
+			pages,
+			pages.length - 1,
+			FilterIndex.getNormalizer(OffsetDateTime.class, 0),
+			FilterIndex.getComparator(PUBLISHED_KEY, OffsetDateTime.class),
+			0
+		);
+	}
+
+	@Nested
+	@DisplayName("Load-side invariant")
+	class LoadInvariantTest {
+
+		@Test
+		@DisplayName("should fail fast on a stale twin page instead of assembling a corrupt bucket tree")
+		void shouldFailFastOnStrictPrefixTwinOnLoad() {
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					// healthy predecessor page
+					page(0, TWIN_PREFIX_SIZE),
+					// the frozen STALE twin: an old snapshot of the next leaf
+					page(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+					// the leaf that superseded it: same 128 buckets plus 62 the leaf gained afterwards
+					page(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE)
+				),
+				"A stale strict-prefix twin must fail fast on reload."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Interleaved (non-monotonic cross-page) twin")
+	class InterleavedTwinTest {
+
+		@Test
+		@DisplayName("should fail fast on an interleaved twin instead of assembling a corrupt bucket tree")
+		void shouldFailFastOnInterleavedTwinOnLoad() {
+			// diverged twins: the stale snapshot holds keys the live leaf no longer starts with, so the two pages
+			// INTERLEAVE (stale: even ordinals 0..38, live successor: odd ordinals 1..39). Both pages are internally
+			// ascending (they pass the within-page bulk-load assertion) yet the cross-page sequence is not monotonic.
+			// This is the post-churn stage of the same corruption: after the twin froze, the live leaf lost its
+			// leading keys and gained interleaving ones.
+			final ValueToRecord[] staleTwin = new ValueToRecord[20];
+			final ValueToRecord[] liveSuccessor = new ValueToRecord[20];
+			for (int i = 0; i < 20; i++) {
+				final int staleOrdinal = 2 * i;
+				final int liveOrdinal = 2 * i + 1;
+				staleTwin[i] = new ValueToRecordPrimitive(key(staleOrdinal), record(staleOrdinal));
+				liveSuccessor[i] = new ValueToRecordPrimitive(key(liveOrdinal), record(liveOrdinal));
+			}
+
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(staleTwin, liveSuccessor),
+				"An interleaved (non-monotonic cross-page) twin must fail fast on reload."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Every twin shape fails fast on reload")
+	class BoundaryTwinShapeTest {
+
+		@Test
+		@DisplayName("should fail fast on an equal-content twin instead of healing it")
+		void shouldRefuseEqualContentTwin() {
+			// two pages with byte-identical content (same keys, same records, same length): the second page's first
+			// key equals the first page's last key, so the cross-leaf boundary is not strictly ascending and the load
+			// fails fast — no twin shape is repaired, every overlap is rejected as corruption
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					page(0, TWIN_PREFIX_SIZE),
+					page(0, TWIN_PREFIX_SIZE)
+				),
+				"An equal-content twin overlaps its predecessor and must fail fast."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("should fail fast on a twin positioned after its superseding page instead of healing it")
+		void shouldRefuseTwinAfterSuperseder() {
+			// the superseding (longer) page comes FIRST, its stale prefix twin AFTER it: the trailing page's keys
+			// overlap the range already covered by the leading page, so the cross-leaf boundary is not strictly
+			// ascending and the load fails fast — this overlap shape is rejected as corruption like every other
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					page(0, GROWN_PAGE_SIZE),
+					page(0, TWIN_PREFIX_SIZE)
+				),
+				"A twin positioned after its superseder overlaps it and must fail fast."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTreeTest.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.index.bPlusTree;
 
+import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import io.evitadb.dataType.ConsistencySensitiveDataStructure.ConsistencyReport;
@@ -2251,6 +2252,74 @@ class TransactionalBucketBPlusTreeTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("Assemble-from-single-leaf-trees cross-leaf order validation")
+	class AssembleFromSingleLeafTreesValidationTest {
+
+		@Test
+		@DisplayName("throws when two single-leaf source trees overlap across the leaf-page boundary")
+		@Tag(INDEXING)
+		@Tag(SERIALIZATION)
+		void shouldThrowWhenSingleLeafTreesOverlapAcrossBoundary() {
+			// block size 9 keeps three buckets in a single leaf, so each source tree rebuilds to exactly one leaf page
+			final TransactionalBucketBPlusTree<Integer> treeA = new TransactionalBucketBPlusTree<>(9, Integer.class);
+			treeA.addRecord(1, 10);
+			treeA.addRecord(2, 20);
+			treeA.addRecord(3, 30);
+			// tree B's first key (2) does not sort strictly after tree A's last key (3): a stale-twin overlap shape
+			final TransactionalBucketBPlusTree<Integer> treeB = new TransactionalBucketBPlusTree<>(9, Integer.class);
+			treeB.addRecord(2, 20);
+			treeB.addRecord(3, 30);
+			treeB.addRecord(4, 40);
+
+			final TransactionalBucketBPlusTree<Integer> target = new TransactionalBucketBPlusTree<>(9, Integer.class);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> target.assembleFromSingleLeafTrees(
+					List.of(treeA, treeB), new int[]{0, 1}, "bucket B+ tree validation test"
+				),
+				"Overlapping single-leaf trees must fail the cross-leaf-order validation."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("throws when a reassembled leaf page has out-of-order interior keys")
+		@Tag(INDEXING)
+		@Tag(SERIALIZATION)
+		void shouldThrowWhenLeafHasOutOfOrderInteriorKeys() {
+			// build a sound single-leaf source tree, then corrupt its interior key order in place (swap two keys) to
+			// simulate a serializer bug / truncated write / bit rot; the intra-leaf order check must reject it
+			final TransactionalBucketBPlusTree<Integer> corrupt =
+				new TransactionalBucketBPlusTree<>(10, 1, 3, 1, Integer.class, null);
+			corrupt.addRecord(1, 10);
+			corrupt.addRecord(2, 20);
+			corrupt.addRecord(3, 30);
+			// the boxed key column backs getKeys() directly, so mutating it corrupts the live leaf: [1,2,3] -> [2,1,3]
+			final BPlusLeafTreeNode<Integer> leaf = (BPlusLeafTreeNode<Integer>) corrupt.getRoot();
+			final Integer[] keys = leaf.getKeys();
+			final Integer swap = keys[0];
+			keys[0] = keys[1];
+			keys[1] = swap;
+
+			final TransactionalBucketBPlusTree<Integer> target =
+				new TransactionalBucketBPlusTree<>(10, 1, 3, 1, Integer.class, null);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> target.assembleFromSingleLeafTrees(
+					List.of(corrupt), new int[]{0}, "bucket B+ tree intra-leaf test"),
+				"A leaf with out-of-order interior keys must fail the intra-leaf-order validation."
+			);
+			assertTrue(
+				ex.getMessage().contains("out-of-order keys"),
+				"Expected the intra-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+	}
+
 	/**
 	 * Verifies the per-leaf version token exposed by {@link BucketCursor#currentLeafId()} — the foundation of the
 	 * leaf-granular formula-cache staleness mechanism. The contract that must hold: after a commit, the leaf that
@@ -2342,5 +2411,435 @@ class TransactionalBucketBPlusTreeTest {
 			final BucketCursor<Integer> cursor = tree.cursor();
 			assertThrows(GenericEvitaInternalError.class, cursor::currentLeafId);
 		}
+	}
+
+	@Nested
+	@DisplayName("Op-time boundary-mutation asserts")
+	class OpTimeBoundaryMutationTest {
+
+		/**
+		 * Builds a single-leaf source tree holding the supplied keys. Block size 10 keeps every supplied key in one
+		 * leaf (no split), so the tree's root stays a leaf that can be reassembled into a controlled spine.
+		 *
+		 * @param keys the keys to place in the leaf, in any order
+		 * @return a single-leaf tree
+		 */
+		@Nonnull
+		private TransactionalBucketBPlusTree<Integer> singleLeaf(@Nonnull int... keys) {
+			final TransactionalBucketBPlusTree<Integer> tree =
+				new TransactionalBucketBPlusTree<>(10, 1, 3, 1, Integer.class, null);
+			for (final int key : keys) {
+				tree.addRecord(key, key * 10);
+			}
+			return tree;
+		}
+
+		/**
+		 * Reassembles the supplied sound single-leaf trees into one tree with a deterministic spine: internal block
+		 * size 3 caps a parent at four children, so five leaves split into two parents (P1 = three leaves, P2 = two).
+		 * The leaves are non-overlapping, so the cross-leaf validation inside the assembler passes; the assembled tree
+		 * is then used to exercise the op-time boundary checks against hypothetical boundary keys.
+		 *
+		 * @param leaves the ordered, non-overlapping single-leaf trees
+		 * @return the assembled tree
+		 */
+		@Nonnull
+		private TransactionalBucketBPlusTree<Integer> assembleSound(
+			@Nonnull List<TransactionalBucketBPlusTree<Integer>> leaves) {
+			final int[] pageSequences = new int[leaves.size()];
+			for (int i = 0; i < pageSequences.length; i++) {
+				pageSequences[i] = i;
+			}
+			return new TransactionalBucketBPlusTree<Integer>(10, 1, 3, 1, Integer.class, null)
+				.assembleFromSingleLeafTrees(leaves, pageSequences, "bucket B+ tree op-time boundary test");
+		}
+
+		@Test
+		@DisplayName("tail insert overlapping the successor leaf under a different parent throws (Check T)")
+		void shouldThrowOnMisroutedTailInsertAcrossParentBoundary() {
+			// spine (internal block 3 => max 4 children => 5 leaves split 3 + 2): P1 = [L0,L1,L2], P2 = [L3,L4].
+			// L2 is the RIGHTMOST child of P1 and its successor L3 is the LEFTMOST child of P2, so the fence
+			// (8 = L3's first key) lives at the ROOT, not L2's immediate parent — this proves the cross-parent walk.
+			final TransactionalBucketBPlusTree<Integer> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(3, 4), singleLeaf(5, 6), singleLeaf(8, 9), singleLeaf(10, 11)
+			));
+			final TransactionalBucketBPlusTree.Cursor<Integer> cursor = tree.createCursor(5);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tree.assertTailBoundary(cursor, 8),
+				"A new last key equal to the successor leaf's first key must be rejected."
+			);
+			assertTrue(
+				ex.getMessage().contains("successor leaf boundary"),
+				"Expected the tail cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+			// a last key strictly below the fence is legal
+			assertDoesNotThrow(() -> tree.assertTailBoundary(cursor, 7));
+		}
+
+		@Test
+		@DisplayName("head insert undercutting the same-parent predecessor throws (Check H)")
+		void shouldThrowOnMisroutedHeadInsertWithinParent() {
+			// three sound leaves under one parent: L0 = [1,5], L1 = [8,12], L2 = [15,16]. L1's predecessor is its
+			// same-parent left sibling L0 (last key 5). A head key of 3 undercuts it.
+			final TransactionalBucketBPlusTree<Integer> tree = assembleSound(List.of(
+				singleLeaf(1, 5), singleLeaf(8, 12), singleLeaf(15, 16)
+			));
+			final TransactionalBucketBPlusTree.Cursor<Integer> cursor = tree.createCursor(8);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tree.assertHeadBoundary(cursor, 3),
+				"A new first key at or below the predecessor leaf's last key must be rejected."
+			);
+			assertTrue(
+				ex.getMessage().contains("predecessor leaf boundary"),
+				"Expected the head cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+			// a first key strictly above the predecessor's last key is legal
+			assertDoesNotThrow(() -> tree.assertHeadBoundary(cursor, 6));
+			// the separator-order belt is INSUFFICIENT for this shape: propagating the mis-routed first key (3) up
+			// as L1's separator yields separators (3, 15) which are still strictly increasing, so the belt would
+			// NOT fire — which is exactly why Check H is required
+			assertDoesNotThrow(
+				() -> TransactionalBucketBPlusTree.assertSeparatorOrder(new Integer[]{3, 15}, 2, 0, null));
+		}
+
+		@Test
+		@DisplayName("head insert undercutting a predecessor under a different parent throws (Check H right-spine)")
+		void shouldThrowOnMisroutedHeadInsertAcrossParentBoundary() {
+			// L3 is the LEFTMOST child of P2; its predecessor L2 is the RIGHTMOST child of P1 (cross-parent). Check
+			// H must walk up to the clamp ancestor (root) and descend P1's right spine to L2 (last key 6).
+			final TransactionalBucketBPlusTree<Integer> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(3, 4), singleLeaf(5, 6), singleLeaf(8, 9), singleLeaf(10, 11)
+			));
+			final TransactionalBucketBPlusTree.Cursor<Integer> cursor = tree.createCursor(8);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tree.assertHeadBoundary(cursor, 5),
+				"A new first key at or below the cross-parent predecessor's last key must be rejected."
+			);
+			assertTrue(
+				ex.getMessage().contains("predecessor leaf boundary"),
+				"Expected the head cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+			assertDoesNotThrow(() -> tree.assertHeadBoundary(cursor, 7));
+		}
+
+		@Test
+		@DisplayName("both boundary checks apply to a single-key (0 to 1) leaf")
+		void shouldRunBothChecksForSingleKeyLeaf() {
+			// sound tree with a single-key middle leaf L_mid = [6] between L_pred = [1,4] and L_succ = [8,9]
+			final TransactionalBucketBPlusTree<Integer> tree = assembleSound(List.of(
+				singleLeaf(1, 4), singleLeaf(6), singleLeaf(8, 9)
+			));
+			final TransactionalBucketBPlusTree.Cursor<Integer> cursor = tree.createCursor(6);
+			// the actual 0->1 key (6) is sound: both checks run and pass
+			assertDoesNotThrow(() -> tree.assertInsertBoundaries(cursor, 6));
+			// the SAME single-key leaf is subject to the head check (a smaller key undercuts L_pred's last key 4)
+			assertThrows(GenericEvitaInternalError.class, () -> tree.assertHeadBoundary(cursor, 3));
+			// ...and to the tail check (a larger key reaches L_succ's first key 8)
+			assertThrows(GenericEvitaInternalError.class, () -> tree.assertTailBoundary(cursor, 8));
+		}
+
+		@Test
+		@DisplayName("sequential bulk append and prepend never trip the op-time boundary asserts (happy-path pin)")
+		void shouldNotThrowOnSequentialInsertions() {
+			// ascending adds are all tail inserts (Check T runs on the rightmost leaf and finds no fence);
+			// descending adds are all head inserts on the leftmost leaf (Check H finds no predecessor)
+			final TransactionalBucketBPlusTree<Integer> ascending = new TransactionalBucketBPlusTree<>(3, Integer.class);
+			assertDoesNotThrow(() -> {
+				for (int i = 1; i <= 256; i++) {
+					ascending.addRecord(i, i * 10);
+				}
+			});
+			final ConsistencyReport ascendingReport = ascending.getConsistencyReport();
+			assertEquals(ConsistencyState.CONSISTENT, ascendingReport.state(), ascendingReport.report());
+
+			final TransactionalBucketBPlusTree<Integer> descending =
+				new TransactionalBucketBPlusTree<>(3, Integer.class);
+			assertDoesNotThrow(() -> {
+				for (int i = 256; i >= 1; i--) {
+					descending.addRecord(i, i * 10);
+				}
+			});
+			final ConsistencyReport descendingReport = descending.getConsistencyReport();
+			assertEquals(ConsistencyState.CONSISTENT, descendingReport.state(), descendingReport.report());
+		}
+
+	}
+
+	@Nested
+	@DisplayName("commit-time structural integrity validation")
+	class DirtyLeafScopeValidationTest {
+
+		/**
+		 * A mutable comparable key. Bucket leaves store the key OBJECTS in a columnar {@link ValueColumn} (there is no
+		 * primitive key array to overwrite), so the columnar analog of the Long/Element tests' "widen a leaf's last key
+		 * array slot" corruption is to mutate a stored key object in place — which is exactly what a reverted / corrupted
+		 * write layer would leave behind.
+		 */
+		private static final class MutableIntKey implements Comparable<MutableIntKey> {
+			int value;
+
+			MutableIntKey(int value) {
+				this.value = value;
+			}
+
+			@Override
+			public int compareTo(@Nonnull MutableIntKey o) {
+				return Integer.compare(this.value, o.value);
+			}
+
+			@Override
+			public boolean equals(Object o) {
+				return o instanceof MutableIntKey k && k.value == this.value;
+			}
+
+			@Override
+			public int hashCode() {
+				return this.value;
+			}
+
+			@Override
+			public String toString() {
+				return String.valueOf(this.value);
+			}
+		}
+
+		@Nonnull
+		private TransactionalBucketBPlusTree<MutableIntKey> singleLeaf(@Nonnull int... keys) {
+			final TransactionalBucketBPlusTree<MutableIntKey> tree =
+				new TransactionalBucketBPlusTree<>(10, 1, 3, 1, MutableIntKey.class, null);
+			for (final int key : keys) {
+				tree.addRecord(new MutableIntKey(key), key * 10);
+			}
+			return tree;
+		}
+
+		@Nonnull
+		private TransactionalBucketBPlusTree<MutableIntKey> assembleSound(
+			@Nonnull List<TransactionalBucketBPlusTree<MutableIntKey>> leaves) {
+			final int[] pageSequences = new int[leaves.size()];
+			for (int i = 0; i < pageSequences.length; i++) {
+				pageSequences[i] = i;
+			}
+			return new TransactionalBucketBPlusTree<MutableIntKey>(10, 1, 3, 1, MutableIntKey.class, null)
+				.assembleFromSingleLeafTrees(leaves, pageSequences, "bucket B+ tree scope test");
+		}
+
+		@Nonnull
+		private BPlusLeafTreeNode<MutableIntKey> leafAt(
+			@Nonnull TransactionalBucketBPlusTree<MutableIntKey> tree, int key) {
+			return tree.createCursor(new MutableIntKey(key)).leafNode();
+		}
+
+		@Test
+		@DisplayName("a sound dirty scope relocates and validates without throwing")
+		void shouldNotThrowWhenDirtyLeavesAreSound() {
+			final TransactionalBucketBPlusTree<MutableIntKey> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(
+				leafAt(tree, 1), leafAt(tree, 5), leafAt(tree, 10)
+			)));
+		}
+
+		@Test
+		@DisplayName("a leaf whose last key was widened past its successor is caught (tail)")
+		void shouldDetectTailOverlapOnRelocateAndValidate() {
+			final TransactionalBucketBPlusTree<MutableIntKey> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			final BPlusLeafTreeNode<MutableIntKey> middle = leafAt(tree, 5);
+			// widen the middle leaf's last key OBJECT from 6 to 10 so it reaches the successor's first key; the
+			// separator is untouched, so relocating by the leaf's own first key (5) still lands on it and the tail
+			// half-invariant fires
+			middle.keyAt(middle.getPeek()).value = 10;
+			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> tree.validateDirtyScope(List.<Object>of(middle))
+			);
+			assertTrue(
+				ex.getMessage().contains("successor leaf boundary"),
+				"Expected the tail cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("a leaf undercut by a widened predecessor is caught (head)")
+		void shouldDetectHeadOverlapOnRelocateAndValidate() {
+			final TransactionalBucketBPlusTree<MutableIntKey> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			// widen the PREDECESSOR leaf's last key OBJECT from 2 to 5 so it reaches the middle leaf's first key;
+			// relocating the middle leaf by its unchanged first key (5) lands on it and the head half-invariant compares
+			// against the predecessor's corrupted last key
+			final BPlusLeafTreeNode<MutableIntKey> predecessor = leafAt(tree, 1);
+			predecessor.keyAt(predecessor.getPeek()).value = 5;
+			final BPlusLeafTreeNode<MutableIntKey> middle = leafAt(tree, 5);
+			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> tree.validateDirtyScope(List.<Object>of(middle))
+			);
+			assertTrue(
+				ex.getMessage().contains("predecessor leaf boundary"),
+				"Expected the head cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("an empty key source is skipped, not dereferenced")
+		void shouldSkipEmptyKeySource() {
+			final TransactionalBucketBPlusTree<MutableIntKey> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6)
+			));
+			// an empty single-leaf source carries no key (peek < 0) — the scope validation must skip it rather than
+			// dereference the peek slot
+			final TransactionalBucketBPlusTree<MutableIntKey> empty =
+				new TransactionalBucketBPlusTree<>(10, 1, 3, 1, MutableIntKey.class, null);
+			//noinspection unchecked
+			final BPlusLeafTreeNode<MutableIntKey> emptyLeaf =
+				(BPlusLeafTreeNode<MutableIntKey>) empty.getRoot();
+			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(emptyLeaf)));
+		}
+
+		@Test
+		@DisplayName("pre-commit pipeline: an int-record add registers its leaf and a healthy scope is accepted")
+		void shouldRegisterDirtiedLeafViaAddRecord() {
+			final TransactionalBucketBPlusTree<MutableIntKey> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertStateAfterCommit(
+				tree,
+				t -> {
+					t.addRecord(new MutableIntKey(7), 70);
+					final TransactionalLayerMaintainer maintainer = Transaction.getTransactionalLayerMaintainer();
+					// registration fired AND the registry is keyed by this exact tree instance — the identity the
+					// pre-commit (pre-WAL) pass and the post-replay merge both look the scope up by
+					assertFalse(
+						maintainer.getDirtyScopeTokens(t).isEmpty(),
+						"the int-record add must register its dirtied leaf under this tree"
+					);
+					assertDoesNotThrow(maintainer::validateDirtyScopesBeforeCommit);
+				},
+				(t, committed) -> assertNotNull(committed)
+			);
+		}
+
+		@Test
+		@DisplayName("pre-commit pipeline: a long-payload add registers its leaf and a healthy scope is accepted")
+		void shouldRegisterDirtiedLeafViaAddLongRecord() {
+			final TransactionalBucketBPlusTree<MutableIntKey> tree = TransactionalBucketBPlusTree.withLongPayload(
+				10, 1, 3, 1, MutableIntKey.class, null,
+				capacity -> new BoxedObjectColumn<>(MutableIntKey.class, capacity)
+			);
+			tree.addLongRecord(new MutableIntKey(1), 1L);
+			tree.addLongRecord(new MutableIntKey(2), 2L);
+			assertStateAfterCommit(
+				tree,
+				t -> {
+					// the long-payload add path is a different leaf primitive than the int-record one — assert it also
+					// registers its dirtied leaf, so the seam is proven wired on BOTH add surfaces
+					t.addLongRecord(new MutableIntKey(5), 5L);
+					final TransactionalLayerMaintainer maintainer = Transaction.getTransactionalLayerMaintainer();
+					assertFalse(
+						maintainer.getDirtyScopeTokens(t).isEmpty(),
+						"the long-payload add must register its dirtied leaf under this tree"
+					);
+					assertDoesNotThrow(maintainer::validateDirtyScopesBeforeCommit);
+				},
+				(t, committed) -> assertNotNull(committed)
+			);
+		}
+
+		@Test
+		@DisplayName("pre-commit pipeline: a corrupted registered leaf is rejected by the pre-commit pass")
+		void shouldRejectCorruptedScopeInPreCommitPass() {
+			final TransactionalBucketBPlusTree<MutableIntKey> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> assertStateAfterCommit(
+					tree,
+					t -> {
+						final MutableIntKey k7 = new MutableIntKey(7);
+						t.addRecord(k7, 70);
+						// widen the dirtied leaf (now [5,6,7]) so its last key reaches the successor's first key (10)
+						k7.value = 10;
+						Transaction.getTransactionalLayerMaintainer().validateDirtyScopesBeforeCommit();
+					},
+					(t, committed) -> fail("the pre-commit pass must reject before commit")
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("post-replay pipeline: a corrupted registered leaf is rejected by the commit merge")
+		void shouldRejectCorruptedScopeInCommitMerge() {
+			final TransactionalBucketBPlusTree<MutableIntKey> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> assertStateAfterCommit(
+					tree,
+					t -> {
+						final MutableIntKey k7 = new MutableIntKey(7);
+						t.addRecord(k7, 70);
+						// no pre-commit pass here — the commit merge (post-replay, inside createCopyWithMergedTransactionalMemory)
+						// must relocate the registered leaf in the merged tree and catch the overlap
+						k7.value = 10;
+					},
+					(t, committed) -> fail("the commit merge must reject the corrupted scope")
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("Registry hygiene: a remove-only transaction still registers its dirtied leaf")
+		void shouldRegisterLeafOnRemoveOnlyTransaction() {
+			final TransactionalBucketBPlusTree<MutableIntKey> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertStateAfterCommit(
+				tree,
+				t -> {
+					// a clean remove (min block size 1 → [5,6] becomes [5], no underflow/rebalance) empties key 6's
+					// bucket and drops it from the leaf; exercises the removal seam only
+					t.removeRecord(new MutableIntKey(6), 60);
+					assertFalse(
+						Transaction.getTransactionalLayerMaintainer().getDirtyScopeTokens(t).isEmpty(),
+						"a remove-only transaction must register the leaf it dirtied"
+					);
+				},
+				(t, committed) -> assertNotNull(committed)
+			);
+		}
+
+		@Test
+		@DisplayName("Registry hygiene: a leaf split registers both halves")
+		void shouldRegisterBothHalvesOnLeafSplit() {
+			// block size 3 splits the root leaf as these four distinct keys are added
+			final TransactionalBucketBPlusTree<MutableIntKey> tree =
+				new TransactionalBucketBPlusTree<>(3, 1, 3, 1, MutableIntKey.class, null);
+			assertStateAfterCommit(
+				tree,
+				t -> {
+					t.addRecord(new MutableIntKey(1), 10);
+					t.addRecord(new MutableIntKey(2), 20);
+					t.addRecord(new MutableIntKey(3), 30);
+					t.addRecord(new MutableIntKey(4), 40);
+					// the split must register BOTH leaf halves; the identity-set size collapses to 1 if only one half
+					// was registered (or one object was registered twice), which fails this assertion
+					assertTrue(
+						Transaction.getTransactionalLayerMaintainer().getDirtyScopeTokens(t).size() >= 2,
+						"a leaf split must register both halves"
+					);
+				},
+				(t, committed) -> assertNotNull(committed)
+			);
+		}
+
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTreeTest.java
@@ -23,8 +23,11 @@
 
 package io.evitadb.index.bPlusTree;
 
+import io.evitadb.core.transaction.Transaction;
+import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.dataType.ConsistencySensitiveDataStructure.ConsistencyReport;
 import io.evitadb.dataType.ConsistencySensitiveDataStructure.ConsistencyState;
+import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.price.model.priceRecord.PriceRecord;
 import io.evitadb.index.price.model.priceRecord.PriceRecordContract;
 import io.evitadb.utils.ArrayUtils;
@@ -50,11 +53,14 @@ import static io.evitadb.test.TestTags.TRANSACTION;
 import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
 import static io.evitadb.utils.AssertionUtils.assertStateAfterRollback;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Verifies the correctness of the {@link TransactionalElementBPlusTree} — the element-keyed B+ tree backing the price
@@ -613,6 +619,68 @@ class TransactionalElementBPlusTreeTest {
 			assertTrue(dirtyOrNew <= 3, "A single deletion must not dirty the whole tree (" + dirtyOrNew + ")");
 		}
 
+		@Test
+		@DisplayName("rejects reassembly when single-leaf pages overlap across a leaf boundary")
+		void shouldThrowWhenSingleLeafTreesOverlapAcrossBoundary() {
+			// a block size large enough that three records never split, so each source tree stays a single leaf page
+			final int blockSize = 64;
+
+			// leaf page A holds keys 1, 2, 3
+			final TransactionalElementBPlusTree<PriceRecordContract> treeA = treeOf(blockSize);
+			treeA.insert(rec(1));
+			treeA.insert(rec(2));
+			treeA.insert(rec(3));
+
+			// leaf page B holds keys 2, 3, 4 — a stale-twin shape overlapping A at 2 and 3, so A's last key (3) does
+			// not sort strictly before B's first key (2)
+			final TransactionalElementBPlusTree<PriceRecordContract> treeB = treeOf(blockSize);
+			treeB.insert(rec(2));
+			treeB.insert(rec(3));
+			treeB.insert(rec(4));
+
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> treeOf(blockSize).assembleFromSingleLeafTrees(
+					List.of(treeA, treeB), new int[]{0, 1}, "element B+ tree validation test"
+				),
+				"Overlapping single-leaf trees must fail the cross-leaf-order validation."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("rejects a reassembled leaf page whose interior keys are out of order")
+		void shouldThrowWhenLeafHasOutOfOrderInteriorKeys() {
+			// build a sound single-leaf source tree, then corrupt its interior key order in place to simulate a
+			// serializer bug / truncated write / bit rot; the intra-leaf order check must reject it. This tree keeps no
+			// key array, so the corruption is expressed by swapping two values whose extracted keys then sit out of order
+			final int blockSize = 64;
+			final TransactionalElementBPlusTree<PriceRecordContract> corrupt = treeOf(blockSize);
+			corrupt.insert(rec(1));
+			corrupt.insert(rec(2));
+			corrupt.insert(rec(3));
+			// mutate the live leaf value array directly so the extracted keys become [2, 1, 3]
+			final PriceRecordContract[] values =
+				((TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract>) corrupt.getRoot()).getValues();
+			final PriceRecordContract swap = values[0];
+			values[0] = values[1];
+			values[1] = swap;
+
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> treeOf(blockSize).assembleFromSingleLeafTrees(
+					List.of(corrupt), new int[]{0}, "element B+ tree intra-leaf test"),
+				"A leaf with out-of-order interior keys must fail the intra-leaf-order validation."
+			);
+			assertTrue(
+				ex.getMessage().contains("out-of-order keys"),
+				"Expected the intra-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+
 		/**
 		 * Models the granular write path: walks the leaf handles in order, allocates a fresh page for every unassigned or
 		 * dirty leaf, clears the dirty flag and captures the page contents.
@@ -669,7 +737,9 @@ class TransactionalElementBPlusTreeTest {
 				}
 				pageTrees.add(pageTree);
 			}
-			return treeOf(blockSize).assembleFromSingleLeafTrees(pageTrees, persisted.sequences());
+			return treeOf(blockSize).assembleFromSingleLeafTrees(
+				pageTrees, persisted.sequences(), "element B+ tree reassembly test"
+			);
 		}
 
 		/**
@@ -711,5 +781,394 @@ class TransactionalElementBPlusTreeTest {
 		@Nonnull List<List<PriceRecordContract>> pages,
 		@Nonnull int[] sequences
 	) {
+	}
+
+	@Nested
+	@DisplayName("op-time boundary-mutation asserts")
+	class OpTimeBoundaryMutationTest {
+
+		/**
+		 * Builds a single-leaf source tree holding the supplied keys. Block size 10 keeps every supplied key in one leaf
+		 * (no split), so the tree's root stays a leaf that can be reassembled into a controlled spine. The internal block
+		 * size is fixed at 3 (cap of four children per parent) so the assembled spine is deterministic — the family's
+		 * derived block sizes are deliberately not used here.
+		 *
+		 * @param keys the keys to place in the leaf, in any order
+		 * @return a single-leaf tree
+		 */
+		@Nonnull
+		private TransactionalElementBPlusTree<PriceRecordContract> singleLeaf(@Nonnull int... keys) {
+			final TransactionalElementBPlusTree<PriceRecordContract> tree =
+				new TransactionalElementBPlusTree<>(10, 1, 3, 1, PriceRecordContract.class, KEY);
+			for (final int key : keys) {
+				tree.insert(rec(key));
+			}
+			return tree;
+		}
+
+		/**
+		 * Reassembles the supplied sound single-leaf trees into one tree with a deterministic spine: internal block size 3
+		 * caps a parent at four children, so five leaves split into two parents. The leaves are non-overlapping, so the
+		 * cross-leaf validation inside the assembler passes; the assembled tree is then used to exercise the op-time
+	 * boundary checks
+		 * against hypothetical boundary keys.
+		 *
+		 * @param leaves the ordered, non-overlapping single-leaf trees
+		 * @return the assembled tree
+		 */
+		@Nonnull
+		private TransactionalElementBPlusTree<PriceRecordContract> assembleSound(
+			@Nonnull List<TransactionalElementBPlusTree<PriceRecordContract>> leaves) {
+			final int[] pageSequences = new int[leaves.size()];
+			for (int i = 0; i < pageSequences.length; i++) {
+				pageSequences[i] = i;
+			}
+			return new TransactionalElementBPlusTree<PriceRecordContract>(10, 1, 3, 1, PriceRecordContract.class, KEY)
+				.assembleFromSingleLeafTrees(leaves, pageSequences, "element B+ tree op-time boundary test");
+		}
+
+		@Test
+		@DisplayName("tail insert overlapping the successor leaf under a different parent throws (Check T)")
+		void shouldThrowOnMisroutedTailInsertAcrossParentBoundary() {
+			// spine (internal block 3 => max 4 children => 5 leaves split 3 + 2): P1 = [L0,L1,L2], P2 = [L3,L4].
+			// L2 is the RIGHTMOST child of P1 and its successor L3 is the LEFTMOST child of P2, so the fence
+			// (8 = L3's first key) lives at the ROOT, not L2's immediate parent — this proves the cross-parent walk.
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(3, 4), singleLeaf(5, 6), singleLeaf(8, 9), singleLeaf(10, 11)
+			));
+			final AbstractTransactionalBPlusTree.Cursor cursor = tree.createCursor(5);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tree.assertTailBoundary(cursor, 8),
+				"A new last key equal to the successor leaf's first key must be rejected."
+			);
+			assertTrue(
+				ex.getMessage().contains("successor leaf boundary"),
+				"Expected the tail cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+			// a last key strictly below the fence is legal
+			assertDoesNotThrow(() -> tree.assertTailBoundary(cursor, 7));
+		}
+
+		@Test
+		@DisplayName("head insert undercutting the same-parent predecessor throws (Check H)")
+		void shouldThrowOnMisroutedHeadInsertWithinParent() {
+			// three sound leaves under one parent: L0 = [1,5], L1 = [8,12], L2 = [15,16]. L1's predecessor is its
+			// same-parent left sibling L0 (last key 5). A head key of 3 undercuts it.
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 5), singleLeaf(8, 12), singleLeaf(15, 16)
+			));
+			final AbstractTransactionalBPlusTree.Cursor cursor = tree.createCursor(8);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tree.assertHeadBoundary(cursor, 3),
+				"A new first key at or below the predecessor leaf's last key must be rejected."
+			);
+			assertTrue(
+				ex.getMessage().contains("predecessor leaf boundary"),
+				"Expected the head cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+			// a first key strictly above the predecessor's last key is legal
+			assertDoesNotThrow(() -> tree.assertHeadBoundary(cursor, 6));
+			// the separator-order belt is INSUFFICIENT for this shape: propagating the mis-routed first key (3) up
+			// as L1's separator yields separators (3, 15) which are still strictly increasing, so the belt would
+			// NOT fire — which is exactly why Check H is required
+			assertDoesNotThrow(
+				() -> TransactionalElementBPlusTree.assertSeparatorOrder(new int[]{3, 15}, 2, 0));
+		}
+
+		@Test
+		@DisplayName("head insert undercutting a predecessor under a different parent throws (Check H right-spine)")
+		void shouldThrowOnMisroutedHeadInsertAcrossParentBoundary() {
+			// L3 is the LEFTMOST child of P2; its predecessor L2 is the RIGHTMOST child of P1 (cross-parent). Check
+			// H must walk up to the clamp ancestor (root) and descend P1's right spine to L2 (last key 6).
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(3, 4), singleLeaf(5, 6), singleLeaf(8, 9), singleLeaf(10, 11)
+			));
+			final AbstractTransactionalBPlusTree.Cursor cursor = tree.createCursor(8);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tree.assertHeadBoundary(cursor, 5),
+				"A new first key at or below the cross-parent predecessor's last key must be rejected."
+			);
+			assertTrue(
+				ex.getMessage().contains("predecessor leaf boundary"),
+				"Expected the head cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+			assertDoesNotThrow(() -> tree.assertHeadBoundary(cursor, 7));
+		}
+
+		@Test
+		@DisplayName("both boundary checks apply to a single-key (0 to 1) leaf")
+		void shouldRunBothChecksForSingleKeyLeaf() {
+			// sound tree with a single-key middle leaf L_mid = [6] between L_pred = [1,4] and L_succ = [8,9]
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 4), singleLeaf(6), singleLeaf(8, 9)
+			));
+			final AbstractTransactionalBPlusTree.Cursor cursor = tree.createCursor(6);
+			// the actual 0->1 key (6) is sound: both checks run and pass
+			assertDoesNotThrow(() -> tree.assertInsertBoundaries(cursor, 6));
+			// the SAME single-key leaf is subject to the head check (a smaller key undercuts L_pred's last key 4)
+			assertThrows(GenericEvitaInternalError.class, () -> tree.assertHeadBoundary(cursor, 3));
+			// ...and to the tail check (a larger key reaches L_succ's first key 8)
+			assertThrows(GenericEvitaInternalError.class, () -> tree.assertTailBoundary(cursor, 8));
+		}
+
+		@Test
+		@DisplayName("sequential bulk append and prepend never trip the op-time boundary asserts (happy-path pin)")
+		void shouldNotThrowOnSequentialInsertions() {
+			// ascending inserts are all tail inserts (Check T runs on the rightmost leaf and finds no fence);
+			// descending inserts are all head inserts on the leftmost leaf (Check H finds no predecessor)
+			final TransactionalElementBPlusTree<PriceRecordContract> ascending = treeOf(3);
+			assertDoesNotThrow(() -> {
+				for (int i = 1; i <= 256; i++) {
+					ascending.insert(rec(i));
+				}
+			});
+			final ConsistencyReport ascendingReport = ascending.getConsistencyReport();
+			assertEquals(ConsistencyState.CONSISTENT, ascendingReport.state(), ascendingReport.report());
+
+			final TransactionalElementBPlusTree<PriceRecordContract> descending = treeOf(3);
+			assertDoesNotThrow(() -> {
+				for (int i = 256; i >= 1; i--) {
+					descending.insert(rec(i));
+				}
+			});
+			final ConsistencyReport descendingReport = descending.getConsistencyReport();
+			assertEquals(ConsistencyState.CONSISTENT, descendingReport.state(), descendingReport.report());
+		}
+
+	}
+
+	@Nested
+	@DisplayName("commit-time structural integrity validation")
+	class DirtyLeafScopeValidationTest {
+
+		@Nonnull
+		private TransactionalElementBPlusTree<PriceRecordContract> singleLeaf(@Nonnull int... keys) {
+			final TransactionalElementBPlusTree<PriceRecordContract> tree =
+				new TransactionalElementBPlusTree<>(10, 1, 3, 1, PriceRecordContract.class, KEY);
+			for (final int key : keys) {
+				tree.insert(rec(key));
+			}
+			return tree;
+		}
+
+		@Nonnull
+		private TransactionalElementBPlusTree<PriceRecordContract> assembleSound(
+			@Nonnull List<TransactionalElementBPlusTree<PriceRecordContract>> leaves) {
+			final int[] pageSequences = new int[leaves.size()];
+			for (int i = 0; i < pageSequences.length; i++) {
+				pageSequences[i] = i;
+			}
+			return new TransactionalElementBPlusTree<PriceRecordContract>(10, 1, 3, 1, PriceRecordContract.class, KEY)
+				.assembleFromSingleLeafTrees(leaves, pageSequences, "element B+ tree scope test");
+		}
+
+		@Nonnull
+		private TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract> leafAt(
+			@Nonnull TransactionalElementBPlusTree<PriceRecordContract> tree, int key) {
+			return tree.createCursor(key).leafNode();
+		}
+
+		@Test
+		@DisplayName("a sound dirty scope relocates and validates without throwing")
+		void shouldNotThrowWhenDirtyLeavesAreSound() {
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(
+				leafAt(tree, 1), leafAt(tree, 5), leafAt(tree, 10)
+			)));
+		}
+
+		@Test
+		@DisplayName("a leaf whose last key was widened past its successor is caught (tail)")
+		void shouldDetectTailOverlapOnRelocateAndValidate() {
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			final TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract> middle = leafAt(tree, 5);
+			// simulate a reverted / lifecycle-corrupted layer widening the middle leaf's derived range from [5,6] to
+			// [5,10]: the key is derived from the value, so replacing the value at the peek slot with rec(10) makes its
+			// last key reach the successor's first key; the separator is untouched, so relocating by the leaf's own
+			// first key (5) still lands on it and the tail half-invariant fires
+			middle.getValues()[middle.getPeek()] = rec(10);
+			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> tree.validateDirtyScope(List.<Object>of(middle))
+			);
+			assertTrue(
+				ex.getMessage().contains("successor leaf boundary"),
+				"Expected the tail cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("a leaf undercut by a widened predecessor is caught (head)")
+		void shouldDetectHeadOverlapOnRelocateAndValidate() {
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			// widen the PREDECESSOR leaf's last key from 2 to 5 so it reaches the middle leaf's first key; relocating
+			// the middle leaf by its unchanged first key (5) lands on it and the head half-invariant compares against
+			// the predecessor's corrupted last key
+			final TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract> predecessor = leafAt(tree, 1);
+			predecessor.getValues()[predecessor.getPeek()] = rec(5);
+			final TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract> middle = leafAt(tree, 5);
+			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> tree.validateDirtyScope(List.<Object>of(middle))
+			);
+			assertTrue(
+				ex.getMessage().contains("predecessor leaf boundary"),
+				"Expected the head cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("an empty key source is skipped, not dereferenced")
+		void shouldSkipEmptyKeySource() {
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6)
+			));
+			// an empty single-leaf source carries no key (peek < 0) — the scope validation must skip it rather than
+			// dereference the peek slot
+			final TransactionalElementBPlusTree<PriceRecordContract> empty =
+				new TransactionalElementBPlusTree<>(10, 1, 3, 1, PriceRecordContract.class, KEY);
+			final TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract> emptyLeaf =
+				(TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract>) empty.getRoot();
+			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(emptyLeaf)));
+		}
+
+		/**
+		 * Widens (in place) the effective last key of the leaf that currently routes {@code leafKey}, simulating a
+		 * lifecycle bug that reverted / corrupted the leaf's write layer so its derived range overlaps the successor.
+		 * Mutates the write layer when one exists (the transactional case), otherwise the leaf itself; the key is
+		 * derived from the value, so the peek slot's value is replaced with one deriving {@code newLastKey}.
+		 */
+		private void corruptLastKey(
+			@Nonnull TransactionalElementBPlusTree<PriceRecordContract> tree, int leafKey, int newLastKey) {
+			final TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract> leaf =
+				tree.createCursor(leafKey).leafNode();
+			final TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract> layer =
+				Transaction.getTransactionalMemoryLayerIfExists(leaf);
+			final TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract> writable =
+				layer != null ? layer : leaf;
+			writable.getValues()[writable.getPeek()] = rec(newLastKey);
+		}
+
+		@Test
+		@DisplayName("pre-commit pipeline: a transactional insert registers its leaf and a healthy scope is accepted")
+		void shouldRegisterDirtiedLeafAndAcceptHealthyScope() {
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertStateAfterCommit(
+				tree,
+				t -> {
+					t.insert(rec(7));
+					final TransactionalLayerMaintainer maintainer = Transaction.getTransactionalLayerMaintainer();
+					// registration fired AND the registry is keyed by this exact tree instance — the identity the
+					// pre-commit pass and the post-replay merge both look the scope up by
+					assertFalse(
+						maintainer.getDirtyScopeTokens(t).isEmpty(),
+						"the transactional insert must register its dirtied leaf under this tree"
+					);
+					// the healthy scope must be accepted by the pre-commit pass (no false positive)
+					assertDoesNotThrow(maintainer::validateDirtyScopesBeforeCommit);
+				},
+				(t, committed) -> assertNotNull(committed)
+			);
+		}
+
+		@Test
+		@DisplayName("pre-commit pipeline: a corrupted registered leaf is rejected by the pre-commit pass")
+		void shouldRejectCorruptedScopeInPreCommitPass() {
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> assertStateAfterCommit(
+					tree,
+					t -> {
+						t.insert(rec(7));
+						// widen the dirtied leaf (now [5,6,7]) so its last key reaches the successor's first key (10)
+						corruptLastKey(t, 5, 10);
+						Transaction.getTransactionalLayerMaintainer().validateDirtyScopesBeforeCommit();
+					},
+					(t, committed) -> fail("the pre-commit pass must reject before commit")
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("post-replay pipeline: a corrupted registered leaf is rejected by the commit merge")
+		void shouldRejectCorruptedScopeInCommitMerge() {
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> assertStateAfterCommit(
+					tree,
+					t -> {
+						t.insert(rec(7));
+						// no pre-commit pass here — the commit merge (post-replay, inside
+						// createCopyWithMergedTransactionalMemory) must relocate the registered
+						// leaf in the merged tree and catch the overlap
+						corruptLastKey(t, 5, 10);
+					},
+					(t, committed) -> fail("the commit merge must reject the corrupted scope")
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("Registry hygiene: a remove-only transaction still registers its dirtied leaf")
+		void shouldRegisterLeafOnRemoveOnlyTransaction() {
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertStateAfterCommit(
+				tree,
+				t -> {
+					// a clean remove (min block size 1 → [5,6] becomes [5], no underflow/rebalance) exercises the
+					// delete seam only; a reverted removal layer is exactly what the pre-commit (pre-WAL) and post-replay
+					// (merge-time) dirty-scope validation must be able to relocate
+					t.delete(6);
+					assertFalse(
+						Transaction.getTransactionalLayerMaintainer().getDirtyScopeTokens(t).isEmpty(),
+						"a remove-only transaction must register the leaf it dirtied"
+					);
+				},
+				(t, committed) -> assertNotNull(committed)
+			);
+		}
+
+		@Test
+		@DisplayName("Registry hygiene: a leaf split registers both halves")
+		void shouldRegisterBothHalvesOnLeafSplit() {
+			// block size 3 splits the root leaf as these four keys are inserted
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = treeOf(3);
+			assertStateAfterCommit(
+				tree,
+				t -> {
+					t.insert(rec(1));
+					t.insert(rec(2));
+					t.insert(rec(3));
+					t.insert(rec(4));
+					// the split must register BOTH leaf halves; the identity-set size collapses to 1 if only one half
+					// was registered (or one object was registered twice), which fails this assertion
+					assertTrue(
+						Transaction.getTransactionalLayerMaintainer().getDirtyScopeTokens(t).size() >= 2,
+						"a leaf split must register both halves"
+					);
+				},
+				(t, committed) -> assertNotNull(committed)
+			);
+		}
+
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTreeTest.java
@@ -26,6 +26,8 @@ package io.evitadb.index.bPlusTree;
 import io.evitadb.dataType.ConsistencySensitiveDataStructure.ConsistencyReport;
 import io.evitadb.dataType.ConsistencySensitiveDataStructure.ConsistencyState;
 import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.core.transaction.Transaction;
+import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.index.bPlusTree.TransactionalLongBPlusTree.Entry;
 import io.evitadb.index.bitmap.TransactionalBitmap;
 import io.evitadb.index.list.TransactionalList;
@@ -2860,6 +2862,474 @@ class TransactionalLongBPlusTreeTest {
 					final TransactionalList<String> list2 = committed.search(2).orElseThrow();
 					assertEquals(2, list2.size());
 				}
+			);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Assemble from single-leaf trees validation")
+	class AssembleFromSingleLeafTreesValidationTest {
+
+		@Test
+		@DisplayName("rejects reassembled single-leaf pages that overlap across a leaf boundary")
+		void shouldThrowWhenSingleLeafTreesOverlapAcrossBoundary() {
+			// two single-leaf source trees whose key ranges overlap (a stale leaf-page twin shape):
+			// leaf A ends at key 3 while leaf B restarts at key 2, so cross-leaf-order validation
+			// must reject them; block size 5 keeps three keys in one leaf so getRoot() is a leaf
+			final TransactionalLongBPlusTree<String> treeA = new TransactionalLongBPlusTree<>(5, 1, 5, 2, String.class);
+			treeA.insert(1L, "Value1");
+			treeA.insert(2L, "Value2");
+			treeA.insert(3L, "Value3");
+
+			final TransactionalLongBPlusTree<String> treeB = new TransactionalLongBPlusTree<>(5, 1, 5, 2, String.class);
+			treeB.insert(2L, "Value2");
+			treeB.insert(3L, "Value3");
+			treeB.insert(4L, "Value4");
+
+			final TransactionalLongBPlusTree<String> assembled = new TransactionalLongBPlusTree<>(5, 1, 5, 2, String.class);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> assembled.assembleFromSingleLeafTrees(
+					List.of(treeA, treeB), new int[]{0, 1}, "long B+ tree validation test"),
+				"Overlapping single-leaf trees must fail the cross-leaf-order validation."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("rejects a reassembled leaf page whose interior keys are out of order")
+		void shouldThrowWhenLeafHasOutOfOrderInteriorKeys() {
+			// build a sound single-leaf source tree, then corrupt its interior key order in place (swap two keys)
+			// to simulate a serializer bug / truncated write / bit rot; the intra-leaf order check must reject it
+			final TransactionalLongBPlusTree<String> corrupt =
+				new TransactionalLongBPlusTree<>(10, 1, 3, 1, String.class);
+			corrupt.insert(1L, "Value1");
+			corrupt.insert(2L, "Value2");
+			corrupt.insert(3L, "Value3");
+			// mutate the live leaf key array directly: [1,2,3] -> [2,1,3]
+			final long[] keys =
+				((TransactionalLongBPlusTree.BPlusLeafTreeNode<String>) corrupt.getRoot()).getKeys();
+			final long swap = keys[0];
+			keys[0] = keys[1];
+			keys[1] = swap;
+
+			final TransactionalLongBPlusTree<String> assembled =
+				new TransactionalLongBPlusTree<>(10, 1, 3, 1, String.class);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> assembled.assembleFromSingleLeafTrees(
+					List.of(corrupt), new int[]{0}, "long B+ tree intra-leaf test"),
+				"A leaf with out-of-order interior keys must fail the intra-leaf-order validation."
+			);
+			assertTrue(
+				ex.getMessage().contains("out-of-order keys"),
+				"Expected the intra-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Op-time boundary-mutation asserts")
+	class OpTimeBoundaryMutationTest {
+
+		/**
+		 * Builds a single-leaf source tree holding the supplied keys. Block size 10 keeps every supplied key in
+		 * one leaf (no split), so the tree's root stays a leaf that can be reassembled into a controlled spine.
+		 *
+		 * @param keys the keys to place in the leaf, in any order
+		 * @return a single-leaf tree
+		 */
+		@Nonnull
+		private TransactionalLongBPlusTree<String> singleLeaf(@Nonnull long... keys) {
+			final TransactionalLongBPlusTree<String> tree =
+				new TransactionalLongBPlusTree<>(10, 1, 3, 1, String.class);
+			for (final long key : keys) {
+				tree.insert(key, "v" + key);
+			}
+			return tree;
+		}
+
+		/**
+		 * Reassembles the supplied sound single-leaf trees into one tree with a deterministic spine: internal
+		 * block size 3 caps a parent at four children, so five leaves split into two parents. The leaves are
+		 * non-overlapping, so the Phase 1 cross-leaf validation inside the assembler passes; the assembled tree is
+		 * then used to exercise the op-time boundary checks against hypothetical boundary keys.
+		 *
+		 * @param leaves the ordered, non-overlapping single-leaf trees
+		 * @return the assembled tree
+		 */
+		@Nonnull
+		private TransactionalLongBPlusTree<String> assembleSound(
+			@Nonnull List<TransactionalLongBPlusTree<String>> leaves) {
+			final int[] pageSequences = new int[leaves.size()];
+			for (int i = 0; i < pageSequences.length; i++) {
+				pageSequences[i] = i;
+			}
+			return new TransactionalLongBPlusTree<String>(10, 1, 3, 1, String.class)
+				.assembleFromSingleLeafTrees(leaves, pageSequences, "long B+ tree op-time boundary test");
+		}
+
+		@Test
+		@DisplayName("tail insert overlapping the successor leaf under a different parent throws (Check T)")
+		void shouldThrowOnMisroutedTailInsertAcrossParentBoundary() {
+			// spine (internal block 3 => max 4 children => 5 leaves split 3 + 2): P1 = [L0,L1,L2], P2 = [L3,L4].
+			// L2 is the RIGHTMOST child of P1 and its successor L3 is the LEFTMOST child of P2, so the fence
+			// (8 = L3's first key) lives at the ROOT, not L2's immediate parent — this proves the cross-parent walk.
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(3, 4), singleLeaf(5, 6), singleLeaf(8, 9), singleLeaf(10, 11)
+			));
+			final AbstractTransactionalBPlusTree.Cursor cursor = tree.createCursor(5);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tree.assertTailBoundary(cursor, 8),
+				"A new last key equal to the successor leaf's first key must be rejected."
+			);
+			assertTrue(
+				ex.getMessage().contains("successor leaf boundary"),
+				"Expected the tail cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+			// a last key strictly below the fence is legal
+			assertDoesNotThrow(() -> tree.assertTailBoundary(cursor, 7));
+		}
+
+		@Test
+		@DisplayName("head insert undercutting the same-parent predecessor throws (Check H)")
+		void shouldThrowOnMisroutedHeadInsertWithinParent() {
+			// three sound leaves under one parent: L0 = [1,5], L1 = [8,12], L2 = [15,16]. L1's predecessor is its
+			// same-parent left sibling L0 (last key 5). A head key of 3 undercuts it.
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 5), singleLeaf(8, 12), singleLeaf(15, 16)
+			));
+			final AbstractTransactionalBPlusTree.Cursor cursor = tree.createCursor(8);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tree.assertHeadBoundary(cursor, 3),
+				"A new first key at or below the predecessor leaf's last key must be rejected."
+			);
+			assertTrue(
+				ex.getMessage().contains("predecessor leaf boundary"),
+				"Expected the head cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+			// a first key strictly above the predecessor's last key is legal
+			assertDoesNotThrow(() -> tree.assertHeadBoundary(cursor, 6));
+			// the separator-order belt is INSUFFICIENT for this shape: propagating the mis-routed first key (3) up
+			// as L1's separator yields separators (3, 15) which are still strictly increasing, so the belt would
+			// NOT fire — which is exactly why Check H is required
+			assertDoesNotThrow(
+				() -> TransactionalLongBPlusTree.assertSeparatorOrder(new long[]{3, 15}, 2, 0));
+		}
+
+		@Test
+		@DisplayName("head insert undercutting a predecessor under a different parent throws (Check H right-spine)")
+		void shouldThrowOnMisroutedHeadInsertAcrossParentBoundary() {
+			// L3 is the LEFTMOST child of P2; its predecessor L2 is the RIGHTMOST child of P1 (cross-parent). Check
+			// H must walk up to the clamp ancestor (root) and descend P1's right spine to L2 (last key 6).
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(3, 4), singleLeaf(5, 6), singleLeaf(8, 9), singleLeaf(10, 11)
+			));
+			final AbstractTransactionalBPlusTree.Cursor cursor = tree.createCursor(8);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> tree.assertHeadBoundary(cursor, 5),
+				"A new first key at or below the cross-parent predecessor's last key must be rejected."
+			);
+			assertTrue(
+				ex.getMessage().contains("predecessor leaf boundary"),
+				"Expected the head cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+			assertDoesNotThrow(() -> tree.assertHeadBoundary(cursor, 7));
+		}
+
+		@Test
+		@DisplayName("both boundary checks apply to a single-key (0 to 1) leaf")
+		void shouldRunBothChecksForSingleKeyLeaf() {
+			// sound tree with a single-key middle leaf L_mid = [6] between L_pred = [1,4] and L_succ = [8,9]
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 4), singleLeaf(6), singleLeaf(8, 9)
+			));
+			final AbstractTransactionalBPlusTree.Cursor cursor = tree.createCursor(6);
+			// the actual 0->1 key (6) is sound: both checks run and pass
+			assertDoesNotThrow(() -> tree.assertInsertBoundaries(cursor, 6));
+			// the SAME single-key leaf is subject to the head check (a smaller key undercuts L_pred's last key 4)
+			assertThrows(GenericEvitaInternalError.class, () -> tree.assertHeadBoundary(cursor, 3));
+			// ...and to the tail check (a larger key reaches L_succ's first key 8)
+			assertThrows(GenericEvitaInternalError.class, () -> tree.assertTailBoundary(cursor, 8));
+		}
+
+		@Test
+		@DisplayName("sequential bulk append and prepend never trip the op-time boundary asserts (happy-path pin)")
+		void shouldNotThrowOnSequentialInsertions() {
+			// ascending inserts are all tail inserts (Check T runs on the rightmost leaf and finds no fence);
+			// descending inserts are all head inserts on the leftmost leaf (Check H finds no predecessor)
+			final TransactionalLongBPlusTree<String> ascending = new TransactionalLongBPlusTree<>(3, String.class);
+			assertDoesNotThrow(() -> {
+				for (long i = 1; i <= 256; i++) {
+					ascending.insert(i, "v" + i);
+				}
+			});
+			final ConsistencyReport ascendingReport = ascending.getConsistencyReport();
+			assertEquals(ConsistencyState.CONSISTENT, ascendingReport.state(), ascendingReport.report());
+
+			final TransactionalLongBPlusTree<String> descending = new TransactionalLongBPlusTree<>(3, String.class);
+			assertDoesNotThrow(() -> {
+				for (long i = 256; i >= 1; i--) {
+					descending.insert(i, "v" + i);
+				}
+			});
+			final ConsistencyReport descendingReport = descending.getConsistencyReport();
+			assertEquals(ConsistencyState.CONSISTENT, descendingReport.state(), descendingReport.report());
+		}
+
+	}
+
+	@Nested
+	@DisplayName("commit-time structural integrity validation")
+	class DirtyLeafScopeValidationTest {
+
+		@Nonnull
+		private TransactionalLongBPlusTree<String> singleLeaf(@Nonnull long... keys) {
+			final TransactionalLongBPlusTree<String> tree =
+				new TransactionalLongBPlusTree<>(10, 1, 3, 1, String.class);
+			for (final long key : keys) {
+				tree.insert(key, "v" + key);
+			}
+			return tree;
+		}
+
+		@Nonnull
+		private TransactionalLongBPlusTree<String> assembleSound(
+			@Nonnull List<TransactionalLongBPlusTree<String>> leaves) {
+			final int[] pageSequences = new int[leaves.size()];
+			for (int i = 0; i < pageSequences.length; i++) {
+				pageSequences[i] = i;
+			}
+			return new TransactionalLongBPlusTree<String>(10, 1, 3, 1, String.class)
+				.assembleFromSingleLeafTrees(leaves, pageSequences, "long B+ tree scope test");
+		}
+
+		@Nonnull
+		private TransactionalLongBPlusTree.BPlusLeafTreeNode<String> leafAt(
+			@Nonnull TransactionalLongBPlusTree<String> tree, long key) {
+			return tree.createCursor(key).leafNode();
+		}
+
+		@Test
+		@DisplayName("a sound dirty scope relocates and validates without throwing")
+		void shouldNotThrowWhenDirtyLeavesAreSound() {
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(
+				leafAt(tree, 1), leafAt(tree, 5), leafAt(tree, 10)
+			)));
+		}
+
+		@Test
+		@DisplayName("a leaf whose last key was widened past its successor is caught (tail)")
+		void shouldDetectTailOverlapOnRelocateAndValidate() {
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			final TransactionalLongBPlusTree.BPlusLeafTreeNode<String> middle = leafAt(tree, 5);
+			// simulate a reverted / lifecycle-corrupted layer widening the middle leaf's range from [5,6] to [5,10]
+			// so its last key reaches the successor's first key; the separator is untouched, so relocating by the
+			// leaf's own first key (5) still lands on it and the tail half-invariant fires
+			final long[] keys = middle.getKeys();
+			keys[1] = 10L;
+			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> tree.validateDirtyScope(List.<Object>of(middle))
+			);
+			assertTrue(
+				ex.getMessage().contains("successor leaf boundary"),
+				"Expected the tail cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("a leaf undercut by a widened predecessor is caught (head)")
+		void shouldDetectHeadOverlapOnRelocateAndValidate() {
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			// widen the PREDECESSOR leaf's last key from 2 to 5 so it reaches the middle leaf's first key; relocating
+			// the middle leaf by its unchanged first key (5) lands on it and the head half-invariant compares against
+			// the predecessor's corrupted last key
+			final long[] predecessorKeys = leafAt(tree, 1).getKeys();
+			predecessorKeys[1] = 5L;
+			final TransactionalLongBPlusTree.BPlusLeafTreeNode<String> middle = leafAt(tree, 5);
+			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> tree.validateDirtyScope(List.<Object>of(middle))
+			);
+			assertTrue(
+				ex.getMessage().contains("predecessor leaf boundary"),
+				"Expected the head cross-leaf diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("an empty key source is skipped, not dereferenced")
+		void shouldSkipEmptyKeySource() {
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6)
+			));
+			// an empty single-leaf source carries no key (peek < 0) — the scope validation must skip it rather than
+			// dereference keys[0]
+			final TransactionalLongBPlusTree<String> empty = new TransactionalLongBPlusTree<>(10, 1, 3, 1, String.class);
+			final TransactionalLongBPlusTree.BPlusLeafTreeNode<String> emptyLeaf =
+				(TransactionalLongBPlusTree.BPlusLeafTreeNode<String>) empty.getRoot();
+			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(emptyLeaf)));
+		}
+
+		/**
+		 * Widens (in place) the effective last key of the leaf that currently routes {@code leafKey}, simulating a
+		 * lifecycle bug that reverted / corrupted the leaf's write layer so its range overlaps the successor. Mutates
+		 * the write layer when one exists (the transactional case), otherwise the leaf itself.
+		 */
+		private void corruptLastKey(
+			@Nonnull TransactionalLongBPlusTree<String> tree, long leafKey, long newLastKey) {
+			final TransactionalLongBPlusTree.BPlusLeafTreeNode<String> leaf = tree.createCursor(leafKey).leafNode();
+			final TransactionalLongBPlusTree.BPlusLeafTreeNode<String> layer =
+				Transaction.getTransactionalMemoryLayerIfExists(leaf);
+			final TransactionalLongBPlusTree.BPlusLeafTreeNode<String> writable = layer != null ? layer : leaf;
+			writable.getKeys()[writable.getPeek()] = newLastKey;
+		}
+
+		@Test
+		@DisplayName("pre-commit pipeline: a transactional insert registers its leaf and a healthy scope is accepted")
+		void shouldRegisterDirtiedLeafAndAcceptHealthyScope() {
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertStateAfterCommit(
+				tree,
+				t -> {
+					t.insert(7, "v7");
+					final TransactionalLayerMaintainer maintainer = Transaction.getTransactionalLayerMaintainer();
+					// registration fired AND the registry is keyed by this exact tree instance — the identity the
+					// pre-commit (pre-WAL) pass and the post-replay merge both look the scope up by
+					assertFalse(
+						maintainer.getDirtyScopeTokens(t).isEmpty(),
+						"the transactional insert must register its dirtied leaf under this tree"
+					);
+					// the healthy scope must be accepted by the pre-commit pass (no false positive)
+					assertDoesNotThrow(maintainer::validateDirtyScopesBeforeCommit);
+				},
+				(t, committed) -> assertNotNull(committed)
+			);
+		}
+
+		@Test
+		@DisplayName("pre-commit pipeline: a corrupted registered leaf is rejected by the pre-commit pass")
+		void shouldRejectCorruptedScopeInPreCommitPass() {
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> assertStateAfterCommit(
+					tree,
+					t -> {
+						t.insert(7, "v7");
+						// widen the dirtied leaf (now [5,6,7]) so its last key reaches the successor's first key (10)
+						corruptLastKey(t, 5, 10L);
+						Transaction.getTransactionalLayerMaintainer().validateDirtyScopesBeforeCommit();
+					},
+					(t, committed) -> fail("the pre-commit pass must reject before commit")
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("post-replay pipeline: a corrupted registered leaf is rejected by the commit merge")
+		void shouldRejectCorruptedScopeInCommitMerge() {
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertThrows(
+				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
+				() -> assertStateAfterCommit(
+					tree,
+					t -> {
+						t.insert(7, "v7");
+						// no pre-commit pass here — the commit merge (post-replay, inside createCopyWithMergedTransactionalMemory)
+						// must relocate the registered leaf in the merged tree and catch the overlap
+						corruptLastKey(t, 5, 10L);
+					},
+					(t, committed) -> fail("the commit merge must reject the corrupted scope")
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("pre-commit pipeline: a rolled-back savepoint does not spuriously reject the commit")
+		void shouldNotRejectAfterSavepointRollback() {
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertStateAfterCommit(
+				tree,
+				t -> {
+					final TransactionalLayerMaintainer maintainer = Transaction.getTransactionalLayerMaintainer();
+					final TransactionalLayerMaintainer.Savepoint savepoint = maintainer.openSavepoint();
+					t.insert(7, "v7");
+					// the insert registered the dirtied leaf inside the savepoint; rolling the savepoint back reverts
+					// the leaf, leaving the registered object stale — but relocating by its key lands on a healthy
+					// leaf, so the pre-commit pass must NOT spuriously reject
+					maintainer.rollbackSavepoint(savepoint);
+					assertDoesNotThrow(maintainer::validateDirtyScopesBeforeCommit);
+				},
+				(t, committed) -> assertNotNull(committed)
+			);
+		}
+
+		@Test
+		@DisplayName("Registry hygiene: a remove-only transaction still registers its dirtied leaf")
+		void shouldRegisterLeafOnRemoveOnlyTransaction() {
+			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
+				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
+			));
+			assertStateAfterCommit(
+				tree,
+				t -> {
+					// a clean remove (min block size 1 → [5,6] becomes [5], no underflow/rebalance) exercises the
+					// delete seam only; a reverted removal layer is exactly what the commit-time passes must be able to relocate
+					t.delete(6);
+					assertFalse(
+						Transaction.getTransactionalLayerMaintainer().getDirtyScopeTokens(t).isEmpty(),
+						"a remove-only transaction must register the leaf it dirtied"
+					);
+				},
+				(t, committed) -> assertNotNull(committed)
+			);
+		}
+
+		@Test
+		@DisplayName("Registry hygiene: a leaf split registers both halves")
+		void shouldRegisterBothHalvesOnLeafSplit() {
+			// block size 3 splits the root leaf as these four keys are inserted (mirrors shouldSplitNodeWhenFull)
+			final TransactionalLongBPlusTree<String> tree = new TransactionalLongBPlusTree<>(3, String.class);
+			assertStateAfterCommit(
+				tree,
+				t -> {
+					t.insert(1, "v1");
+					t.insert(2, "v2");
+					t.insert(3, "v3");
+					t.insert(4, "v4");
+					// the split must register BOTH leaf halves; the identity-set size collapses to 1 if only one half
+					// was registered (or one object was registered twice), which fails this assertion
+					assertTrue(
+						Transaction.getTransactionalLayerMaintainer().getDirtyScopeTokens(t).size() >= 2,
+						"a leaf split must register both halves"
+					);
+				},
+				(t, committed) -> assertNotNull(committed)
 			);
 		}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndexPagingRoundTripTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndexPagingRoundTripTest.java
@@ -627,7 +627,7 @@ class ReferenceTypeCardinalityIndexPagingRoundTripTest implements EvitaTestSuppo
 			perPagePayloads[i] = leafPage.getPayloads();
 		}
 		return ReferenceTypeCardinalityIndex.fromPersistedPages(
-			orderedPageSequences, perPageKeys, perPagePayloads,
+			"reference `test`", orderedPageSequences, perPageKeys, perPagePayloads,
 			root.getHighWaterPageSequence(), root.getReferencedPrimaryKeysIndex()
 		);
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndexStaleLeafPageTwinTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndexStaleLeafPageTwinTest.java
@@ -1,0 +1,184 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.cardinality;
+
+import io.evitadb.exception.GenericEvitaInternalError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that reloading a {@link ReferenceTypeCardinalityIndex} from its persisted leaf pages detects the "stale
+ * leaf-page twin" corruption and fails fast: the persisted leaf-page list can end up referencing both a frozen,
+ * superseded leaf page and the newer page that replaced it (the twin), with the two pages covering an overlapping run of
+ * composed keys. The composed-key → count map is backed by a UNIQUE `long`-keyed bucket tree persisted per leaf page;
+ * its spine builder used to assemble such a twin silently — duplicating a run of composed keys in a UNIQUE tree and
+ * misrouting later cardinality lookups.
+ *
+ * The reassembler now validates strict cross-leaf key order, so the reload must reject any twin with a
+ * {@link GenericEvitaInternalError} rather than attempting to heal it — regardless of the overlap shape (a provable
+ * strict-prefix twin whose keys are an exact prefix of the superseding leaf's keys, or a same-key twin whose cardinality
+ * count diverges from its superseder).
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(INDEXING)
+@Tag(REFERENCE)
+@DisplayName("Stale leaf-page twin fails fast on the ReferenceTypeCardinalityIndex reload path")
+class ReferenceTypeCardinalityIndexStaleLeafPageTwinTest {
+
+	private static final int TWIN_PREFIX_SIZE = 128;
+	private static final int GROWN_PAGE_SIZE = 190;
+
+	/**
+	 * Returns the `i`-th composed key (distinct ascending signed `long`s).
+	 *
+	 * @param i the key ordinal
+	 * @return the composed key
+	 */
+	private static long key(int i) {
+		return 100_000L + i;
+	}
+
+	/**
+	 * Returns the cardinality count stored at the `i`-th key (distinct, so a diverged count is observable).
+	 *
+	 * @param i the key ordinal
+	 * @return the cardinality count
+	 */
+	private static long count(int i) {
+		return 1L + i;
+	}
+
+	/**
+	 * Builds the key column of a page for the ordinals `[from, to)`.
+	 */
+	@Nonnull
+	private static long[] keyPage(int from, int to) {
+		final long[] keys = new long[to - from];
+		for (int i = from; i < to; i++) {
+			keys[i - from] = key(i);
+		}
+		return keys;
+	}
+
+	/**
+	 * Builds the count column of a page for the ordinals `[from, to)`.
+	 */
+	@Nonnull
+	private static long[] countPage(int from, int to) {
+		final long[] counts = new long[to - from];
+		for (int i = from; i < to; i++) {
+			counts[i - from] = count(i);
+		}
+		return counts;
+	}
+
+	/**
+	 * Loads a {@link ReferenceTypeCardinalityIndex} from the passed persisted pages the way the catalog-open path does
+	 * (see `ReferenceTypeCardinalityLoader`): page sequences `0..n-1`, an empty referenced-primary-keys companion.
+	 *
+	 * @param keyPages   the per-page key columns
+	 * @param countPages the per-page count columns, positionally aligned with `keyPages`
+	 * @return the rebuilt index
+	 */
+	@Nonnull
+	private static ReferenceTypeCardinalityIndex loadFromPersistedPages(@Nonnull long[][] keyPages, @Nonnull long[][] countPages) {
+		final int[] pageSequences = new int[keyPages.length];
+		for (int i = 0; i < keyPages.length; i++) {
+			pageSequences[i] = i;
+		}
+		return ReferenceTypeCardinalityIndex.fromPersistedPages(
+			"reference `categories`", pageSequences, keyPages, countPages, keyPages.length - 1, Map.of()
+		);
+	}
+
+	@Nested
+	@DisplayName("Strict-prefix twin fails fast")
+	class FailFastTest {
+
+		@Test
+		@DisplayName("should throw on a stale strict-prefix twin page instead of silently healing it")
+		void shouldThrowOnStrictPrefixTwin() {
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					new long[][]{
+						keyPage(0, TWIN_PREFIX_SIZE),
+						keyPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						keyPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE)
+					},
+					new long[][]{
+						countPage(0, TWIN_PREFIX_SIZE),
+						countPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						countPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE)
+					}
+				),
+				"A stale leaf-page twin must fail fast on reload rather than being silently healed."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Unhealable overlap fails fast")
+	class HardFailureTest {
+
+		@Test
+		@DisplayName("should throw on a same-key twin whose cardinality count diverges from its superseder")
+		void shouldRefuseDivergedCountTwin() {
+			final long[] divergedCounts = countPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE);
+			// same composed key as the twin's first key, but a different cardinality count => not a provable strict prefix
+			divergedCounts[0] = count(TWIN_PREFIX_SIZE) + 999L;
+			assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					new long[][]{
+						keyPage(0, TWIN_PREFIX_SIZE),
+						keyPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						keyPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE)
+					},
+					new long[][]{
+						countPage(0, TWIN_PREFIX_SIZE),
+						countPage(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+						divergedCounts
+					}
+				),
+				"A same-key twin with a diverged cardinality count is an unknown corruption shape and must fail fast."
+			);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndexTest.java
@@ -839,14 +839,14 @@ class ReferenceTypeCardinalityIndexTest {
 			assertThrows(
 				GenericEvitaInternalError.class,
 				() -> ReferenceTypeCardinalityIndex.fromPersistedPages(
-					new int[0], new long[0][], new long[0][], 0, Collections.emptyMap()
+					"reference `test`", new int[0], new long[0][], new long[0][], 0, Collections.emptyMap()
 				)
 			);
 			// the alignment premise: the page-sequence count must match the leaf-page array counts
 			assertThrows(
 				GenericEvitaInternalError.class,
 				() -> ReferenceTypeCardinalityIndex.fromPersistedPages(
-					new int[]{0, 1}, new long[][]{{10L}}, new long[][]{{1L}}, 1, Collections.emptyMap()
+					"reference `test`", new int[]{0, 1}, new long[][]{{10L}}, new long[][]{{1L}}, 1, Collections.emptyMap()
 				)
 			);
 		}
@@ -860,7 +860,8 @@ class ReferenceTypeCardinalityIndexTest {
 			final long[] seedPayloads = {1L, 2L, 3L};
 			final ReferenceTypeCardinalityIndex index =
 				ReferenceTypeCardinalityIndex.fromPersistedPages(
-					new int[]{0}, new long[][]{seedKeys}, new long[][]{seedPayloads}, 0, Collections.emptyMap()
+					"reference `test`", new int[]{0}, new long[][]{seedKeys}, new long[][]{seedPayloads}, 0,
+					Collections.emptyMap()
 				);
 
 			assertFalse(index.isPaged(), "a single leaf page must reassemble as SINGLE");

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndexStaleLeafPageTwinTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndexStaleLeafPageTwinTest.java
@@ -1,0 +1,172 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.price;
+
+import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.index.price.model.PriceIndexKey;
+import io.evitadb.index.price.model.priceRecord.PriceRecord;
+import io.evitadb.index.price.model.priceRecord.PriceRecordContract;
+import io.evitadb.index.range.RangeIndex;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Currency;
+
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.PRICE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduces the stale leaf-page twin corruption on the {@link PriceListAndCurrencyPriceSuperIndex} paged restore
+ * path: a writer race can leave a frozen stale snapshot of a leaf page persisted alongside the page that superseded
+ * it. The price-record tree is an element-keyed `TransactionalElementBPlusTree` (keyed by `internalPriceId`)
+ * persisted per leaf page; the spine builder validates strict cross-leaf key order, so a twin whose key run overlaps
+ * its successor leaf page (the corruption shape that previously loaded silently and, amplified, fed the SAME price
+ * record twice into {@code EntityPrices.addPriceRecord}) is now detected at reassembly.
+ *
+ * The reload must reject any such twin with {@link GenericEvitaInternalError} — it fails fast at
+ * {@link PriceListAndCurrencyPriceSuperIndex#fromPersistedPages} rather than assembling a corrupt index.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(INDEXING)
+@Tag(PRICE)
+@DisplayName("Stale leaf-page twin fails fast on the PriceListAndCurrencyPriceSuperIndex reload path")
+class PriceListAndCurrencyPriceSuperIndexStaleLeafPageTwinTest {
+
+	private static final PriceIndexKey PRICE_INDEX_KEY = new PriceIndexKey(
+		"basic", Currency.getInstance("EUR"), PriceInnerRecordHandling.NONE
+	);
+	/**
+	 * Twin/successor page sizes mirror the observed corruption shape (a strict-prefix twin next to a longer successor
+	 * that grew before the frozen twin was superseded) but are scaled to fit within a single element-tree leaf (default
+	 * block size 64) — a persisted leaf page is always one leaf, so both must stay under that capacity.
+	 */
+	private static final int TWIN_PREFIX_SIZE = 30;
+	private static final int GROWN_PAGE_SIZE = 50;
+	/** First internal price id of the twin/superseder run (1-based to avoid a 0 internal price id). */
+	private static final int TWIN_BASE = 1 + TWIN_PREFIX_SIZE;
+
+	/**
+	 * Produces a distinct price record keyed on its internal price id, with `entityPrimaryKey == internalPriceId` so a
+	 * duplicated record surfaces in that entity's {@code EntityPrices}. Content is derivable from the key, so a twin's
+	 * prefix record is byte-identical to the superseding page's record.
+	 *
+	 * @param internalPriceId the internal price id (the tree key and the owning entity primary key)
+	 * @return the price record
+	 */
+	@Nonnull
+	private static PriceRecord rec(int internalPriceId) {
+		return new PriceRecord(
+			internalPriceId, internalPriceId + 1000, internalPriceId, internalPriceId * 100 + 21, internalPriceId * 100
+		);
+	}
+
+	/**
+	 * Builds a page of price records for the internal-price-id ordinals `[from, to)`.
+	 *
+	 * @param from the first ordinal (inclusive)
+	 * @param to   the last ordinal (exclusive)
+	 * @return the page records in ascending internal-price-id order
+	 */
+	@Nonnull
+	private static PriceRecordContract[] page(int from, int to) {
+		final PriceRecordContract[] records = new PriceRecordContract[to - from];
+		for (int i = from; i < to; i++) {
+			records[i - from] = rec(i);
+		}
+		return records;
+	}
+
+	/**
+	 * Loads a {@link PriceListAndCurrencyPriceSuperIndex} from the passed persisted pages the way the catalog-open path
+	 * does (see `PriceSuperIndexLoader`): page sequences `0..n-1`, an empty validity index.
+	 *
+	 * @param pages the persisted leaf pages in list order
+	 * @return the rebuilt index
+	 */
+	@Nonnull
+	private static PriceListAndCurrencyPriceSuperIndex loadFromPersistedPages(@Nonnull PriceRecordContract[]... pages) {
+		final int[] pageSequences = new int[pages.length];
+		for (int i = 0; i < pages.length; i++) {
+			pageSequences[i] = i;
+		}
+		return PriceListAndCurrencyPriceSuperIndex.fromPersistedPages(
+			PRICE_INDEX_KEY, new RangeIndex(), pageSequences, pages, pages.length - 1
+		);
+	}
+
+	@Nested
+	@DisplayName("Strict-prefix twin fails fast")
+	class FailFastTest {
+
+		@Test
+		@DisplayName("should throw on a stale strict-prefix twin page instead of assembling a corrupt index")
+		void shouldThrowOnStrictPrefixTwin() {
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					// healthy predecessor page (internal price ids 1..TWIN_PREFIX_SIZE)
+					page(1, 1 + TWIN_PREFIX_SIZE),
+					// the frozen STALE twin (page sequence 1): internal price ids TWIN_BASE .. TWIN_BASE+TWIN_PREFIX_SIZE
+					page(TWIN_BASE, TWIN_BASE + TWIN_PREFIX_SIZE),
+					// the superseder (page sequence 2): same prefix plus later ids
+					page(TWIN_BASE, TWIN_BASE + GROWN_PAGE_SIZE)
+				),
+				"A stale leaf-page twin must fail fast on reload instead of loading silently."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Unhealable overlap fails fast")
+	class HardFailureTest {
+
+		@Test
+		@DisplayName("should throw on a same-price-id twin whose price record diverges from its superseder")
+		void shouldRefuseDivergedPriceRecordTwin() {
+			final PriceRecordContract[] divergedSuperseder = page(TWIN_BASE, TWIN_BASE + GROWN_PAGE_SIZE);
+			// same internal price id as the twin's first record, but a different price amount => not a strict prefix
+			divergedSuperseder[0] = new PriceRecord(TWIN_BASE, TWIN_BASE + 1000, TWIN_BASE, 424_242, 424_200);
+			assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					page(1, 1 + TWIN_PREFIX_SIZE),
+					page(TWIN_BASE, TWIN_BASE + TWIN_PREFIX_SIZE),
+					divergedSuperseder
+				),
+				"A same-price-id twin with a diverged price record is an unknown corruption shape and must fail fast."
+			);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/range/RangeIndexStaleLeafPageTwinTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/range/RangeIndexStaleLeafPageTwinTest.java
@@ -1,0 +1,202 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.range;
+
+import io.evitadb.exception.GenericEvitaInternalError;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.FILTER;
+import static io.evitadb.test.TestTags.INDEXING;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduces the stale leaf-page twin corruption on the {@link RangeIndex} paged restore path. A `PAGED` range index
+ * persists one leaf page per B+ tree leaf and a root part listing the ordered leaf-page sequences;
+ * {@link RangeIndex#fromPersistedPages} re-assembles one in-memory leaf per persisted page. Its
+ * {@code TransactionalLongBPlusTree.assembleFromSingleLeafTrees} spine builder takes each leaf's left boundary
+ * threshold as a separator — so a frozen stale leaf referenced alongside the page that superseded it (the twin) would
+ * duplicate a run of thresholds and their starts/ends bitmaps if it were loaded silently.
+ *
+ * The reassembler now validates strict cross-leaf key order: the reload must reject any twin (or any other overlapping
+ * leaf-page sequence) with a {@link GenericEvitaInternalError} rather than loading silently corrupted state.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@Tag(FILTER)
+@DisplayName("Stale leaf-page twin fails fast on the RangeIndex reload path")
+class RangeIndexStaleLeafPageTwinTest {
+
+	/**
+	 * Threshold base of the synthesized key space; the concrete values are irrelevant, monotonic spacing matters.
+	 */
+	private static final long BASE = 1_000L;
+	/**
+	 * Number of range points in the frozen (stale) twin page — sized well past a trivial one- or two-point page so the
+	 * strict-prefix comparison exercises a realistic multi-hundred-entry leaf.
+	 */
+	private static final int TWIN_PREFIX_SIZE = 128;
+	/**
+	 * Number of range points the superseding page grew to before it was persisted — strictly larger than
+	 * {@link #TWIN_PREFIX_SIZE} so the twin is a genuine (non-trivial) strict prefix of it.
+	 */
+	private static final int GROWN_PAGE_SIZE = 190;
+
+	/**
+	 * Returns the `i`-th generated threshold: {@link #BASE} shifted by `i`.
+	 *
+	 * @param i the threshold ordinal
+	 * @return the generated threshold
+	 */
+	private static long threshold(int i) {
+		return BASE + i;
+	}
+
+	/**
+	 * Builds a range point at the `i`-th threshold with deterministic single-record starts/ends bitmaps, so a twin
+	 * prefix is byte-identical to the superseding page's prefix.
+	 *
+	 * @param i the threshold ordinal
+	 * @return the range point
+	 */
+	@Nonnull
+	private static TransactionalRangePoint point(int i) {
+		return new TransactionalRangePoint(threshold(i), new int[]{500_000 + i}, new int[]{900_000 + i});
+	}
+
+	/**
+	 * Builds a page of range points for the threshold ordinals `[from, to)`.
+	 *
+	 * @param from the first ordinal (inclusive)
+	 * @param to   the last ordinal (exclusive)
+	 * @return the page points in ascending threshold order
+	 */
+	@Nonnull
+	private static TransactionalRangePoint[] page(int from, int to) {
+		final TransactionalRangePoint[] points = new TransactionalRangePoint[to - from];
+		for (int i = from; i < to; i++) {
+			points[i - from] = point(i);
+		}
+		return points;
+	}
+
+	/**
+	 * Loads a {@link RangeIndex} from the passed persisted pages exactly the way the catalog-open path does
+	 * (see `AttributeIndexLoader.loadRangeIndex`): page sequences `0..n-1`.
+	 *
+	 * @param pages the persisted leaf pages in list order
+	 * @return the rebuilt index
+	 */
+	@Nonnull
+	private static RangeIndex loadFromPersistedPages(@Nonnull TransactionalRangePoint[]... pages) {
+		final int[] pageSequences = new int[pages.length];
+		for (int i = 0; i < pages.length; i++) {
+			pageSequences[i] = i;
+		}
+		return RangeIndex.fromPersistedPages("attribute `published`", pageSequences, pages, pages.length - 1);
+	}
+
+	@Nested
+	@DisplayName("Any twin fails fast on reload")
+	class FailFastTest {
+
+		@Test
+		@DisplayName("should fail fast on a stale strict-prefix twin page")
+		void shouldThrowOnStrictPrefixTwin() {
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					// healthy predecessor page
+					page(0, TWIN_PREFIX_SIZE),
+					// the frozen STALE twin: an old snapshot of the next leaf (page sequence 1)
+					page(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+					// the leaf that superseded it: same 128 points plus 62 the leaf gained afterwards (page sequence 2)
+					page(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE)
+				),
+				"A stale strict-prefix leaf-page twin must fail fast on reload instead of loading silently."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+
+		@Test
+		@DisplayName("should fail fast on a sentinel-bearing stale first-page twin")
+		void shouldThrowOnSentinelBearingFirstPageTwin() {
+			// the stale twin and the grown first leaf both carry the MIN_VALUE border sentinel at position 0
+			final TransactionalRangePoint[] staleFirst = new TransactionalRangePoint[1 + 64];
+			final TransactionalRangePoint[] grownFirst = new TransactionalRangePoint[1 + TWIN_PREFIX_SIZE];
+			staleFirst[0] = new TransactionalRangePoint(Long.MIN_VALUE);
+			grownFirst[0] = new TransactionalRangePoint(Long.MIN_VALUE);
+			for (int i = 0; i < 64; i++) {
+				staleFirst[1 + i] = point(i);
+			}
+			for (int i = 0; i < TWIN_PREFIX_SIZE; i++) {
+				grownFirst[1 + i] = point(i);
+			}
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(staleFirst, grownFirst),
+				"A sentinel-bearing stale first-page twin must fail fast on reload instead of loading silently."
+			);
+			assertTrue(
+				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Unhealable overlap fails fast")
+	class HardFailureTest {
+
+		@Test
+		@DisplayName("should throw on a same-threshold twin whose starts bitmap diverges from its superseder")
+		void shouldRefuseDivergedPayloadTwin() {
+			final TransactionalRangePoint[] divergedSuperseder = page(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + GROWN_PAGE_SIZE);
+			// same threshold as the twin's first point, but a different starts bitmap => not a provable strict prefix
+			divergedSuperseder[0] = new TransactionalRangePoint(
+				threshold(TWIN_PREFIX_SIZE), new int[]{123_456_789}, new int[]{900_000 + TWIN_PREFIX_SIZE}
+			);
+			assertThrows(
+				GenericEvitaInternalError.class,
+				() -> loadFromPersistedPages(
+					page(0, TWIN_PREFIX_SIZE),
+					page(TWIN_PREFIX_SIZE, TWIN_PREFIX_SIZE + TWIN_PREFIX_SIZE),
+					divergedSuperseder
+				),
+				"A same-threshold twin with a diverged payload is an unknown corruption shape and must fail fast."
+			);
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/range/RangeIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/range/RangeIndexTest.java
@@ -1732,7 +1732,9 @@ class RangeIndexTest {
 			}
 
 			// reload boundary-stable (one leaf per page, page identities + change-detection baseline restored)
-			final RangeIndex reloaded = RangeIndex.fromPersistedPages(orderedPageSequences, perPagePoints, highWater);
+			final RangeIndex reloaded = RangeIndex.fromPersistedPages(
+				"attribute `test`", orderedPageSequences, perPagePoints, highWater
+			);
 			assertTrue(reloaded.isPaged(), "Reloaded range must still be paged.");
 			assertEquals(index, reloaded, "Reloaded range must be content-equal to the original.");
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/server/EvitaServerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/server/EvitaServerTest.java
@@ -1100,7 +1100,6 @@ class EvitaServerTest implements TestConstants, EvitaTestSupport {
 						property("export.fileSystem.enabled", "true"),
 						property("export.fileSystem.directory", getTestDirectory().resolve(DIR_EVITA_SERVER_TEST + "_export").toString()),
 						property("cache.enabled", "false"),
-						property("server.directExecutor", "false"),
 						property("api.requestTimeoutInMillis", "10K")
 					),
 					allApis.stream()

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/WalReplayAgainstLocalServerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/WalReplayAgainstLocalServerTest.java
@@ -124,6 +124,9 @@ public class WalReplayAgainstLocalServerTest implements EvitaTestSupport {
 					.host(SERVER_HOST)
 					.port(SERVER_PORT)
 					.systemApiPort(SERVER_SYSTEM_PORT)
+					// disable the keep-alive ping in the test lane: a long inline call on a direct-executor
+					// test server can stall the event loop past the ping budget and self-cancel the connection
+					.pingIntervalMillis(0)
 					.tls(
 						ClientTlsOptions.builder()
 							.mtlsEnabled(false)

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogIntegrationTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogIntegrationTest.java
@@ -75,6 +75,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
@@ -88,6 +91,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.LongConsumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService.WAL_FILE_SUFFIX;
 import static io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService.getWalFileName;
@@ -518,6 +522,85 @@ public class CatalogWriteAheadLogIntegrationTest implements EvitaTestSupport {
 				)
 			);
 			assertFalse(txId.isPresent());
+		}
+	}
+
+	/**
+	 * Reproduces a reader advancing past an already-delivered transaction into a next transaction record
+	 * that is genuinely truncated or underflowing — the same shape of failure a reader would hit if it
+	 * observed a concurrent, in-progress write mid-flush. The corruption is a real Kryo-level buffer
+	 * underflow during deserialization (not merely a coarse length pre-check failure), triggered while
+	 * {@link MutationSupplier#get()} advances past an already-delivered transaction to look for the next
+	 * one.
+	 */
+	@Nested
+	@DisplayName("Forward-read visibility race: advancing into a genuinely underflowing transaction")
+	class MisalignedReadSwallowTests {
+
+		/**
+		 * Writes two genuine transactions (real entity mutations, not synthetic bytes), then corrupts
+		 * transaction 2's on-disk record surgically: its 4-byte content-length prefix is overwritten
+		 * with a small LIE, and the file is truncated to exactly match that lie. This makes the coarse
+		 * length pre-check that gates deserialization pass — a plausible content length, with enough raw
+		 * bytes on disk per that (lying) declaration — while the REAL, unmodified leading bytes of
+		 * transaction 2's serialized {@code TransactionMutation} genuinely run out mid-deserialization,
+		 * because a `TransactionMutation` needs far more than a handful of bytes (a UUID alone is 16).
+		 * This is a deterministic stand-in for what a torn/partially-visible concurrent write of
+		 * transaction 2 would look like to a reader mid-scan.
+		 *
+		 * Transaction 1 is left completely untouched and must be delivered in full. Only reading
+		 * PAST it — advancing into transaction 2 inside {@link MutationSupplier#get()}'s
+		 * checksum-validation-and-advancement step — hits the corruption.
+		 */
+		@Test
+		@DisplayName("must not silently end the stream when advancing into a genuinely underflowing transaction")
+		void shouldNotSilentlyEndStreamWhenAdvancingIntoAGenuinelyUnderflowingTransaction() throws IOException {
+			final int[] txSizes = {2, 3};
+			final Map<Long, List<Mutation>> txInMutations = writeWal(
+				CatalogWriteAheadLogIntegrationTest.this.bigOffHeapMemoryManager, txSizes
+			);
+
+			final TransactionMutationWithLocation tx2Location =
+				(TransactionMutationWithLocation) txInMutations.get(2L).get(0);
+			final long tx2Start = tx2Location.getTransactionSpan().startingPosition();
+
+			final Path walFilePath = CatalogWriteAheadLogIntegrationTest.this.wal.getWalFilePath();
+			try (RandomAccessFile raf = new RandomAccessFile(walFilePath.toFile(), "rw")) {
+				// lie about transaction 2's declared content length so the coarse length pre-check
+				// is satisfied by a handful of genuine (unmodified) leading bytes, then truncate the
+				// file to match the lie - Kryo will start deserializing real bytes and run out
+				// part-way through, exactly like a torn concurrent write would look
+				final int lyingContentLength = 4;
+				raf.seek(tx2Start);
+				final byte[] prefix = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN)
+					.putInt(lyingContentLength).array();
+				raf.write(prefix);
+				raf.setLength(tx2Start + 4 + lyingContentLength + AbstractMutationLog.CUMULATIVE_CRC32_SIZE);
+			}
+
+			List<CatalogBoundMutation> mutations = null;
+			Exception thrown = null;
+			try (
+				final Stream<CatalogBoundMutation> stream = CatalogWriteAheadLogIntegrationTest.this.wal
+					.getCommittedMutationStreamAvoidingPartiallyWrittenBuffer(1L, 2L)
+			) {
+				mutations = stream.toList();
+			} catch (Exception ex) {
+				thrown = ex;
+			}
+
+			assertNotNull(
+				thrown,
+				"getCommittedMutationStreamAvoidingPartiallyWrittenBuffer(1, 2) silently ended the " +
+					"stream after " + (mutations == null ? "?" : mutations.size()) + " element(s) " +
+					"(transaction 1 only) instead of surfacing the read failure it hit while advancing " +
+					"into transaction 2's genuinely underflowing header. A broad catch-and-return-null " +
+					"around the checksum-validation-and-advancement step swallowed whatever underflow or " +
+					"deserialization error the buffered input produced and reported an exhausted stream " +
+					"instead of a failure. A caller that already believes the requested version was " +
+					"durably written cannot distinguish this from \"nothing more to process\" and would " +
+					"silently finalize at a stale version instead of retrying or failing loudly."
+			);
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
@@ -27,6 +27,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.util.Pool;
 import io.evitadb.api.configuration.StorageOptions;
 import io.evitadb.api.configuration.TransactionOptions;
+import io.evitadb.api.requestResponse.mutation.CatalogBoundMutation;
 import io.evitadb.api.requestResponse.mutation.infrastructure.TransactionMutation;
 import io.evitadb.core.executor.Scheduler;
 import io.evitadb.exception.GenericEvitaInternalError;
@@ -34,7 +35,9 @@ import io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService;
 import io.evitadb.spi.store.engine.exception.WriteAheadLogCorruptedException;
 import io.evitadb.store.checksum.Checksum;
 import io.evitadb.store.checksum.Crc32CChecksumFactory;
+import io.evitadb.store.kryo.ObservableOutputKeeper;
 import io.evitadb.store.model.reference.LogFileRecordReference;
+import io.evitadb.store.offsetIndex.io.CatalogOffHeapMemoryManager;
 import io.evitadb.store.offsetIndex.io.OffHeapWithFileBackupReference;
 import io.evitadb.store.settings.StorageSettings;
 import io.evitadb.store.shared.kryo.KryoFactory;
@@ -54,9 +57,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Tag;
 
 import static io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService.getWalFileName;
@@ -337,6 +343,107 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 			assertTrue(
 				exception.getMessage().contains(orphanWalPath.toFile().getName()),
 				"Exception message should identify the offending file: " + exception.getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Reproduces a same-JVM visibility race between a WAL writer and a reader that already believes a
+	 * given catalog version was durably written.
+	 *
+	 * A transaction-processing caller that treats {@code lastWrittenCatalogVersion == N} as a durable
+	 * promise that transaction {@code N} is fully readable will ask the mutation stream for exactly that
+	 * version. If that call returns a dry stream, such a caller can misread "nothing visible yet" as
+	 * "already processed everything" and stop without retrying — which in turn leaves anything waiting for
+	 * transaction {@code N} to be finalized spinning forever, since nothing will ever finalize it.
+	 *
+	 * These tests freeze the exact window deterministically: a transaction is appended through the
+	 * real {@link CatalogWriteAheadLog#append} API (so it is genuinely, legitimately written — no
+	 * mock WAL layer), then its trailing cumulative checksum alone is stripped off — the very last thing
+	 * {@link AbstractMutationLog#append} writes, strictly after the header and content. This reproduces
+	 * the on-disk state a torn/partially-visible flush would leave behind without depending on real
+	 * thread timing.
+	 *
+	 * Unlike the sibling nested classes, these tests **consume the transaction content as mutations**.
+	 * The shared {@link #setUp()} fixture fills transaction content with opaque test bytes — fine for
+	 * header/positioning tests, but unreadable by Kryo — so the fixture below replaces the WAL with
+	 * one whose content consists of genuinely serialized entity mutations written through the real
+	 * isolated-WAL pipeline (see {@link CatalogWriteAheadLogIntegrationTest#writeWal}).
+	 */
+	@Nested
+	@DisplayName("Dry-read visibility race: requested version durable but trailing checksum not yet visible")
+	class DryReadVisibilityRaceTests {
+		/**
+		 * Off-heap memory manager backing the isolated-WAL writes of the real-mutation fixture.
+		 */
+		private final CatalogOffHeapMemoryManager offHeapMemoryManager = new CatalogOffHeapMemoryManager(
+			TEST_CATALOG, 10_000_000, 4, Crc32CChecksumFactory.INSTANCE
+		);
+		/**
+		 * Keeper of observable outputs used by the isolated-WAL write handle.
+		 */
+		private final ObservableOutputKeeper observableOutputKeeper = ObservableOutputKeeper._internalBuild(
+			Mockito.mock(Scheduler.class)
+		);
+
+		/**
+		 * Replaces the WAL created by the outer {@link #setUp()} with one holding the same number of
+		 * transactions (catalog versions `1..txSizes.length`) whose content is real serialized entity
+		 * mutations, so the mutation stream under test can deserialize what it reads.
+		 */
+		@BeforeEach
+		void rebuildWalWithRealMutationContent() throws IOException {
+			CatalogWriteAheadLogTest.this.tested.close();
+			cleanTestSubDirectory(CatalogWriteAheadLogTest.class.getSimpleName());
+			CatalogWriteAheadLogTest.this.walDirectory.toFile().mkdirs();
+			CatalogWriteAheadLogTest.this.tested = createTestWal();
+			CatalogWriteAheadLogIntegrationTest.writeWal(
+				this.offHeapMemoryManager,
+				CatalogWriteAheadLogTest.this.txSizes,
+				null,
+				CatalogWriteAheadLogTest.this.walDirectory.resolve("isolatedWal.tmp"),
+				this.observableOutputKeeper,
+				CatalogWriteAheadLogTest.this.tested
+			);
+		}
+
+		@AfterEach
+		void releaseWriteInfrastructure() {
+			this.observableOutputKeeper.close();
+		}
+
+		@Test
+		@DisplayName("getCommittedMutationStreamAvoidingPartiallyWrittenBuffer(N,N) must not go dry for a " +
+			"version whose content is on disk but whose trailing checksum has not landed yet")
+		void shouldNotReturnDryStreamForLastAppendedVersionMissingOnlyTrailingChecksum() throws IOException {
+			// version = 1 + transactionIndex in setUp(), so the last transaction appended is at this version
+			final long lastAppendedVersion = CatalogWriteAheadLogTest.this.txSizes.length;
+
+			// strip only the trailing 8-byte cumulative checksum of the last transaction - its header
+			// and content are fully durable on disk, exactly mirroring the moment append() has written
+			// everything except the final checksum write
+			modifyWalFile(raf -> {
+				raf.setLength(raf.length() - AbstractMutationLog.CUMULATIVE_CRC32_SIZE);
+				return null;
+			});
+
+			final List<CatalogBoundMutation> mutations;
+			try (
+				final Stream<CatalogBoundMutation> stream = CatalogWriteAheadLogTest.this.tested
+					.getCommittedMutationStreamAvoidingPartiallyWrittenBuffer(lastAppendedVersion, lastAppendedVersion)
+			) {
+				mutations = stream.toList();
+			}
+
+			assertFalse(
+				mutations.isEmpty(),
+				"getCommittedMutationStreamAvoidingPartiallyWrittenBuffer(" + lastAppendedVersion + ", " +
+					lastAppendedVersion + ") returned a DRY stream even though transaction " +
+					lastAppendedVersion + "'s header and content are durably on disk (only its trailing " +
+					"checksum is momentarily missing). A caller that already believes this version is " +
+					"written (as a production catalog-version tracker would) has no way to distinguish " +
+					"this from \"nothing left to process\" and will silently drop the transaction instead " +
+					"of retrying."
 			);
 		}
 	}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/driver/LongRunningCdcHeartbeatTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/driver/LongRunningCdcHeartbeatTest.java
@@ -194,6 +194,9 @@ class LongRunningCdcHeartbeatTest implements TestConstants, EvitaTestSupport {
 				.host(grpcHost.hostAddress())
 				.port(grpcHost.port())
 				.systemApiPort(systemHost.port())
+				// disable the keep-alive ping in the test lane: a long inline call on a direct-executor
+				// test server can stall the event loop past the ping budget and self-cancel the connection
+				.pingIntervalMillis(0)
 				.tls(
 					ClientTlsOptions.builder()
 						.mtlsEnabled(false)

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/driver/LongRunningEvitaClientReadWriteTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/driver/LongRunningEvitaClientReadWriteTest.java
@@ -228,6 +228,9 @@ class LongRunningEvitaClientReadWriteTest implements TestConstants, EvitaTestSup
 			.host(grpcHost.hostAddress())
 			.port(grpcHost.port())
 			.systemApiPort(systemHost.port())
+			// disable the keep-alive ping in the test lane: a long inline call on a direct-executor
+			// test server can stall the event loop past the ping budget and self-cancel the connection
+			.pingIntervalMillis(0)
 			.tls(
 				ClientTlsOptions.builder()
 					.mtlsEnabled(false)
@@ -430,6 +433,9 @@ class LongRunningEvitaClientReadWriteTest implements TestConstants, EvitaTestSup
 			.host(grpcHost.hostAddress())
 			.port(grpcHost.port())
 			.systemApiPort(systemHost.port())
+			// disable the keep-alive ping in the test lane: a long inline call on a direct-executor
+			// test server can stall the event loop past the ping budget and self-cancel the connection
+			.pingIntervalMillis(0)
 			.tls(
 				ClientTlsOptions.builder()
 					.mtlsEnabled(false)
@@ -848,6 +854,9 @@ class LongRunningEvitaClientReadWriteTest implements TestConstants, EvitaTestSup
 					.host(evitaClient.getConfiguration().host())
 					.port(evitaClient.getConfiguration().port())
 					.systemApiPort(evitaClient.getConfiguration().systemApiPort())
+					// disable the HTTP/2 keep-alive ping in the test lane so it does not confound the
+					// app-level CDC heartbeat under test on this direct-executor server
+					.pingIntervalMillis(0)
 					.timeouts(
 						ClientTimeoutOptions.builder()
 							.streamingTimeout(6, TimeUnit.SECONDS)

--- a/evita_test/evita_test_support/src/main/java/io/evitadb/test/annotation/DataSet.java
+++ b/evita_test/evita_test_support/src/main/java/io/evitadb/test/annotation/DataSet.java
@@ -90,4 +90,19 @@ public @interface DataSet {
 	 */
 	CatalogState expectedCatalogState() default CatalogState.ALIVE;
 
+	/**
+	 * When set to true this dataset runs its evitaDB server on real (asynchronous) thread pools instead of the
+	 * deterministic direct/immediate executor the test lane uses by default.
+	 *
+	 * The direct executor collapses the request pool and the scheduler into an immediate executor so that, under
+	 * CPU-saturated parallel test execution, no asynchronous handoff can introduce timing flakiness. That determinism
+	 * is what most tests rely on. A handful of behaviours only manifest under real pools — the gRPC session
+	 * cancellation cascade and the change-data-capture register-then-mutate ordering — and can only be regression
+	 * tested with production-like asynchronous execution. Opt those datasets in with this flag.
+	 *
+	 * Do not enable it for datasets whose tests mutate a catalog schema and then immediately query the regenerated
+	 * REST/GraphQL API: that API rebuild is asynchronous under real pools, so the follow-up call would race it.
+	 */
+	boolean useRealThreadPools() default false;
+
 }

--- a/evita_test/evita_test_support/src/main/java/io/evitadb/test/extension/EvitaParameterResolver.java
+++ b/evita_test/evita_test_support/src/main/java/io/evitadb/test/extension/EvitaParameterResolver.java
@@ -239,7 +239,8 @@ public class EvitaParameterResolver
 							new LinkedList<>(),
 							it.openWebApi(),
 							it.readOnly(),
-							it.destroyAfterClass()
+							it.destroyAfterClass(),
+							it.useRealThreadPools()
 						)
 					);
 				});
@@ -268,12 +269,14 @@ public class EvitaParameterResolver
 	/**
 	 * Creates new evitaDB instance with one catalog of `catalogName`.
 	 *
-	 * @param catalogName      name of the catalog to be created
-	 * @param randomFolderName unique folder name to be usedfor evitaDB storage
+	 * @param catalogName        name of the catalog to be created
+	 * @param randomFolderName   unique folder name to be used for evitaDB storage
+	 * @param useRealThreadPools when true the instance runs on real (asynchronous) thread pools instead of the
+	 *                           deterministic direct/immediate executor the test lane uses by default
 	 * @return new evitaDB instance
 	 */
 	@Nonnull
-	private Evita createEvita(@Nonnull String catalogName, @Nonnull String randomFolderName) {
+	private Evita createEvita(@Nonnull String catalogName, @Nonnull String randomFolderName, boolean useRealThreadPools) {
 		// dataset-scoped paths: all test methods sharing the same @UseDataSet see the same storage/export
 		// directories for the lifetime of the dataset, which is why randomFolderName is caller-supplied rather
 		// than freshly allocated via createTestPaths(String).
@@ -297,33 +300,35 @@ public class EvitaParameterResolver
 		}
 		Assert.isTrue(paths.storage().toFile().mkdirs(), "Fail to create directory: " + paths.storage());
 		Assert.isTrue(paths.export().toFile().mkdirs(), "Fail to create directory: " + paths.export());
+		// disable automatic session termination to avoid closing sessions when you stop at breakpoint
+		final ServerOptions.Builder serverOptionsBuilder = ServerOptions
+			.builder()
+			.closeSessionsAfterSecondsOfInactivity(-1)
+			.serviceThreadPool(
+				ThreadPoolOptions.serviceThreadPoolBuilder()
+				                 .minThreadCount(1)
+				                 .maxThreadCount(1)
+				                 .queueSize(10_000)
+				                 .build()
+			)
+			.requestThreadPool(
+				ThreadPoolOptions.requestThreadPoolBuilder()
+				                 .queueSize(10_000)
+				                 .build()
+			)
+			.transactionThreadPool(
+				ThreadPoolOptions.transactionThreadPoolBuilder()
+				                 .queueSize(10_000)
+				                 .build()
+			);
+		// A dataset may opt into real (asynchronous) thread pools via @DataSet(useRealThreadPools = true). The
+		// default collapses the request pool and the scheduler into an immediate executor so that CPU-saturated
+		// parallel tests stay deterministic; the few behaviours that only manifest under real pools (the gRPC
+		// session-cancellation cascade, the CDC register-then-mutate ordering) opt in to be regression tested.
+		// Everything else keeps the deterministic direct executor, hence directExecutor = !useRealThreadPools.
 		final Evita evita = new Evita(
 			newTestEvitaConfigurationBuilder(paths)
-				.server(
-					// disable automatic session termination
-					// to avoid closing sessions when you stop at breakpoint
-					ServerOptions
-						.builder()
-						.closeSessionsAfterSecondsOfInactivity(-1)
-						.serviceThreadPool(
-							ThreadPoolOptions.serviceThreadPoolBuilder()
-							                 .minThreadCount(1)
-							                 .maxThreadCount(1)
-							                 .queueSize(10_000)
-							                 .build()
-						)
-						.requestThreadPool(
-							ThreadPoolOptions.requestThreadPoolBuilder()
-							                 .queueSize(10_000)
-							                 .build()
-						)
-						.transactionThreadPool(
-							ThreadPoolOptions.transactionThreadPoolBuilder()
-							                 .queueSize(10_000)
-							                 .build()
-						)
-						.build()
-				)
+				.server(serverOptionsBuilder.build())
 				// preserve dataset-specific storage tuning that newTestEvitaConfigurationBuilder does not know about
 				.storage(
 					StorageOptions.builder()
@@ -339,7 +344,11 @@ public class EvitaParameterResolver
 					            .enabled(false)
 					            .build()
 				)
-				.build()
+				.build(),
+			true,
+			null,
+			null,
+			!useRealThreadPools
 		);
 		evita.defineCatalog(catalogName);
 		return evita;
@@ -851,6 +860,12 @@ public class EvitaParameterResolver
 								.host(grpcConfig.getHost()[0].hostAddress())
 								.port(grpcConfig.getHost()[0].port())
 								.systemApiPort(systemConfig.getHost()[0].port())
+								// disable the client keep-alive ping in the test lane: with the direct executor a
+								// legitimate long inline call (e.g. a bulk dataset build) holds the event loop well
+								// past any finite ping interval, so a ping would self-kill a healthy connection
+								// (spurious CANCELLED). The dedicated keep-alive test builds its own client with a
+								// ping. The server ping is already disabled by default (ApiOptions.DEFAULT_PING_INTERVAL).
+								.pingIntervalMillis(0)
 								.tls(
 									ClientTlsOptions.builder()
 										.certificateFolderPath(
@@ -991,8 +1006,9 @@ public class EvitaParameterResolver
 			final DataSetInfo alreadyExistingAnonymousInstance = dataSetIndex.get(anonymousEvita);
 			if (alreadyExistingAnonymousInstance == null) {
 
-				// method doesn't use data set - so it needs to start with empty db
-				final Evita evita = createEvita(TestConstants.TEST_CATALOG, evitaInstanceId);
+				// method doesn't use data set - so it needs to start with empty db; anonymous instances never open
+				// web APIs, so they keep the deterministic direct executor
+				final Evita evita = createEvita(TestConstants.TEST_CATALOG, evitaInstanceId, false);
 				evita.updateCatalog(
 					TestConstants.TEST_CATALOG, EvitaSessionContract::goLiveAndClose
 				);
@@ -1002,6 +1018,7 @@ public class EvitaParameterResolver
 					null,
 					Collections.emptyList(),
 					new String[0],
+					false,
 					false,
 					false,
 					new AtomicReference<>(
@@ -1065,10 +1082,13 @@ public class EvitaParameterResolver
 							// capture dataset build start so slow datasets can be surfaced at the end of the run
 							final long buildStartNanos = System.nanoTime();
 							final String randomFolderName = Long.toHexString(RANDOM.nextLong());
-							final Evita evita = createEvita(dataSetInfo.catalogName(), randomFolderName);
+							final boolean webApiEnabled = !ArrayUtils.isEmpty(dataSetInfo.webApi());
+							final Evita evita = createEvita(
+								dataSetInfo.catalogName(), randomFolderName, dataSetInfo.useRealThreadPools()
+							);
 							EvitaServer evitaServer = null;
 							try {
-								if (!ArrayUtils.isEmpty(dataSetInfo.webApi())) {
+								if (webApiEnabled) {
 									final ApiOptions apiOptions = createApiOptions(
 										dataSetToUse, evita, getPortManager(), dataSetInfo.webApi()
 									);
@@ -1255,6 +1275,7 @@ public class EvitaParameterResolver
 		@Nonnull String[] webApi,
 		boolean readOnly,
 		boolean destroyAfterClass,
+		boolean useRealThreadPools,
 		@Nonnull AtomicReference<DataSetState> dataSetInfoAtomicReference
 	) {
 
@@ -1264,11 +1285,11 @@ public class EvitaParameterResolver
 		public DataSetInfo(
 			@Nonnull String name, @Nonnull String catalogName, @Nullable CatalogInitMethod initMethod,
 			@Nonnull List<Method> destroyMethods, @Nonnull String[] webApi,
-			boolean readOnly, boolean destroyAfterClass
+			boolean readOnly, boolean destroyAfterClass, boolean useRealThreadPools
 		) {
 			this(
 				name, catalogName, initMethod, destroyMethods, webApi, readOnly, destroyAfterClass,
-				new AtomicReference<>()
+				useRealThreadPools, new AtomicReference<>()
 			);
 		}
 


### PR DESCRIPTION
Follow-up work that accumulated on top of the (already-merged) warmup allocation
branch, split here into eight coherent, single-theme commits on a branch freshly
based on `dev`. Eighteen demo-server example snapshots that were also staged are
**not** included — they are already in `dev` via `docs: refresh stale demo-server
example snapshots` and were byte-identical, so re-committing them would have been a
no-op (or, from the old base, a spurious revert).

### What's here (one commit per theme)

**perf: cut per-reference allocation on the entity upsert hot path**
The WARM_UP bulk upsert was GC-bound — every reference materialized its full
attribute-key set into a fresh `HashSet` just to membership-test the few
schema-declared default/mandatory attributes. Replaced with an allocation-free
probe (`Reference.isAttributeValuePresentAndExists`), plus a bounded ICU
collation-key cache (`CollationKeyCache`) whose recomputation dominated CPU during
localized attribute indexing.

**feat: expose GROUP constraint children in the GraphQL and REST schemas**
Constraints nested in a reference scope could target the referenced entity but not
its referenced GROUP entity. Adds `buildGroupChildren` (no root-level fallback — a
GROUP constraint only makes sense where the reference schema declares a group type)
and wires it into both schema builders.

**feat: make the gRPC keep-alive ping and connection idle timeout configurable**
Both server and client hard-coded a 1000 ms HTTP/2 ping; under production GC/CPU
pauses that is a probe frequency, not a stall budget, so a slow-but-alive call could
be killed and surface as a spurious `CANCELLED`. Introduces configurable ping / idle
knobs (client defaults 30 s / 300 s, server ping default disabled), decouples the
connection idle timeout from the per-call deadline, and warns on an Armeria-silently-
disabling ping/idle pair. Documents both in the Java connector guide (en + cs).

**refactor: move the test-only directExecutor switch off the public ServerOptions record**
`ServerOptions.directExecutor` leaked a test-only executor switch as a user-settable
`server.directExecutor` YAML key. Moves the decision to a new 5-arg `Evita`
constructor (test-run default preserved); the test harness opts specific datasets
into real pools via `@DataSet(useRealThreadPools)`. Record arity 11 → 10 (accepted BWC
break on this unreleased line).

**fix: fail fast on corrupt transactional data structures via dirty-scope validation**
The paged B+ tree layout has never shipped, so a stale leaf-page twin can only come
from a now-guarded writer bug; healing such a state contradicts the defensive-design
rule. `DirtyScopeValidator` re-derives structural invariants per dirty scope and fails
fast with a `DataStructureCorruptedException` — pre-commit (before the shared WAL is
touched, so the client can recover) and post-replay (re-wrapped as a poison-pill,
since the transaction is already durable).

**fix: stop trunk incorporation spinning forever on a dry WAL read**
Under concurrent write load a durably-written transaction could be misread as
"already processed": a dry WAL read returned a silent `null`, the trunk stage
finalized at a stale version, and the commit-progress future hung while the bounded
wait burned a core. The dry read now surfaces as a `WriteAheadLogCorruptedException`
until the requested version is delivered; the wait spins briefly, then parks.

**fix: harden the gRPC session cancellation cascade and CDC ordering**
A transport failure mid-session-call orphaned the server invocation and the client's
close raced it into a `ConcurrentSessionAccessException` cascade. Transport failures
are now classified over the whole cause chain and terminate the session locally
(rethrowing `TransportException`) instead of racing a remote close; CDC
register-then-mutate ordering is fixed so a fresh subscription can't miss the first
mutation.

**test: stabilize ProgressRecordTest**
Inline the progress executor so callbacks complete deterministically under
CPU-saturated parallel runs, keeping one real-pool test for concurrency coverage.

### Verification
The change content is byte-identical to the working set that was validated per
workstream; this PR only regroups it onto `dev` (the only `dev` delta was the docs
refresh, no code). Combined-tree verification is left to CI.
