### PR TITLE
fix: carve out granular conflict items from the coarse entity conflict scope

### DIFF
--- a/.github/workflows/ci-dev-documentation.yml
+++ b/.github/workflows/ci-dev-documentation.yml
@@ -38,9 +38,9 @@ jobs:
       with:
         dotnet-version: '8.0.X'    # setup dotnet 8.0.X for building
 
-    - name: Build with Maven       # run Maven with tests
-      run: |
-        mvn -T 1C -B package -P documentation -V --fail-at-end -Dmaven.test.skip=false --file pom.xml
+    - name: Build with Maven       # run Maven with tests; RoaringBitmap's vendored suite is irrelevant
+      run: |                       # here and must stay skipped, else it drowns out the doc test report
+        mvn -T 1C -B package -P documentation -V --fail-at-end -Dmaven.test.skip=false -DroaringBitmap.skipTests=true --file pom.xml
 
     - name: Upload test results    # upload XML with unit test results for debugging
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/EntityMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/EntityMutation.java
@@ -31,6 +31,7 @@ import io.evitadb.api.requestResponse.mutation.conflict.ConflictGenerationContex
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictKey;
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictPolicy;
 import io.evitadb.api.requestResponse.mutation.conflict.EntityConflictKey;
+import io.evitadb.api.requestResponse.mutation.conflict.EntityResidualConflictKey;
 import io.evitadb.api.requestResponse.schema.CatalogSchemaContract;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.api.requestResponse.schema.EntitySchemaEditor.EntitySchemaBuilder;
@@ -99,7 +100,10 @@ public non-sealed interface EntityMutation extends CatalogBoundMutation {
 	/**
 	 * Generates a stream of {@link ConflictKey} objects based on the provided parameters. The method collects
 	 * conflict keys from the specified local mutations and appends additional conflict keys if any mutation fails
-	 * to produce a key and relevant conflict policies are applied.
+	 * to produce a key and relevant conflict policies are applied. Under {@link ConflictPolicy#ENTITY} the
+	 * appended key is not always the full {@link EntityConflictKey}: a forced creation emits the full key (it
+	 * contends on the entity's very existence, which subsumes every carved-out item), while a missing granular
+	 * key on its own only emits the finer {@link EntityResidualConflictKey} for the entity's shared surface.
 	 *
 	 * @param entityType       the type of the entity for which the conflict keys are generated, must not be null
 	 * @param entityPrimaryKey the primary key of the entity, may be null
@@ -139,19 +143,26 @@ public non-sealed interface EntityMutation extends CatalogBoundMutation {
 		// primary key contend on the entity's very existence even when they touch disjoint fields
 		// and each emit only granular keys, so a fully-granular creation must still surface the
 		// entity-level conflict. NONE policy still emits nothing (coarsePolicy yields neither ENTITY nor COLLECTION),
-		// preserving the opt-out.
+		// preserving the opt-out. Under ENTITY policy the fallback key itself is split: a forced creation
+		// contends on the entity's very existence, which already subsumes every carved-out item, so the full
+		// entity key is emitted; otherwise the fallback is triggered solely by a missing granular key, meaning
+		// some mutation only touched the entity's shared, non-carved-out surface, so the finer residual key is
+		// emitted instead — it still conflicts with another shared-surface writer, but no longer with a writer
+		// of a disjoint carved-out item.
 		if (atLeastOneKeyMissing || expects == EntityExistence.MUST_NOT_EXIST) {
 			final ConflictPolicy coarsePolicy = context.coarsePolicy();
 			if (entityPrimaryKey == null) {
 				if (coarsePolicy == ConflictPolicy.COLLECTION) {
 					keys.add(new CollectionConflictKey(entityType));
 				}
-			} else {
-				if (coarsePolicy == ConflictPolicy.ENTITY) {
+			} else if (coarsePolicy == ConflictPolicy.ENTITY) {
+				if (expects == EntityExistence.MUST_NOT_EXIST) {
 					keys.add(new EntityConflictKey(entityType, entityPrimaryKey));
-				} else if (coarsePolicy == ConflictPolicy.COLLECTION) {
-					keys.add(new CollectionConflictKey(entityType));
+				} else {
+					keys.add(new EntityResidualConflictKey(entityType, entityPrimaryKey));
 				}
+			} else if (coarsePolicy == ConflictPolicy.COLLECTION) {
+				keys.add(new CollectionConflictKey(entityType));
 			}
 		}
 

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute/ApplyDeltaAttributeMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute/ApplyDeltaAttributeMutation.java
@@ -196,6 +196,9 @@ public class ApplyDeltaAttributeMutation<T extends Number> extends AttributeSche
 		// right coarse fallback (the absolute attribute key when carved out, the shared-surface residual
 		// otherwise) even when the range guard is the sole reason the key is emitted.
 		final boolean shouldEmit = context.shouldEmitEntityAttributeKey(this.attributeKey.attributeName());
+		// an attribute that is not carved out into its own granular key belongs to the entity's shared
+		// surface, so its delta key must route through the residual rather than the absolute attribute key
+		final boolean sharedSurface = !shouldEmit;
 		return this.requiredRangeAfterApplication != null || shouldEmit ?
 			Stream.of(
 				new AttributeDeltaConflictKey(
@@ -204,7 +207,7 @@ public class ApplyDeltaAttributeMutation<T extends Number> extends AttributeSche
 					this.attributeKey,
 					this.delta,
 					this.requiredRangeAfterApplication,
-					!shouldEmit
+					sharedSurface
 				)
 			) :
 			Stream.empty();

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute/ApplyDeltaAttributeMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/attribute/ApplyDeltaAttributeMutation.java
@@ -191,16 +191,20 @@ public class ApplyDeltaAttributeMutation<T extends Number> extends AttributeSche
 	) {
 		// A range-constrained delta must always emit its conflict key, regardless of the resolved
 		// conflict policy: keeping the accumulated value inside the required range is a hard invariant,
-		// not something the user opts out of by relaxing conflict granularity.
-		return this.requiredRangeAfterApplication != null
-			|| context.shouldEmitEntityAttributeKey(this.attributeKey.attributeName()) ?
+		// not something the user opts out of by relaxing conflict granularity. Whether the attribute was
+		// carved out of the entity's shared surface is still resolved so the key's parent chain reaches the
+		// right coarse fallback (the absolute attribute key when carved out, the shared-surface residual
+		// otherwise) even when the range guard is the sole reason the key is emitted.
+		final boolean shouldEmit = context.shouldEmitEntityAttributeKey(this.attributeKey.attributeName());
+		return this.requiredRangeAfterApplication != null || shouldEmit ?
 			Stream.of(
 				new AttributeDeltaConflictKey(
 					context.getEntityType(),
 					context.getEntityPrimaryKey(),
 					this.attributeKey,
 					this.delta,
-                    this.requiredRangeAfterApplication
+					this.requiredRangeAfterApplication,
+					!shouldEmit
 				)
 			) :
 			Stream.empty();

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/reference/ReferenceAttributeMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/reference/ReferenceAttributeMutation.java
@@ -120,9 +120,15 @@ public class ReferenceAttributeMutation extends ReferenceMutation<ReferenceKeyWi
 		if (this.attributeMutation instanceof ApplyDeltaAttributeMutation<?> adam) {
 			// A range-constrained delta must always emit its conflict key, regardless of the resolved
 			// conflict policy: keeping the accumulated value inside the required range is a hard
-			// invariant, not something relaxed conflict granularity opts out of.
-			return adam.getRequiredRangeAfterApplication() != null
-				|| context.shouldEmitReferenceAttributeKey(this.referenceKey.referenceName(), this.attributeKey.attributeName()) ?
+			// invariant, not something relaxed conflict granularity opts out of. Whether the reference
+			// attribute was carved out of the entity's shared surface is still resolved so the key's parent
+			// chain reaches the right coarse fallback (the absolute reference-attribute key when carved out,
+			// the shared-surface residual otherwise) even when the range guard is the sole reason the key
+			// is emitted.
+			final boolean shouldEmit = context.shouldEmitReferenceAttributeKey(
+				this.referenceKey.referenceName(), this.attributeKey.attributeName()
+			);
+			return adam.getRequiredRangeAfterApplication() != null || shouldEmit ?
 				Stream.of(
 					new ReferenceAttributeDeltaConflictKey(
 						context.getEntityType(),
@@ -130,7 +136,8 @@ public class ReferenceAttributeMutation extends ReferenceMutation<ReferenceKeyWi
 						this.referenceKey,
 						this.attributeKey,
 						adam.getDelta(),
-						adam.getRequiredRangeAfterApplication()
+						adam.getRequiredRangeAfterApplication(),
+						!shouldEmit
 					)
 				) :
 				Stream.empty();

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/reference/ReferenceAttributeMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/reference/ReferenceAttributeMutation.java
@@ -128,6 +128,10 @@ public class ReferenceAttributeMutation extends ReferenceMutation<ReferenceKeyWi
 			final boolean shouldEmit = context.shouldEmitReferenceAttributeKey(
 				this.referenceKey.referenceName(), this.attributeKey.attributeName()
 			);
+			// a reference attribute that is not carved out into its own granular key belongs to the entity's
+			// shared surface, so its delta key must route through the residual rather than the absolute
+			// reference-attribute key
+			final boolean sharedSurface = !shouldEmit;
 			return adam.getRequiredRangeAfterApplication() != null || shouldEmit ?
 				Stream.of(
 					new ReferenceAttributeDeltaConflictKey(
@@ -137,7 +141,7 @@ public class ReferenceAttributeMutation extends ReferenceMutation<ReferenceKeyWi
 						this.attributeKey,
 						adam.getDelta(),
 						adam.getRequiredRangeAfterApplication(),
-						!shouldEmit
+						sharedSurface
 					)
 				) :
 				Stream.empty();

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/scope/SetEntityScopeMutation.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/data/mutation/scope/SetEntityScopeMutation.java
@@ -25,8 +25,11 @@ package io.evitadb.api.requestResponse.data.mutation.scope;
 
 import io.evitadb.api.requestResponse.cdc.Operation;
 import io.evitadb.api.requestResponse.data.mutation.LocalMutation;
+import io.evitadb.api.requestResponse.mutation.conflict.CollectionConflictKey;
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictGenerationContext;
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictKey;
+import io.evitadb.api.requestResponse.mutation.conflict.ConflictPolicy;
+import io.evitadb.api.requestResponse.mutation.conflict.EntityConflictKey;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.dataType.ContainerType;
 import io.evitadb.dataType.Scope;
@@ -101,17 +104,32 @@ public class SetEntityScopeMutation implements LocalMutation<Scope, Scope> {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * A scope change contributes no dedicated conflict key: concurrent scope contention is instead covered
-	 * by the coarse entity-level fallback in `EntityMutation#getConflictKeyStream` (the absent granular key
-	 * forces the whole-entity key to be emitted). The empty stream here is therefore deliberate, not an
-	 * unimplemented stub.
+	 * A scope change (archive/restore) is a whole-entity operation, not an ordinary field write: it must
+	 * conflict with every writer of the entity, including one touching a carved-out granular item. The
+	 * coarse fallback in `EntityMutation#getConflictKeyStream` only covers the entity's shared surface (it
+	 * emits the finer {@link io.evitadb.api.requestResponse.mutation.conflict.EntityResidualConflictKey}
+	 * for a merely-missing granular key), so this mutation cannot rely on that fallback and emits the full
+	 * entity/collection key itself, mirroring
+	 * {@link io.evitadb.api.requestResponse.data.mutation.EntityRemoveMutation#collectConflictKeys}.
+	 * A null primary key under {@link ConflictPolicy#ENTITY} means the entity is brand new (no scope change
+	 * can target it yet), so no key is emitted in that case either.
 	 */
 	@Nonnull
 	@Override
 	public Stream<ConflictKey> collectConflictKeys(
 		@Nonnull ConflictGenerationContext context
 	) {
-		return Stream.empty();
+		final ConflictPolicy coarsePolicy = context.coarsePolicy();
+		if (coarsePolicy == ConflictPolicy.ENTITY) {
+			final Integer entityPrimaryKey = context.getEntityPrimaryKey();
+			return entityPrimaryKey == null ?
+				Stream.empty() :
+				Stream.of(new EntityConflictKey(context.getEntityType(), entityPrimaryKey));
+		} else if (coarsePolicy == ConflictPolicy.COLLECTION) {
+			return Stream.of(new CollectionConflictKey(context.getEntityType()));
+		} else {
+			return Stream.empty();
+		}
 	}
 
 	@Override

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/AttributeDeltaConflictKey.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/AttributeDeltaConflictKey.java
@@ -45,106 +45,120 @@ public record AttributeDeltaConflictKey(
 	@Nullable Integer entityPrimaryKey,
 	@Nonnull AttributeKey attributeKey,
 	@Nonnull Number deltaValue,
-	@Nullable NumberRange<?> allowedRange
+	@Nullable NumberRange<?> allowedRange,
+	boolean sharedSurface
 ) implements CommutativeConflictKey<Number> {
 
-    /**
-     * A range-constrained attribute delta is contained by the absolute attribute-level write it can conflict with: an
-     * unconditional overwrite of the same attribute invalidates the delta's post-application range guard, so the two
-     * must serialize. The owning {@link AttributeConflictKey} is keyed by name only, so the delta's locale-bearing
-     * {@link AttributeKey} is projected to its name. When the entity primary key is not yet assigned (delta applied
-     * during entity creation) no entity- or attribute-level key can be formed, so the finest derivable containing
-     * scope is the collection.
-     *
-     * @return an {@link AttributeConflictKey} for the same attribute when the primary key is known, otherwise a
-     *         {@link CollectionConflictKey} for the entity's collection
-     */
-    @Nonnull
-    @Override
-    public ConflictKey parentConflictKey() {
-        return this.entityPrimaryKey == null ?
-            new CollectionConflictKey(this.entityType) :
-            new AttributeConflictKey(this.entityType, this.entityPrimaryKey, this.attributeKey.attributeName());
-    }
+	/**
+	 * A range-constrained attribute delta is contained by the write it can conflict with. When the entity
+	 * primary key is not yet assigned (delta applied during entity creation) no entity-level key can be
+	 * formed, so the finest derivable containing scope is the collection. Otherwise the parent depends on
+	 * whether the attribute was carved out of the entity's shared surface at the time this key was emitted:
+	 * a carved-out attribute ({@link #sharedSurface} false) reaches the absolute {@link AttributeConflictKey}
+	 * it can conflict with — the owning key is name-only, so the delta's locale-bearing {@link AttributeKey}
+	 * is projected to its name — while a delta on the shared surface ({@link #sharedSurface} true) reaches
+	 * the {@link EntityResidualConflictKey} a coarse writer of that surface would emit instead.
+	 *
+	 * @return an {@link AttributeConflictKey} for the same attribute, an {@link EntityResidualConflictKey} for
+	 *         the owning entity's shared surface, or a {@link CollectionConflictKey} when the primary key is
+	 *         not yet known
+	 */
+	@Nonnull
+	@Override
+	public ConflictKey parentConflictKey() {
+		if (this.entityPrimaryKey == null) {
+			return new CollectionConflictKey(this.entityType);
+		}
+		return this.sharedSurface ?
+			new EntityResidualConflictKey(this.entityType, this.entityPrimaryKey) :
+			new AttributeConflictKey(this.entityType, this.entityPrimaryKey, this.attributeKey.attributeName());
+	}
 
-    @Nonnull
-    @Override
-    public Number aggregate(@Nonnull Number one, @Nonnull Number two) {
-        return NumberUtils.sum(one, two);
-    }
+	@Nonnull
+	@Override
+	public Number aggregate(@Nonnull Number one, @Nonnull Number two) {
+		return NumberUtils.sum(one, two);
+	}
 
-    @Override
-    public boolean isConstrainedToRange() {
-        return this.allowedRange != null;
-    }
+	@Override
+	public boolean isConstrainedToRange() {
+		return this.allowedRange != null;
+	}
 
-    @Override
-    public void assertInAllowedRange(
-        @Nonnull String catalogName,
-        long catalogVersion,
-        @Nonnull Number accumulatedValue
-    ) {
-        if (this.allowedRange != null && !this.allowedRange.isWithin(accumulatedValue)) {
-            throw new ConflictingCatalogCommutativeMutationException(
-                catalogName,
-                this,
-                catalogVersion,
-                "The accumulated value `" + accumulatedValue + "` for " + this +
-                    " is outside the allowed range `" + this.allowedRange + "`."
-            );
-        }
-    }
+	@Override
+	public void assertInAllowedRange(
+		@Nonnull String catalogName,
+		long catalogVersion,
+		@Nonnull Number accumulatedValue
+	) {
+		if (this.allowedRange != null && !this.allowedRange.isWithin(accumulatedValue)) {
+			throw new ConflictingCatalogCommutativeMutationException(
+				catalogName,
+				this,
+				catalogVersion,
+				"The accumulated value `" + accumulatedValue + "` for " + this +
+					" is outside the allowed range `" + this.allowedRange + "`."
+			);
+		}
+	}
 
-    @Override
-    public boolean equals(@Nullable Object o) {
-        if (!(o instanceof AttributeDeltaConflictKey that)) return false;
+	@Override
+	public boolean equals(@Nullable Object o) {
+		if (!(o instanceof AttributeDeltaConflictKey that)) return false;
 
-        return this.entityType.equals(that.entityType) &&
-            Objects.equals(this.deltaValue, that.deltaValue) &&
-            Objects.equals(this.entityPrimaryKey, that.entityPrimaryKey) &&
-            this.attributeKey.equals(that.attributeKey) &&
-            Objects.equals(this.allowedRange, that.allowedRange);
-    }
+		return this.entityType.equals(that.entityType) &&
+			Objects.equals(this.deltaValue, that.deltaValue) &&
+			Objects.equals(this.entityPrimaryKey, that.entityPrimaryKey) &&
+			this.attributeKey.equals(that.attributeKey) &&
+			Objects.equals(this.allowedRange, that.allowedRange) &&
+			this.sharedSurface == that.sharedSurface;
+	}
 
-    /**
-     * Hashes the full identity, consistent with {@link #equals(Object)} (including the delta value and
-     * allowed range). Accumulation grouping is handled separately by {@link #aggregationKey()}, so the hash
-     * no longer needs to collapse keys that differ only in their delta.
-     */
-    @Override
-    public int hashCode() {
-        int result = this.entityType.hashCode();
-        result = 31 * result + Objects.hashCode(this.entityPrimaryKey);
-        result = 31 * result + this.attributeKey.hashCode();
-        result = 31 * result + this.deltaValue.hashCode();
-        result = 31 * result + Objects.hashCode(this.allowedRange);
-        return result;
-    }
+	/**
+	 * Hashes the full identity, consistent with {@link #equals(Object)} (including the delta value, allowed
+	 * range and the shared-surface flag). Accumulation grouping is handled separately by
+	 * {@link #aggregationKey()}, so the hash no longer needs to collapse keys that differ only in their delta.
+	 */
+	@Override
+	public int hashCode() {
+		int result = this.entityType.hashCode();
+		result = 31 * result + Objects.hashCode(this.entityPrimaryKey);
+		result = 31 * result + this.attributeKey.hashCode();
+		result = 31 * result + this.deltaValue.hashCode();
+		result = 31 * result + Objects.hashCode(this.allowedRange);
+		result = 31 * result + Boolean.hashCode(this.sharedSurface);
+		return result;
+	}
 
-    /**
-     * {@inheritDoc}
-     *
-     * Requires a resolved {@link #entityPrimaryKey()}: commit-time accumulation is the sole consumer of the
-     * aggregation key, and by then a generated primary key has already been assigned during upsert (see
-     * {@code EntityCollection.verifyPrimaryKeyAssignment}) — well before the mutation is read back from the
-     * WAL for conflict resolution. A null primary key here would collapse the accumulation slot of every
-     * concurrently-created entity of the same type into one, so it is rejected as a programming error rather
-     * than silently mis-merged. This precondition is deliberately stricter than {@link #parentConflictKey()},
-     * which stays null-tolerant because it serves the scope/containment path, not accumulation.
-     *
-     * @return a {@link DeltaAggregationKey} over the entity type, primary key and attribute key, so deltas on
-     *         the same attribute accumulate regardless of their individual delta value or allowed range
-     */
-    @Nonnull
-    @Override
-    public Object aggregationKey() {
-        Assert.isPremiseValid(
-            this.entityPrimaryKey != null,
-            "A commutative attribute-delta conflict key must carry a resolved entity primary key before it " +
-                "can take part in commit-time accumulation."
-        );
-        return new DeltaAggregationKey(this.entityType, this.entityPrimaryKey, null, this.attributeKey);
-    }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Requires a resolved {@link #entityPrimaryKey()}: commit-time accumulation is the sole consumer of the
+	 * aggregation key, and by then a generated primary key has already been assigned during upsert (see
+	 * {@code EntityCollection.verifyPrimaryKeyAssignment}) — well before the mutation is read back from the
+	 * WAL for conflict resolution. A null primary key here would collapse the accumulation slot of every
+	 * concurrently-created entity of the same type into one, so it is rejected as a programming error rather
+	 * than silently mis-merged. This precondition is deliberately stricter than {@link #parentConflictKey()},
+	 * which stays null-tolerant because it serves the scope/containment path, not accumulation.
+	 *
+	 * Deliberately does not include {@link #sharedSurface}: two deltas on the same attribute must accumulate
+	 * into a single running total regardless of whether the attribute was carved out at the time either delta
+	 * was emitted, since the carve-out decision can only be evaluated against the schema in effect at emission
+	 * time and must not fragment a single attribute's accumulation slot.
+	 *
+	 * @return a {@link DeltaAggregationKey} over the entity type, primary key and attribute key, so deltas on
+	 *         the same attribute accumulate regardless of their individual delta value or allowed range
+	 */
+	@Nonnull
+	@Override
+	public Object aggregationKey() {
+		Assert.isPremiseValid(
+			this.entityPrimaryKey != null,
+			"A commutative attribute-delta conflict key must carry a resolved entity primary key before it " +
+				"can take part in commit-time accumulation."
+		);
+		return new DeltaAggregationKey(this.entityType, this.entityPrimaryKey, null, this.attributeKey);
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -157,7 +171,7 @@ public record AttributeDeltaConflictKey(
 		return ConflictScope.ATTRIBUTE;
 	}
 
-    /**
+	/**
 	 * Returns a concise, human-readable representation of this conflict key.
 	 *
 	 * @return non-null string representation

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/AttributeDeltaConflictKey.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/AttributeDeltaConflictKey.java
@@ -172,14 +172,18 @@ public record AttributeDeltaConflictKey(
 	}
 
 	/**
-	 * Returns a concise, human-readable representation of this conflict key.
+	 * Returns a concise, human-readable representation of this conflict key. The shared-surface routing is
+	 * appended when active, since it changes which coarse key this delta is contained by ({@link
+	 * EntityResidualConflictKey} instead of the absolute {@link AttributeConflictKey}) and would otherwise
+	 * render identically to a carved-out delta in a conflict diagnostic.
 	 *
 	 * @return non-null string representation
 	 */
 	@Nonnull
 	@Override
 	public String toString() {
-		return "attribute delta `" + this.attributeKey + "` of entity `" + this.entityType + "` with primary key `" + this.entityPrimaryKey + '`';
+		return "attribute delta `" + this.attributeKey + "` of entity `" + this.entityType + "` with primary key `" + this.entityPrimaryKey + '`' +
+			(this.sharedSurface ? " (shared surface)" : "");
 	}
 
 }

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/EntityConflictKey.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/EntityConflictKey.java
@@ -29,9 +29,16 @@ import javax.annotation.Nonnull;
 /**
  * Entity-level conflict key for serializing concurrent engine mutations.
  *
- * The mutation conflict resolver uses this key to group all mutations that target the same entity.
+ * Represents a whole-entity operation: removal, forced creation ({@link
+ * io.evitadb.api.requestResponse.data.mutation.EntityMutation.EntityExistence#MUST_NOT_EXIST}) or a scope
+ * change (archive/restore). These are the only writes that must conflict with *every* part of the entity,
+ * including an item that was carved out into its own granular conflict key — which is why every granular
+ * key's containment chain still reaches this key. An ordinary write that merely touches some of the entity's
+ * non-carved-out fields, without changing its existence or identity, instead produces the finer
+ * {@link EntityResidualConflictKey}, a sibling of the granular keys and a child of this one.
  *
  * @see ConflictKey
+ * @see EntityResidualConflictKey
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
  */
 public record EntityConflictKey(

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/EntityResidualConflictKey.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/EntityResidualConflictKey.java
@@ -1,0 +1,95 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.requestResponse.mutation.conflict;
+
+
+import javax.annotation.Nonnull;
+
+/**
+ * Marks that a transaction touched an entity's shared, non-carved-out surface.
+ *
+ * {@link EntityConflictKey} conflates two distinct facts about a transaction: "it changed the entity's very
+ * existence or identity" (removal, forced creation, scope change) and "it touched some of the entity's
+ * ordinary fields that were not carved out into their own granular key" (the coarse-policy catch-all). Only
+ * the first fact must conflict with every carved-out item of the entity; the second must conflict only with
+ * other writers of that same shared surface, not with a writer of a `GRANULAR`-overridden item. This key
+ * represents the second fact alone, so a coarse writer of an ordinary field and a writer of a carved-out item
+ * of the same entity stop falsely conflicting.
+ *
+ * This key is a sibling of the granular per-item keys ({@link AttributeConflictKey},
+ * {@link AssociatedDataConflictKey}, {@link PriceConflictKey}, {@link ReferenceConflictKey},
+ * {@link ReferenceAttributeConflictKey}, {@link HierarchyConflictKey}), never their ancestor or descendant:
+ * every granular key is only ever produced for an item that was carved out of this residual surface in the
+ * first place, so the two families never need to be compared against each other. It remains a *child* of the
+ * full {@link EntityConflictKey}: whole-entity operations still conflict with the shared surface, exactly as
+ * they conflict with every carved-out item.
+ *
+ * Carries no schema-derived payload beyond the entity coordinates: matching between the write path and the
+ * historical recompute path is by hash equality alone, so the two paths agree without needing to re-derive
+ * which items were carved out at emission time.
+ *
+ * @see ConflictKey
+ * @see EntityConflictKey
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public record EntityResidualConflictKey(
+	@Nonnull String entityType,
+	int entityPrimaryKey
+) implements ConflictKey {
+
+	/**
+	 * The shared surface is contained by the full entity: any whole-entity conflict (removal, forced
+	 * creation, scope change) implies a conflict on the entity's shared, non-carved-out surface too.
+	 *
+	 * @return an {@link EntityConflictKey} for the owning entity
+	 */
+	@Nonnull
+	@Override
+	public ConflictKey parentConflictKey() {
+		return new EntityConflictKey(this.entityType, this.entityPrimaryKey);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return {@link ConflictScope#ENTITY}
+	 */
+	@Nonnull
+	@Override
+	public ConflictScope conflictScope() {
+		return ConflictScope.ENTITY;
+	}
+
+	/**
+	 * Returns a concise, human-readable representation of this conflict key.
+	 *
+	 * @return non-null string representation
+	 */
+	@Nonnull
+	@Override
+	public String toString() {
+		return "shared surface of entity `" + this.entityType + "` with primary key `" + this.entityPrimaryKey + '`';
+	}
+
+}

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/ReferenceAttributeDeltaConflictKey.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/ReferenceAttributeDeltaConflictKey.java
@@ -183,14 +183,18 @@ public record ReferenceAttributeDeltaConflictKey(
 	}
 
 	/**
-	 * Returns a concise, human-readable representation of this conflict key.
+	 * Returns a concise, human-readable representation of this conflict key. The shared-surface routing is
+	 * appended when active, since it changes which coarse key this delta is contained by ({@link
+	 * EntityResidualConflictKey} instead of the absolute {@link ReferenceAttributeConflictKey}) and would
+	 * otherwise render identically to a carved-out delta in a conflict diagnostic.
 	 *
 	 * @return non-null string representation
 	 */
 	@Nonnull
 	@Override
 	public String toString() {
-		return "reference `" + this.referenceKey + "` attribute delta `" + this.attributeKey + "` of entity `" + this.entityType + "` with primary key `" + this.entityPrimaryKey + '`';
+		return "reference `" + this.referenceKey + "` attribute delta `" + this.attributeKey + "` of entity `" + this.entityType + "` with primary key `" + this.entityPrimaryKey + '`' +
+			(this.sharedSurface ? " (shared surface)" : "");
 	}
 
 }

--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/ReferenceAttributeDeltaConflictKey.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/mutation/conflict/ReferenceAttributeDeltaConflictKey.java
@@ -44,117 +44,132 @@ import java.util.Objects;
 public record ReferenceAttributeDeltaConflictKey(
 	@Nonnull String entityType,
 	@Nullable Integer entityPrimaryKey,
-    @Nonnull ReferenceKey referenceKey,
+	@Nonnull ReferenceKey referenceKey,
 	@Nonnull AttributeKey attributeKey,
 	@Nonnull Number deltaValue,
-	@Nullable NumberRange<?> allowedRange
+	@Nullable NumberRange<?> allowedRange,
+	boolean sharedSurface
 ) implements CommutativeConflictKey<Number> {
 
-    /**
-     * A range-constrained reference-attribute delta is contained by the absolute reference-attribute write it can
-     * conflict with: an unconditional overwrite of the same reference attribute invalidates the delta's
-     * post-application range guard, so the two must serialize. The owning {@link ReferenceAttributeConflictKey} is
-     * keyed by name only, so the delta's locale-bearing {@link AttributeKey} is projected to its name. When the entity
-     * primary key is not yet assigned (delta applied during entity creation) no entity- or reference-level key can be
-     * formed, so the finest derivable containing scope is the collection.
-     *
-     * @return a {@link ReferenceAttributeConflictKey} for the same reference attribute when the primary key is known,
-     *         otherwise a {@link CollectionConflictKey} for the entity's collection
-     */
-    @Nonnull
-    @Override
-    public ConflictKey parentConflictKey() {
-        return this.entityPrimaryKey == null ?
-            new CollectionConflictKey(this.entityType) :
-            new ReferenceAttributeConflictKey(
-                this.entityType,
-                this.entityPrimaryKey,
-                this.referenceKey.referenceName(),
-                this.referenceKey.primaryKey(),
-                this.attributeKey.attributeName()
-            );
-    }
+	/**
+	 * A range-constrained reference-attribute delta is contained by the write it can conflict with. When the
+	 * entity primary key is not yet assigned (delta applied during entity creation) no entity-level key can be
+	 * formed, so the finest derivable containing scope is the collection. Otherwise the parent depends on
+	 * whether the reference attribute was carved out of the entity's shared surface at the time this key was
+	 * emitted: a carved-out reference attribute ({@link #sharedSurface} false) reaches the absolute
+	 * {@link ReferenceAttributeConflictKey} it can conflict with — the owning key is name-only, so the delta's
+	 * locale-bearing {@link AttributeKey} is projected to its name — while a delta on the shared surface
+	 * ({@link #sharedSurface} true) reaches the {@link EntityResidualConflictKey} a coarse writer of that
+	 * surface would emit instead.
+	 *
+	 * @return a {@link ReferenceAttributeConflictKey} for the same reference attribute, an
+	 *         {@link EntityResidualConflictKey} for the owning entity's shared surface, or a
+	 *         {@link CollectionConflictKey} when the primary key is not yet known
+	 */
+	@Nonnull
+	@Override
+	public ConflictKey parentConflictKey() {
+		if (this.entityPrimaryKey == null) {
+			return new CollectionConflictKey(this.entityType);
+		}
+		return this.sharedSurface ?
+			new EntityResidualConflictKey(this.entityType, this.entityPrimaryKey) :
+			new ReferenceAttributeConflictKey(
+				this.entityType,
+				this.entityPrimaryKey,
+				this.referenceKey.referenceName(),
+				this.referenceKey.primaryKey(),
+				this.attributeKey.attributeName()
+			);
+	}
 
-    @Nonnull
-    @Override
-    public Number aggregate(@Nonnull Number one, @Nonnull Number two) {
-        return NumberUtils.sum(one, two);
-    }
+	@Nonnull
+	@Override
+	public Number aggregate(@Nonnull Number one, @Nonnull Number two) {
+		return NumberUtils.sum(one, two);
+	}
 
-    @Override
-    public boolean isConstrainedToRange() {
-        return this.allowedRange != null;
-    }
+	@Override
+	public boolean isConstrainedToRange() {
+		return this.allowedRange != null;
+	}
 
-    @Override
-    public void assertInAllowedRange(
-        @Nonnull String catalogName,
-        long catalogVersion,
-        @Nonnull Number accumulatedValue
-    ) {
-        if (this.allowedRange != null && !this.allowedRange.isWithin(accumulatedValue)) {
-            throw new ConflictingCatalogCommutativeMutationException(
-                catalogName,
-                this,
-                catalogVersion,
-                "The accumulated value `" + accumulatedValue + "` for " + this +
-                    " is outside the allowed range `" + this.allowedRange + "`."
-            );
-        }
-    }
+	@Override
+	public void assertInAllowedRange(
+		@Nonnull String catalogName,
+		long catalogVersion,
+		@Nonnull Number accumulatedValue
+	) {
+		if (this.allowedRange != null && !this.allowedRange.isWithin(accumulatedValue)) {
+			throw new ConflictingCatalogCommutativeMutationException(
+				catalogName,
+				this,
+				catalogVersion,
+				"The accumulated value `" + accumulatedValue + "` for " + this +
+					" is outside the allowed range `" + this.allowedRange + "`."
+			);
+		}
+	}
 
-    @Override
-    public boolean equals(@Nullable Object o) {
-        if (!(o instanceof ReferenceAttributeDeltaConflictKey that)) return false;
+	@Override
+	public boolean equals(@Nullable Object o) {
+		if (!(o instanceof ReferenceAttributeDeltaConflictKey that)) return false;
 
-        return this.entityType.equals(that.entityType) &&
-            Objects.equals(this.referenceKey, that.referenceKey) &&
-            Objects.equals(this.deltaValue, that.deltaValue) &&
-            Objects.equals(this.entityPrimaryKey, that.entityPrimaryKey) &&
-            this.attributeKey.equals(that.attributeKey) &&
-            Objects.equals(this.allowedRange, that.allowedRange);
-    }
+		return this.entityType.equals(that.entityType) &&
+			Objects.equals(this.referenceKey, that.referenceKey) &&
+			Objects.equals(this.deltaValue, that.deltaValue) &&
+			Objects.equals(this.entityPrimaryKey, that.entityPrimaryKey) &&
+			this.attributeKey.equals(that.attributeKey) &&
+			Objects.equals(this.allowedRange, that.allowedRange) &&
+			this.sharedSurface == that.sharedSurface;
+	}
 
-    /**
-     * Hashes the full identity, consistent with {@link #equals(Object)} (including the delta value and
-     * allowed range). Accumulation grouping is handled separately by {@link #aggregationKey()}, so the hash
-     * no longer needs to collapse keys that differ only in their delta.
-     */
-    @Override
-    public int hashCode() {
-        int result = this.entityType.hashCode();
-        result = 31 * result + Objects.hashCode(this.referenceKey);
-        result = 31 * result + Objects.hashCode(this.entityPrimaryKey);
-        result = 31 * result + this.attributeKey.hashCode();
-        result = 31 * result + this.deltaValue.hashCode();
-        result = 31 * result + Objects.hashCode(this.allowedRange);
-        return result;
-    }
+	/**
+	 * Hashes the full identity, consistent with {@link #equals(Object)} (including the delta value, allowed
+	 * range and the shared-surface flag). Accumulation grouping is handled separately by
+	 * {@link #aggregationKey()}, so the hash no longer needs to collapse keys that differ only in their delta.
+	 */
+	@Override
+	public int hashCode() {
+		int result = this.entityType.hashCode();
+		result = 31 * result + Objects.hashCode(this.referenceKey);
+		result = 31 * result + Objects.hashCode(this.entityPrimaryKey);
+		result = 31 * result + this.attributeKey.hashCode();
+		result = 31 * result + this.deltaValue.hashCode();
+		result = 31 * result + Objects.hashCode(this.allowedRange);
+		result = 31 * result + Boolean.hashCode(this.sharedSurface);
+		return result;
+	}
 
-    /**
-     * {@inheritDoc}
-     *
-     * Requires a resolved {@link #entityPrimaryKey()}: commit-time accumulation is the sole consumer of the
-     * aggregation key, and by then a generated primary key has already been assigned during upsert (see
-     * {@code EntityCollection.verifyPrimaryKeyAssignment}) — well before the mutation is read back from the
-     * WAL for conflict resolution. A null primary key here would collapse the accumulation slot of every
-     * concurrently-created entity of the same type into one, so it is rejected as a programming error rather
-     * than silently mis-merged. This precondition is deliberately stricter than {@link #parentConflictKey()},
-     * which stays null-tolerant because it serves the scope/containment path, not accumulation.
-     *
-     * @return a {@link DeltaAggregationKey} over the entity type, primary key, reference key and attribute
-     *         key, so deltas on the same reference attribute accumulate regardless of delta value or range
-     */
-    @Nonnull
-    @Override
-    public Object aggregationKey() {
-        Assert.isPremiseValid(
-            this.entityPrimaryKey != null,
-            "A commutative reference-attribute-delta conflict key must carry a resolved entity primary key " +
-                "before it can take part in commit-time accumulation."
-        );
-        return new DeltaAggregationKey(this.entityType, this.entityPrimaryKey, this.referenceKey, this.attributeKey);
-    }
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Requires a resolved {@link #entityPrimaryKey()}: commit-time accumulation is the sole consumer of the
+	 * aggregation key, and by then a generated primary key has already been assigned during upsert (see
+	 * {@code EntityCollection.verifyPrimaryKeyAssignment}) — well before the mutation is read back from the
+	 * WAL for conflict resolution. A null primary key here would collapse the accumulation slot of every
+	 * concurrently-created entity of the same type into one, so it is rejected as a programming error rather
+	 * than silently mis-merged. This precondition is deliberately stricter than {@link #parentConflictKey()},
+	 * which stays null-tolerant because it serves the scope/containment path, not accumulation.
+	 *
+	 * Deliberately does not include {@link #sharedSurface}: two deltas on the same reference attribute must
+	 * accumulate into a single running total regardless of whether the attribute was carved out at the time
+	 * either delta was emitted, since the carve-out decision can only be evaluated against the schema in
+	 * effect at emission time and must not fragment a single attribute's accumulation slot.
+	 *
+	 * @return a {@link DeltaAggregationKey} over the entity type, primary key, reference key and attribute
+	 *         key, so deltas on the same reference attribute accumulate regardless of delta value or range
+	 */
+	@Nonnull
+	@Override
+	public Object aggregationKey() {
+		Assert.isPremiseValid(
+			this.entityPrimaryKey != null,
+			"A commutative reference-attribute-delta conflict key must carry a resolved entity primary key " +
+				"before it can take part in commit-time accumulation."
+		);
+		return new DeltaAggregationKey(this.entityType, this.entityPrimaryKey, this.referenceKey, this.attributeKey);
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -167,7 +182,7 @@ public record ReferenceAttributeDeltaConflictKey(
 		return ConflictScope.REFERENCE_ATTRIBUTE;
 	}
 
-    /**
+	/**
 	 * Returns a concise, human-readable representation of this conflict key.
 	 *
 	 * @return non-null string representation

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTransactionalFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/EvitaTransactionalFunctionalTest.java
@@ -62,6 +62,7 @@ import io.evitadb.core.executor.Scheduler;
 import io.evitadb.core.session.EvitaSession;
 import io.evitadb.core.transaction.Transaction;
 import io.evitadb.dataType.LongNumberRange;
+import io.evitadb.dataType.Scope;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.function.Functions;
 import io.evitadb.function.TriFunction;
@@ -175,6 +176,8 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 		.build();
 	private static final String BRAND_PRIORITY = "brandPriority";
 	private static final String STORE_PRIORITY = "storePriority";
+	private static final String ASSOCIATED_DATA_FEED_HEUREKA = "feed-heureka";
+	private static final String ATTRIBUTE_SNIPPET_EXPIRATION = "snippetExpiration";
 	private final DataGenerator dataGenerator = GENERATOR_FACTORY.get();
 	private final Pool<Kryo> catalogKryoPool = new Pool<>(false, false, 1) {
 		@Override
@@ -1828,6 +1831,382 @@ public class EvitaTransactionalFunctionalTest implements EvitaTestSupport {
 					log.info("Attempting to commit a second creation of the same primary key...");
 				}
 			)
+		);
+	}
+
+	/**
+	 * Reinitializes evita with coarse {@link ConflictPolicy#ENTITY} and declares the associated data
+	 * {@link #ASSOCIATED_DATA_FEED_HEUREKA} and the attribute {@link #ATTRIBUTE_SNIPPET_EXPIRATION} as
+	 * per-item {@link ConflictResolutionOverride#GRANULAR} on the product schema — the carve-out fixture
+	 * shared by the end-to-end conflict tests below.
+	 *
+	 * @param originalEvita the evita instance to reinitialize
+	 * @param productSchema the product schema to declare the carved-out items on
+	 * @return the reinitialized evita instance
+	 */
+	@Nonnull
+	private static Evita setUpPerItemCarveOutSchema(
+		@Nonnull EvitaContract originalEvita, @Nonnull SealedEntitySchema productSchema
+	) throws Exception {
+		final Evita evita = reinitializeEvitaWithConfig(
+			originalEvita,
+			builder -> builder.transaction(
+				TransactionOptions.builder(builder.build().transaction())
+					.conflictResolution(ConflictPolicy.ENTITY)
+					.build()
+			)
+		);
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.getEntitySchema(productSchema.getName())
+					.orElseThrow()
+					.openForWrite()
+					.withAssociatedData(
+						ASSOCIATED_DATA_FEED_HEUREKA, String.class,
+						whichIs -> whichIs.nullable().withConflictResolutionOverride(ConflictResolutionOverride.GRANULAR))
+					.withAttribute(
+						ATTRIBUTE_SNIPPET_EXPIRATION, Long.class,
+						whichIs -> whichIs.nullable().withConflictResolutionOverride(ConflictResolutionOverride.GRANULAR))
+					.updateVia(session);
+			}
+		);
+		return evita;
+	}
+
+	/**
+	 * Reinitializes evita with coarse {@link ConflictPolicy#ENTITY} refined by the
+	 * {@link GranularConflictPolicy#ASSOCIATED_DATA} granularity-set flavor (no per-item schema overrides at
+	 * all): every associated data item of every entity of this type is carved out purely by the inherited
+	 * refinement. Declares {@link #ASSOCIATED_DATA_FEED_HEUREKA} on the schema without any per-item override
+	 * so its carve-out status comes solely from the granularity set.
+	 *
+	 * @param originalEvita the evita instance to reinitialize
+	 * @param productSchema the product schema to declare the associated data item on
+	 * @return the reinitialized evita instance
+	 */
+	@Nonnull
+	private static Evita setUpGranularitySetCarveOutSchema(
+		@Nonnull EvitaContract originalEvita, @Nonnull SealedEntitySchema productSchema
+	) throws Exception {
+		final Evita evita = reinitializeEvitaWithConfig(
+			originalEvita,
+			builder -> builder.transaction(
+				TransactionOptions.builder(builder.build().transaction())
+					.conflictResolution(ConflictPolicy.ENTITY, GranularConflictPolicy.ASSOCIATED_DATA)
+					.build()
+			)
+		);
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.getEntitySchema(productSchema.getName())
+					.orElseThrow()
+					.openForWrite()
+					.withAssociatedData(ASSOCIATED_DATA_FEED_HEUREKA, String.class, whichIs -> whichIs.nullable())
+					.updateVia(session);
+			}
+		);
+		return evita;
+	}
+
+	@DisplayName("A coarse writer of a plain attribute and a writer of a carved-out associated data item do not conflict — the granular carve-out fix.")
+	@UseDataSet(value = TRANSACTIONAL_DATA_SET, destroyAfterTest = true)
+	@Test
+	void shouldNotRaiseConflictBetweenCoarseAttributeAndCarvedOutAssociatedDataWriters(
+		EvitaContract originalEvita, SealedEntitySchema productSchema) throws Exception {
+		final Evita evita = setUpPerItemCarveOutSchema(originalEvita, productSchema);
+		final SealedEntity addedEntity = upsertSingleGeneratedProduct(evita, productSchema);
+
+		// txn A writes a plain, non-carved-out attribute (the entity's shared surface); txn B writes the
+		// carved-out associated data item - before the fix, A's coarse fallback key would have been the
+		// full entity key, which falsely contained B's granular key
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				setPriority(session, productSchema, addedEntity.getPrimaryKey(), 19846L);
+
+				try {
+					executeConcurrentUpdate(
+						evita, TEST_CATALOG, concurrentSession -> {
+							concurrentSession.getEntity(productSchema.getName(), addedEntity.getPrimaryKey(), entityFetchAllContent())
+								.orElseThrow()
+								.openForWrite()
+								.setAssociatedData(ASSOCIATED_DATA_FEED_HEUREKA, "payload")
+								.upsertVia(concurrentSession);
+						}
+					);
+				} catch (InterruptedException e) {
+					fail("Test thread was interrupted!", e);
+				}
+
+				log.info("Committing transaction expected NOT to conflict via the residual/granular carve-out...");
+			}
+		);
+	}
+
+	@DisplayName("Two concurrent writers of the same carved-out associated data item still conflict.")
+	@UseDataSet(value = TRANSACTIONAL_DATA_SET, destroyAfterTest = true)
+	@Test
+	void shouldRaiseConflictBetweenTwoWritersOfSameCarvedOutAssociatedDataItem(
+		EvitaContract originalEvita, SealedEntitySchema productSchema) throws Exception {
+		final Evita evita = setUpPerItemCarveOutSchema(originalEvita, productSchema);
+		final SealedEntity addedEntity = upsertSingleGeneratedProduct(evita, productSchema);
+
+		assertThrows(
+			ConflictingCatalogMutationException.class,
+			() -> evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(productSchema.getName(), addedEntity.getPrimaryKey(), entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setAssociatedData(ASSOCIATED_DATA_FEED_HEUREKA, "payload-A")
+						.upsertVia(session);
+
+					try {
+						executeConcurrentUpdate(
+							evita, TEST_CATALOG, concurrentSession -> {
+								concurrentSession.getEntity(productSchema.getName(), addedEntity.getPrimaryKey(), entityFetchAllContent())
+									.orElseThrow()
+									.openForWrite()
+									.setAssociatedData(ASSOCIATED_DATA_FEED_HEUREKA, "payload-B")
+									.upsertVia(concurrentSession);
+							}
+						);
+					} catch (InterruptedException e) {
+						fail("Test thread was interrupted!", e);
+					}
+
+					log.info("Attempting to commit conflicting write to the same carved-out associated data item...");
+				}
+			)
+		);
+	}
+
+	@DisplayName("Two coarse writers touching disjoint non-carved-out items (an attribute and a price) still conflict via the shared residual key.")
+	@UseDataSet(value = TRANSACTIONAL_DATA_SET, destroyAfterTest = true)
+	@Test
+	void shouldRaiseConflictBetweenTwoCoarseWritersOfDisjointNonGranularItems(
+		EvitaContract originalEvita, SealedEntitySchema productSchema) throws Exception {
+		final Evita evita = setUpPerItemCarveOutSchema(originalEvita, productSchema);
+		final SealedEntity addedEntity = upsertSingleGeneratedProduct(evita, productSchema);
+
+		assertThrows(
+			ConflictingCatalogMutationException.class,
+			() -> evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					setPriority(session, productSchema, addedEntity.getPrimaryKey(), 19846L);
+
+					try {
+						executeConcurrentUpdate(
+							evita, TEST_CATALOG, concurrentSession -> {
+								concurrentSession.getEntity(productSchema.getName(), addedEntity.getPrimaryKey(), entityFetchAllContent())
+									.orElseThrow()
+									.openForWrite()
+									// a distinct price list avoids AmbiguousPriceException against the
+									// generated entity's existing (unbounded-validity) basic-price-list price
+									.setPrice(555, "carveout", CURRENCY_CZK, BigDecimal.TEN, BigDecimal.ZERO, BigDecimal.TEN, true)
+									.upsertVia(concurrentSession);
+							}
+						);
+					} catch (InterruptedException e) {
+						fail("Test thread was interrupted!", e);
+					}
+
+					log.info("Attempting to commit conflicting transaction sharing the entity's residual surface...");
+				}
+			)
+		);
+	}
+
+	@DisplayName("Entity removal conflicts with a concurrent writer of a carved-out associated data item.")
+	@UseDataSet(value = TRANSACTIONAL_DATA_SET, destroyAfterTest = true)
+	@Test
+	void shouldRaiseConflictBetweenEntityRemovalAndCarvedOutAssociatedDataWriter(
+		EvitaContract originalEvita, SealedEntitySchema productSchema) throws Exception {
+		final Evita evita = setUpPerItemCarveOutSchema(originalEvita, productSchema);
+		final SealedEntity addedEntity = upsertSingleGeneratedProduct(evita, productSchema);
+
+		assertThrows(
+			ConflictingCatalogMutationException.class,
+			() -> evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					// this mutation will generate a conflict, but only at the time of the commit, not now
+					session.deleteEntity(productSchema.getName(), addedEntity.getPrimaryKey());
+
+					try {
+						executeConcurrentUpdate(
+							evita, TEST_CATALOG, concurrentSession -> {
+								concurrentSession.getEntity(productSchema.getName(), addedEntity.getPrimaryKey(), entityFetchAllContent())
+									.orElseThrow()
+									.openForWrite()
+									.setAssociatedData(ASSOCIATED_DATA_FEED_HEUREKA, "payload")
+									.upsertVia(concurrentSession);
+							}
+						);
+					} catch (InterruptedException e) {
+						fail("Test thread was interrupted!", e);
+					}
+
+					log.info("Attempting to commit removal conflicting with a carved-out associated data writer...");
+				}
+			)
+		);
+	}
+
+	@DisplayName("A scope change conflicts with a concurrent writer of a carved-out associated data item.")
+	@UseDataSet(value = TRANSACTIONAL_DATA_SET, destroyAfterTest = true)
+	@Test
+	void shouldRaiseConflictBetweenScopeChangeAndCarvedOutAssociatedDataWriter(
+		EvitaContract originalEvita, SealedEntitySchema productSchema) throws Exception {
+		final Evita evita = setUpPerItemCarveOutSchema(originalEvita, productSchema);
+		final SealedEntity addedEntity = upsertSingleGeneratedProduct(evita, productSchema);
+
+		assertThrows(
+			ConflictingCatalogMutationException.class,
+			() -> evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					// a scope change is a whole-entity operation: it must conflict with every carved-out
+					// item too, even though the coarse fallback now only covers the shared surface
+					session.getEntity(productSchema.getName(), addedEntity.getPrimaryKey(), entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setScope(Scope.ARCHIVED)
+						.upsertVia(session);
+
+					try {
+						executeConcurrentUpdate(
+							evita, TEST_CATALOG, concurrentSession -> {
+								concurrentSession.getEntity(productSchema.getName(), addedEntity.getPrimaryKey(), entityFetchAllContent())
+									.orElseThrow()
+									.openForWrite()
+									.setAssociatedData(ASSOCIATED_DATA_FEED_HEUREKA, "payload")
+									.upsertVia(concurrentSession);
+							}
+						);
+					} catch (InterruptedException e) {
+						fail("Test thread was interrupted!", e);
+					}
+
+					log.info("Attempting to commit scope change conflicting with a carved-out associated data writer...");
+				}
+			)
+		);
+	}
+
+	@DisplayName("Forced creation of the same primary key conflicts with a concurrent carved-out associated data writer on that pk.")
+	@UseDataSet(value = TRANSACTIONAL_DATA_SET, destroyAfterTest = true)
+	@Test
+	void shouldRaiseConflictBetweenForcedCreationAndCarvedOutAssociatedDataWriterOnSamePrimaryKey(
+		EvitaContract originalEvita, SealedEntitySchema productSchema) throws Exception {
+		final Evita evita = setUpPerItemCarveOutSchema(originalEvita, productSchema);
+
+		final int sharedPrimaryKey = 2000;
+
+		// both transactions create the same, not-yet-existing primary key (MUST_NOT_EXIST): forced
+		// creation always emits the full entity key, which conflicts with the concurrent writer's
+		// carved-out associated data key too, even though the two touch disjoint items
+		assertThrows(
+			ConflictingCatalogMutationException.class,
+			() -> evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(productSchema.getName(), sharedPrimaryKey)
+						.setAttribute(ATTRIBUTE_PRIORITY, 19846L)
+						.upsertVia(session);
+
+					try {
+						executeConcurrentUpdate(
+							evita, TEST_CATALOG, concurrentSession -> {
+								// `priority` is a mandatory attribute, so a brand new entity must set it
+								// regardless of which item this transaction is actually exercising
+								concurrentSession.createNewEntity(productSchema.getName(), sharedPrimaryKey)
+									.setAttribute(ATTRIBUTE_PRIORITY, 27954L)
+									.setAssociatedData(ASSOCIATED_DATA_FEED_HEUREKA, "payload")
+									.upsertVia(concurrentSession);
+							}
+						);
+					} catch (InterruptedException e) {
+						fail("Test thread was interrupted!", e);
+					}
+
+					log.info("Attempting to commit a second creation of the same primary key...");
+				}
+			)
+		);
+	}
+
+	@DisplayName("A coarse writer and a writer touching only carved-out items (a granular attribute and a granular associated data item) do not conflict.")
+	@UseDataSet(value = TRANSACTIONAL_DATA_SET, destroyAfterTest = true)
+	@Test
+	void shouldNotRaiseConflictBetweenCoarseWriterAndFullyGranularWriter(
+		EvitaContract originalEvita, SealedEntitySchema productSchema) throws Exception {
+		final Evita evita = setUpPerItemCarveOutSchema(originalEvita, productSchema);
+		final SealedEntity addedEntity = upsertSingleGeneratedProduct(evita, productSchema);
+
+		// txn A writes the shared surface (residual key); txn B writes two DIFFERENT carved-out items
+		// (a granular attribute and a granular associated data item) - since every one of B's mutations
+		// produces its own granular key, B never falls back to the residual or full entity key at all
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				setPriority(session, productSchema, addedEntity.getPrimaryKey(), 19846L);
+
+				try {
+					executeConcurrentUpdate(
+						evita, TEST_CATALOG, concurrentSession -> {
+							concurrentSession.getEntity(productSchema.getName(), addedEntity.getPrimaryKey(), entityFetchAllContent())
+								.orElseThrow()
+								.openForWrite()
+								.setAttribute(ATTRIBUTE_SNIPPET_EXPIRATION, 1234L)
+								.setAssociatedData(ASSOCIATED_DATA_FEED_HEUREKA, "payload")
+								.upsertVia(concurrentSession);
+						}
+					);
+				} catch (InterruptedException e) {
+					fail("Test thread was interrupted!", e);
+				}
+
+				log.info("Committing transaction expected NOT to conflict — the writer touches only carved-out items...");
+			}
+		);
+	}
+
+	@DisplayName("Granularity-set flavor: an attribute writer and an associated-data writer do not conflict when ASSOCIATED_DATA is carved out via the entity's granularity set (no per-item overrides).")
+	@UseDataSet(value = TRANSACTIONAL_DATA_SET, destroyAfterTest = true)
+	@Test
+	void shouldNotRaiseConflictUnderGranularitySetCarveOut(
+		EvitaContract originalEvita, SealedEntitySchema productSchema) throws Exception {
+		final Evita evita = setUpGranularitySetCarveOutSchema(originalEvita, productSchema);
+		final SealedEntity addedEntity = upsertSingleGeneratedProduct(evita, productSchema);
+
+		// no per-item ConflictResolutionOverride is declared anywhere: the associated data item is carved
+		// out purely because the entity's inherited granularity set includes ASSOCIATED_DATA
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				setPriority(session, productSchema, addedEntity.getPrimaryKey(), 19846L);
+
+				try {
+					executeConcurrentUpdate(
+						evita, TEST_CATALOG, concurrentSession -> {
+							concurrentSession.getEntity(productSchema.getName(), addedEntity.getPrimaryKey(), entityFetchAllContent())
+								.orElseThrow()
+								.openForWrite()
+								.setAssociatedData(ASSOCIATED_DATA_FEED_HEUREKA, "payload")
+								.upsertVia(concurrentSession);
+						}
+					);
+				} catch (InterruptedException e) {
+					fail("Test thread was interrupted!", e);
+				}
+
+				log.info("Committing transaction expected NOT to conflict via the granularity-set carve-out...");
+			}
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/mutation/DataMutationConflictKeyEmissionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/mutation/DataMutationConflictKeyEmissionTest.java
@@ -45,6 +45,7 @@ import io.evitadb.api.requestResponse.mutation.conflict.ConflictKey;
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictPolicy;
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictResolution;
 import io.evitadb.api.requestResponse.mutation.conflict.EntityConflictKey;
+import io.evitadb.api.requestResponse.mutation.conflict.EntityResidualConflictKey;
 import io.evitadb.api.requestResponse.mutation.conflict.GranularConflictPolicy;
 import io.evitadb.api.requestResponse.mutation.conflict.HierarchyConflictKey;
 import io.evitadb.api.requestResponse.mutation.conflict.PriceConflictKey;
@@ -72,6 +73,7 @@ import java.util.Optional;
 import static io.evitadb.test.TestTags.CONTRACT;
 import static io.evitadb.test.TestTags.TRANSACTION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -198,16 +200,39 @@ class DataMutationConflictKeyEmissionTest {
 	class EntityUpsertCoarseFallback {
 
 		@Test
-		@DisplayName("A non-granular mutation triggers the coarse entity key under ENTITY policy")
-		void shouldEmitEntityKeyWhenAtLeastOneKeyMissing() {
-			// a plain attribute upsert produces no granular key when ENTITY_ATTRIBUTE is not refined,
-			// so the coarse entity fallback is triggered by the missing key
+		@DisplayName("A non-granular mutation triggers the coarse residual key, not the full entity key, under ENTITY policy")
+		void shouldEmitResidualKeyWhenAtLeastOneKeyMissing() {
+			// a plain attribute upsert produces no granular key when ENTITY_ATTRIBUTE is not refined, so the
+			// coarse fallback is triggered by the missing key; since this is not a forced creation, the
+			// fallback is the finer residual key (the entity's shared surface), not the full entity key -
+			// this is the carve-out fix itself: a coarse writer must no longer contain a carved-out sibling
 			final EntityUpsertMutation mutation = new EntityUpsertMutation(
 				ENTITY, PK, EntityExistence.MAY_EXIST,
 				new UpsertAttributeMutation(ATTRIBUTE, "foo")
 			);
 			final List<ConflictKey> keys = mutation.collectConflictKeys(coarse(ConflictPolicy.ENTITY)).toList();
-			assertEquals(List.of(new EntityConflictKey(ENTITY, PK)), keys);
+			assertEquals(List.of(new EntityResidualConflictKey(ENTITY, PK)), keys);
+		}
+
+		@Test
+		@DisplayName("Forced creation emits the full entity key alongside a granular key, never the residual key")
+		void shouldEmitFullEntityKeyAlongsideGranularKeyForForcedCreation() {
+			// mixed mutations: the attribute is carved out (its own key is produced), the associated data is
+			// not (ASSOCIATED_DATA is not refined) - so a missing granular key is present too. Forced creation
+			// must still win with the full entity key, never the residual, since the full key already
+			// bidirectionally contains the residual
+			final ConflictGenerationContext context = entityGranular(GranularConflictPolicy.ENTITY_ATTRIBUTE);
+			final List<? extends LocalMutation<?, ?>> mutations = List.of(
+				new UpsertAttributeMutation(ATTRIBUTE, "foo"),
+				new UpsertAssociatedDataMutation(ASSOCIATED_DATA, "bar")
+			);
+			final List<ConflictKey> keys = context.withEntityType(
+				ENTITY, PK,
+				ctx -> EntityMutation.getConflictKeyStream(ENTITY, PK, mutations, EntityExistence.MUST_NOT_EXIST, ctx).toList()
+			);
+			assertTrue(keys.contains(new AttributeConflictKey(ENTITY, PK, ATTRIBUTE)));
+			assertTrue(keys.contains(new EntityConflictKey(ENTITY, PK)));
+			assertFalse(keys.contains(new EntityResidualConflictKey(ENTITY, PK)));
 		}
 
 		@Test
@@ -241,6 +266,60 @@ class DataMutationConflictKeyEmissionTest {
 			);
 			final List<ConflictKey> keys = mutation.collectConflictKeys(coarse(ConflictPolicy.NONE)).toList();
 			assertTrue(keys.isEmpty());
+		}
+	}
+
+	@Nested
+	@DisplayName("Coarse fallback interplay with carved-out items")
+	class CoarseFallbackInterplayWithGranularItems {
+
+		@Test
+		@DisplayName("A carved-out associated data alongside a non-granular attribute emits the granular key plus the residual, never the full entity key")
+		void shouldEmitGranularKeyAndResidualForMixedCarveOut() {
+			// only ASSOCIATED_DATA is refined: the associated data mutation is carved out and produces its own
+			// key, while the attribute mutation is not and produces none - triggering the residual fallback.
+			// The two keys are disjoint siblings, not a whole-entity key
+			final ConflictGenerationContext context = entityGranular(GranularConflictPolicy.ASSOCIATED_DATA);
+			final List<? extends LocalMutation<?, ?>> mutations = List.of(
+				new UpsertAttributeMutation(ATTRIBUTE, "foo"),
+				new UpsertAssociatedDataMutation(ASSOCIATED_DATA, "bar")
+			);
+			final List<ConflictKey> keys = context.withEntityType(
+				ENTITY, PK,
+				ctx -> EntityMutation.getConflictKeyStream(ENTITY, PK, mutations, EntityExistence.MAY_EXIST, ctx).toList()
+			);
+			assertEquals(
+				List.of(
+					new AssociatedDataConflictKey(ENTITY, PK, ASSOCIATED_DATA),
+					new EntityResidualConflictKey(ENTITY, PK)
+				),
+				keys
+			);
+		}
+
+		@Test
+		@DisplayName("Fully granular mutations emit only their own keys, with no entity-level key at all")
+		void shouldEmitOnlyGranularKeysWhenNothingIsMissing() {
+			// every mutation produces its own granular key (both refinements are active), so the coarse
+			// fallback is never triggered: no residual and no full entity key appears alongside them
+			final ConflictGenerationContext context = entityGranular(
+				GranularConflictPolicy.ENTITY_ATTRIBUTE, GranularConflictPolicy.ASSOCIATED_DATA
+			);
+			final List<? extends LocalMutation<?, ?>> mutations = List.of(
+				new UpsertAttributeMutation(ATTRIBUTE, "foo"),
+				new UpsertAssociatedDataMutation(ASSOCIATED_DATA, "bar")
+			);
+			final List<ConflictKey> keys = context.withEntityType(
+				ENTITY, PK,
+				ctx -> EntityMutation.getConflictKeyStream(ENTITY, PK, mutations, EntityExistence.MAY_EXIST, ctx).toList()
+			);
+			assertEquals(
+				List.of(
+					new AttributeConflictKey(ENTITY, PK, ATTRIBUTE),
+					new AssociatedDataConflictKey(ENTITY, PK, ASSOCIATED_DATA)
+				),
+				keys
+			);
 		}
 	}
 
@@ -536,7 +615,7 @@ class DataMutationConflictKeyEmissionTest {
 				PK
 			);
 			assertEquals(
-				List.of(new AttributeDeltaConflictKey(ENTITY, PK, new AttributeKey(ATTRIBUTE), 5, null)),
+				List.of(new AttributeDeltaConflictKey(ENTITY, PK, new AttributeKey(ATTRIBUTE), 5, null, false)),
 				keys
 			);
 		}
@@ -550,6 +629,40 @@ class DataMutationConflictKeyEmissionTest {
 				PK
 			);
 			assertTrue(keys.isEmpty());
+		}
+
+		@Test
+		@DisplayName("A range-constrained delta on a non-carved-out attribute is marked shared-surface, parented by the residual key")
+		void shouldEmitSharedSurfaceDeltaKeyForNonGranularRangeConstrainedDelta() {
+			// the range guard forces emission even though ENTITY_ATTRIBUTE is not refined; since the attribute
+			// was not carved out, the key must route through the entity's shared surface, not the absolute
+			// attribute key, so it still conflicts with a coarse writer of an unrelated non-carved-out field
+			final List<ConflictKey> keys = keysWithin(
+				coarse(ConflictPolicy.ENTITY),
+				new ApplyDeltaAttributeMutation<>(ATTRIBUTE, 5, IntegerNumberRange.between(0, 100)),
+				PK
+			);
+			assertEquals(1, keys.size());
+			final AttributeDeltaConflictKey key = (AttributeDeltaConflictKey) keys.get(0);
+			assertTrue(key.sharedSurface());
+			assertEquals(new EntityResidualConflictKey(ENTITY, PK), key.parentConflictKey());
+		}
+
+		@Test
+		@DisplayName("A range-constrained delta on a carved-out attribute is not marked shared-surface, parented by the absolute attribute key")
+		void shouldEmitCarvedOutDeltaKeyForGranularRangeConstrainedDelta() {
+			// the attribute is carved out (ENTITY_ATTRIBUTE refined), so even though the range guard alone
+			// would force emission, the key still routes through the absolute attribute key it can conflict
+			// with, not the shared surface
+			final List<ConflictKey> keys = keysWithin(
+				entityGranular(GranularConflictPolicy.ENTITY_ATTRIBUTE),
+				new ApplyDeltaAttributeMutation<>(ATTRIBUTE, 5, IntegerNumberRange.between(0, 100)),
+				PK
+			);
+			assertEquals(1, keys.size());
+			final AttributeDeltaConflictKey key = (AttributeDeltaConflictKey) keys.get(0);
+			assertFalse(key.sharedSurface());
+			assertEquals(new AttributeConflictKey(ENTITY, PK, ATTRIBUTE), key.parentConflictKey());
 		}
 	}
 
@@ -615,14 +728,14 @@ class DataMutationConflictKeyEmissionTest {
 			);
 			assertEquals(
 				List.of(new ReferenceAttributeDeltaConflictKey(
-					ENTITY, PK, new ReferenceKey(REFERENCE, REFERENCE_PK), new AttributeKey(ATTRIBUTE), 5, null
+					ENTITY, PK, new ReferenceKey(REFERENCE, REFERENCE_PK), new AttributeKey(ATTRIBUTE), 5, null, false
 				)),
 				keys
 			);
 		}
 
 		@Test
-		@DisplayName("A range-constrained wrapped delta emits its key even when the refinement is inactive")
+		@DisplayName("A range-constrained wrapped delta emits its key even when the refinement is inactive, marked shared-surface")
 		void shouldEmitReferenceAttributeDeltaKeyForConstrainedDeltaUnderNonePolicy() {
 			final List<ConflictKey> keys = keysWithin(
 				coarse(ConflictPolicy.NONE),
@@ -635,10 +748,29 @@ class DataMutationConflictKeyEmissionTest {
 			assertEquals(
 				List.of(new ReferenceAttributeDeltaConflictKey(
 					ENTITY, PK, new ReferenceKey(REFERENCE, REFERENCE_PK), new AttributeKey(ATTRIBUTE), 5,
-					IntegerNumberRange.between(0, 100)
+					IntegerNumberRange.between(0, 100), true
 				)),
 				keys
 			);
+		}
+
+		@Test
+		@DisplayName("A range-constrained delta on a non-carved-out reference attribute is marked shared-surface, parented by the residual key")
+		void shouldEmitSharedSurfaceReferenceAttributeDeltaKeyForNonGranularRangeConstrainedDelta() {
+			// REFERENCE_ATTRIBUTE is not refined, so the reference attribute is not carved out; the range
+			// guard alone forces emission, and the key must route through the entity's shared surface
+			final List<ConflictKey> keys = keysWithin(
+				coarse(ConflictPolicy.ENTITY),
+				new ReferenceAttributeMutation(
+					new ReferenceKey(REFERENCE, REFERENCE_PK),
+					new ApplyDeltaAttributeMutation<>(ATTRIBUTE, 5, IntegerNumberRange.between(0, 100))
+				),
+				PK
+			);
+			assertEquals(1, keys.size());
+			final ReferenceAttributeDeltaConflictKey key = (ReferenceAttributeDeltaConflictKey) keys.get(0);
+			assertTrue(key.sharedSurface());
+			assertEquals(new EntityResidualConflictKey(ENTITY, PK), key.parentConflictKey());
 		}
 	}
 
@@ -647,10 +779,10 @@ class DataMutationConflictKeyEmissionTest {
 	class SetEntityScopeMutationEmission {
 
 		@Test
-		@DisplayName("Emits nothing even under a fully granular emit-capable resolution")
-		void shouldEmitNothingEvenWhenOtherMutationsWould() {
-			// the scope mutation is intentionally silent: entity-scope conflicts are covered by the coarse
-			// entity-level fallback, so it must not contribute a key even where every refinement is active
+		@DisplayName("Emits the full entity key under ENTITY policy, even where every granular refinement is active")
+		void shouldEmitFullEntityKeyUnderEntityPolicy() {
+			// a scope change is a whole-entity operation, so it must conflict with every carved-out item too -
+			// it can no longer free-ride on the coarse fallback, which now only covers the shared surface
 			final ConflictGenerationContext context = entityGranular(
 				GranularConflictPolicy.ENTITY_ATTRIBUTE,
 				GranularConflictPolicy.ASSOCIATED_DATA,
@@ -660,6 +792,33 @@ class DataMutationConflictKeyEmissionTest {
 				GranularConflictPolicy.HIERARCHY
 			);
 			final List<ConflictKey> keys = keysWithin(context, new SetEntityScopeMutation(Scope.ARCHIVED), PK);
+			assertEquals(List.of(new EntityConflictKey(ENTITY, PK)), keys);
+		}
+
+		@Test
+		@DisplayName("Emits the collection key under COLLECTION policy")
+		void shouldEmitCollectionKeyUnderCollectionPolicy() {
+			final List<ConflictKey> keys = keysWithin(
+				coarse(ConflictPolicy.COLLECTION), new SetEntityScopeMutation(Scope.ARCHIVED), PK
+			);
+			assertEquals(List.of(new CollectionConflictKey(ENTITY)), keys);
+		}
+
+		@Test
+		@DisplayName("Emits nothing under NONE policy")
+		void shouldEmitNothingUnderNonePolicy() {
+			final List<ConflictKey> keys = keysWithin(
+				coarse(ConflictPolicy.NONE), new SetEntityScopeMutation(Scope.ARCHIVED), PK
+			);
+			assertTrue(keys.isEmpty());
+		}
+
+		@Test
+		@DisplayName("Emits nothing under ENTITY policy when the primary key is not yet assigned")
+		void shouldEmitNothingWhenPrimaryKeyIsNullUnderEntityPolicy() {
+			final List<ConflictKey> keys = keysWithin(
+				coarse(ConflictPolicy.ENTITY), new SetEntityScopeMutation(Scope.ARCHIVED), null
+			);
 			assertTrue(keys.isEmpty());
 		}
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/mutation/DataMutationConflictKeyEmissionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/data/mutation/DataMutationConflictKeyEmissionTest.java
@@ -84,7 +84,7 @@ import static org.mockito.Mockito.when;
  * the two historically missing emission gaps, this class exercises the whole per-mutation emission matrix:
  * each local mutation's predicate-true branch (the exact key it must contribute) and its predicate-false /
  * empty branch, plus the coarse entity/collection fallback assembled by
- * {@link EntityMutation#getConflictKeyStream} and the deliberately-silent scope mutation.
+ * {@link EntityMutation#getConflictKeyStream} and the whole-entity key the scope mutation emits.
  *
  * Assertions compare against full key instances (type, entity type, primary key, and every element
  * coordinate) rather than mere key-class membership, so a regression that emits a key of the right shape but

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/mutation/conflict/ConflictKeyTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/mutation/conflict/ConflictKeyTest.java
@@ -149,6 +149,56 @@ class ConflictKeyTest implements EvitaTestSupport {
 	}
 
 	@Nested
+	@DisplayName("EntityResidualConflictKey")
+	class EntityResidualConflictKeyTest {
+
+		@Test
+		@DisplayName("should be equal for same entity type and primary key")
+		void shouldBeEqualForSameEntityTypeAndPrimaryKey() {
+			final EntityResidualConflictKey key1 = new EntityResidualConflictKey("Product", 1);
+			final EntityResidualConflictKey key2 = new EntityResidualConflictKey("Product", 1);
+
+			assertEquals(key1, key2);
+			assertEquals(key1.hashCode(), key2.hashCode());
+		}
+
+		@Test
+		@DisplayName("should not be equal for different primary keys")
+		void shouldNotBeEqualForDifferentPrimaryKeys() {
+			final EntityResidualConflictKey key1 = new EntityResidualConflictKey("Product", 1);
+			final EntityResidualConflictKey key2 = new EntityResidualConflictKey("Product", 2);
+
+			assertNotEquals(key1, key2);
+		}
+
+		@Test
+		@DisplayName("should not be equal to the full entity key it is contained by")
+		void shouldNotBeEqualToFullEntityKey() {
+			final EntityResidualConflictKey residual = new EntityResidualConflictKey("Product", 1);
+			final EntityConflictKey full = new EntityConflictKey("Product", 1);
+
+			assertNotEquals(residual, full);
+			assertNotEquals(full, residual);
+		}
+
+		@Test
+		@DisplayName("should map to the ENTITY scope, same as the full entity key")
+		void shouldMapToEntityScope() {
+			assertEquals(ConflictScope.ENTITY, new EntityResidualConflictKey("Product", 1).conflictScope());
+		}
+
+		@Test
+		@DisplayName("should produce readable toString")
+		void shouldProduceReadableToString() {
+			final EntityResidualConflictKey key = new EntityResidualConflictKey("Product", 42);
+			final String str = key.toString();
+
+			assertTrue(str.contains("Product"));
+			assertTrue(str.contains("42"));
+		}
+	}
+
+	@Nested
 	@DisplayName("AttributeConflictKey")
 	class AttributeConflictKeyTest {
 
@@ -381,7 +431,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("should aggregate numbers using sum")
 		void shouldAggregateNumbersUsingSum() {
 			final AttributeDeltaConflictKey key = new AttributeDeltaConflictKey(
-				"Product", 1, new AttributeKey("quantity"), 5, null
+				"Product", 1, new AttributeKey("quantity"), 5, null, false
 			);
 
 			final Number result = key.aggregate(3, 7);
@@ -393,7 +443,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("should not be constrained to range when allowedRange is null")
 		void shouldNotBeConstrainedWhenRangeIsNull() {
 			final AttributeDeltaConflictKey key = new AttributeDeltaConflictKey(
-				"Product", 1, new AttributeKey("quantity"), 5, null
+				"Product", 1, new AttributeKey("quantity"), 5, null, false
 			);
 
 			assertFalse(key.isConstrainedToRange());
@@ -403,7 +453,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("should be constrained to range when allowedRange is present")
 		void shouldBeConstrainedWhenRangeIsPresent() {
 			final AttributeDeltaConflictKey key = new AttributeDeltaConflictKey(
-				"Product", 1, new AttributeKey("quantity"), 5, IntegerNumberRange.between(0, 100)
+				"Product", 1, new AttributeKey("quantity"), 5, IntegerNumberRange.between(0, 100), false
 			);
 
 			assertTrue(key.isConstrainedToRange());
@@ -413,7 +463,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("should pass range check when value is within range")
 		void shouldPassRangeCheckWhenWithinRange() {
 			final AttributeDeltaConflictKey key = new AttributeDeltaConflictKey(
-				"Product", 1, new AttributeKey("quantity"), 5, IntegerNumberRange.between(0, 100)
+				"Product", 1, new AttributeKey("quantity"), 5, IntegerNumberRange.between(0, 100), false
 			);
 
 			assertDoesNotThrow(() -> key.assertInAllowedRange("catalog", 1L, 50));
@@ -423,7 +473,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("should throw when value is outside allowed range")
 		void shouldThrowWhenValueIsOutsideRange() {
 			final AttributeDeltaConflictKey key = new AttributeDeltaConflictKey(
-				"Product", 1, new AttributeKey("quantity"), 5, IntegerNumberRange.between(0, 100)
+				"Product", 1, new AttributeKey("quantity"), 5, IntegerNumberRange.between(0, 100), false
 			);
 
 			assertThrows(
@@ -436,14 +486,27 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("custom equals includes deltaValue and allowedRange")
 		void customEqualsIncludesDeltaValueAndAllowedRange() {
 			final AttributeDeltaConflictKey key1 = new AttributeDeltaConflictKey(
-				"Product", 1, new AttributeKey("quantity"), 5, null
+				"Product", 1, new AttributeKey("quantity"), 5, null, false
 			);
 			final AttributeDeltaConflictKey key2 = new AttributeDeltaConflictKey(
-				"Product", 1, new AttributeKey("quantity"), 10, null
+				"Product", 1, new AttributeKey("quantity"), 10, null, false
 			);
 
 			// Different deltaValue means not equal
 			assertNotEquals(key1, key2);
+		}
+
+		@Test
+		@DisplayName("custom equals distinguishes sharedSurface")
+		void customEqualsDistinguishesSharedSurface() {
+			final AttributeDeltaConflictKey carvedOut = new AttributeDeltaConflictKey(
+				"Product", 1, new AttributeKey("quantity"), 5, null, false
+			);
+			final AttributeDeltaConflictKey sharedSurface = new AttributeDeltaConflictKey(
+				"Product", 1, new AttributeKey("quantity"), 5, null, true
+			);
+
+			assertNotEquals(carvedOut, sharedSurface);
 		}
 
 		@Test
@@ -453,13 +516,13 @@ class ConflictKeyTest implements EvitaTestSupport {
 			// on the same attribute accumulate into a single running total; equals()/hashCode() stay
 			// delta-sensitive for per-transaction key sets and the conflict ring buffer
 			final AttributeDeltaConflictKey key1 = new AttributeDeltaConflictKey(
-				"Product", 1, new AttributeKey("quantity"), 5, null
+				"Product", 1, new AttributeKey("quantity"), 5, null, false
 			);
 			final AttributeDeltaConflictKey key2 = new AttributeDeltaConflictKey(
-				"Product", 1, new AttributeKey("quantity"), 10, IntegerNumberRange.between(0, 100)
+				"Product", 1, new AttributeKey("quantity"), 10, IntegerNumberRange.between(0, 100), false
 			);
 			final AttributeDeltaConflictKey differentAttribute = new AttributeDeltaConflictKey(
-				"Product", 1, new AttributeKey("weight"), 5, null
+				"Product", 1, new AttributeKey("weight"), 5, null, false
 			);
 
 			assertEquals(key1.aggregationKey(), key2.aggregationKey());
@@ -468,8 +531,25 @@ class ConflictKeyTest implements EvitaTestSupport {
 			// hashCode is now consistent with the delta-sensitive equals: identical keys share a hash
 			assertEquals(
 				key1.hashCode(),
-				new AttributeDeltaConflictKey("Product", 1, new AttributeKey("quantity"), 5, null).hashCode()
+				new AttributeDeltaConflictKey("Product", 1, new AttributeKey("quantity"), 5, null, false).hashCode()
 			);
+		}
+
+		@Test
+		@DisplayName("aggregation key groups deltas that differ only in sharedSurface")
+		void aggregationKeyGroupsDeltasRegardlessOfSharedSurface() {
+			// a carved-out delta and a shared-surface delta on the same attribute must still accumulate into
+			// a single running total: the carve-out decision is an emission-time classification, not a
+			// distinct accumulation slot
+			final AttributeDeltaConflictKey carvedOut = new AttributeDeltaConflictKey(
+				"Product", 1, new AttributeKey("quantity"), 5, null, false
+			);
+			final AttributeDeltaConflictKey sharedSurface = new AttributeDeltaConflictKey(
+				"Product", 1, new AttributeKey("quantity"), 10, null, true
+			);
+
+			assertEquals(carvedOut.aggregationKey(), sharedSurface.aggregationKey());
+			assertEquals(carvedOut.aggregationKey().hashCode(), sharedSurface.aggregationKey().hashCode());
 		}
 
 		@Test
@@ -479,7 +559,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 			// assigned during upsert before the mutation is read back from the WAL, so a null primary key
 			// here would collapse every concurrently-created entity into one slot and is rejected fail-fast
 			final AttributeDeltaConflictKey unresolved = new AttributeDeltaConflictKey(
-				"Product", null, new AttributeKey("quantity"), 5, IntegerNumberRange.between(0, 100)
+				"Product", null, new AttributeKey("quantity"), 5, IntegerNumberRange.between(0, 100), false
 			);
 			assertThrows(GenericEvitaInternalError.class, unresolved::aggregationKey);
 		}
@@ -488,7 +568,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("should produce readable toString")
 		void shouldProduceReadableToString() {
 			final AttributeDeltaConflictKey key = new AttributeDeltaConflictKey(
-				"Product", 1, new AttributeKey("quantity"), 5, null
+				"Product", 1, new AttributeKey("quantity"), 5, null, false
 			);
 			final String str = key.toString();
 
@@ -505,7 +585,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("should aggregate numbers using sum")
 		void shouldAggregateNumbersUsingSum() {
 			final ReferenceAttributeDeltaConflictKey key = new ReferenceAttributeDeltaConflictKey(
-				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, false
 			);
 
 			final Number result = key.aggregate(3, 7);
@@ -517,7 +597,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("should not be constrained to range when allowedRange is null")
 		void shouldNotBeConstrainedWhenRangeIsNull() {
 			final ReferenceAttributeDeltaConflictKey key = new ReferenceAttributeDeltaConflictKey(
-				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, false
 			);
 
 			assertFalse(key.isConstrainedToRange());
@@ -528,7 +608,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		void shouldThrowWhenValueIsOutsideRange() {
 			final ReferenceAttributeDeltaConflictKey key = new ReferenceAttributeDeltaConflictKey(
 				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5,
-				IntegerNumberRange.between(0, 100)
+				IntegerNumberRange.between(0, 100), false
 			);
 
 			assertThrows(
@@ -542,7 +622,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		void shouldBeConstrainedWhenRangePresent() {
 			final ReferenceAttributeDeltaConflictKey key = new ReferenceAttributeDeltaConflictKey(
 				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5,
-				IntegerNumberRange.between(0, 100)
+				IntegerNumberRange.between(0, 100), false
 			);
 
 			assertTrue(key.isConstrainedToRange());
@@ -553,7 +633,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		void shouldNotThrowWhenValueWithinRange() {
 			final ReferenceAttributeDeltaConflictKey key = new ReferenceAttributeDeltaConflictKey(
 				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5,
-				IntegerNumberRange.between(0, 100)
+				IntegerNumberRange.between(0, 100), false
 			);
 
 			assertDoesNotThrow(() -> key.assertInAllowedRange("catalog", 1L, 50));
@@ -563,27 +643,40 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("custom equals includes deltaValue and allowedRange")
 		void customEqualsIncludesDeltaValueAndAllowedRange() {
 			final ReferenceAttributeDeltaConflictKey key1 = new ReferenceAttributeDeltaConflictKey(
-				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, false
 			);
 			final ReferenceAttributeDeltaConflictKey key2 = new ReferenceAttributeDeltaConflictKey(
-				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 10, null
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 10, null, false
 			);
 
 			assertNotEquals(key1, key2);
 		}
 
 		@Test
+		@DisplayName("custom equals distinguishes sharedSurface")
+		void customEqualsDistinguishesSharedSurface() {
+			final ReferenceAttributeDeltaConflictKey carvedOut = new ReferenceAttributeDeltaConflictKey(
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, false
+			);
+			final ReferenceAttributeDeltaConflictKey sharedSurface = new ReferenceAttributeDeltaConflictKey(
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, true
+			);
+
+			assertNotEquals(carvedOut, sharedSurface);
+		}
+
+		@Test
 		@DisplayName("aggregation key groups reference-attribute deltas that differ only in value or range")
 		void aggregationKeyGroupsDeltasByReferenceAttribute() {
 			final ReferenceAttributeDeltaConflictKey key1 = new ReferenceAttributeDeltaConflictKey(
-				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, false
 			);
 			final ReferenceAttributeDeltaConflictKey key2 = new ReferenceAttributeDeltaConflictKey(
 				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 10,
-				IntegerNumberRange.between(0, 100)
+				IntegerNumberRange.between(0, 100), false
 			);
 			final ReferenceAttributeDeltaConflictKey differentReference = new ReferenceAttributeDeltaConflictKey(
-				"Product", 1, new ReferenceKey("brand", 20), new AttributeKey("priority"), 5, null
+				"Product", 1, new ReferenceKey("brand", 20), new AttributeKey("priority"), 5, null, false
 			);
 
 			assertEquals(key1.aggregationKey(), key2.aggregationKey());
@@ -592,9 +685,23 @@ class ConflictKeyTest implements EvitaTestSupport {
 			assertEquals(
 				key1.hashCode(),
 				new ReferenceAttributeDeltaConflictKey(
-					"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null
+					"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, false
 				).hashCode()
 			);
+		}
+
+		@Test
+		@DisplayName("aggregation key groups reference-attribute deltas that differ only in sharedSurface")
+		void aggregationKeyGroupsDeltasRegardlessOfSharedSurface() {
+			final ReferenceAttributeDeltaConflictKey carvedOut = new ReferenceAttributeDeltaConflictKey(
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, false
+			);
+			final ReferenceAttributeDeltaConflictKey sharedSurface = new ReferenceAttributeDeltaConflictKey(
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 10, null, true
+			);
+
+			assertEquals(carvedOut.aggregationKey(), sharedSurface.aggregationKey());
+			assertEquals(carvedOut.aggregationKey().hashCode(), sharedSurface.aggregationKey().hashCode());
 		}
 
 		@Test
@@ -604,7 +711,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 			// null one (never produced once the mutation is read back from the WAL) fails fast
 			final ReferenceAttributeDeltaConflictKey unresolved = new ReferenceAttributeDeltaConflictKey(
 				"Product", null, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5,
-				IntegerNumberRange.between(0, 100)
+				IntegerNumberRange.between(0, 100), false
 			);
 			assertThrows(GenericEvitaInternalError.class, unresolved::aggregationKey);
 		}
@@ -613,7 +720,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("should produce readable toString")
 		void shouldProduceReadableToString() {
 			final ReferenceAttributeDeltaConflictKey key = new ReferenceAttributeDeltaConflictKey(
-				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, false
 			);
 			final String str = key.toString();
 
@@ -660,6 +767,20 @@ class ConflictKeyTest implements EvitaTestSupport {
 			assertEquals(
 				new CollectionConflictKey("Product"),
 				new EntityConflictKey("Product", 1).parentConflictKey()
+			);
+		}
+
+		@Test
+		@DisplayName("residual key is contained by the full entity key, never equal to a granular key")
+		void shouldChainResidualToFullEntity() {
+			assertEquals(
+				new EntityConflictKey("Product", 1),
+				new EntityResidualConflictKey("Product", 1).parentConflictKey()
+			);
+			// the residual is a sibling of the granular keys, never their ancestor or descendant
+			assertNotEquals(
+				new AttributeConflictKey("Product", 1, "name"),
+				new EntityResidualConflictKey("Product", 1)
 			);
 		}
 
@@ -712,26 +833,38 @@ class ConflictKeyTest implements EvitaTestSupport {
 		}
 
 		@Test
-		@DisplayName("attribute delta with known primary key reaches the absolute attribute key")
+		@DisplayName("attribute delta with known primary key reaches the absolute attribute key when carved out")
 		void shouldChainAttributeDeltaToAbsoluteAttribute() {
 			final AttributeDeltaConflictKey delta =
-				new AttributeDeltaConflictKey("Product", 1, new AttributeKey("stock"), 5, null);
+				new AttributeDeltaConflictKey("Product", 1, new AttributeKey("stock"), 5, null, false);
 			assertEquals(new AttributeConflictKey("Product", 1, "stock"), delta.parentConflictKey());
 		}
 
 		@Test
-		@DisplayName("attribute delta without primary key falls back to the collection")
-		void shouldChainPklessAttributeDeltaToCollection() {
+		@DisplayName("attribute delta with known primary key reaches the residual key when on the shared surface")
+		void shouldChainSharedSurfaceAttributeDeltaToResidual() {
 			final AttributeDeltaConflictKey delta =
-				new AttributeDeltaConflictKey("Product", null, new AttributeKey("stock"), 5, null);
-			assertEquals(new CollectionConflictKey("Product"), delta.parentConflictKey());
+				new AttributeDeltaConflictKey("Product", 1, new AttributeKey("stock"), 5, null, true);
+			assertEquals(new EntityResidualConflictKey("Product", 1), delta.parentConflictKey());
 		}
 
 		@Test
-		@DisplayName("reference-attribute delta with known primary key reaches the absolute reference attribute key")
+		@DisplayName("attribute delta without primary key falls back to the collection regardless of sharedSurface")
+		void shouldChainPklessAttributeDeltaToCollection() {
+			final AttributeDeltaConflictKey carvedOut =
+				new AttributeDeltaConflictKey("Product", null, new AttributeKey("stock"), 5, null, false);
+			assertEquals(new CollectionConflictKey("Product"), carvedOut.parentConflictKey());
+
+			final AttributeDeltaConflictKey sharedSurface =
+				new AttributeDeltaConflictKey("Product", null, new AttributeKey("stock"), 5, null, true);
+			assertEquals(new CollectionConflictKey("Product"), sharedSurface.parentConflictKey());
+		}
+
+		@Test
+		@DisplayName("reference-attribute delta with known primary key reaches the absolute reference attribute key when carved out")
 		void shouldChainReferenceAttributeDeltaToAbsoluteReferenceAttribute() {
 			final ReferenceAttributeDeltaConflictKey delta = new ReferenceAttributeDeltaConflictKey(
-				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, false
 			);
 			assertEquals(
 				new ReferenceAttributeConflictKey("Product", 1, "brand", 10, "priority"),
@@ -740,12 +873,26 @@ class ConflictKeyTest implements EvitaTestSupport {
 		}
 
 		@Test
-		@DisplayName("reference-attribute delta without primary key falls back to the collection")
-		void shouldChainPklessReferenceAttributeDeltaToCollection() {
+		@DisplayName("reference-attribute delta with known primary key reaches the residual key when on the shared surface")
+		void shouldChainSharedSurfaceReferenceAttributeDeltaToResidual() {
 			final ReferenceAttributeDeltaConflictKey delta = new ReferenceAttributeDeltaConflictKey(
-				"Product", null, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null
+				"Product", 1, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, true
 			);
-			assertEquals(new CollectionConflictKey("Product"), delta.parentConflictKey());
+			assertEquals(new EntityResidualConflictKey("Product", 1), delta.parentConflictKey());
+		}
+
+		@Test
+		@DisplayName("reference-attribute delta without primary key falls back to the collection regardless of sharedSurface")
+		void shouldChainPklessReferenceAttributeDeltaToCollection() {
+			final ReferenceAttributeDeltaConflictKey carvedOut = new ReferenceAttributeDeltaConflictKey(
+				"Product", null, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, false
+			);
+			assertEquals(new CollectionConflictKey("Product"), carvedOut.parentConflictKey());
+
+			final ReferenceAttributeDeltaConflictKey sharedSurface = new ReferenceAttributeDeltaConflictKey(
+				"Product", null, new ReferenceKey("brand", 10), new AttributeKey("priority"), 5, null, true
+			);
+			assertEquals(new CollectionConflictKey("Product"), sharedSurface.parentConflictKey());
 		}
 	}
 
@@ -757,6 +904,7 @@ class ConflictKeyTest implements EvitaTestSupport {
 		@DisplayName("entity-scoped keys report their entity type")
 		void shouldReportEntityTypeForEntityScopedKeys() {
 			assertEquals("Product", new EntityConflictKey("Product", 1).entityType());
+			assertEquals("Product", new EntityResidualConflictKey("Product", 1).entityType());
 			assertEquals("Product", new CollectionConflictKey("Product").entityType());
 			assertEquals("Product", new AttributeConflictKey("Product", 1, "name").entityType());
 		}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/mutation/conflict/ConflictScopeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/mutation/conflict/ConflictScopeTest.java
@@ -87,11 +87,11 @@ class ConflictScopeTest {
 	void shouldCollapseDeltaKeysOntoAbsoluteScope() {
 		assertEquals(
 			ConflictScope.ATTRIBUTE,
-			new AttributeDeltaConflictKey("Product", 1, ATTRIBUTE_KEY, 5, null).conflictScope()
+			new AttributeDeltaConflictKey("Product", 1, ATTRIBUTE_KEY, 5, null, false).conflictScope()
 		);
 		assertEquals(
 			ConflictScope.REFERENCE_ATTRIBUTE,
-			new ReferenceAttributeDeltaConflictKey("Product", 1, REFERENCE_KEY, ATTRIBUTE_KEY, 5, null)
+			new ReferenceAttributeDeltaConflictKey("Product", 1, REFERENCE_KEY, ATTRIBUTE_KEY, 5, null, false)
 				.conflictScope()
 		);
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/mutation/conflict/IncomingConflictScopeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/requestResponse/mutation/conflict/IncomingConflictScopeTest.java
@@ -43,7 +43,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * by an already committed transaction conflicts with the incoming transaction when the two write scopes
  * overlap along the {@link ConflictKey#parentConflictKey()} ancestry chain, in either direction. Special
  * attention is paid to the commutative (range-constrained delta) probe, which must catch delete/set
- * -vs-delta while letting two deltas of the same key commute.
+ * -vs-delta while letting two deltas of the same key commute, and to {@link EntityResidualConflictKey}'s
+ * containment: a sibling of the granular keys (never their ancestor or descendant) yet a child of the full
+ * {@link EntityConflictKey}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
  */
@@ -112,7 +114,7 @@ class IncomingConflictScopeTest {
 			// committed absolute write on `price` must not match the delta's coveredAncestors (guards
 			// against a future collapse of the dir-1 probe onto coveredAncestors, which would over-detect)
 			final IncomingConflictScope scope = scopeOf(
-				new AttributeDeltaConflictKey(ENTITY, 1, new AttributeKey("stock"), 5, IntegerNumberRange.between(0, 100))
+				new AttributeDeltaConflictKey(ENTITY, 1, new AttributeKey("stock"), 5, IntegerNumberRange.between(0, 100), false)
 			);
 			assertFalse(scope.conflictsWithAbsolute(new AttributeConflictKey(ENTITY, 1, "price")));
 		}
@@ -133,6 +135,102 @@ class IncomingConflictScopeTest {
 	}
 
 	@Nested
+	@DisplayName("Residual (shared-surface) containment")
+	class ResidualContainment {
+
+		@Test
+		@DisplayName("Residual does not conflict with a committed granular associated-data key of the same entity")
+		void shouldNotConflictResidualVsGranularAssociatedData() {
+			final IncomingConflictScope scope = scopeOf(new EntityResidualConflictKey(ENTITY, 1));
+			assertFalse(scope.conflictsWithAbsolute(new AssociatedDataConflictKey(ENTITY, 1, "feed-heureka")));
+		}
+
+		@Test
+		@DisplayName("A granular associated-data key does not conflict with an incoming residual key of the same entity")
+		void shouldNotConflictGranularAssociatedDataVsIncomingResidual() {
+			final IncomingConflictScope scope = scopeOf(new AssociatedDataConflictKey(ENTITY, 1, "feed-heureka"));
+			assertFalse(scope.conflictsWithAbsolute(new EntityResidualConflictKey(ENTITY, 1)));
+		}
+
+		@Test
+		@DisplayName("Identical residual keys conflict (equality preserved)")
+		void shouldConflictOnIdenticalResidualKeys() {
+			final IncomingConflictScope scope = scopeOf(new EntityResidualConflictKey(ENTITY, 1));
+			assertTrue(scope.conflictsWithAbsolute(new EntityResidualConflictKey(ENTITY, 1)));
+		}
+
+		@Test
+		@DisplayName("Incoming residual key conflicts with a committed full entity key of the same entity")
+		void shouldConflictResidualVsCommittedFullEntity() {
+			final IncomingConflictScope scope = scopeOf(new EntityResidualConflictKey(ENTITY, 1));
+			assertTrue(scope.conflictsWithAbsolute(new EntityConflictKey(ENTITY, 1)));
+		}
+
+		@Test
+		@DisplayName("Incoming full entity key conflicts with a committed residual key of the same entity")
+		void shouldConflictFullEntityVsCommittedResidual() {
+			final IncomingConflictScope scope = scopeOf(new EntityConflictKey(ENTITY, 1));
+			assertTrue(scope.conflictsWithAbsolute(new EntityResidualConflictKey(ENTITY, 1)));
+		}
+
+		@Test
+		@DisplayName("Incoming full entity key contains a committed granular associated-data key")
+		void shouldConflictFullEntityVsCommittedGranularAssociatedData() {
+			final IncomingConflictScope scope = scopeOf(new EntityConflictKey(ENTITY, 1));
+			assertTrue(scope.conflictsWithAbsolute(new AssociatedDataConflictKey(ENTITY, 1, "feed-heureka")));
+		}
+
+		@Test
+		@DisplayName("Incoming granular associated-data key conflicts with a committed full entity key")
+		void shouldConflictGranularAssociatedDataVsCommittedFullEntity() {
+			final IncomingConflictScope scope = scopeOf(new AssociatedDataConflictKey(ENTITY, 1, "feed-heureka"));
+			assertTrue(scope.conflictsWithAbsolute(new EntityConflictKey(ENTITY, 1)));
+		}
+
+		@Test
+		@DisplayName("Residual of one entity does not conflict with a granular attribute of a different entity")
+		void shouldNotConflictResidualVsGranularAttributeOfDifferentEntity() {
+			final IncomingConflictScope scope = scopeOf(new EntityResidualConflictKey(ENTITY, 1));
+			assertFalse(scope.conflictsWithAbsolute(new AttributeConflictKey(ENTITY, 2, "name")));
+		}
+
+		@Test
+		@DisplayName("A granular attribute of a different entity does not conflict with an incoming residual key")
+		void shouldNotConflictGranularAttributeOfDifferentEntityVsIncomingResidual() {
+			final IncomingConflictScope scope = scopeOf(new AttributeConflictKey(ENTITY, 2, "name"));
+			assertFalse(scope.conflictsWithAbsolute(new EntityResidualConflictKey(ENTITY, 1)));
+		}
+
+		@Test
+		@DisplayName("Committed collection key contains an incoming residual key of that collection")
+		void shouldConflictCollectionContainsResidual() {
+			final IncomingConflictScope scope = scopeOf(new EntityResidualConflictKey(ENTITY, 1));
+			assertTrue(scope.conflictsWithAbsolute(new CollectionConflictKey(ENTITY)));
+		}
+
+		@Test
+		@DisplayName("Incoming collection key contains a committed residual key of that collection")
+		void shouldConflictResidualContainedByIncomingCollection() {
+			final IncomingConflictScope scope = scopeOf(new CollectionConflictKey(ENTITY));
+			assertTrue(scope.conflictsWithAbsolute(new EntityResidualConflictKey(ENTITY, 1)));
+		}
+
+		@Test
+		@DisplayName("Committed catalog key contains an incoming residual key")
+		void shouldConflictWhenCommittedCatalogContainsResidual() {
+			final IncomingConflictScope scope = scopeOf(new EntityResidualConflictKey(ENTITY, 1));
+			assertTrue(scope.conflictsWithAbsolute(new CatalogConflictKey(CATALOG)));
+		}
+
+		@Test
+		@DisplayName("Incoming catalog key contains a committed residual key")
+		void shouldConflictWhenIncomingCatalogContainsResidual() {
+			final IncomingConflictScope scope = scopeOf(new CatalogConflictKey(CATALOG));
+			assertTrue(scope.conflictsWithAbsolute(new EntityResidualConflictKey(ENTITY, 1)));
+		}
+	}
+
+	@Nested
 	@DisplayName("Catalog-wide containment")
 	class CatalogContainment {
 
@@ -143,7 +241,7 @@ class IncomingConflictScopeTest {
 			assertTrue(scope.conflictsWithAbsolute(new AttributeConflictKey(ENTITY, 7, "x")));
 			assertTrue(scope.conflictsWithAbsolute(new EntityConflictKey(ENTITY, 9)));
 			assertTrue(scope.conflictsWithCommutative(
-				new AttributeDeltaConflictKey(ENTITY, 1, new AttributeKey("stock"), 5, IntegerNumberRange.between(0, 100))
+				new AttributeDeltaConflictKey(ENTITY, 1, new AttributeKey("stock"), 5, IntegerNumberRange.between(0, 100), false)
 			));
 		}
 
@@ -169,7 +267,19 @@ class IncomingConflictScopeTest {
 		@Nonnull
 		private AttributeDeltaConflictKey delta(int deltaValue) {
 			return new AttributeDeltaConflictKey(
-				ENTITY, 1, new AttributeKey("stock"), deltaValue, IntegerNumberRange.between(0, 100)
+				ENTITY, 1, new AttributeKey("stock"), deltaValue, IntegerNumberRange.between(0, 100), false
+			);
+		}
+
+		/**
+		 * A delta on an attribute that was NOT carved out of the entity's shared surface at emission time
+		 * (`sharedSurface` true), so its parent chain reaches {@link EntityResidualConflictKey} instead of
+		 * the absolute {@link AttributeConflictKey}.
+		 */
+		@Nonnull
+		private AttributeDeltaConflictKey sharedDelta(int deltaValue) {
+			return new AttributeDeltaConflictKey(
+				ENTITY, 1, new AttributeKey("stock"), deltaValue, IntegerNumberRange.between(0, 100), true
 			);
 		}
 
@@ -206,6 +316,33 @@ class IncomingConflictScopeTest {
 		void shouldNotConflictCommittedDeltaVsSiblingAbsolute() {
 			final IncomingConflictScope scope = scopeOf(new AttributeConflictKey(ENTITY, 1, "price"));
 			assertFalse(scope.conflictsWithCommutative(delta(5)));
+		}
+
+		@Test
+		@DisplayName("Committed shared-surface delta conflicts with an incoming residual key (commutative path)")
+		void shouldConflictSharedSurfaceDeltaVsIncomingResidual() {
+			// the shared-surface delta's parent is the residual, not the absolute attribute key, so it must
+			// still be caught by a coarse writer of the same entity's shared surface
+			final IncomingConflictScope scope = scopeOf(new EntityResidualConflictKey(ENTITY, 1));
+			assertTrue(scope.conflictsWithCommutative(sharedDelta(5)));
+		}
+
+		@Test
+		@DisplayName("Committed carved-out delta does not conflict with an incoming residual key")
+		void shouldNotConflictCarvedOutDeltaVsIncomingResidual() {
+			// the carved-out delta's parent is the absolute attribute key, which is disjoint from the
+			// residual - a coarse writer of the shared surface must not be blocked by it
+			final IncomingConflictScope scope = scopeOf(new EntityResidualConflictKey(ENTITY, 1));
+			assertFalse(scope.conflictsWithCommutative(delta(5)));
+		}
+
+		@Test
+		@DisplayName("Committed shared-surface delta vs incoming full entity key (e.g. a removal) conflicts")
+		void shouldConflictSharedSurfaceDeltaVsIncomingFullEntity() {
+			// the extra hop through the residual must still terminate at the full entity key: a whole-entity
+			// operation conflicts with a shared-surface delta exactly as it does with a carved-out one
+			final IncomingConflictScope scope = scopeOf(new EntityConflictKey(ENTITY, 1));
+			assertTrue(scope.conflictsWithCommutative(sharedDelta(5)));
 		}
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/metric/event/transaction/TransactionConflictEventTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/metric/event/transaction/TransactionConflictEventTest.java
@@ -118,7 +118,7 @@ class TransactionConflictEventTest {
 		final ConflictingCatalogCommutativeMutationException conflict =
 			new ConflictingCatalogCommutativeMutationException(
 				"testCatalog",
-				new AttributeDeltaConflictKey("Product", 42, new AttributeKey("count"), 5, null),
+				new AttributeDeltaConflictKey("Product", 42, new AttributeKey("count"), 5, null, false),
 				11L,
 				"The accumulated value is outside the allowed range."
 			);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/TransactionManagerConflictWindowTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/TransactionManagerConflictWindowTest.java
@@ -26,12 +26,21 @@ package io.evitadb.core.transaction;
 import io.evitadb.api.configuration.ChangeDataCaptureOptions;
 import io.evitadb.api.configuration.EvitaConfiguration;
 import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.configuration.TransactionOptions;
 import io.evitadb.api.exception.ConflictingCatalogCommutativeMutationException;
 import io.evitadb.api.exception.ConflictingCatalogMutationException;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.api.requestResponse.data.mutation.EntityRemoveMutation;
+import io.evitadb.api.requestResponse.data.mutation.EntityUpsertMutation;
+import io.evitadb.api.requestResponse.data.mutation.EntityMutation.EntityExistence;
+import io.evitadb.api.requestResponse.data.mutation.attribute.UpsertAttributeMutation;
+import io.evitadb.api.requestResponse.mutation.CatalogBoundMutation;
+import io.evitadb.api.requestResponse.mutation.conflict.AssociatedDataConflictKey;
 import io.evitadb.api.requestResponse.mutation.conflict.AttributeDeltaConflictKey;
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictKey;
+import io.evitadb.api.requestResponse.mutation.conflict.ConflictPolicy;
 import io.evitadb.api.requestResponse.mutation.conflict.EntityConflictKey;
+import io.evitadb.api.requestResponse.mutation.conflict.GranularConflictPolicy;
 import io.evitadb.api.requestResponse.schema.SealedCatalogSchema;
 import io.evitadb.core.Evita;
 import io.evitadb.core.catalog.Catalog;
@@ -41,6 +50,7 @@ import io.evitadb.core.executor.Scheduler;
 import io.evitadb.dataType.IntegerNumberRange;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -50,6 +60,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.TRANSACTION;
@@ -114,7 +125,7 @@ class TransactionManagerConflictWindowTest {
 	 */
 	@Nonnull
 	private static AttributeDeltaConflictKey quantityDeltaForEntity(int entityPrimaryKey, int delta) {
-		return new AttributeDeltaConflictKey(ENTITY_TYPE, entityPrimaryKey, QUANTITY, delta, ALLOWED_RANGE);
+		return new AttributeDeltaConflictKey(ENTITY_TYPE, entityPrimaryKey, QUANTITY, delta, ALLOWED_RANGE, false);
 	}
 
 	@BeforeEach
@@ -333,6 +344,110 @@ class TransactionManagerConflictWindowTest {
 				INITIAL_VERSION, 12L, OffsetDateTime.now(), keys(quantityDeltaForEntity(1, 60))
 			)
 		);
+	}
+
+	/**
+	 * Drives {@link TransactionManager#identifyConflicts} through the historical recompute path
+	 * ({@code identifyConflictsInOldCommittedTransactions}) rather than the conflict ring buffer: the
+	 * committing transaction's snapshot version is older than the ring buffer's effective start (seeded
+	 * from the living catalog's version at construction time), so the very first scan throws the ring
+	 * buffer's {@code OutsideScopeException} and the manager falls back to recomputing conflict keys from
+	 * {@link Catalog#getCommittedLiveMutationStream(long, long)}. This is the same code path a real,
+	 * genuinely aged-out ring-buffer entry would take; forcing it via the snapshot/effective-start gap
+	 * avoids depending on the ring buffer's internal eviction/capacity bookkeeping.
+	 *
+	 * The engine default is configured with {@link GranularConflictPolicy#ASSOCIATED_DATA} carved out, so
+	 * the recomputed historical mutation and the incoming granular write can disagree on scope exactly as
+	 * the write-time path would.
+	 */
+	@Nested
+	@DisplayName("Recompute path for aged-out entries")
+	class RecomputePath {
+		private static final long RECOMPUTE_LIVING_VERSION = 10L;
+		private static final long AGED_OUT_SESSION_VERSION = 5L;
+
+		/**
+		 * Builds a {@link TransactionManager} whose ring buffer's effective start already sits ahead of
+		 * {@link #AGED_OUT_SESSION_VERSION}, so any {@code identifyConflicts} call with that snapshot
+		 * immediately falls back to the recompute path, replaying the given committed mutation.
+		 */
+		@Nonnull
+		private TransactionManager recomputeTransactionManagerFor(@Nonnull CatalogBoundMutation committedMutation) {
+			final SealedCatalogSchema catalogSchema = mock(SealedCatalogSchema.class);
+			when(catalogSchema.version()).thenReturn(1);
+			when(catalogSchema.getConflictResolution()).thenReturn(Optional.empty());
+
+			final Catalog catalog = mock(Catalog.class);
+			when(catalog.getName()).thenReturn(CATALOG_NAME);
+			when(catalog.getVersion()).thenReturn(RECOMPUTE_LIVING_VERSION);
+			when(catalog.getSchema()).thenReturn(catalogSchema);
+			when(catalog.getLastCatalogVersionInMutationStream()).thenReturn(RECOMPUTE_LIVING_VERSION);
+			when(catalog.getFirstCatalogVersionInMutationStream()).thenReturn(RECOMPUTE_LIVING_VERSION);
+			when(catalog.getEntitySchema(anyString())).thenReturn(Optional.empty());
+			when(catalog.getCommittedLiveMutationStream(anyLong(), anyLong()))
+				.thenReturn(Stream.of(committedMutation));
+
+			final EvitaConfiguration configuration = EvitaConfiguration.builder()
+				.server(
+					ServerOptions.builder()
+						.changeDataCapture(ChangeDataCaptureOptions.builder().enabled(false).build())
+						.build()
+				)
+				.transaction(
+					TransactionOptions.builder()
+						.conflictResolution(ConflictPolicy.ENTITY, GranularConflictPolicy.ASSOCIATED_DATA)
+						.build()
+				)
+				.build();
+			final Evita evita = mock(Evita.class);
+			when(evita.getConfiguration()).thenReturn(configuration);
+
+			final ObservableExecutorService synchronousExecutor = mock(ObservableExecutorService.class);
+			doAnswer(invocation -> {
+				((Runnable) invocation.getArgument(0)).run();
+				return null;
+			}).when(synchronousExecutor).execute(any(Runnable.class));
+
+			return new TransactionManager(
+				catalog, evita, mock(Scheduler.class), synchronousExecutor, synchronousExecutor,
+				newCatalog -> {
+				},
+				RECOMPUTE_LIVING_VERSION
+			);
+		}
+
+		@Test
+		@DisplayName("aged-out coarse writer recomputes to the residual key, which does not conflict with an incoming granular write")
+		void shouldNotConflictAgedOutResidualWriterVsIncomingGranularWrite() {
+			// the historical mutation only touches a plain, non-carved-out attribute: it recomputes to
+			// EntityResidualConflictKey, a sibling of - not an ancestor of - the incoming granular key
+			final TransactionManager manager = recomputeTransactionManagerFor(
+				new EntityUpsertMutation(
+					ENTITY_TYPE, 1, EntityExistence.MAY_EXIST, new UpsertAttributeMutation("name", "foo")
+				)
+			);
+			assertDoesNotThrow(
+				() -> manager.identifyConflicts(
+					AGED_OUT_SESSION_VERSION, RECOMPUTE_LIVING_VERSION + 1, OffsetDateTime.now(),
+					keys(new AssociatedDataConflictKey(ENTITY_TYPE, 1, "feed-heureka"))
+				)
+			);
+		}
+
+		@Test
+		@DisplayName("aged-out removal recomputes to the full entity key, which conflicts with an incoming granular write")
+		void shouldConflictAgedOutRemovalVsIncomingGranularWrite() {
+			// the historical mutation removed the entity: it recomputes to the full EntityConflictKey, which
+			// contains every carved-out item, including the incoming granular associated-data write
+			final TransactionManager manager = recomputeTransactionManagerFor(new EntityRemoveMutation(ENTITY_TYPE, 1));
+			assertThrows(
+				ConflictingCatalogMutationException.class,
+				() -> manager.identifyConflicts(
+					AGED_OUT_SESSION_VERSION, RECOMPUTE_LIVING_VERSION + 1, OffsetDateTime.now(),
+					keys(new AssociatedDataConflictKey(ENTITY_TYPE, 1, "feed-heureka"))
+				)
+			);
+		}
 	}
 
 }


### PR DESCRIPTION
## Summary

A schema item declared with `ConflictResolutionOverride.GRANULAR` (or covered by a dimension in the entity's granularity set) is documented to isolate concurrent writes touching only that item from writes touching other parts of the same entity. It did not deliver that promise against a sibling writer running under the coarse `ConflictPolicy.ENTITY` policy: the coarse writer's fallback emitted the monolithic `EntityConflictKey`, which is an ancestor of every granular key on the entity, so two transactions touching disjoint items falsely conflicted (observed as production write contention between an incremental indexer and a feed-snippet job writing the same `Product`).

## Design

The entity-level key is split into two notions:

- **`EntityConflictKey`** (existing) now represents only whole-entity operations — removal, forced creation (`MUST_NOT_EXIST`), scope change. It remains an ancestor of every finer key, so these still conflict with everything, including carved-out items.
- **`EntityResidualConflictKey`** (new) represents the entity's shared, non-carved-out surface and is emitted by the policy-coarseness fallback instead. It conflicts with other shared-surface writers by equality and is contained by the full entity key, but it is a sibling of the granular keys — a coarse data writer no longer conflicts with a writer of a carved-out item. It carries no schema-derived payload: absolute granular keys are only ever emitted for carved-out items, so the residual never needs to contain anything.

Two consequential adjustments:

- `SetEntityScopeMutation` emits the full entity key explicitly (mirroring `EntityRemoveMutation`) instead of relying on the fallback, which would have demoted a scope change to the residual.
- Range-constrained delta keys (`AttributeDeltaConflictKey`, `ReferenceAttributeDeltaConflictKey`) are emitted even for non-carved-out items, so they bake the emit-time carve-out decision into their parent chain via a new `sharedSurface` component: a shared-surface delta routes through the residual (still serializes against a coarse absolute writer), a carved-out delta keeps the absolute item key parent. The flag is deliberately excluded from `aggregationKey()`, so delta accumulation is unaffected and same-item deltas still commute.

No matcher (`IncomingConflictScope`) changes, no persistence/WAL format changes (conflict keys are never persisted), no external API changes. Schemas with no declared granularity behave exactly as before (residual-vs-residual conflicts pairwise like the entity key did).

## Tests

272 tests across the conflict suite, 0 failures: emission-level (`DataMutationConflictKeyEmissionTest`), bidirectional containment matrix incl. commutative paths (`IncomingConflictScopeTest`, `ConflictKeyTest`), engine recompute/aged-out path (`TransactionManagerConflictWindowTest`), and 8 new end-to-end concurrent-transaction scenarios (`EvitaTransactionalFunctionalTest`), covering: carve-out isolation (the fix), same-item serialization, shared-surface conflicts, removal/scope-change/forced-creation racing carved-out writers, and the granularity-set flavor.

Related to #503.