### PR TITLE
Backport of #1288 to dev: reflected reference maintenance across LIVE/ARCHIVED scopes

### DIFF
--- a/documentation/developer/reflected-references-across-scopes.md
+++ b/documentation/developer/reflected-references-across-scopes.md
@@ -1,0 +1,198 @@
+# Reflected references across scopes
+
+This document describes how *reflected references* behave when the entities that participate in a reflected relation
+live in - or move between - the `LIVE` and `ARCHIVED` [scopes](../user/en/use/schema.md#scopes). It is the reference
+for the behavior implemented by
+<SourceClass>evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java</SourceClass>
+and verified by
+<SourceClass>evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaArchivingTest.java</SourceClass>.
+Reflected references combined with scopes form one of the more intricate corners of the engine; this page is meant to
+give a developer the complete mental model before touching the code.
+
+## 1. Concepts
+
+Consider two entity types and a relation between them:
+
+- **Holder (`H`)** owns the **primary reference** `H -> T` (e.g. `Product.categories`). The primary reference is the
+  single source of truth for the relation.
+- **Target (`T`)** owns the **reflected reference** `T -> H` (e.g. `Category.products`), declared with
+  `withReflectedReferenceToEntity(...)`. The reflected reference is a *derived mirror* of the primary reference on the
+  opposite entity.
+
+Together the primary reference and its reflected counterpart form a single **bi-directional relation**. A reflected
+reference is never an independent source of truth: unlike a primary reference (which may be *orphaned* - point at a
+target that does not exist yet), a reflected reference can only exist while its primary reference exists.
+
+## 2. The bi-directional contract
+
+While the relation is *maintained* (see section 3), the following holds:
+
+1. **Shared existence.** The reflected reference exists if and only if the primary reference it mirrors exists.
+2. **Shared attributes.** Attributes that the reflected reference schema declares as *inherited*
+   (`withAttributesInherited()`) are carried over from the primary reference and kept in sync with it.
+3. **Symmetric propagation.** A change made on *either* end (create, update of an inherited attribute, remove) is
+   propagated to the other end. Manipulating the primary reference updates the reflected reference, and manipulating the
+   reflected reference updates the primary reference.
+
+## 3. Index visibility is the enabling condition
+
+Propagation is only possible when the engine has the *means to find the other side* of the relation, and that means is
+the **reference index in the relevant scope**. A reference schema indexed in a scope makes the relation traversable in
+that scope; a reference schema not indexed in a scope makes it invisible there.
+
+The single governing rule is:
+
+> **A reflected reference is maintained in a given scope arrangement of `H` and `T` if and only if both the primary
+> reference schema and the reflected reference schema are indexed in every scope that the relation currently spans.**
+
+- When `H` and `T` are in the **same scope `S`**, the relation spans `{S}` - the reflected reference is maintained iff
+  both schemas are indexed in `S`.
+- When `H` and `T` are in **different scopes** (one `LIVE`, the other `ARCHIVED`), the relation spans `{LIVE, ARCHIVED}`
+  - the reflected reference is maintained iff both schemas are indexed in **both** scopes.
+
+When the condition is **not** met, the bi-directional contract cannot be upheld (a change on the invisible side could
+not propagate), so the reflected reference is **discarded** rather than left in a silently divergent state. A stale
+half-maintained mirror is strictly worse than no mirror. When a later scope change **restores** full mutual visibility,
+the reflected reference is **recreated** from the still-authoritative primary reference (including its inherited
+attributes).
+
+The **primary reference is unaffected by this rule**: it is retained wherever its own schema is indexed, independently
+of whether the reflected mirror can be maintained. Discarding a reflected reference never removes or hides the primary
+reference.
+
+## 4. Legal indexing configurations
+
+A reflected reference may only be indexed in a subset of the scopes in which its primary reference is indexed (enforced
+by schema validation). That leaves three legal configurations:
+
+| Id | Primary indexed in | Reflected indexed in | Name |
+|----|--------------------|----------------------|------|
+| C1 | `{LIVE}`           | `{LIVE}`             | symmetric LIVE-only |
+| C2 | `{LIVE, ARCHIVED}` | `{LIVE, ARCHIVED}`   | symmetric both-scopes |
+| C3 | `{LIVE, ARCHIVED}` | `{LIVE}`             | asymmetric (primary both / reflected LIVE-only) |
+
+Applying the rule of section 3:
+
+- **C1** - the reflected reference is maintained only while **both** `H` and `T` are `LIVE`. Archiving either side spans
+  two scopes while the reflected is LIVE-only, so the reflected reference is discarded. It is recreated only when both
+  ends are back in `LIVE`.
+- **C2** - the reflected reference is maintained in **every** scope arrangement (both `LIVE`, both `ARCHIVED`, or split
+  across scopes). C2 is the only configuration that supports a *cross-scope* reflected reference. All mutations
+  propagate regardless of the scopes of `H` and `T`.
+- **C3** - the reflected reference is maintained only while **both** `H` and `T` are `LIVE` (same as C1, because the
+  reflected side is LIVE-only). The difference from C1 is that the **primary** reference remains indexed - and therefore
+  queryable - in the `ARCHIVED` scope as well.
+
+## 5. Scope-transition rules
+
+When an entity moves between scopes (archive / restore):
+
+1. **Primary references are always retained** on the moved entity, and remain indexed in whatever scopes their schema
+   declares. They are never dropped by a scope transition.
+2. **Reflected references are re-evaluated** against the rule of section 3 for the new scope arrangement:
+   - if the condition is met in the new arrangement, the reflected reference is kept (or recreated if it had been
+     discarded earlier);
+   - if the condition is not met, the reflected reference is discarded.
+3. **Transitions never fail** because of the state of the *other* side of the relation. Archiving, restoring or deleting
+   one participant must not depend on the other participant living in the same scope.
+
+## 6. Behavior matrix (operation x configuration)
+
+`H` = holder (owns primary), `T` = target (owns reflected). "mirror" = the reflected reference on `T`. Unless stated,
+`T` is `LIVE`.
+
+| Operation | C1 (both LIVE-only) | C2 (both both-scopes) | C3 (primary both / reflected LIVE-only) |
+|-----------|---------------------|-----------------------|------------------------------------------|
+| Archive `H` | mirror discarded; primary retained (LIVE index only) | mirror **retained** (cross-scope); primary retained in both | mirror discarded; **primary retained and queryable in `ARCHIVED`** |
+| Restore `H` (mirror previously discarded) | mirror **recreated** on `T` | n/a (never discarded) | mirror **recreated** on `T` |
+| Add primary ref on archived `H` -> live `T` | no mirror (not mutually visible) | mirror **created** on `T` | no mirror (reflected LIVE-only) |
+| Update inherited attr on archived `H` | n/a (no mirror) | mirror **updated** on `T` | n/a (no mirror) |
+| Remove one of several primary refs on archived `H` | only that mirror gone | only that mirror gone; **surviving siblings' mirrors intact** | only that mirror gone |
+| Remove dangling primary ref on archived `H` (target already removed) | succeeds; ref removed | succeeds; ref removed | succeeds; ref removed |
+| Archive `T` while `H` is `LIVE` | mirror discarded; succeeds | mirror **retained** cross-scope; succeeds | mirror discarded; succeeds |
+| Delete archived `H` | mirror (if any) removed; succeeds | mirror on `T` removed; succeeds | succeeds |
+
+The full combinatoric space is larger than this table (each of create / update-attr / remove-ref / archive / restore /
+delete can be applied to `H` or `T`, in each of the three configurations, with `T` alive or removed and in either
+scope). The table lists the load-bearing cases; the E2E suite covers the space systematically.
+
+## 7. How the engine maintains reflected references
+
+Reflected references are not stored twice. Each side is an ordinary reference on its own entity; the engine keeps the
+two sides in sync by generating **implicit mutations** against the counterpart entity whenever one side changes. This
+happens in
+<SourceClass>evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java</SourceClass>
+while a mutation batch is applied.
+
+The relevant entry points are:
+
+- **`insertReflectedReferences`** - runs when an entity is created and fully set up (and when it is moved between
+  scopes). For every primary reference the entity holds it sets up the matching reflected reference on the referenced
+  entity, and for every reflected reference it sets up the matching primary reference on the referenced entity -
+  provided the counterpart schema exists.
+- **`verifyReflectedReferences`** - runs for each reference mutation in the batch. An `InsertReferenceMutation` or a
+  `RemoveReferenceMutation` on one side is propagated to the other side.
+- Both funnel into **`propagateReferencesToEntangledEntities`** -> **`propagateReferenceModification`**, which emits the
+  implicit <SourceClass>evita_engine/src/main/java/io/evitadb/core/transaction/stage/mutation/ServerEntityUpsertMutation.java</SourceClass>
+  (carrying an `InsertReferenceMutation` or `RemoveReferenceMutation`) against the counterpart entity.
+
+Because the two participants of a relation may live in different scopes, the engine first **partitions the referenced
+primary keys by the scope the counterpart entity currently exists in** (by intersecting them with the `GLOBAL` entity
+index of the referenced collection in each scope; keys found in no scope belong to removed or not-yet-created
+entities). For every `(entity scope, counterpart scope)` pair it then evaluates the **visibility rule of section 3**
+(`isRelationMaintained` - both schemas indexed in both scopes of the span) and decides by the `CreateMode`:
+
+| `CreateMode` | Trigger | Behavior per counterpart-scope partition |
+|--------------|---------|------------------------------------------|
+| `INSERT_MISSING` | entity created, scope changed or reference inserted | create the missing counterpart iff the relation is maintained; a reflected reference pointing at a primary key existing in **no** scope raises `EntityMissingException` |
+| `REMOVE_NON_INDEXED` | scope transition | when the relation is **not** maintained: if the entity owns the **reflected** side, its own mirror is discarded **locally**; if it owns the **primary** side, the mirror on the counterpart is removed - the primary reference itself is never touched |
+| `REMOVE_ALL_EXISTING` | explicit reference removal or entity deletion | propagate the removal to the counterpart iff the relation is maintained - a discarded mirror has nothing to clean up and a dangling reference must remain freely removable |
+
+The direction awareness in `REMOVE_NON_INDEXED` is essential: a scope transition may only ever discard the *derived*
+side (the mirror). Discarding is a local, non-propagating operation - the primary reference stays the source of truth
+from which the mirror is recreated when a later transition restores visibility (invariants I4 and I5). Explicit
+removals (`REMOVE_ALL_EXISTING`), by contrast, do propagate to the other side - that is the symmetric propagation of
+section 2 - but only while the relation is maintained.
+
+Finding the counterpart relies on the per-scope indexes. The `GLOBAL` entity index of the referenced collection tells
+the engine in which scope a target entity exists; the `REDUCED` (`REFERENCED_ENTITY`) index carries the per-reference
+reduced data and always follows the scope of the entity it indexes - all reduced-index lookups for the counterpart are
+therefore performed in the *counterpart's* scope, while lookups in the entity's own collection use the entity's
+(target) scope. The same scope-resolution applies to inherited attribute propagation
+(`propagateOrphanedReferenceAttributeMutations`) and to the mirror setup on entity creation / scope transition
+(`createAndRegisterReferencePropagationMutation`), which searches the primary holders' reduced indexes in every scope
+where the relation is maintained.
+
+Scope transitions reuse this same machinery: archiving or restoring an entity applies a scope change through
+`changeEntityScopeInternal`, which re-runs the reflected-reference maintenance (`popImplicitMutations` ->
+`insertReflectedReferences` / `verifyReflectedReferences`). This is why moving an entity between scopes automatically
+re-evaluates its reflected references against the rule in section 3.
+
+The query side mirrors the same principle (invariant I1): when a `referenceHaving` filter restricts referenced entity
+primary keys, the existence superset built by
+<SourceClass>evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormula.java</SourceClass>
+unions the referenced collection's `GLOBAL` indexes across **all** scopes - the scope of a query constrains the
+*queried* entities only, never the scope the referenced entity happens to live in (an archived product referencing a
+live category is found by that reference when querying the `ARCHIVED` scope).
+
+## 8. Invariants
+
+- **I1 - Primary survival.** A primary reference is queryable in every scope in which its schema is indexed, before and
+  after any scope transition of its holder.
+- **I2 - No stale mirror.** A reflected reference is either fully consistent with its primary (existence + inherited
+  attributes) or absent. It is never present with diverged data.
+- **I3 - Full propagation under visibility.** When the section 3 condition holds, create / update / remove on the
+  primary side is reflected on the mirror, and vice versa - including when `H` and `T` are in different scopes (C2).
+- **I4 - Clean discard.** When the condition does not hold, exactly the reflected side is discarded; the primary side and
+  the mirrors of *other* relations are untouched.
+- **I5 - Recreation on regained visibility.** When a scope transition restores the condition, the mirror is recreated
+  from the primary, with current inherited attributes.
+- **I6 - No cross-scope failures.** No scope transition or reference mutation fails because the other side of the
+  relation lives in a different scope.
+
+## References
+
+- User documentation: [Scopes](../user/en/use/schema.md#scopes), [reflected references](../user/en/use/data-model.md)
+- Engine: <SourceClass>evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java</SourceClass>
+- Contracts: <SourceClass>evita_api/src/main/java/io/evitadb/api/requestResponse/data/ReferenceContract.java</SourceClass>, <SourceClass>evita_api/src/main/java/io/evitadb/api/requestResponse/schema/ReflectedReferenceSchemaContract.java</SourceClass>
+- E2E tests: <SourceClass>evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaArchivingTest.java</SourceClass>

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormula.java
@@ -78,6 +78,12 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula
 	 */
 	private static final long CLASS_ID = 2738491562847195632L;
 	/**
+	 * Placeholder transactional id recorded for a scope whose GLOBAL index does not exist yet. It makes the
+	 * cache-invalidation hash (see {@link #includeAdditionalHash(LongHashFunction)}) change once the index is
+	 * created later, so a cached empty superset is not incorrectly reused when the referenced entity appears.
+	 */
+	private static final long INDEX_ABSENT_TRANSACTIONAL_ID = -1L;
+	/**
 	 * Error message thrown when {@link #getCloneWithInnerFormulas(Formula...)} receives more than one inner formula.
 	 */
 	public static final String ERROR_SINGLE_FORMULA_EXPECTED = "Exactly one inner formula is expected!";
@@ -146,7 +152,7 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula
 	 *
 	 * When the target entity type is managed, this constructor also builds a superset of allowed
 	 * entity primary keys by querying {@link GlobalEntityIndex} for the target entity type in
-	 * <b>all</b> scopes. The scope of the query constrains only the queried entities - a reference may
+	 * **all** scopes. The scope of the query constrains only the queried entities - a reference may
 	 * point to an entity living in a different scope (e.g. an archived product referencing a live
 	 * category), so the existence check must not be limited to the scopes the query is evaluated in.
 	 * The union of these bitmaps is used to filter the inner result during evaluation. Transactional
@@ -183,6 +189,10 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula
 				final Optional<GlobalEntityIndex> globalEntityIndex = referencedEntitySuperSetSupplier
 					.apply(targetEntityType, theScope);
 				if (globalEntityIndex.isEmpty()) {
+					// the GLOBAL index for this scope does not exist yet - record a deterministic placeholder so the
+					// cache-invalidation hash changes once the index is created later (otherwise a cached empty
+					// superset could be reused after the referenced entity appears)
+					transactionalIds[transactionalIdIndex++] = INDEX_ABSENT_TRANSACTIONAL_ID;
 					continue;
 				}
 				final Bitmap allPrimaryKeys = globalEntityIndex.get().getAllPrimaryKeys();

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormula.java
@@ -84,8 +84,9 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula
 	/**
 	 * Optional union bitmap of all referenced entity primary keys that are allowed to participate
 	 * in the translation. The bitmap is built from {@link GlobalEntityIndex#getAllPrimaryKeys()}
-	 * across all scopes where the reference is indexed. When {@code null}, no additional
-	 * restriction applies (either the referenced type is not managed or the index is unavailable).
+	 * across all scopes (a reference may point to an entity living in a different scope than the
+	 * queried entity). When {@code null} the referenced type is not managed and no restriction
+	 * applies; for a managed type the superset is always present (possibly empty).
 	 */
 	private final Bitmap referencedEntitySuperSet;
 	/**
@@ -144,11 +145,13 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula
 	 * inner formula and lazily maps them to primary keys of the referenced-type entity index.
 	 *
 	 * When the target entity type is managed, this constructor also builds a superset of allowed
-	 * entity primary keys by querying {@link GlobalEntityIndex} for the target entity type in all
-	 * provided scopes where the reference is indexed. The union of these bitmaps is used to filter
-	 * the inner result during evaluation. Transactional ids of the contributing indices are captured
-	 * so that {@link #includeAdditionalHash(LongHashFunction)} can properly invalidate caches when
-	 * any of them changes.
+	 * entity primary keys by querying {@link GlobalEntityIndex} for the target entity type in
+	 * <b>all</b> scopes. The scope of the query constrains only the queried entities - a reference may
+	 * point to an entity living in a different scope (e.g. an archived product referencing a live
+	 * category), so the existence check must not be limited to the scopes the query is evaluated in.
+	 * The union of these bitmaps is used to filter the inner result during evaluation. Transactional
+	 * ids of the contributing indices are captured so that {@link #includeAdditionalHash(LongHashFunction)}
+	 * can properly invalidate caches when any of them changes.
 	 *
 	 * @param referenceSchema schema of the processed reference
 	 * @param targetEntityType the entity type to resolve the superset for (referenced entity type

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/reference/ReferencedEntityIndexPrimaryKeyTranslatingFormula.java
@@ -43,7 +43,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 
@@ -58,9 +57,11 @@ import java.util.function.UnaryOperator;
  * {@link ReferenceOwnerTranslatingFormula}, but the resulting bitmap contains primary keys of the
  * referenced-entity index, not owner entity primary keys.
  *
- * If the reference is indexed only in selected {@link io.evitadb.dataType.Scope scopes} or the
- * referenced entity type is managed, the translation can be restricted by a precomputed superset of
- * referenced entities available in those scopes. Only ids present in that superset are considered.
+ * If the referenced entity type is managed, the translation is restricted by a precomputed superset of
+ * referenced entities that exist in **any** scope. The scope of the query constrains the queried entities
+ * only - the referenced entity may legitimately live in a different scope than the queried entity (e.g.
+ * an archived product referencing a live category), so referenced-entity existence must be checked across
+ * all scopes. Only ids present in that superset are considered.
  *
  * The final result is a bitmap of primary keys that identify rows inside
  * {@link ReferencedTypeEntityIndex}.
@@ -157,7 +158,6 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula
 	 *        target entity type and a scope
 	 * @param referencedTypeEntityIndex target referenced-type entity index
 	 * @param innerFormula inner formula producing referenced entity primary keys
-	 * @param scopes scopes the query is evaluated in
 	 */
 	public ReferencedEntityIndexPrimaryKeyTranslatingFormula(
 		@Nonnull ReferenceSchemaContract referenceSchema,
@@ -166,36 +166,39 @@ public class ReferencedEntityIndexPrimaryKeyTranslatingFormula
 		@Nonnull BiFunction<String, Scope, Optional<GlobalEntityIndex>> referencedEntitySuperSetSupplier,
 		@Nonnull ReferencedTypeEntityIndex referencedTypeEntityIndex,
 		@Nonnull Formula innerFormula,
-		@Nonnull Set<Scope> scopes,
 		@Nullable UnaryOperator<Bitmap> expansionFunction
 	) {
 		if (isTargetManaged) {
+			final Scope[] allScopes = Scope.values();
 			PersistentRoaringBitmap bitmap = null;
-			final long[] transactionalIds = new long[scopes.size()];
+			final long[] transactionalIds = new long[allScopes.length];
 			int transactionalIdIndex = 0;
-			for (Scope theScope : scopes) {
-				// if the schema is not indexed in particular scope, we must keep original formula results in place
-				// to avoid their removal from the final result
-				if (referenceSchema.isIndexedInScope(theScope)) {
-					final Optional<GlobalEntityIndex> globalEntityIndex = referencedEntitySuperSetSupplier
-						.apply(targetEntityType, theScope);
-					final Bitmap allPrimaryKeys;
-					if (globalEntityIndex.isPresent()) {
-						allPrimaryKeys = globalEntityIndex.get().getAllPrimaryKeys();
-						transactionalIds[transactionalIdIndex++] = globalEntityIndex.get().getId();
-					} else {
-						allPrimaryKeys = EmptyBitmap.INSTANCE;
-					}
-					bitmap = bitmap == null ?
-						RoaringBitmapBackedBitmap.getRoaringBitmap(allPrimaryKeys) :
-						PersistentRoaringBitmap.or(bitmap, RoaringBitmapBackedBitmap.getRoaringBitmap(allPrimaryKeys));
+			for (Scope theScope : allScopes) {
+				// the scope of the query constrains only the queried entities - a reference may point to an entity
+				// living in a different scope (e.g. an archived product referencing a live category), so the
+				// existence check must span all scopes, not just the scopes the query is evaluated in
+				final Optional<GlobalEntityIndex> globalEntityIndex = referencedEntitySuperSetSupplier
+					.apply(targetEntityType, theScope);
+				if (globalEntityIndex.isEmpty()) {
+					continue;
 				}
+				final Bitmap allPrimaryKeys = globalEntityIndex.get().getAllPrimaryKeys();
+				transactionalIds[transactionalIdIndex++] = globalEntityIndex.get().getId();
+				if (allPrimaryKeys.isEmpty()) {
+					// an empty contribution would not change the union - skipping it keeps the common
+					// single-contributing-scope case zero-copy (no OR with an empty bitmap)
+					continue;
+				}
+				bitmap = bitmap == null ?
+					RoaringBitmapBackedBitmap.getRoaringBitmap(allPrimaryKeys) :
+					PersistentRoaringBitmap.or(bitmap, RoaringBitmapBackedBitmap.getRoaringBitmap(allPrimaryKeys));
 			}
-			this.referencedEntitySuperSet = bitmap == null ?
-				null : new BaseBitmap(bitmap);
-			this.referencedEntityTypeSuperSetTransactionalIds = transactionalIdIndex == transactionalIds.length ?
-				transactionalIds :
-				Arrays.copyOfRange(transactionalIds, 0, transactionalIdIndex);
+			// for a managed referenced type the superset always applies - when no scope contributed any primary
+			// keys the superset is empty (no referenced entity exists anywhere), never unrestricted
+			this.referencedEntitySuperSet = bitmap == null ? EmptyBitmap.INSTANCE : new BaseBitmap(bitmap);
+			this.referencedEntityTypeSuperSetTransactionalIds = transactionalIdIndex == transactionalIds.length
+				? transactionalIds
+				: Arrays.copyOfRange(transactionalIds, 0, transactionalIdIndex);
 		} else {
 			this.referencedEntitySuperSet = null;
 			this.referencedEntityTypeSuperSetTransactionalIds = ArrayUtils.EMPTY_LONG_ARRAY;

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/entity/EntityPrimaryKeyInSetTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/entity/EntityPrimaryKeyInSetTranslator.java
@@ -111,7 +111,6 @@ public class EntityPrimaryKeyInSetTranslator implements FilteringConstraintTrans
 								filterByVisitor::getGlobalEntityIndexIfExists,
 								it,
 								standardResult,
-								processingScope.getScopes(),
 								processingScope.getReferencedEntityExpansionFunction()
 							);
 						})

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/reference/HavingTranslatorHelper.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/reference/HavingTranslatorHelper.java
@@ -322,7 +322,6 @@ class HavingTranslatorHelper {
 											filterByVisitor::getGlobalEntityIndexIfExists,
 											it,
 											nestedResult.filter(),
-											processingScope.getScopes(),
 											processingScope.getReferencedEntityExpansionFunction()
 										)
 									)

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
@@ -327,7 +327,6 @@ public final class ContainerizedLocalMutationExecutor
 		// evaluated on both schemas for every scope the primary holders may live in
 		final Optional<ReferenceSchemaContract> counterpartSchemaRef = catalogSchema
 			.getEntitySchema(referenceSchema.getReferencedEntityType())
-			.map(it -> ((EntitySchemaDecorator) it).getDelegate())
 			.flatMap(it -> it.getReference(referenceSchema.getReflectedReferenceName()));
 
 		// we need to access index in target entity collection, because we need to retrieve index with primary

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/storagePart/ContainerizedLocalMutationExecutor.java
@@ -125,7 +125,6 @@ import java.util.Map.Entry;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
-import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.IntSupplier;
@@ -307,7 +306,8 @@ public final class ContainerizedLocalMutationExecutor
 	 * content to read internal primary keys of those entities.
 	 *
 	 * @param entityPrimaryKey           the primary key of the entity to which the references should point
-	 * @param scope                      the scope in which the reference index should be looked up
+	 * @param scope                      the scope this entity lives in (or is being moved to)
+	 * @param catalogSchema              the catalog schema used to resolve the counterpart reference schema
 	 * @param referenceSchema            the reference schema, must not be {@code null}
 	 * @param referencesStorageContainer the references storage container if exists
 	 * @param mutationCollector          the mutation collector, must not be {@code null}
@@ -316,19 +316,42 @@ public final class ContainerizedLocalMutationExecutor
 	private void createAndRegisterReferencePropagationMutation(
 		int entityPrimaryKey,
 		@Nonnull Scope scope,
+		@Nonnull CatalogSchema catalogSchema,
 		@Nonnull ReflectedReferenceSchema referenceSchema,
 		@Nullable ReferencesStoragePart referencesStorageContainer,
 		@Nonnull DataStoreReader dataStoreReader,
 		@Nonnull MutationCollector mutationCollector,
 		@Nonnull BiConsumer<List<ReferenceKey>, DataStoreReader> eachReferenceConsumer
 	) {
-		// we need to access index in target entity collection, because we need to retrieve index with primary references
-		final List<ReducedEntityIndex> indexes = getAllReducedReferencedEntityIndexes(
-			dataStoreReader, scope,
-			referenceSchema.getReflectedReferenceName(),
-			this.entityPrimaryKey,
-			referenceSchema.getCardinality().allowsDuplicates()
-		);
+		// resolve the counterpart (primary) reference schema in the referenced collection - the visibility rule is
+		// evaluated on both schemas for every scope the primary holders may live in
+		final Optional<ReferenceSchemaContract> counterpartSchemaRef = catalogSchema
+			.getEntitySchema(referenceSchema.getReferencedEntityType())
+			.map(it -> ((EntitySchemaDecorator) it).getDelegate())
+			.flatMap(it -> it.getReference(referenceSchema.getReflectedReferenceName()));
+
+		// we need to access index in target entity collection, because we need to retrieve index with primary
+		// references; the primary holders may live in any scope, so all scopes where the relation is maintained
+		// for this entity's scope are searched
+		final List<ReducedEntityIndex> indexes;
+		if (counterpartSchemaRef.isEmpty()) {
+			indexes = Collections.emptyList();
+		} else {
+			final ReferenceSchemaContract counterpartSchema = counterpartSchemaRef.get();
+			indexes = new ArrayList<>(4);
+			for (Scope counterpartScope : Scope.values()) {
+				if (isRelationMaintained(referenceSchema, counterpartSchema, scope, counterpartScope)) {
+					indexes.addAll(
+						getAllReducedReferencedEntityIndexes(
+							dataStoreReader, counterpartScope,
+							referenceSchema.getReflectedReferenceName(),
+							this.entityPrimaryKey,
+							referenceSchema.getCardinality().allowsDuplicates()
+						)
+					);
+				}
+			}
+		}
 
 		for (ReducedEntityIndex referenceIndexWithPrimaryReferences : indexes) {
 			// for each such entity create internal (reflected) reference to it (if it doesn't exist)
@@ -363,7 +386,7 @@ public final class ContainerizedLocalMutationExecutor
 				final ReferenceKey insertedRefKey = new ReferenceKey(
 					referenceSchema.getName(), epk, primaryRefKeyWithInternalPk.internalPrimaryKey()
 				);
-				if (referencesStorageContainer == null || !referencesStorageContainer.contains(insertedRefKey)) {
+				if (referencesStorageContainer == null || !containsExistingReference(referencesStorageContainer, insertedRefKey)) {
 					mutationCollector.addLocalMutation(new InsertReferenceMutation(insertedRefKey));
 					referenceKeys.add(insertedRefKey);
 				}
@@ -862,6 +885,205 @@ public final class ContainerizedLocalMutationExecutor
 				);
 			}
 		}
+	}
+
+	/**
+	 * Checks the single governing visibility rule for reflected references: the relation between an entity living in
+	 * `entityScope` and its counterpart living in `counterpartScope` is *maintained* if and only if both reference
+	 * schemas (the primary one and the reflected one) are indexed in every scope the relation spans. When the rule is
+	 * not met the mirror cannot be kept in sync and must be discarded rather than left in a silently divergent state.
+	 *
+	 * @param referenceSchema  reference schema on the side of the currently mutated entity
+	 * @param counterpartSchema reference schema on the side of the counterpart (referenced) entity
+	 * @param entityScope      scope the currently mutated entity lives in (or is being moved to)
+	 * @param counterpartScope scope the counterpart entity currently lives in
+	 * @return true when the reflected reference relation is maintained for the given scope span
+	 */
+	private static boolean isRelationMaintained(
+		@Nonnull ReferenceSchemaContract referenceSchema,
+		@Nonnull ReferenceSchemaContract counterpartSchema,
+		@Nonnull Scope entityScope,
+		@Nonnull Scope counterpartScope
+	) {
+		return referenceSchema.isIndexedInScope(entityScope) &&
+			referenceSchema.isIndexedInScope(counterpartScope) &&
+			counterpartSchema.isIndexedInScope(entityScope) &&
+			counterpartSchema.isIndexedInScope(counterpartScope);
+	}
+
+	/**
+	 * Partitions the provided referenced primary keys by the scope the referenced entity currently exists in. Result
+	 * is an array indexed by {@link Scope#ordinal()}; primary keys not present in any scope's global index (removed
+	 * or not yet created entities) are collected in the extra bitmap at index {@code Scope.values().length}. Slots
+	 * for scopes with no matching primary keys are left {@code null} to avoid unnecessary allocations.
+	 *
+	 * @param referencedDataStoreReader reader of the referenced entity collection
+	 * @param referencedPrimaryKeys     referenced primary keys to partition
+	 * @return array of bitmaps indexed by scope ordinal, with non-existent primary keys at the last index
+	 */
+	@Nonnull
+	private static PersistentRoaringBitmap[] partitionReferencedPksByScope(
+		@Nonnull DataStoreReader referencedDataStoreReader,
+		@Nonnull PersistentRoaringBitmap referencedPrimaryKeys
+	) {
+		final Scope[] scopes = Scope.values();
+		final PersistentRoaringBitmap[] result = new PersistentRoaringBitmap[scopes.length + 1];
+		PersistentRoaringBitmap remaining = referencedPrimaryKeys;
+		for (Scope scope : scopes) {
+			if (remaining.isEmpty()) {
+				break;
+			}
+			final GlobalEntityIndex globalIndex = referencedDataStoreReader.getIndexIfExists(
+				new EntityIndexKey(EntityIndexType.GLOBAL, scope),
+				entityIndexKey -> null
+			);
+			if (globalIndex != null) {
+				final PersistentRoaringBitmap pksInScope = PersistentRoaringBitmap.and(
+					remaining,
+					getRoaringBitmap(globalIndex.getAllPrimaryKeys())
+				);
+				if (!pksInScope.isEmpty()) {
+					result[scope.ordinal()] = pksInScope;
+					remaining = PersistentRoaringBitmap.andNot(remaining, pksInScope);
+				}
+			}
+		}
+		result[scopes.length] = remaining;
+		return result;
+	}
+
+	/**
+	 * Creates a predicate testing whether the counterpart side of the relation is already established in the reduced
+	 * index of the referenced collection in the given scope. The reduced indexes follow the scope of the entity they
+	 * index, so the check must always be performed in the scope the counterpart entity currently lives in.
+	 *
+	 * @param hardReference        true when the reference name equals the counterpart schema name
+	 * @param dataStoreReader      reader of the referenced entity collection
+	 * @param referencedSchemaName name of the counterpart reference schema
+	 * @param entityPrimaryKey     primary key of the currently mutated entity
+	 * @param usedScope            scope the counterpart entity lives in
+	 * @return predicate testing counterpart reduced index membership
+	 */
+	@Nonnull
+	private static IntObjPredicate<Serializable[]> createCounterpartPresencePredicate(
+		boolean hardReference,
+		@Nonnull DataStoreReader dataStoreReader,
+		@Nonnull String referencedSchemaName,
+		int entityPrimaryKey,
+		@Nonnull Scope usedScope
+	) {
+		if (hardReference) {
+			// provide reduced entity index related to provided entity primary key
+			return (epk, representativeAttributeValues) -> {
+				final ReducedEntityIndex targetReducedIndex = dataStoreReader.getIndexIfExists(
+					new EntityIndexKey(
+						EntityIndexType.REFERENCED_ENTITY,
+						usedScope,
+						new RepresentativeReferenceKey(
+							new ReferenceKey(referencedSchemaName, epk),
+							representativeAttributeValues
+						)
+					),
+					__ -> null
+				);
+				// always check this entity primary key
+				return targetReducedIndex != null && targetReducedIndex.getAllPrimaryKeys().contains(entityPrimaryKey);
+			};
+		} else {
+			// always provide the same reference index
+			return (epk, representativeAttributeValues) -> {
+				final ReducedEntityIndex targetReducedIndex = dataStoreReader.getIndexIfExists(
+					new EntityIndexKey(
+						EntityIndexType.REFERENCED_ENTITY,
+						usedScope,
+						new RepresentativeReferenceKey(
+							new ReferenceKey(referencedSchemaName, entityPrimaryKey),
+							representativeAttributeValues
+						)
+					),
+					__ -> null
+				);
+				return targetReducedIndex != null && targetReducedIndex.getAllPrimaryKeys().contains(epk);
+			};
+		}
+	}
+
+	/**
+	 * Discards this entity's own reflected references pointing to the provided referenced primary keys by emitting
+	 * local {@link RemoveReferenceMutation} mutations. Used when a scope transition breaks the visibility rule - the
+	 * mirror is removed from this entity only, the primary reference on the counterpart entity is left untouched so
+	 * the mirror can be recreated from it when visibility is regained.
+	 *
+	 * @param referenceName         name of the reflected reference schema
+	 * @param referencedPrimaryKeys primary keys of the counterpart entities whose mirrors are to be discarded
+	 * @param mutationCollector     collector for the generated local mutations
+	 */
+	private void discardLocalReflectedReferences(
+		@Nonnull String referenceName,
+		@Nonnull PersistentRoaringBitmap referencedPrimaryKeys,
+		@Nonnull MutationCollector mutationCollector
+	) {
+		final PeekableIntIterator iterator = referencedPrimaryKeys.getIntIterator();
+		while (iterator.hasNext()) {
+			final int epk = iterator.next();
+			final List<ReferenceContract> localReferences = this.referencesStorageContainer.findAllReferences(
+				new ReferenceKey(referenceName, epk), Droppable::exists
+			);
+			for (ReferenceContract localReference : localReferences) {
+				mutationCollector.addLocalMutation(
+					new RemoveReferenceMutation(localReference.getReferenceKey())
+				);
+			}
+		}
+	}
+
+	/**
+	 * Finds the scope the referenced entity with the given primary key currently exists in by probing the global
+	 * indexes of the referenced collection in all scopes.
+	 *
+	 * @param referencedDataStoreReader reader of the referenced entity collection
+	 * @param referencedPrimaryKey      primary key of the referenced entity
+	 * @return scope the referenced entity lives in, or null when it does not exist in any scope
+	 */
+	@Nullable
+	private static Scope findScopeOfReferencedEntity(
+		@Nonnull DataStoreReader referencedDataStoreReader,
+		int referencedPrimaryKey
+	) {
+		for (Scope scope : Scope.values()) {
+			final GlobalEntityIndex globalIndex = referencedDataStoreReader.getIndexIfExists(
+				new EntityIndexKey(EntityIndexType.GLOBAL, scope),
+				entityIndexKey -> null
+			);
+			if (globalIndex != null && globalIndex.contains(referencedPrimaryKey)) {
+				return scope;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Checks whether the references storage container holds an existing (non-dropped) reference with the given key.
+	 * Unlike {@link ReferencesStoragePart#contains(ReferenceKey)} this method ignores references dropped earlier in
+	 * the same transaction, so a previously discarded mirror does not block its own recreation.
+	 *
+	 * @param referencesStorageContainer container with the entity references
+	 * @param referenceKey               reference key to look up
+	 * @return true when an existing reference with the given key is present
+	 */
+	private static boolean containsExistingReference(
+		@Nonnull ReferencesStoragePart referencesStorageContainer,
+		@Nonnull ReferenceKey referenceKey
+	) {
+		final List<ReferenceContract> references = referencesStorageContainer.findAllReferences(
+			new ReferenceKey(referenceKey.referenceName(), referenceKey.primaryKey()), Droppable::exists
+		);
+		for (ReferenceContract reference : references) {
+			if (reference.getReferenceKey().equals(referenceKey)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public ContainerizedLocalMutationExecutor(
@@ -2025,6 +2247,7 @@ public final class ContainerizedLocalMutationExecutor
 						dataStoreReader -> createAndRegisterReferencePropagationMutation(
 							entityPrimaryKey,
 							scope,
+							catalogSchema,
 							reflectedReferenceSchema,
 							referencesStorageContainer,
 							dataStoreReader,
@@ -2296,128 +2519,120 @@ public final class ContainerizedLocalMutationExecutor
 				);
 			// if there is any reflected reference schemas
 			if (referencedSchemaRef.isPresent()) {
-				final BiPredicate<ReferenceSchemaContract, ReferenceSchemaContract> propagationPredicate;
-				switch (createMode) {
-					case INSERT_MISSING -> propagationPredicate = (rs1, rs2) ->
-						rs1.isIndexedInScope(targetEntityScope) && rs2.isIndexedInScope(targetEntityScope);
-					case REMOVE_NON_INDEXED -> propagationPredicate = (rs1, rs2) ->
-						!rs1.isIndexedInScope(targetEntityScope) || !rs2.isIndexedInScope(targetEntityScope);
-					case REMOVE_ALL_EXISTING -> propagationPredicate = (rs1, rs2) ->
-						true;
-					default -> throw new GenericEvitaInternalError("Unknown create mode: " + createMode);
-				}
-				// test the predicate
 				final ReferenceSchema referencedSchema = referencedSchemaRef.get();
-				if (propagationPredicate.test(referenceSchema, referencedSchema)) {
-					final String referencedSchemaName = referencedSchema.getName();
-					final boolean allowsDuplicates = referencedSchema.getCardinality().allowsDuplicates();
-					// lets collect all primary keys of the reference with the same name into a bitmap
-					final ReferenceBlock<T> referenceBlock = referenceBlockSupplier.get();
-					final GlobalEntityIndex globalIndex = dataStoreReader.getIndexIfExists(
-						new EntityIndexKey(EntityIndexType.GLOBAL, targetEntityScope),
-						entityIndexKey -> null
-					);
-					// if global index is found there is at least one entity of such type
-					final PersistentRoaringBitmap referencedPrimaryKeys = referenceBlock.getReferencedPrimaryKeys();
-					// but we need to match only those our entity refers to via this reference
-					final PersistentRoaringBitmap existingEntityPks = globalIndex == null ?
-						null :
-						PersistentRoaringBitmap.and(
-							referencedPrimaryKeys,
-							getRoaringBitmap(globalIndex.getAllPrimaryKeys())
-						);
+				final String referencedSchemaName = referencedSchema.getName();
+				final boolean allowsDuplicates = referencedSchema.getCardinality().allowsDuplicates();
+				// lets collect all primary keys of the reference with the same name into a bitmap
+				final ReferenceBlock<T> referenceBlock = referenceBlockSupplier.get();
+				final PersistentRoaringBitmap referencedPrimaryKeys = referenceBlock.getReferencedPrimaryKeys();
+				// the referenced (counterpart) entities may live in a different scope than this entity - the relation
+				// may span both scopes (e.g. an archived holder referencing a live target); partition the referenced
+				// primary keys by the scope the referenced entity currently exists in and evaluate the visibility
+				// rule for each (entity scope, counterpart scope) pair separately
+				final Scope[] scopes = Scope.values();
+				final PersistentRoaringBitmap[] pksByScope = partitionReferencedPksByScope(dataStoreReader, referencedPrimaryKeys);
+				final PersistentRoaringBitmap missingPks = pksByScope[scopes.length];
 
-					// when the reflected reference is used, we can reuse shared reduced entity index
-					final boolean hardReference = referenceName.equals(referencedSchemaName);
-					final Scope usedScope = createMode == CreateMode.INSERT_MISSING ? targetEntityScope : sourceEntityScope;
-					final IntObjPredicate<Serializable[]> primaryKeyPredicate;
-					if (hardReference) {
-						// provide reduced entity index related to provided entity primary key
-						primaryKeyPredicate = (epk, representativeAttributeValues) -> {
-							final ReducedEntityIndex targetReducedIndex = dataStoreReader.getIndexIfExists(
-								new EntityIndexKey(
-									EntityIndexType.REFERENCED_ENTITY,
-									usedScope,
-									new RepresentativeReferenceKey(
-										new ReferenceKey(referencedSchemaName, epk),
-										representativeAttributeValues
-									)
-								),
-								__ -> null
+				// when the reflected reference is used, we can reuse shared reduced entity index
+				final boolean hardReference = referenceName.equals(referencedSchemaName);
+				switch (createMode) {
+					case INSERT_MISSING -> {
+						// a reflected reference may never point to a non-existent counterpart entity
+						if (referenceSchema instanceof ReflectedReferenceSchema && !missingPks.isEmpty()) {
+							throw new EntityMissingException(
+								referencedEntityType, missingPks.toArray(),
+								"Cannot set up main reference via reflected reference with name `" + referenceName + "`!"
 							);
-							// always check this entity primary key
-							return targetReducedIndex != null && targetReducedIndex.getAllPrimaryKeys().contains(entityPrimaryKey);
-						};
-					} else {
-						// always provide the same reference index
-						primaryKeyPredicate = (epk, representativeAttributeValues) -> {
-							final ReducedEntityIndex targetReducedIndex = dataStoreReader.getIndexIfExists(
-								new EntityIndexKey(
-									EntityIndexType.REFERENCED_ENTITY,
-									usedScope,
-									new RepresentativeReferenceKey(
-										new ReferenceKey(referencedSchemaName, entityPrimaryKey),
-										representativeAttributeValues
-									)
-								),
-								__ -> null
-							);
-							return targetReducedIndex != null && targetReducedIndex.getAllPrimaryKeys().contains(epk);
-						};
-					}
-					switch (createMode) {
-						case INSERT_MISSING -> {
-							if (existingEntityPks == null
-								&& referenceSchema instanceof ReflectedReferenceSchema
-								&& !referencedPrimaryKeys.isEmpty()) {
-								throw new EntityMissingException(
-									referencedEntityType, referencedPrimaryKeys.toArray(),
-									"Cannot set up main reference via reflected reference with name `" + referenceName + "`!"
-								);
-							} else if (existingEntityPks != null) {
+						}
+						for (Scope counterpartScope : scopes) {
+							final PersistentRoaringBitmap pksInScope = pksByScope[counterpartScope.ordinal()];
+							// the counterpart reference is created only when the relation is maintained in the scope span
+							if (pksInScope != null && isRelationMaintained(referenceSchema, referencedSchema, targetEntityScope, counterpartScope)) {
 								generateMissing(
 									entityPrimaryKey,
 									mutationCollector,
 									dataStoreReader,
-									existingEntityPks,
+									pksInScope,
 									referenceSchema,
 									referencedSchemaName,
 									referencedEntityType,
 									epk ->
 										getAllReducedReferencedEntityIndexes(
 											this.dataStoreReader,
-											usedScope,
+											targetEntityScope,
 											referenceName,
 											epk,
 											allowsDuplicates
 										),
 									referenceBlock.getAttributeSupplier(),
 									// we need to negate the predicate, because we want to insert missing references
-									primaryKeyPredicate.negate(),
+									createCounterpartPresencePredicate(
+										hardReference, dataStoreReader, referencedSchemaName, entityPrimaryKey, counterpartScope
+									).negate(),
 									// we need to take into account references removed in this turn
 									getReferenceKeyManager()::isRepresentativeReferenceKeyRemoved,
 									implicitMutations
 								);
 							}
 						}
-						case REMOVE_ALL_EXISTING -> removeExistingEntityPks(
-							entityPrimaryKey, mutationCollector,
-							existingEntityPks == null ? referencedPrimaryKeys : existingEntityPks,
-							referenceSchema,
-							referencedSchemaName,
-							referencedEntityType,
-							primaryKeyPredicate,
-							Droppable::dropped
-						);
-						case REMOVE_NON_INDEXED -> removeExistingEntityPks(
-							entityPrimaryKey, mutationCollector,
-							existingEntityPks == null ? referencedPrimaryKeys : existingEntityPks,
-							referenceSchema,
-							referencedSchemaName,
-							referencedEntityType,
-							primaryKeyPredicate,
-							Droppable::exists
-						);
+					}
+					case REMOVE_NON_INDEXED -> {
+						if (referenceSchema instanceof ReflectedReferenceSchema) {
+							// this entity owns the reflected (mirror) side - when the visibility rule is broken the
+							// mirror is discarded locally; a scope transition must never remove the primary reference
+							// on the counterpart entity (the primary reference stays the source of truth the mirror
+							// can be recreated from when visibility is regained)
+							for (Scope counterpartScope : scopes) {
+								final PersistentRoaringBitmap pksInScope = pksByScope[counterpartScope.ordinal()];
+								if (pksInScope != null && !isRelationMaintained(referenceSchema, referencedSchema, targetEntityScope, counterpartScope)) {
+									discardLocalReflectedReferences(referenceName, pksInScope, mutationCollector);
+								}
+							}
+							// mirrors pointing to counterpart entities that no longer exist are discarded as well
+							if (!missingPks.isEmpty()) {
+								discardLocalReflectedReferences(referenceName, missingPks, mutationCollector);
+							}
+						} else {
+							// this entity owns the primary side - mirrors on counterpart entities that lost mutual
+							// visibility are removed there; the primary reference itself is always retained
+							for (Scope counterpartScope : scopes) {
+								final PersistentRoaringBitmap pksInScope = pksByScope[counterpartScope.ordinal()];
+								if (pksInScope != null && !isRelationMaintained(referenceSchema, referencedSchema, targetEntityScope, counterpartScope)) {
+									removeExistingEntityPks(
+										entityPrimaryKey, mutationCollector,
+										pksInScope,
+										referenceSchema,
+										referencedSchemaName,
+										referencedEntityType,
+										createCounterpartPresencePredicate(
+											hardReference, dataStoreReader, referencedSchemaName, entityPrimaryKey, counterpartScope
+										),
+										Droppable::exists
+									);
+								}
+							}
+						}
+					}
+					case REMOVE_ALL_EXISTING -> {
+						// explicit removal (reference removed or entity deleted) is propagated to the counterpart only
+						// when the relation is maintained - a discarded mirror has nothing to clean up on the other
+						// side and a dangling reference to a removed counterpart must remain freely removable
+						for (Scope counterpartScope : scopes) {
+							final PersistentRoaringBitmap pksInScope = pksByScope[counterpartScope.ordinal()];
+							if (pksInScope != null && isRelationMaintained(referenceSchema, referencedSchema, sourceEntityScope, counterpartScope)) {
+								removeExistingEntityPks(
+									entityPrimaryKey, mutationCollector,
+									pksInScope,
+									referenceSchema,
+									referencedSchemaName,
+									referencedEntityType,
+									createCounterpartPresencePredicate(
+										hardReference, dataStoreReader, referencedSchemaName, entityPrimaryKey, counterpartScope
+									),
+									Droppable::dropped
+								);
+							}
+						}
 					}
 				}
 			}
@@ -2550,26 +2765,59 @@ public final class ContainerizedLocalMutationExecutor
 						this.dataStoreReaderAccessor.apply(referenceSchema.getReferencedEntityType());
 					// and if such is found (collection might not yet exist, but we can still reference to it)
 					if (dataStoreReader != null) {
-						// check whether global index exists (there is at least one entity of such type)
-						final GlobalEntityIndex globalIndex = dataStoreReader.getIndexIfExists(
-							new EntityIndexKey(EntityIndexType.GLOBAL, scope),
-							entityIndexKey -> null
-						);
-						if (globalIndex != null) {
-							// and whether it contains the entity we are referencing to
-							if (globalIndex.contains(referenceKey.primaryKey())) {
-								// if the current reference is a reflected reference
-								if (referenceSchema instanceof ReflectedReferenceSchemaContract rrsc) {
-									final boolean attributeVisibleFromOtherSide = catalogSchema
-										.getEntitySchema(rrsc.getReferencedEntityType())
-										.flatMap(it -> it.getReference(rrsc.getReflectedReferenceName()))
-										.flatMap(it -> it.getAttribute(ram.getAttributeKey().attributeName()))
-										.isPresent();
-									// create a mutation to counterpart reference in the referenced entity
-									// but only if the attribute is visible from that point of view
-									if (attributeVisibleFromOtherSide) {
+						// the referenced entity may live in a different scope than this entity - locate it first
+						final Scope counterpartScope = findScopeOfReferencedEntity(dataStoreReader, referenceKey.primaryKey());
+						if (counterpartScope != null) {
+							// if the current reference is a reflected reference
+							if (referenceSchema instanceof ReflectedReferenceSchemaContract rrsc) {
+								final Optional<ReferenceSchemaContract> counterpartSchema = catalogSchema
+									.getEntitySchema(rrsc.getReferencedEntityType())
+									.flatMap(it -> it.getReference(rrsc.getReflectedReferenceName()));
+								final boolean attributeVisibleFromOtherSide = counterpartSchema
+									.flatMap(it -> it.getAttribute(ram.getAttributeKey().attributeName()))
+									.isPresent();
+								// create a mutation to counterpart reference in the referenced entity, but only if
+								// the attribute is visible from that point of view and the relation is maintained
+								// for the current scope span (an invisible mirror would not exist to update)
+								if (attributeVisibleFromOtherSide &&
+									isRelationMaintained(referenceSchema, counterpartSchema.get(), scope, counterpartScope)) {
+									final ReferenceKey referenceKeyToUpdate = new ReferenceKey(
+										rrsc.getReflectedReferenceName(), this.entityPrimaryKey,
+										ram.getReferenceKey().internalPrimaryKey()
+									);
+									if (getReferenceKeyManager().isReferenceKeyNotRemoved(referenceKeyToUpdate)) {
+										// only if the counterpart reference wasn't removed in the same update
+										registerPropagatedReferenceAttributeMutation(
+											referenceSchema, ram, referenceAttributeMutationsByEntityReference,
+											referenceKey, referenceKeyToUpdate
+										);
+									}
+								}
+							} else {
+								// otherwise check whether there is reflected reference in the referenced entity
+								// that relates to our standard reference
+								final Optional<ReflectedReferenceSchema> reflectedReferenceSchema =
+									catalogSchema.getEntitySchema(referenceSchema.getReferencedEntityType())
+									             .map(it -> ((EntitySchemaDecorator) it).getDelegate())
+									             .flatMap(it -> it.getReflectedReferenceFor(
+										                      entitySchema.getName(),
+										                      referenceName
+									                      )
+									             );
+								if (reflectedReferenceSchema.isPresent()) {
+									final ReflectedReferenceSchema rrsc = reflectedReferenceSchema.get();
+									// if such is found, create a mutation to counterpart reflected reference
+									// in the referenced entity
+									final boolean attributeVisibleFromOtherSide = rrsc.getAttribute(
+										ram.getAttributeKey().attributeName()
+									).isPresent();
+									// create a mutation to counterpart reference in the referenced entity, but only
+									// if the attribute is visible from that point of view and the relation is
+									// maintained for the current scope span (a discarded mirror cannot be updated)
+									if (attributeVisibleFromOtherSide &&
+										isRelationMaintained(referenceSchema, rrsc, scope, counterpartScope)) {
 										final ReferenceKey referenceKeyToUpdate = new ReferenceKey(
-											rrsc.getReflectedReferenceName(), this.entityPrimaryKey,
+											rrsc.getName(), this.entityPrimaryKey,
 											ram.getReferenceKey().internalPrimaryKey()
 										);
 										if (getReferenceKeyManager().isReferenceKeyNotRemoved(referenceKeyToUpdate)) {
@@ -2578,41 +2826,6 @@ public final class ContainerizedLocalMutationExecutor
 												referenceSchema, ram, referenceAttributeMutationsByEntityReference,
 												referenceKey, referenceKeyToUpdate
 											);
-										}
-									}
-								} else {
-									// otherwise check whether there is reflected reference in the referenced entity
-									// that relates to our standard reference
-									final Optional<ReflectedReferenceSchema> reflectedReferenceSchema =
-										catalogSchema.getEntitySchema(referenceSchema.getReferencedEntityType())
-										             .map(it -> ((EntitySchemaDecorator) it).getDelegate())
-										             .flatMap(it -> it.getReflectedReferenceFor(
-											                      entitySchema.getName(),
-											                      referenceName
-										                      )
-										             );
-									if (reflectedReferenceSchema.isPresent()) {
-										final ReflectedReferenceSchema rrsc = reflectedReferenceSchema.get();
-										// if such is found, create a mutation to counterpart reflected reference
-										// in the referenced entity
-										final boolean attributeVisibleFromOtherSide = rrsc.getAttribute(
-											ram.getAttributeKey().attributeName()
-										).isPresent();
-										// create a mutation to counterpart reference in the referenced entity
-										// but only if the attribute is visible from that point of view
-										if (attributeVisibleFromOtherSide) {
-											final ReferenceKey referenceKeyToUpdate = new ReferenceKey(
-												rrsc.getName(), this.entityPrimaryKey,
-												ram.getReferenceKey().internalPrimaryKey()
-											);
-											if (getReferenceKeyManager().isReferenceKeyNotRemoved(referenceKeyToUpdate)) {
-												// only if the counterpart reference wasn't removed in the same update
-												// only if the counterpart reference wasn't removed in the same update
-												registerPropagatedReferenceAttributeMutation(
-													referenceSchema, ram, referenceAttributeMutationsByEntityReference,
-													referenceKey, referenceKeyToUpdate
-												);
-											}
 										}
 									}
 								}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaArchivingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaArchivingTest.java
@@ -1713,12 +1713,7 @@ public class EvitaArchivingTest implements EvitaTestSupport, IndexingTestSupport
 					session.createNewEntity(Entities.PRODUCT, 100)
 						.setAttribute(ATTRIBUTE_CODE, "TV-123")
 						.setAttribute(ATTRIBUTE_NAME, Locale.ENGLISH, "TV")
-						.setReference(
-							Entities.CATEGORY, 2,
-							whichIs -> whichIs
-								.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "EU")
-								.setAttribute(ATTRIBUTE_CATEGORY_OPEN, true)
-						)
+						.setReference(Entities.CATEGORY, 2, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "EU").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
 						.setPrice(1, PRICE_LIST_BASIC, CURRENCY_CZK, new BigDecimal("100"), new BigDecimal("21"), new BigDecimal("121"), true)
 						.setPrice(1, PRICE_LIST_BASIC, CURRENCY_EUR, new BigDecimal("10"), new BigDecimal("21"), new BigDecimal("12.1"), true)
 						.upsertVia(session);
@@ -1759,18 +1754,19 @@ public class EvitaArchivingTest implements EvitaTestSupport, IndexingTestSupport
 				}
 			);
 			assertNotNull(categoryAfterArchiving);
-			final ReferenceContract productsAfterArchiving =
-				categoryAfterArchiving.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null);
+			final ReferenceContract productsAfterArchiving = categoryAfterArchiving.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null);
 			assertNotNull(productsAfterArchiving);
 
 			// client can query for category by having product
 			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE, Scope.ARCHIVED);
 			assertProductContainsCategory(new EntityReference(Entities.PRODUCT, 100), 2, Scope.LIVE, Scope.ARCHIVED);
-			// but not in each scope separately
-			assertCategoryDoesNotContainProduct(100, Scope.LIVE);
+			// each entity is reachable only in its own scope, but the cross-scope relation is visible from both ends:
+			// the live category keeps its maintained mirror to the archived product, and the archived product keeps its
+			// primary reference queryable in the archived scope (invariant I1)
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE);
 			assertCategoryDoesNotContainProduct(100, Scope.ARCHIVED);
 			assertProductDoesNotContainCategory(2, Scope.LIVE);
-			assertProductDoesNotContainCategory(2, Scope.ARCHIVED);
+			assertProductContainsCategory(new EntityReference(Entities.PRODUCT, 100), 2, Scope.ARCHIVED);
 
 			// archive category entity
 			EvitaArchivingTest.this.evita.updateCatalog(
@@ -1801,8 +1797,7 @@ public class EvitaArchivingTest implements EvitaTestSupport, IndexingTestSupport
 			);
 
 			assertNotNull(archivedCategory);
-			final ReferenceContract archivedProducts =
-				archivedCategory.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null);
+			final ReferenceContract archivedProducts = archivedCategory.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null);
 			assertNotNull(archivedProducts);
 			assertEquals("EU", archivedProducts.getAttribute(ATTRIBUTE_CATEGORY_MARKET));
 
@@ -1833,8 +1828,7 @@ public class EvitaArchivingTest implements EvitaTestSupport, IndexingTestSupport
 				}
 			);
 			assertNotNull(categoryAfterRestore);
-			final ReferenceContract productsAfterRestore =
-				categoryAfterRestore.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null);
+			final ReferenceContract productsAfterRestore = categoryAfterRestore.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null);
 			assertNotNull(productsAfterRestore);
 			assertEquals("EU", productsAfterRestore.getAttribute(ATTRIBUTE_CATEGORY_MARKET));
 
@@ -3066,5 +3060,2106 @@ public class EvitaArchivingTest implements EvitaTestSupport, IndexingTestSupport
 			)
 			.build();
 	}
+
+
+	/**
+	 * Defines a catalog schema where {@link Entities#PRODUCT} owns the primary reference to {@link Entities#CATEGORY}
+	 * and {@link Entities#CATEGORY} carries the reflected reference back to the product. Both references are indexed in
+	 * the {@link Scope#LIVE} scope only, so archiving the product drops the reflected reference on the target side.
+	 */
+	private void defineLiveOnlyReflectedSchema() {
+		this.evita.defineCatalog(TEST_CATALOG)
+			.withAttribute(ATTRIBUTE_CODE, String.class, thatIs -> thatIs.uniqueGlobally().sortable())
+			.updateViaNewSession(this.evita);
+
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.CATEGORY)
+					.withoutGeneratedPrimaryKey()
+					.withGlobalAttribute(ATTRIBUTE_CODE)
+					.withReflectedReferenceToEntity(
+						REFLECTED_REFERENCE_NAME,
+						Entities.PRODUCT,
+						Entities.CATEGORY,
+						whichIs -> whichIs.indexedForFilteringAndPartitioning().withAttributesInherited()
+					)
+					.updateVia(session);
+
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withGlobalAttribute(ATTRIBUTE_CODE)
+					.withAttribute(ATTRIBUTE_NAME, String.class, thatIs -> thatIs.localized().filterable().sortable())
+					.withPriceInCurrency(CURRENCY_CZK, CURRENCY_EUR)
+					.withReferenceToEntity(
+						Entities.CATEGORY,
+						Entities.CATEGORY,
+						Cardinality.ZERO_OR_MORE,
+						thatIs -> thatIs
+							.indexedForFilteringAndPartitioning()
+							.withAttribute(ATTRIBUTE_CATEGORY_MARKET, String.class, whichIs -> whichIs.filterable().sortable())
+							.withAttribute(ATTRIBUTE_CATEGORY_OPEN, Boolean.class, AttributeSchemaEditor::filterable)
+					)
+					.updateVia(session);
+			}
+		);
+	}
+
+	/**
+	 * Creates category 2 and product 100 with the product holding a primary reference to that category (the product
+	 * references a reflected-target entity that some scenarios later remove).
+	 */
+	private void createArchivingFixtureEntities() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.createNewEntity(Entities.CATEGORY, 2)
+					.setAttribute(ATTRIBUTE_CODE, "TV")
+					.upsertVia(session);
+			}
+		);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.createNewEntity(Entities.PRODUCT, 100)
+					.setAttribute(ATTRIBUTE_CODE, "TV-123")
+					.setAttribute(ATTRIBUTE_NAME, Locale.ENGLISH, "TV")
+					.setReference(Entities.CATEGORY, 2, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "EU").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+					.setPrice(1, PRICE_LIST_BASIC, CURRENCY_CZK, new BigDecimal("100"), new BigDecimal("21"), new BigDecimal("121"), true)
+					.setPrice(1, PRICE_LIST_BASIC, CURRENCY_EUR, new BigDecimal("10"), new BigDecimal("21"), new BigDecimal("12.1"), true)
+					.upsertVia(session);
+			}
+		);
+	}
+
+	/**
+	 * Variant of {@link #defineLiveOnlyReflectedSchema()} where both the primary reference and the reflected reference
+	 * are indexed in the {@link Scope#LIVE} and {@link Scope#ARCHIVED} scopes. In this configuration archiving the
+	 * holder retains the reflected reference across scopes instead of dropping it.
+	 */
+	private void defineBothScopesReflectedSchema() {
+		final Scope[] scopes = new Scope[]{Scope.LIVE, Scope.ARCHIVED};
+		this.evita.defineCatalog(TEST_CATALOG)
+			.withAttribute(ATTRIBUTE_CODE, String.class, thatIs -> thatIs.uniqueGloballyInScope(scopes).sortableInScope(scopes))
+			.updateViaNewSession(this.evita);
+
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.CATEGORY)
+					.withoutGeneratedPrimaryKey()
+					.withGlobalAttribute(ATTRIBUTE_CODE)
+					.withReflectedReferenceToEntity(
+						REFLECTED_REFERENCE_NAME,
+						Entities.PRODUCT,
+						Entities.CATEGORY,
+						whichIs -> whichIs.indexedInScope(scopes).withAttributesInherited()
+					)
+					.updateVia(session);
+
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withGlobalAttribute(ATTRIBUTE_CODE)
+					.withAttribute(ATTRIBUTE_NAME, String.class, thatIs -> thatIs.localized().filterableInScope(scopes).sortableInScope(scopes))
+					.withPriceInCurrency(CURRENCY_CZK, CURRENCY_EUR)
+					.withReferenceToEntity(
+						Entities.CATEGORY,
+						Entities.CATEGORY,
+						Cardinality.ZERO_OR_MORE,
+						thatIs -> thatIs
+							.indexedInScope(scopes)
+							.withAttribute(ATTRIBUTE_CATEGORY_MARKET, String.class, whichIs -> whichIs.filterableInScope(scopes).sortableInScope(scopes))
+							.withAttribute(ATTRIBUTE_CATEGORY_OPEN, Boolean.class, whichIs -> whichIs.filterableInScope(scopes))
+					)
+					.updateVia(session);
+			}
+		);
+	}
+
+	/**
+	 * Variant of the reflected schema where the primary reference is indexed in both the {@link Scope#LIVE} and
+	 * {@link Scope#ARCHIVED} scopes while the reflected reference is indexed in the {@link Scope#LIVE} scope only. This
+	 * is the third legal indexing configuration (the reflected scopes must be a subset of the primary scopes): archiving
+	 * the holder drops the reflected mirror on the target yet keeps the holder's primary reference indexed in the
+	 * archived scope.
+	 */
+	private void defineMixedScopeReflectedSchema() {
+		final Scope[] bothScopes = new Scope[]{Scope.LIVE, Scope.ARCHIVED};
+		this.evita.defineCatalog(TEST_CATALOG)
+			.withAttribute(ATTRIBUTE_CODE, String.class, thatIs -> thatIs.uniqueGloballyInScope(bothScopes).sortableInScope(bothScopes))
+			.updateViaNewSession(this.evita);
+
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.CATEGORY)
+					.withoutGeneratedPrimaryKey()
+					.withGlobalAttribute(ATTRIBUTE_CODE)
+					.withReflectedReferenceToEntity(
+						REFLECTED_REFERENCE_NAME,
+						Entities.PRODUCT,
+						Entities.CATEGORY,
+						whichIs -> whichIs.indexedForFilteringAndPartitioning().withAttributesInherited()
+					)
+					.updateVia(session);
+
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withGlobalAttribute(ATTRIBUTE_CODE)
+					.withAttribute(ATTRIBUTE_NAME, String.class, thatIs -> thatIs.localized().filterableInScope(bothScopes).sortableInScope(bothScopes))
+					.withPriceInCurrency(CURRENCY_CZK, CURRENCY_EUR)
+					.withReferenceToEntity(
+						Entities.CATEGORY,
+						Entities.CATEGORY,
+						Cardinality.ZERO_OR_MORE,
+						thatIs -> thatIs
+							.indexedInScope(bothScopes)
+							.withAttribute(ATTRIBUTE_CATEGORY_MARKET, String.class, whichIs -> whichIs.filterableInScope(bothScopes).sortableInScope(bothScopes))
+							.withAttribute(ATTRIBUTE_CATEGORY_OPEN, Boolean.class, whichIs -> whichIs.filterableInScope(bothScopes))
+					)
+					.updateVia(session);
+			}
+		);
+	}
+
+	/**
+	 * Variant of {@link #createArchivingFixtureEntities()} that creates two reflected-target categories (2 and 3) and a
+	 * product 100 holding a primary reference to both. Used by the cardinality scenarios that remove one target while
+	 * the other survives.
+	 */
+	private void createTwoTargetArchivingFixture() {
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.createNewEntity(Entities.CATEGORY, 2)
+					.setAttribute(ATTRIBUTE_CODE, "TV")
+					.upsertVia(session);
+				session.createNewEntity(Entities.CATEGORY, 3)
+					.setAttribute(ATTRIBUTE_CODE, "Radio")
+					.upsertVia(session);
+			}
+		);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.createNewEntity(Entities.PRODUCT, 100)
+					.setAttribute(ATTRIBUTE_CODE, "TV-123")
+					.setAttribute(ATTRIBUTE_NAME, Locale.ENGLISH, "TV")
+					.setReference(Entities.CATEGORY, 2, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "EU").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+					.setReference(Entities.CATEGORY, 3, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "US").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+					.setPrice(1, PRICE_LIST_BASIC, CURRENCY_CZK, new BigDecimal("100"), new BigDecimal("21"), new BigDecimal("121"), true)
+					.setPrice(1, PRICE_LIST_BASIC, CURRENCY_EUR, new BigDecimal("10"), new BigDecimal("21"), new BigDecimal("12.1"), true)
+					.upsertVia(session);
+			}
+		);
+	}
+
+	/**
+	 * Missing E2E coverage for archiving/removal behaviour of plain (non-reflected) references. These scenarios act as
+	 * the control group for the reflected-reference scenarios: a plain reference carries no reflected mirror, so the
+	 * cross-scope reflected maintenance is never triggered and the primary-side bookkeeping must stay consistent.
+	 */
+	@Nested
+	@DisplayName("Simple (non-reflected) reference behaviour across scopes")
+	class SimpleReferenceArchivingScenarios {
+
+		@DisplayName("Removing a dangling simple reference from an archived holder whose target was removed from the archived scope must not fail")
+		@Test
+		void shouldRemoveDanglingSimpleReferenceWhenTargetRemovedFromArchivedScope() {
+			createSimpleReferenceFixture(Scope.LIVE, Scope.ARCHIVED);
+
+			// archive both the holder and the target so the target is removed later from the ARCHIVED scope
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+					session.archiveEntity(Entities.CATEGORY, 2);
+				}
+			);
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.CATEGORY, 2));
+				}
+			);
+
+			final SealedEntity archivedProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProduct);
+			assertNotNull(archivedProduct.getReference(Entities.CATEGORY, 2).orElse(null));
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.removeReference(Entities.CATEGORY, 2)
+						.upsertVia(session);
+				}
+			);
+
+			final SealedEntity archivedProductAfter = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProductAfter);
+			assertNull(archivedProductAfter.getReference(Entities.CATEGORY, 2).orElse(null));
+		}
+
+		@DisplayName("Deleting an archived holder with a simple reference to a live target must not fail")
+		@Test
+		void shouldDeleteArchivedHolderWithSimpleReferenceWhenTargetAlive() {
+			createSimpleReferenceFixture(Scope.LIVE, Scope.ARCHIVED);
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+
+			// delete the archived holder while the target is alive
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						assertTrue(session.deleteEntity(Entities.PRODUCT, 100));
+					}
+				),
+				"Deleting an archived holder with a live simple-reference target must not fail"
+			);
+
+			// the holder is gone from every scope, the target is untouched
+			final SealedEntity product = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.LIVE, Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNull(product);
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+		}
+
+		@DisplayName("Removing a dangling sibling simple reference from an archived holder keeps the surviving sibling intact")
+		@Test
+		void shouldRemoveOnlyDanglingSimpleSiblingAndKeepLiveSibling() {
+			createSimpleTwoTargetFixture(Scope.LIVE, Scope.ARCHIVED);
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			// remove one target (category 3) -> its reference on the archived holder becomes dangling
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.CATEGORY, 3));
+				}
+			);
+			// remove the dangling sibling reference (category 3) from the archived holder
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.removeReference(Entities.CATEGORY, 3)
+						.upsertVia(session);
+				}
+			);
+
+			// EXACT: the surviving sibling reference stays, the dead sibling reference is gone
+			final SealedEntity archivedProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProduct);
+			assertNotNull(archivedProduct.getReference(Entities.CATEGORY, 2).orElse(null));
+			assertNull(archivedProduct.getReference(Entities.CATEGORY, 3).orElse(null));
+		}
+
+		@DisplayName("Removing a dangling simple reference from an archived holder must not fail when the target was removed before archiving")
+		@Test
+		void shouldRemoveDanglingSimpleReferenceWhenTargetRemovedBeforeHolderArchived() {
+			createSimpleReferenceFixture(Scope.LIVE);
+
+			// remove the target first while the holder is live (reverse order)
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.CATEGORY, 2));
+				}
+			);
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+
+			final SealedEntity archivedProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProduct);
+			if (archivedProduct.getReference(Entities.CATEGORY, 2).isPresent()) {
+				assertDoesNotThrow(
+					() -> EvitaArchivingTest.this.evita.updateCatalog(
+						TEST_CATALOG,
+						session -> {
+							session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+								.orElseThrow()
+								.openForWrite()
+								.removeReference(Entities.CATEGORY, 2)
+								.upsertVia(session);
+						}
+					),
+					"Removing the dangling simple reference after reverse-order removal must not fail"
+				);
+			}
+			final SealedEntity archivedProductAfter = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProductAfter);
+			assertNull(archivedProductAfter.getReference(Entities.CATEGORY, 2).orElse(null));
+		}
+
+		@DisplayName("Restoring an archived holder whose simple-reference target was removed must not fail")
+		@Test
+		void shouldRestoreArchivedHolderWithSimpleReferenceWhenTargetRemoved() {
+			createSimpleReferenceFixture(Scope.LIVE);
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.CATEGORY, 2));
+				}
+			);
+
+			// restore the archived holder to live even though its simple-reference target no longer exists
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.restoreEntity(Entities.PRODUCT, 100);
+					}
+				),
+				"Restoring an archived holder whose simple-reference target was removed must not fail"
+			);
+
+			final SealedEntity liveProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(liveProduct);
+		}
+
+		@DisplayName("Archiving a simple-reference target while the holder stays live must keep both entities consistent")
+		@Test
+		void shouldArchiveSimpleReferenceTargetWhileHolderStaysLive() {
+			createSimpleReferenceFixture(Scope.LIVE, Scope.ARCHIVED);
+
+			// archive the referenced target while the holder stays live
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.archiveEntity(Entities.CATEGORY, 2);
+					}
+				),
+				"Archiving a simple-reference target must not fail"
+			);
+
+			final SealedEntity liveHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(liveHolder);
+			final SealedEntity archivedTarget = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedTarget);
+
+			// the holder's simple reference must remain removable without error
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent())
+							.orElseThrow()
+							.openForWrite()
+							.removeReference(Entities.CATEGORY, 2)
+							.upsertVia(session);
+					}
+				),
+				"Removing the simple reference after the target was archived must not fail"
+			);
+		}
+
+		/**
+		 * Builds the plain-reference fixture with two target categories (2 and 3) referenced by product 100. Used by the
+		 * cardinality scenario that removes one target while the other survives.
+		 *
+		 * @param indexScope the scopes in which the schema elements are indexed
+		 */
+		private void createSimpleTwoTargetFixture(@Nonnull Scope... indexScope) {
+			createSchemaForEntityArchiving(indexScope);
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(Entities.CATEGORY, 2)
+						.setAttribute(ATTRIBUTE_CODE, "TV")
+						.upsertVia(session);
+					session.createNewEntity(Entities.CATEGORY, 3)
+						.setAttribute(ATTRIBUTE_CODE, "Radio")
+						.upsertVia(session);
+				}
+			);
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(Entities.PRODUCT, 100)
+						.setAttribute(ATTRIBUTE_CODE, "TV-123")
+						.setAttribute(ATTRIBUTE_NAME, Locale.ENGLISH, "TV")
+						.setReference(Entities.CATEGORY, 2, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "EU").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+						.setReference(Entities.CATEGORY, 3, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "US").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+						.setPrice(1, PRICE_LIST_BASIC, CURRENCY_CZK, new BigDecimal("100"), new BigDecimal("21"), new BigDecimal("121"), true)
+						.setPrice(1, PRICE_LIST_BASIC, CURRENCY_EUR, new BigDecimal("10"), new BigDecimal("21"), new BigDecimal("12.1"), true)
+						.upsertVia(session);
+				}
+			);
+		}
+
+		@DisplayName("Removing a dangling simple reference from an archived holder after its target was removed must not fail")
+		@Test
+		void shouldRemoveDanglingSimpleReferenceOnArchivedHolderWhenTargetRemoved() {
+			createSimpleReferenceFixture(Scope.LIVE);
+
+			// archive the holder
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			// remove the referenced target entity
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.CATEGORY, 2));
+				}
+			);
+			// the archived holder still carries the now-dangling simple reference
+			final SealedEntity archivedProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProduct);
+			assertNotNull(archivedProduct.getReference(Entities.CATEGORY, 2).orElse(null));
+
+			// removing the dangling simple reference must succeed - no reflected maintenance is involved here
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.removeReference(Entities.CATEGORY, 2)
+						.upsertVia(session);
+				}
+			);
+
+			final SealedEntity archivedProductAfter = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProductAfter);
+			assertNull(archivedProductAfter.getReference(Entities.CATEGORY, 2).orElse(null));
+		}
+
+		/**
+		 * Builds the plain-reference fixture: the {@link #createSchemaForEntityArchiving(Scope...)} schema (product owns
+		 * a plain reference to a category), categories 1 and 2, and product 100 referencing category 2.
+		 *
+		 * @param indexScope the scopes in which the schema elements are indexed
+		 */
+		private void createSimpleReferenceFixture(@Nonnull Scope... indexScope) {
+			createSchemaForEntityArchiving(indexScope);
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(Entities.CATEGORY, 2)
+						.setAttribute(ATTRIBUTE_CODE, "TV")
+						.upsertVia(session);
+				}
+			);
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(Entities.PRODUCT, 100)
+						.setAttribute(ATTRIBUTE_CODE, "TV-123")
+						.setAttribute(ATTRIBUTE_NAME, Locale.ENGLISH, "TV")
+						.setReference(Entities.CATEGORY, 2, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "EU").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+						.setPrice(1, PRICE_LIST_BASIC, CURRENCY_CZK, new BigDecimal("100"), new BigDecimal("21"), new BigDecimal("121"), true)
+						.setPrice(1, PRICE_LIST_BASIC, CURRENCY_EUR, new BigDecimal("10"), new BigDecimal("21"), new BigDecimal("12.1"), true)
+						.upsertVia(session);
+				}
+			);
+		}
+	}
+
+	/**
+	 * Missing E2E coverage for archiving/removal behaviour of reflected references across the LIVE and ARCHIVED scopes.
+	 * The holder (product) owns the primary reference to the target (category); the target carries the reflected mirror
+	 * back to the holder. These scenarios exercise the full lifecycle matrix across the three legal indexing
+	 * configurations (primary+reflected LIVE-only, primary+reflected both-scopes, primary both-scopes / reflected
+	 * LIVE-only).
+	 */
+	@SuppressWarnings("SameParameterValue")
+	@Nested
+	@DisplayName("Reflected reference behaviour across scopes")
+	class ReflectedReferenceArchivingScenarios {
+
+		@DisplayName("Removing a primary reference from a live holder removes the reflected mirror on a live target (both scopes indexed) - LIVE control")
+		@Test
+		void shouldRemoveReflectedMirrorFromLiveTargetWhenPrimaryRemovedFromLiveHolder() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// holder stays LIVE; the reflected mirror is present in the LIVE scope
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE);
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.removeReference(Entities.CATEGORY, 2)
+						.upsertVia(session);
+				}
+			);
+
+			// EXACT: the reflected mirror on the live target must be gone
+			assertCategoryDoesNotContainProduct(100, Scope.LIVE);
+
+			final SealedEntity liveProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(liveProduct);
+			assertNull(liveProduct.getReference(Entities.CATEGORY, 2).orElse(null));
+		}
+
+		@DisplayName("Deleting an archived holder removes the reflected mirror on a live target (both scopes indexed)")
+		@Test
+		void shouldRemoveReflectedMirrorFromLiveTargetWhenArchivedHolderDeleted() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE, Scope.ARCHIVED);
+
+			// delete the archived holder entirely
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.PRODUCT, 100));
+				}
+			);
+
+			// EXACT: the reflected mirror on the live target must be gone in every scope
+			assertCategoryDoesNotContainProduct(100, Scope.LIVE);
+			assertCategoryDoesNotContainProduct(100, Scope.ARCHIVED);
+			// the target category itself is untouched
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+		}
+
+		@DisplayName("Deleting a live holder removes the reflected mirror on a live target (both scopes indexed) - LIVE control")
+		@Test
+		void shouldRemoveReflectedMirrorFromLiveTargetWhenLiveHolderDeleted() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE);
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.PRODUCT, 100));
+				}
+			);
+
+			assertCategoryDoesNotContainProduct(100, Scope.LIVE);
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+		}
+
+		@DisplayName("Archiving a holder drops the LIVE-only reflected mirror while keeping the primary reference indexed in the archived scope (mixed scopes)")
+		@Test
+		void shouldDropReflectedMirrorButRetainIndexedPrimaryWhenHolderArchivedWithMixedScopes() {
+			defineMixedScopeReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// before archiving: mirror present in LIVE and the holder is queryable by its primary reference in LIVE
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE);
+			assertProductContainsCategory(new EntityReference(Entities.PRODUCT, 100), 2, Scope.LIVE);
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+
+			// EXACT: the LIVE-only reflected mirror is dropped in the LIVE scope (it is not indexed in ARCHIVED, so the
+			// reflected reference cannot be queried there at all)
+			assertCategoryDoesNotContainProduct(100, Scope.LIVE);
+			// EXACT: the primary reference is indexed in ARCHIVED, so the archived holder is still queryable by it
+			assertProductContainsCategory(new EntityReference(Entities.PRODUCT, 100), 2, Scope.ARCHIVED);
+		}
+
+		@DisplayName("Removing a dangling primary reference from an archived holder whose target was removed must not fail (mixed scopes)")
+		@Test
+		void shouldRemoveDanglingPrimaryReferenceOnArchivedHolderWithMixedScopesWhenTargetRemoved() {
+			defineMixedScopeReflectedSchema();
+			createArchivingFixtureEntities();
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.CATEGORY, 2));
+				}
+			);
+
+			// the archived holder still carries the now-dangling primary reference
+			final SealedEntity archivedProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProduct);
+			assertNotNull(archivedProduct.getReference(Entities.CATEGORY, 2).orElse(null));
+
+			// removing the dangling primary reference must succeed
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.removeReference(Entities.CATEGORY, 2)
+						.upsertVia(session);
+				}
+			);
+
+			final SealedEntity archivedProductAfter = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProductAfter);
+			assertNull(archivedProductAfter.getReference(Entities.CATEGORY, 2).orElse(null));
+		}
+
+		@DisplayName("Archiving the reflected target while the holder stays live must keep both entities consistent and the primary reference removable")
+		@Test
+		void shouldArchiveReflectedTargetWhileHolderStaysLive() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// archive the TARGET (the reflected-mirror holder) while the primary holder stays LIVE
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.archiveEntity(Entities.CATEGORY, 2);
+					}
+				),
+				"Archiving the reflected target must not fail"
+			);
+
+			// INVARIANT: both entities remain retrievable in their respective scopes
+			final SealedEntity liveHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(liveHolder);
+			final SealedEntity archivedTarget = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedTarget);
+
+			// INVARIANT: whatever the mirror state, the holder's primary reference must remain removable without error
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent())
+							.orElseThrow()
+							.openForWrite()
+							.removeReference(Entities.CATEGORY, 2)
+							.upsertVia(session);
+					}
+				),
+				"Removing the primary reference after the reflected target was archived must not fail"
+			);
+		}
+
+		@DisplayName("Removing a dangling primary reference from an archived holder whose target was removed from the archived scope must not fail")
+		@Test
+		void shouldRemoveDanglingPrimaryReferenceWhenTargetRemovedFromArchivedScope() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// archive BOTH the holder and the target; with both-scopes indexing the mirror lives in the archived scope
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+					session.archiveEntity(Entities.CATEGORY, 2);
+				}
+			);
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.ARCHIVED);
+
+			// remove the target from the ARCHIVED scope
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.CATEGORY, 2));
+				}
+			);
+
+			// the archived holder must stay consistent: whether the reference dangles or was auto-cleaned by the
+			// reflected maintenance, the holder must remain retrievable and must not keep a reference that cannot be removed
+			final SealedEntity archivedProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProduct);
+			if (archivedProduct.getReference(Entities.CATEGORY, 2).isPresent()) {
+				EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+							.orElseThrow()
+							.openForWrite()
+							.removeReference(Entities.CATEGORY, 2)
+							.upsertVia(session);
+					}
+				);
+			}
+
+			final SealedEntity archivedProductAfter = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProductAfter);
+			assertNull(archivedProductAfter.getReference(Entities.CATEGORY, 2).orElse(null));
+		}
+
+		@DisplayName("Restoring the holder to live while the reflected target stays archived must keep both entities consistent")
+		@Test
+		void shouldRestoreHolderToLiveWhileReflectedTargetStaysArchived() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// archive both holder and target
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+					session.archiveEntity(Entities.CATEGORY, 2);
+				}
+			);
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.ARCHIVED);
+
+			// restore ONLY the holder to LIVE; the target remains ARCHIVED
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.restoreEntity(Entities.PRODUCT, 100);
+					}
+				),
+				"Restoring the holder while its reflected target stays archived must not fail"
+			);
+
+			// INVARIANT: holder retrievable in LIVE, target retrievable in ARCHIVED
+			final SealedEntity liveHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(liveHolder);
+			final SealedEntity archivedTarget = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedTarget);
+
+			// INVARIANT: the holder's primary reference must remain removable without error
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent())
+							.orElseThrow()
+							.openForWrite()
+							.removeReference(Entities.CATEGORY, 2)
+							.upsertVia(session);
+					}
+				),
+				"Removing the primary reference after asymmetric restore must not fail"
+			);
+		}
+
+		@DisplayName("Restoring a holder recreates the reflected mirror only on the surviving target, skipping the removed one")
+		@Test
+		void shouldRecreateReflectedMirrorOnlyForSurvivingTargetWhenHolderRestored() {
+			defineLiveOnlyReflectedSchema();
+			createTwoTargetArchivingFixture();
+
+			// both targets carry the reflected mirror while the holder is live
+			assertReflectedMirrorOnCategory(2, true);
+			assertReflectedMirrorOnCategory(3, true);
+
+			// archive the holder -> LIVE-only mirrors are dropped
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			assertCategoryDoesNotContainProduct(100, Scope.LIVE);
+
+			// remove ONE target (category 3) while the holder is archived
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.CATEGORY, 3));
+				}
+			);
+
+			// restore the holder to LIVE
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.restoreEntity(Entities.PRODUCT, 100);
+				}
+			);
+
+			// EXACT: exactly the surviving target (category 2) mirrors the product again; the removed one does not
+			final List<Integer> categoriesReferencingProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.queryList(
+						Query.query(
+							collection(Entities.CATEGORY),
+							filterBy(
+								referenceHaving(REFLECTED_REFERENCE_NAME, entityPrimaryKeyInSet(100)),
+								scope(Scope.LIVE)
+							)
+						),
+						EntityReference.class
+					).stream().map(EntityReference::getPrimaryKey).toList();
+				}
+			);
+			assertEquals(List.of(2), categoriesReferencingProduct);
+		}
+
+		@DisplayName("Removing a dangling sibling reference from an archived holder keeps the surviving sibling and its reflected mirror intact")
+		@Test
+		void shouldRemoveOnlyDanglingSiblingReferenceAndKeepLiveSiblingOnArchivedHolder() {
+			defineBothScopesReflectedSchema();
+			createTwoTargetArchivingFixture();
+
+			// archive the holder -> both mirrors retained across scopes
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			// the mirrors live on the (still LIVE) categories - they are retained across the scope span; both
+			// categories mirror the product, so their presence is asserted on the entity bodies directly
+			assertReflectedMirrorOnCategory(2, true);
+			assertReflectedMirrorOnCategory(3, true);
+
+			// remove ONE target (category 3); with both-scopes indexing the relation is maintained across the scope
+			// split, so the removal may propagate to the holder's primary reference automatically
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.CATEGORY, 3));
+				}
+			);
+
+			// if the sibling reference (category 3) still dangles on the archived holder, remove it explicitly
+			final SealedEntity archivedProductBefore = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProductBefore);
+			if (archivedProductBefore.getReference(Entities.CATEGORY, 3).isPresent()) {
+				EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+							.orElseThrow()
+							.openForWrite()
+							.removeReference(Entities.CATEGORY, 3)
+							.upsertVia(session);
+					}
+				);
+			}
+
+			// EXACT (adversarial for the existence-filter fix): the surviving sibling and its mirror must stay intact
+			final SealedEntity archivedProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProduct);
+			assertNotNull(archivedProduct.getReference(Entities.CATEGORY, 2).orElse(null));
+			assertNull(archivedProduct.getReference(Entities.CATEGORY, 3).orElse(null));
+			// after removing the dangling sibling only category 2 mirrors the product - now queryOne is unambiguous
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE, Scope.ARCHIVED);
+		}
+
+		@DisplayName("Updating an inherited reference attribute on an archived holder propagates to the reflected mirror on a live target")
+		@Test
+		void shouldPropagateInheritedAttributeToReflectedMirrorWhenArchivedHolderReferenceUpdated() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			// the mirror initially inherits market = "EU"
+			assertReflectedMirrorMarket("EU");
+
+			// update the inherited attribute on the archived holder's primary reference
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setReference(Entities.CATEGORY, 2, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "US").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+						.upsertVia(session);
+				}
+			);
+
+			// the primary-side write must have landed on the archived holder itself (isolates "write dropped" from
+			// "mirror propagation skipped")
+			final SealedEntity archivedHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedHolder);
+			assertEquals("US", archivedHolder.getReference(Entities.CATEGORY, 2).orElseThrow().getAttribute(ATTRIBUTE_CATEGORY_MARKET));
+
+			// EXACT: the reflected mirror on the live target reflects the updated inherited attribute
+			assertReflectedMirrorMarket("US");
+		}
+
+		@DisplayName("Updating an inherited reference attribute on a live holder propagates to the reflected mirror - LIVE control")
+		@Test
+		void shouldPropagateInheritedAttributeToReflectedMirrorWhenLiveHolderReferenceUpdated() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			assertReflectedMirrorMarket("EU");
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setReference(Entities.CATEGORY, 2, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "US").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+						.upsertVia(session);
+				}
+			);
+
+			assertReflectedMirrorMarket("US");
+		}
+
+		@DisplayName("Removing a dangling primary reference from an archived holder must not fail when the target was removed before archiving")
+		@Test
+		void shouldRemoveDanglingPrimaryReferenceWhenTargetRemovedBeforeHolderArchived() {
+			defineLiveOnlyReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// remove the target FIRST while the holder is live (reverse of the usual archive-then-remove order)
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.CATEGORY, 2));
+				}
+			);
+
+			// archive the holder (its reference to the removed target may still dangle)
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+
+			// INVARIANT: the archived holder must not end up with a reference that cannot be removed
+			final SealedEntity archivedProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProduct);
+			if (archivedProduct.getReference(Entities.CATEGORY, 2).isPresent()) {
+				assertDoesNotThrow(
+					() -> EvitaArchivingTest.this.evita.updateCatalog(
+						TEST_CATALOG,
+						session -> {
+							session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+								.orElseThrow()
+								.openForWrite()
+								.removeReference(Entities.CATEGORY, 2)
+								.upsertVia(session);
+						}
+					),
+					"Removing the dangling reference after reverse-order removal must not fail"
+				);
+			}
+			final SealedEntity archivedProductAfter = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProductAfter);
+			assertNull(archivedProductAfter.getReference(Entities.CATEGORY, 2).orElse(null));
+		}
+
+		@DisplayName("Adding a primary reference to an archived holder creates the reflected mirror on the target")
+		@Test
+		void shouldCreateReflectedMirrorWhenPrimaryReferenceAddedToArchivedHolder() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// add a second live target the holder does not yet reference
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(Entities.CATEGORY, 3)
+						.setAttribute(ATTRIBUTE_CODE, "Radio")
+						.upsertVia(session);
+				}
+			);
+
+			// archive the holder
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+
+			// before: category 3 carries no reflected mirror to the holder
+			final SealedEntity categoryBefore = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 3, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(categoryBefore);
+			assertNull(categoryBefore.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null));
+
+			// add a primary reference to category 3 on the archived holder
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setReference(Entities.CATEGORY, 3, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "US").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+						.upsertVia(session);
+				}
+			);
+
+			// the primary-side write must have landed on the archived holder itself (isolates "write dropped" from
+			// "mirror not created")
+			final SealedEntity archivedHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedHolder);
+			assertNotNull(archivedHolder.getReference(Entities.CATEGORY, 3).orElse(null));
+
+			// EXACT: the reflected mirror on category 3 is created
+			final SealedEntity categoryAfter = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 3, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(categoryAfter);
+			assertNotNull(categoryAfter.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null));
+		}
+
+		/**
+		 * Asserts that the reflected mirror on category 2 pointing back to product 100 inherits the given market
+		 * attribute value.
+		 *
+		 * @param expectedMarket the expected inherited market attribute value on the reflected mirror
+		 */
+		private void assertReflectedMirrorMarket(@Nonnull String expectedMarket) {
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+			final ReferenceContract mirror = category.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null);
+			assertNotNull(mirror);
+			assertEquals(expectedMarket, mirror.getAttribute(ATTRIBUTE_CATEGORY_MARKET));
+		}
+
+		/**
+		 * Asserts the presence or absence of the reflected mirror to product 100 on the given category, checking the
+		 * category entity body directly (works even when several categories mirror the same product, where a
+		 * reference-having query would match more than one record).
+		 *
+		 * @param categoryPk      the primary key of the category to inspect
+		 * @param expectedPresent whether the reflected mirror to product 100 is expected on the category
+		 */
+		private void assertReflectedMirrorOnCategory(int categoryPk, boolean expectedPresent) {
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, categoryPk, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+			if (expectedPresent) {
+				assertNotNull(category.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null));
+			} else {
+				assertNull(category.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null));
+			}
+		}
+
+		@DisplayName("Removing a primary reference from an archived holder removes the reflected mirror on a live target (both scopes indexed)")
+		@Test
+		void shouldRemoveReflectedMirrorFromLiveTargetWhenPrimaryRemovedFromArchivedHolder() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// archive the holder: with both-scopes indexing the reflected mirror is retained across scopes
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			// the reflected mirror on the (still live) category 2 must be present across scopes
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE, Scope.ARCHIVED);
+
+			// remove the primary reference from the archived holder while the target is still alive
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.removeReference(Entities.CATEGORY, 2)
+						.upsertVia(session);
+				}
+			);
+
+			// EXACT: the reflected mirror on the live target must be gone in every scope
+			assertCategoryDoesNotContainProduct(100, Scope.LIVE);
+			assertCategoryDoesNotContainProduct(100, Scope.ARCHIVED);
+
+			// and the archived holder no longer carries the reference
+			final SealedEntity archivedProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProduct);
+			assertNull(archivedProduct.getReference(Entities.CATEGORY, 2).orElse(null));
+		}
+
+		/**
+		 * Asserts the presence or absence of the reflected mirror to product 100 on the given category fetched from the
+		 * given scope, reading the category entity body directly. Unlike {@link #assertReflectedMirrorOnCategory(int,
+		 * boolean)} this variant works when the category itself was archived and therefore cannot be reached in the
+		 * default {@link Scope#LIVE} scope.
+		 *
+		 * @param categoryPk      the primary key of the category to inspect
+		 * @param scope           the scope from which the category is fetched
+		 * @param expectedPresent whether the reflected mirror to product 100 is expected on the category
+		 */
+		private void assertReflectedMirrorOnCategoryInScope(int categoryPk, @Nonnull Scope scope, boolean expectedPresent) {
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, categoryPk, new Scope[]{scope}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+			if (expectedPresent) {
+				assertNotNull(category.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null));
+			} else {
+				assertNull(category.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null));
+			}
+		}
+
+		/**
+		 * Asserts that the reflected mirror to product 100 on the given category fetched from the given scope inherits
+		 * the expected market attribute value. Complements {@link #assertReflectedMirrorMarket(String)} for cases where
+		 * the category was archived and therefore is not reachable in the default {@link Scope#LIVE} scope.
+		 *
+		 * @param categoryPk     the primary key of the category to inspect
+		 * @param scope          the scope from which the category is fetched
+		 * @param expectedMarket the expected inherited market attribute value on the reflected mirror
+		 */
+		private void assertReflectedMirrorMarketInScope(int categoryPk, @Nonnull Scope scope, @Nonnull String expectedMarket) {
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, categoryPk, new Scope[]{scope}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+			final ReferenceContract mirror = category.getReference(REFLECTED_REFERENCE_NAME, 100).orElse(null);
+			assertNotNull(mirror);
+			assertEquals(expectedMarket, mirror.getAttribute(ATTRIBUTE_CATEGORY_MARKET));
+		}
+
+		@DisplayName("Restoring a mixed-scope holder to live recreates the reflected mirror discarded on archiving")
+		@Test
+		void shouldRecreateReflectedMirrorWhenMixedScopeHolderRestoredToLive() {
+			defineMixedScopeReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// before archiving: the LIVE-only mirror is present on the live target
+			assertReflectedMirrorOnCategory(2, true);
+
+			// archive the holder -> the LIVE-only mirror is discarded
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			assertReflectedMirrorOnCategory(2, false);
+
+			// restore the holder back to LIVE -> both ends are LIVE again, so the mirror must be recreated
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.restoreEntity(Entities.PRODUCT, 100);
+				}
+			);
+
+			// EXACT: the reflected mirror is recreated on the target with its inherited attribute intact
+			assertReflectedMirrorOnCategory(2, true);
+			assertReflectedMirrorMarket("EU");
+		}
+
+		@DisplayName("Archiving a mixed-scope reflected target while the holder stays live discards the mirror yet keeps the primary reference queryable")
+		@Test
+		void shouldArchiveReflectedTargetWithMixedScopesWhileHolderStaysLive() {
+			defineMixedScopeReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// before archiving: the LIVE-only mirror is present on the still-live target
+			assertReflectedMirrorOnCategory(2, true);
+
+			// archive the TARGET while the holder stays LIVE -> the relation spans two scopes, reflected is LIVE-only
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.archiveEntity(Entities.CATEGORY, 2);
+					}
+				),
+				"Archiving the mixed-scope reflected target must not fail"
+			);
+
+			// INVARIANT: discarding the mirror must never remove the holder's primary reference (spec section 3); the
+			// live holder keeps its primary reference on its body regardless of the target moving to the archived scope
+			final SealedEntity liveHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(liveHolder);
+			assertNotNull(liveHolder.getReference(Entities.CATEGORY, 2).orElse(null));
+
+			// EXACT: the mirror is discarded on the now-archived target
+			assertReflectedMirrorOnCategoryInScope(2, Scope.ARCHIVED, false);
+		}
+
+		@DisplayName("Archiving a LIVE-only reflected target while the holder stays live discards the mirror without failing")
+		@Test
+		void shouldArchiveReflectedTargetWithLiveOnlyScopesWhileHolderStaysLive() {
+			defineLiveOnlyReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// before archiving: the LIVE-only mirror is present on the still-live target
+			assertReflectedMirrorOnCategory(2, true);
+
+			// archive the TARGET while the holder stays LIVE -> the relation spans two scopes, reflected is LIVE-only
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.archiveEntity(Entities.CATEGORY, 2);
+					}
+				),
+				"Archiving the LIVE-only reflected target must not fail"
+			);
+
+			// INVARIANT: the live holder remains retrievable and keeps its primary reference (LIVE index)
+			final SealedEntity liveHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(liveHolder);
+			assertNotNull(liveHolder.getReference(Entities.CATEGORY, 2).orElse(null));
+
+			// EXACT: the mirror is discarded on the now-archived target
+			assertReflectedMirrorOnCategoryInScope(2, Scope.ARCHIVED, false);
+		}
+
+		@DisplayName("Adding a primary reference to an archived mixed-scope holder lands the write but creates no LIVE-only mirror")
+		@Test
+		void shouldNotCreateReflectedMirrorWhenPrimaryReferenceAddedToArchivedMixedScopeHolder() {
+			defineMixedScopeReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// add a second live target the holder does not yet reference
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(Entities.CATEGORY, 3)
+						.setAttribute(ATTRIBUTE_CODE, "Radio")
+						.upsertVia(session);
+				}
+			);
+
+			// archive the holder
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+
+			// add a primary reference to the live category 3 on the archived holder
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+							.orElseThrow()
+							.openForWrite()
+							.setReference(Entities.CATEGORY, 3, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "US").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+							.upsertVia(session);
+					}
+				),
+				"Adding a primary reference to the archived mixed-scope holder must not fail"
+			);
+
+			// EXACT: the primary-side write lands on the archived holder and is queryable in the ARCHIVED scope
+			final SealedEntity archivedHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedHolder);
+			assertNotNull(archivedHolder.getReference(Entities.CATEGORY, 3).orElse(null));
+
+			// EXACT: the reflected reference is LIVE-only, so no mirror is created on the live target
+			assertReflectedMirrorOnCategory(3, false);
+
+			// EXACT: the primary schema is indexed in ARCHIVED, so the newly added primary reference is queryable there
+			assertProductContainsCategory(new EntityReference(Entities.PRODUCT, 100), 3, Scope.ARCHIVED);
+		}
+
+		@DisplayName("Deleting an archived mixed-scope holder while its reflected target is alive must not fail")
+		@Test
+		void shouldDeleteArchivedMixedScopeHolderWhenReflectedTargetAlive() {
+			defineMixedScopeReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// archive the holder while the target stays LIVE
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+
+			// delete the archived holder entirely
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						assertTrue(session.deleteEntity(Entities.PRODUCT, 100));
+					}
+				),
+				"Deleting the archived mixed-scope holder must not fail"
+			);
+
+			// EXACT: the holder is gone from both scopes
+			final SealedEntity liveHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNull(liveHolder);
+			final SealedEntity archivedHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNull(archivedHolder);
+
+			// EXACT: the target category is untouched
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+		}
+
+		@DisplayName("Removing a dangling sibling reference from an archived mixed-scope holder keeps the surviving primary reference intact")
+		@Test
+		void shouldRemoveOnlyDanglingSiblingReferenceWithMixedScopesOnArchivedHolder() {
+			defineMixedScopeReflectedSchema();
+			createTwoTargetArchivingFixture();
+
+			// archive the holder -> LIVE-only mirrors are discarded but the primary references remain in the archived scope
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			// the archived holder retains both primary references on its body; the references are inspected on the entity
+			// body directly to isolate sibling handling from the archived-scope primary reference index
+			final SealedEntity archivedHolderBefore = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedHolderBefore);
+			assertNotNull(archivedHolderBefore.getReference(Entities.CATEGORY, 2).orElse(null));
+			assertNotNull(archivedHolderBefore.getReference(Entities.CATEGORY, 3).orElse(null));
+
+			// remove ONE target (category 3) -> its reference on the archived holder becomes dangling
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.CATEGORY, 3));
+				}
+			);
+
+			// remove the dangling sibling reference (category 3) from the archived holder
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+							.orElseThrow()
+							.openForWrite()
+							.removeReference(Entities.CATEGORY, 3)
+							.upsertVia(session);
+					}
+				),
+				"Removing the dangling sibling reference on the archived mixed-scope holder must not fail"
+			);
+
+			// EXACT: the surviving sibling reference stays intact, only the dangling one is gone
+			final SealedEntity archivedProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProduct);
+			assertNotNull(archivedProduct.getReference(Entities.CATEGORY, 2).orElse(null));
+			assertNull(archivedProduct.getReference(Entities.CATEGORY, 3).orElse(null));
+		}
+
+		@DisplayName("Updating an inherited attribute while both holder and target are archived propagates to the mirror (both scopes indexed)")
+		@Test
+		void shouldPropagateInheritedAttributeToReflectedMirrorWhenBothHolderAndTargetArchived() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// archive BOTH the holder and the target; with both-scopes indexing the mirror lives in the archived scope
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+					session.archiveEntity(Entities.CATEGORY, 2);
+				}
+			);
+			// the mirror on the archived target initially inherits market = "EU"
+			assertReflectedMirrorMarketInScope(2, Scope.ARCHIVED, "EU");
+
+			// update the inherited attribute on the archived holder's primary reference
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setReference(Entities.CATEGORY, 2, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "US").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+						.upsertVia(session);
+				}
+			);
+
+			// the primary-side write must have landed on the archived holder itself
+			final SealedEntity archivedHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedHolder);
+			assertEquals("US", archivedHolder.getReference(Entities.CATEGORY, 2).orElseThrow().getAttribute(ATTRIBUTE_CATEGORY_MARKET));
+
+			// EXACT: the reflected mirror on the archived target reflects the updated inherited attribute
+			assertReflectedMirrorMarketInScope(2, Scope.ARCHIVED, "US");
+		}
+
+		@DisplayName("Adding a primary reference while both holder and target are archived creates the mirror (both scopes indexed)")
+		@Test
+		void shouldCreateReflectedMirrorWhenPrimaryReferenceAddedToBothArchivedHolderAndTarget() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// add a second target the holder does not yet reference
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(Entities.CATEGORY, 3)
+						.setAttribute(ATTRIBUTE_CODE, "Radio")
+						.upsertVia(session);
+				}
+			);
+
+			// archive BOTH the holder and the new target
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+					session.archiveEntity(Entities.CATEGORY, 3);
+				}
+			);
+
+			// before: the archived category 3 carries no reflected mirror to the holder
+			assertReflectedMirrorOnCategoryInScope(3, Scope.ARCHIVED, false);
+
+			// add a primary reference to the archived category 3 on the archived holder
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setReference(Entities.CATEGORY, 3, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "US").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+						.upsertVia(session);
+				}
+			);
+
+			// the primary-side write must have landed on the archived holder itself
+			final SealedEntity archivedHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedHolder);
+			assertNotNull(archivedHolder.getReference(Entities.CATEGORY, 3).orElse(null));
+
+			// EXACT: the reflected mirror is created on the archived target (both schemas indexed in ARCHIVED)
+			assertReflectedMirrorOnCategoryInScope(3, Scope.ARCHIVED, true);
+		}
+
+		@DisplayName("Adding a primary reference to an archived LIVE-only holder lands the write but creates no mirror")
+		@Test
+		void shouldNotCreateReflectedMirrorWhenPrimaryReferenceAddedToArchivedLiveOnlyHolder() {
+			defineLiveOnlyReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// archive the holder
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+
+			// add a fresh live target the holder does not yet reference
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.createNewEntity(Entities.CATEGORY, 3)
+						.setAttribute(ATTRIBUTE_CODE, "Radio")
+						.upsertVia(session);
+				}
+			);
+
+			// add a primary reference to the live category 3 on the archived holder
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+							.orElseThrow()
+							.openForWrite()
+							.setReference(Entities.CATEGORY, 3, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "US").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+							.upsertVia(session);
+					}
+				),
+				"Adding a primary reference to the archived LIVE-only holder must not fail"
+			);
+
+			// EXACT: the primary-side write lands on the archived holder body (the primary is LIVE-only, so it is not
+			// queryable in the ARCHIVED scope, but the reference is stored on the entity)
+			final SealedEntity archivedHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedHolder);
+			assertNotNull(archivedHolder.getReference(Entities.CATEGORY, 3).orElse(null));
+
+			// EXACT: the ends are not mutually visible, so no mirror is created on the live target
+			assertReflectedMirrorOnCategory(3, false);
+		}
+
+		@DisplayName("Restoring a LIVE-only reflected target while the holder stays live recreates the discarded mirror")
+		@Test
+		void shouldRecreateReflectedMirrorWhenLiveOnlyTargetRestoredWhileHolderStaysLive() {
+			defineLiveOnlyReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// before archiving: the LIVE-only mirror is present on the live target
+			assertReflectedMirrorOnCategory(2, true);
+
+			// archive the TARGET while the holder stays LIVE -> the mirror is discarded
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.CATEGORY, 2);
+				}
+			);
+			assertReflectedMirrorOnCategoryInScope(2, Scope.ARCHIVED, false);
+
+			// restore the TARGET back to LIVE -> both ends are LIVE again, so the mirror must be recreated
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.restoreEntity(Entities.CATEGORY, 2);
+				}
+			);
+
+			// EXACT: the reflected mirror is recreated on the restored target with its inherited attribute intact
+			assertReflectedMirrorOnCategory(2, true);
+			assertReflectedMirrorMarket("EU");
+		}
+
+		@DisplayName("Updating an inherited attribute on an archived mixed-scope holder lands the primary write without a LIVE-only mirror")
+		@Test
+		void shouldLandPrimaryWriteWithoutMirrorWhenArchivedMixedScopeHolderAttributeUpdated() {
+			defineMixedScopeReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// archive the holder -> the LIVE-only mirror is discarded, the primary reference stays in the archived scope
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			assertReflectedMirrorOnCategory(2, false);
+
+			// update the inherited attribute on the archived holder's primary reference
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+							.orElseThrow()
+							.openForWrite()
+							.setReference(Entities.CATEGORY, 2, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "US").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+							.upsertVia(session);
+					}
+				),
+				"Updating the inherited attribute on the archived mixed-scope holder must not fail"
+			);
+
+			// EXACT: the primary-side write lands and is queryable in the ARCHIVED scope
+			final SealedEntity archivedHolder = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedHolder);
+			assertEquals("US", archivedHolder.getReference(Entities.CATEGORY, 2).orElseThrow().getAttribute(ATTRIBUTE_CATEGORY_MARKET));
+
+			// EXACT: the reflected reference is LIVE-only and the mirror was discarded, so none exists on the live target
+			assertReflectedMirrorOnCategory(2, false);
+		}
+
+		@DisplayName("Updating an inherited attribute on a live holder propagates to the archived target's mirror (both scopes indexed)")
+		@Test
+		void shouldPropagateInheritedAttributeToArchivedTargetWhenLiveHolderReferenceUpdated() {
+			defineBothScopesReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// archive ONLY the target; with both-scopes indexing the mirror is retained cross-scope on the archived target
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.CATEGORY, 2);
+				}
+			);
+			assertReflectedMirrorMarketInScope(2, Scope.ARCHIVED, "EU");
+
+			// update the inherited attribute on the live holder's primary reference
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.setReference(Entities.CATEGORY, 2, whichIs -> whichIs.setAttribute(ATTRIBUTE_CATEGORY_MARKET, "US").setAttribute(ATTRIBUTE_CATEGORY_OPEN, true))
+						.upsertVia(session);
+				}
+			);
+
+			// EXACT: the cross-scope mirror on the archived target reflects the updated inherited attribute
+			assertReflectedMirrorMarketInScope(2, Scope.ARCHIVED, "US");
+		}
+
+		@DisplayName("Removing a primary reference from an archived LIVE-only holder whose target is alive must not fail")
+		@Test
+		void shouldRemovePrimaryReferenceOnArchivedLiveOnlyHolderWhenTargetAlive() {
+			defineLiveOnlyReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// archive the holder while the target stays LIVE (the LIVE-only mirror is discarded on archiving)
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+
+			// the archived holder still carries the primary reference on its body
+			final SealedEntity archivedProduct = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProduct);
+			assertNotNull(archivedProduct.getReference(Entities.CATEGORY, 2).orElse(null));
+
+			// remove the primary reference on the archived holder while the target is alive
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+							.orElseThrow()
+							.openForWrite()
+							.removeReference(Entities.CATEGORY, 2)
+							.upsertVia(session);
+					}
+				),
+				"Removing the primary reference on the archived LIVE-only holder must not fail"
+			);
+
+			// EXACT: the reference is gone from the archived holder body; the target category is untouched
+			final SealedEntity archivedProductAfter = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProductAfter);
+			assertNull(archivedProductAfter.getReference(Entities.CATEGORY, 2).orElse(null));
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+		}
+
+		@DisplayName("Removing a primary reference from an archived mixed-scope holder whose target is alive must not fail")
+		@Test
+		void shouldRemovePrimaryReferenceOnArchivedMixedScopeHolderWhenTargetAlive() {
+			defineMixedScopeReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// archive the holder while the target stays LIVE
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.archiveEntity(Entities.PRODUCT, 100);
+				}
+			);
+			// the archived holder retains the primary reference on its body; the reference is inspected on the entity
+			// body directly to isolate removal handling from the archived-scope primary reference index
+			final SealedEntity archivedProductBefore = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProductBefore);
+			assertNotNull(archivedProductBefore.getReference(Entities.CATEGORY, 2).orElse(null));
+
+			// remove the primary reference on the archived holder while the target is alive
+			assertDoesNotThrow(
+				() -> EvitaArchivingTest.this.evita.updateCatalog(
+					TEST_CATALOG,
+					session -> {
+						session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent())
+							.orElseThrow()
+							.openForWrite()
+							.removeReference(Entities.CATEGORY, 2)
+							.upsertVia(session);
+					}
+				),
+				"Removing the primary reference on the archived mixed-scope holder must not fail"
+			);
+
+			// EXACT: the reference is gone from the holder body; the target is untouched
+			final SealedEntity archivedProductAfter = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.PRODUCT, 100, new Scope[]{Scope.ARCHIVED}, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(archivedProductAfter);
+			assertNull(archivedProductAfter.getReference(Entities.CATEGORY, 2).orElse(null));
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+		}
+
+		@DisplayName("Removing a primary reference from a live LIVE-only holder removes the reflected mirror on the live target - LIVE control")
+		@Test
+		void shouldRemoveReflectedMirrorFromLiveTargetWhenPrimaryRemovedFromLiveOnlyHolder() {
+			defineLiveOnlyReflectedSchema();
+			createArchivingFixtureEntities();
+
+			// holder stays LIVE; the reflected mirror is present in the LIVE scope
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE);
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.removeReference(Entities.CATEGORY, 2)
+						.upsertVia(session);
+				}
+			);
+
+			// EXACT: the reflected mirror on the live target must be gone
+			assertCategoryDoesNotContainProduct(100, Scope.LIVE);
+		}
+
+		@DisplayName("Deleting a live LIVE-only holder removes the reflected mirror on the live target - LIVE control")
+		@Test
+		void shouldRemoveReflectedMirrorFromLiveTargetWhenLiveOnlyHolderDeleted() {
+			defineLiveOnlyReflectedSchema();
+			createArchivingFixtureEntities();
+
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE);
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.PRODUCT, 100));
+				}
+			);
+
+			assertCategoryDoesNotContainProduct(100, Scope.LIVE);
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+		}
+
+		@DisplayName("Removing a primary reference from a live mixed-scope holder removes the reflected mirror on the live target - LIVE control")
+		@Test
+		void shouldRemoveReflectedMirrorFromLiveTargetWhenPrimaryRemovedFromLiveMixedScopeHolder() {
+			defineMixedScopeReflectedSchema();
+			createArchivingFixtureEntities();
+
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE);
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					session.getEntity(Entities.PRODUCT, 100, entityFetchAllContent())
+						.orElseThrow()
+						.openForWrite()
+						.removeReference(Entities.CATEGORY, 2)
+						.upsertVia(session);
+				}
+			);
+
+			assertCategoryDoesNotContainProduct(100, Scope.LIVE);
+		}
+
+		@DisplayName("Deleting a live mixed-scope holder removes the reflected mirror on the live target - LIVE control")
+		@Test
+		void shouldRemoveReflectedMirrorFromLiveTargetWhenLiveMixedScopeHolderDeleted() {
+			defineMixedScopeReflectedSchema();
+			createArchivingFixtureEntities();
+
+			assertCategoryContainsProduct(new EntityReference(Entities.CATEGORY, 2), 100, Scope.LIVE);
+
+			EvitaArchivingTest.this.evita.updateCatalog(
+				TEST_CATALOG,
+				session -> {
+					assertTrue(session.deleteEntity(Entities.PRODUCT, 100));
+				}
+			);
+
+			assertCategoryDoesNotContainProduct(100, Scope.LIVE);
+			final SealedEntity category = EvitaArchivingTest.this.evita.queryCatalog(
+				TEST_CATALOG,
+				session -> {
+					return session.getEntity(Entities.CATEGORY, 2, entityFetchAllContent()).orElse(null);
+				}
+			);
+			assertNotNull(category);
+		}
+	}
+
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaArchivingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/EvitaArchivingTest.java
@@ -3255,7 +3255,7 @@ public class EvitaArchivingTest implements EvitaTestSupport, IndexingTestSupport
 	}
 
 	/**
-	 * Missing E2E coverage for archiving/removal behaviour of plain (non-reflected) references. These scenarios act as
+	 * End-to-end coverage for archiving/removal behaviour of plain (non-reflected) references. These scenarios act as
 	 * the control group for the reflected-reference scenarios: a plain reference carries no reflected mirror, so the
 	 * cross-scope reflected maintenance is never triggered and the primary-side bookkeeping must stay consistent.
 	 */
@@ -3648,7 +3648,7 @@ public class EvitaArchivingTest implements EvitaTestSupport, IndexingTestSupport
 	}
 
 	/**
-	 * Missing E2E coverage for archiving/removal behaviour of reflected references across the LIVE and ARCHIVED scopes.
+	 * End-to-end coverage for archiving/removal behaviour of reflected references across the LIVE and ARCHIVED scopes.
 	 * The holder (product) owns the primary reference to the target (category); the target carries the reflected mirror
 	 * back to the holder. These scenarios exercise the full lifecycle matrix across the three legal indexing
 	 * configurations (primary+reflected LIVE-only, primary+reflected both-scopes, primary both-scopes / reflected


### PR DESCRIPTION
Backport of #1288 to `dev` (the release fix targets `release_2026-1` in PR #1289).

Ports the reflected-reference cross-scope maintenance fix onto the dev engine, which differs from the release baseline: dev uses `PersistentRoaringBitmap`, and the referenced-entity superset formula carries extra generalization parameters (`targetEntityType`/`isTargetManaged`) with the having-logic factored into `HavingTranslatorHelper`.

## Changes
- **`ContainerizedLocalMutationExecutor`** - scope-aware reflected-reference maintenance: partition referenced primary keys by the counterpart's actual scope; gate every propagation by the visibility rule (both schemas indexed in every scope the relation spans); direction-aware removal that discards only the local mirror, never the counterpart's primary reference; scope-resolved attribute propagation.
- **`ReferencedEntityIndexPrimaryKeyTranslatingFormula`** - referenced-entity existence superset now spans all scopes, so a reference is queryable regardless of the referenced entity's scope; the common single-scope case stays allocation-free. This formula is reached only from entity-reference filtering (`EntityHavingTranslator`'s discovery phase and `EntityPrimaryKeyInSetTranslator`); group-having uses a separate, unrestricted path (`allReducedIndexPksFormula`) and is unaffected by this change.
- **`EntityPrimaryKeyInSetTranslator`, `HavingTranslatorHelper`** - drop the now-unused query-scope argument.
- **`EvitaArchivingTest`** - reflected and plain-reference archiving scenarios across the LIVE/ARCHIVED combinations; updates the pre-existing `shouldRecreateReflectedReferencesInSeparateScopes` assertions to the new cross-scope visibility (invariant I1).
- **`documentation/developer/reflected-references-across-scopes.md`** - developer design document.

## Verification
- Full `unitAndFunctional` on dev: **20,488 tests, 0 failures, 0 errors** (37 skipped).
- External-API functional suites (GraphQL/REST/gRPC) live in separate modules not built by this reactor run and are unverified here (same scope as the release PR).

Refs #1288
