### PR TITLE
fix: prevent and diagnose overlapping-leaf-page corruption in warm-up paged index flushes

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/buffer/DataStoreMemoryBuffer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/buffer/DataStoreMemoryBuffer.java
@@ -100,4 +100,15 @@ public interface DataStoreMemoryBuffer extends DataStoreReader {
 	@Nonnull
 	TrappedChanges popTrappedChanges();
 
+	/**
+	 * Reports that the flush which collected this buffer's trapped changes has FAILED, so the buffer must never serve
+	 * another collect. Defaults to a no-op: only the warm-up buffer needs it, because only a warm-up collect is
+	 * destructive without a transaction to roll it back.
+	 *
+	 * @param cause the failure that broke the flush
+	 */
+	default void poison(@Nonnull Throwable cause) {
+		// no-op: the transactional buffer is discarded wholesale on a failed commit, so it cannot outlive its flush
+	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/core/buffer/WarmUpDataStoreMemoryBuffer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/buffer/WarmUpDataStoreMemoryBuffer.java
@@ -24,6 +24,7 @@
 package io.evitadb.core.buffer;
 
 import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.Index;
 import io.evitadb.index.IndexKey;
 import io.evitadb.spi.store.catalog.persistence.StoragePartPersistenceService;
@@ -54,6 +55,10 @@ public class WarmUpDataStoreMemoryBuffer implements DataStoreMemoryBuffer {
 	 * DTO contains all trapped changes in this memory buffer.
 	 */
 	@Nonnull private final DataStoreChanges dataStoreChanges;
+	/**
+	 * The failure of a previous flush, or {@code null} while this buffer is healthy.
+	 */
+	@Nullable private Throwable flushFailure;
 
 	public WarmUpDataStoreMemoryBuffer(
 		@Nonnull StoragePartPersistenceService persistenceService
@@ -172,7 +177,26 @@ public class WarmUpDataStoreMemoryBuffer implements DataStoreMemoryBuffer {
 	@Nonnull
 	@Override
 	public TrappedChanges popTrappedChanges() {
+		// every warm-up collect passes through here, whatever triggered it - a session close, a collection being
+		// created / removed / replaced, going live or terminating - so this is the single point at which a collection
+		// whose flush failed can be stopped before it writes again
+		if (this.flushFailure != null) {
+			throw new GenericEvitaInternalError(
+				"Cannot collect changes: a previous flush of this collection failed, so the changes it had already " +
+					"collected are lost and its persisted state is incomplete. Reload the catalog from disk to recover.",
+				this.flushFailure
+			);
+		}
 		return this.dataStoreChanges.popTrappedUpdates();
+	}
+
+	@Override
+	public void poison(@Nonnull Throwable cause) {
+		// keep the FIRST failure: it is the one that actually lost the collected changes, and every later refusal is
+		// merely its consequence
+		if (this.flushFailure == null) {
+			this.flushFailure = cause;
+		}
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/buffer/WarmUpDataStoreMemoryBuffer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/buffer/WarmUpDataStoreMemoryBuffer.java
@@ -56,9 +56,12 @@ public class WarmUpDataStoreMemoryBuffer implements DataStoreMemoryBuffer {
 	 */
 	@Nonnull private final DataStoreChanges dataStoreChanges;
 	/**
-	 * The failure of a previous flush, or {@code null} while this buffer is healthy.
+	 * The failure of a previous flush, or {@code null} while this buffer is healthy. Declared {@code volatile} because
+	 * the catalog-level buffer is poisoned from inside a flush-future completion callback that may run on a worker
+	 * thread, while {@link #popTrappedChanges()} reads this field on the catalog writer thread — a plain field would not
+	 * guarantee the writer observes the poison.
 	 */
-	@Nullable private Throwable flushFailure;
+	@Nullable private volatile Throwable flushFailure;
 
 	public WarmUpDataStoreMemoryBuffer(
 		@Nonnull StoragePartPersistenceService persistenceService
@@ -178,12 +181,13 @@ public class WarmUpDataStoreMemoryBuffer implements DataStoreMemoryBuffer {
 	@Override
 	public TrappedChanges popTrappedChanges() {
 		// every warm-up collect passes through here, whatever triggered it - a session close, a collection being
-		// created / removed / replaced, going live or terminating - so this is the single point at which a collection
-		// whose flush failed can be stopped before it writes again
+		// created / removed / replaced, going live or terminating - so this is the single point at which a warm-up
+		// buffer whose flush failed can be stopped before it writes again (this buffer backs both an entity collection
+		// and the catalog, so the refusal is phrased for either)
 		if (this.flushFailure != null) {
 			throw new GenericEvitaInternalError(
-				"Cannot collect changes: a previous flush of this collection failed, so the changes it had already " +
-					"collected are lost and its persisted state is incomplete. Reload the catalog from disk to recover.",
+				"Cannot collect changes: a previous warm-up flush failed, so the changes it had already collected are " +
+					"lost and the persisted state is incomplete. Reload the catalog from disk to recover.",
 				this.flushFailure
 			);
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -1798,8 +1798,12 @@ public final class Catalog
 			"Cannot flush catalog in transactional mode. Any changes could occur only in transaction!"
 		);
 
+		// this pops the CATALOG's own trapped changes here and now, on this thread, before a single collection future is
+		// even constructed - while they are written only in the combine step below, once every collection has flushed.
+		// A collection whose write fails therefore strands these already-popped changes with no combine step to persist
+		// them, so the catalog buffer must be poisoned alongside the collection's own (see whenComplete below).
 		final TrappedChanges trappedChanges = this.dataStoreBuffer.popTrappedChanges();
-		return new ProgressingFuture<>(
+		final ProgressingFuture<Void> flushFuture = new ProgressingFuture<>(
 			trappedChanges.getTrappedChangesCount(),
 			// first flush all entity collections
 			this.entityCollections
@@ -1847,6 +1851,26 @@ public final class Catalog
 			},
 			Functions.noOpConsumer()
 		);
+		// whether a collection's write failed or the combine step itself did, this catalog's own popped changes are lost
+		// either way: refuse every later catalog flush rather than store a header describing a state never written
+		flushFuture.whenComplete(
+			(result, ex) -> {
+				if (ex != null) {
+					this.dataStoreBuffer.poison(ex);
+				}
+			}
+		);
+		return flushFuture;
+	}
+
+	/**
+	 * Returns the newest catalog version that has actually reached disk, which may lag {@link #getVersion()} while a
+	 * commit is in flight. Tells apart a failure that struck before its version was durable from one that struck after.
+	 *
+	 * @return the last catalog version present in persistent storage
+	 */
+	public long getLastPersistedCatalogVersion() {
+		return this.persistenceService.getLastCatalogVersion();
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
@@ -1657,36 +1657,47 @@ public final class EntityCollection implements
 		@Nonnull IntConsumer progressObserver,
 		@Nonnull TrappedChanges trappedChanges
 	) {
-		this.persistenceService.flushTrappedUpdates(0L, trappedChanges, progressObserver);
-		final EntityCollectionHeader entityCollectionHeader = this.persistenceService.getEntityCollectionHeader();
-		final long previousVersion = entityCollectionHeader.version();
-		return this.catalogPersistenceService.flush(
-				0L,
-				this.headerInfoSupplier,
-				entityCollectionHeader,
-				this.dataStoreBuffer
-			)
-			.map(
-				it -> {
-					final EntityCollectionHeader newHeader = it.getEntityCollectionHeader();
-					return this.persistenceService == it ?
-						new EntityCollectionHeaderWithCollection(
-							newHeader,
-							this,
-							newHeader.version() > previousVersion
-						) :
-						new EntityCollectionHeaderWithCollection(
-							newHeader,
-							this.createCopyWithNewPersistenceService(newHeader.version(), CatalogState.WARMING_UP, it),
-							true
-						);
-				}
-			)
-			.orElseGet(
-				() -> new EntityCollectionHeaderWithCollection(
-					this.getEntityCollectionHeader(), this, false
+		// the caller has already popped `trappedChanges` off the buffer, destructively and along with every index's
+		// change-detection baseline, so nothing below can be re-collected if it fails. Both flush shapes - the
+		// asynchronous `createFlushFuture` and the synchronous `flush` - run their write through here, which makes this
+		// the single point where such a failure can be recorded against the collection that suffered it.
+		try {
+			this.persistenceService.flushTrappedUpdates(0L, trappedChanges, progressObserver);
+			final EntityCollectionHeader entityCollectionHeader = this.persistenceService.getEntityCollectionHeader();
+			final long previousVersion = entityCollectionHeader.version();
+			return this.catalogPersistenceService.flush(
+					0L,
+					this.headerInfoSupplier,
+					entityCollectionHeader,
+					this.dataStoreBuffer
 				)
-			);
+				.map(
+					it -> {
+						final EntityCollectionHeader newHeader = it.getEntityCollectionHeader();
+						return this.persistenceService == it ?
+							new EntityCollectionHeaderWithCollection(
+								newHeader,
+								this,
+								newHeader.version() > previousVersion
+							) :
+							new EntityCollectionHeaderWithCollection(
+								newHeader,
+								this.createCopyWithNewPersistenceService(newHeader.version(), CatalogState.WARMING_UP, it),
+								true
+							);
+					}
+				)
+				.orElseGet(
+					() -> new EntityCollectionHeaderWithCollection(
+						this.getEntityCollectionHeader(), this, false
+					)
+				);
+		} catch (Throwable ex) {
+			// the collected changes are lost and this collection's persisted state is now incomplete: refuse every
+			// later flush of it rather than write on top of baselines that claim the lost changes were persisted
+			this.dataStoreBuffer.poison(ex);
+			throw ex;
+		}
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
@@ -1694,7 +1694,10 @@ public final class EntityCollection implements
 				);
 		} catch (Throwable ex) {
 			// the collected changes are lost and this collection's persisted state is now incomplete: refuse every
-			// later flush of it rather than write on top of baselines that claim the lost changes were persisted
+			// later flush of it rather than write on top of baselines that claim the lost changes were persisted.
+			// Catching Throwable rather than RuntimeException is deliberate: an Error such as an OutOfMemoryError mid
+			// flush must poison too, otherwise a later collect could silently write over baselines. The cause is always
+			// rethrown, so this never uses exceptions for control flow
 			this.dataStoreBuffer.poison(ex);
 			throw ex;
 		}

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
@@ -254,6 +254,16 @@ public class TransactionManager implements Closeable {
 	 */
 	@Getter private final PendingCommitProgressRegistry pendingCommitProgressRegistry = new PendingCommitProgressRegistry();
 	/**
+	 * Set once a trunk-incorporation flush or merge has failed, which suspends all further transaction processing for
+	 * this catalog; `null` while the catalog is healthy.
+	 *
+	 * A failed flush leaves the persisted page baselines describing a write that never landed. A retry against those
+	 * baselines is what turns a transient I/O failure into a corrupt catalog, so once one has failed no further
+	 * transaction may be processed until an operator reloads the catalog. Reads are deliberately unaffected: the
+	 * in-memory tree is correct — only the persisted state and the baselines lie — so readers keep being served.
+	 */
+	private final AtomicReference<CatalogSuspension> suspension = new AtomicReference<>();
+	/**
 	 * Conflict ring buffer that holds the conflict keys for recent catalog versions.
 	 */
 	private final ConflictRingBuffer conflictRingBuffer;
@@ -479,6 +489,10 @@ public class TransactionManager implements Closeable {
 		long nextCatalogVersion,
 		@Nonnull LongConsumer progressCallback
 	) {
+		Assert.isPremiseValid(
+			this.suspension.get() == null,
+			"Cannot process the write-ahead log of a suspended catalog."
+		);
 		return processTransactions(
 			nextCatalogVersion,
 			Long.MAX_VALUE,
@@ -486,6 +500,91 @@ public class TransactionManager implements Closeable {
 			true, // we should obtain lock here easily, since this is called only on catalog instantiation
 			progressCallback
 		);
+	}
+
+	/**
+	 * Suspends all further transaction processing for this catalog after a trunk-incorporation flush or merge failed,
+	 * and fails every commit already parked on the pipeline so no client waits forever. Only the FIRST failure is kept:
+	 * it is the one that describes what actually broke.
+	 *
+	 * Deliberately does NOT stop readers. The in-memory catalog is still correct — it is the persisted state and the
+	 * page baselines that no longer agree — so the safe move is to stop writing, not to stop serving.
+	 *
+	 * @param cause the flush/merge failure that forced the suspension
+	 * @param durable whether the failed version had already reached disk when the failure struck
+	 * @param failedCatalogVersion the catalog version whose incorporation failed
+	 */
+	public void suspend(@Nonnull Throwable cause, boolean durable, long failedCatalogVersion) {
+		final long servingCatalogVersion = getLastFinalizedCatalogVersion();
+		final CatalogSuspension theSuspension = new CatalogSuspension(
+			cause, durable, failedCatalogVersion, servingCatalogVersion
+		);
+		if (this.suspension.compareAndSet(null, theSuspension)) {
+			if (durable) {
+				// the version reached disk but its merge into the live catalog failed: the bytes on disk describe a
+				// state whose validation did not pass, and a deterministic failure will re-fail on replay, so a plain
+				// reload may not be enough
+				log.error(
+					"Catalog `{}` SUSPENDED after version {} failed to be incorporated AFTER it reached disk (serving " +
+						"version {}). Reads continue to be served from memory, writes are refused. Disk holds a SUSPECT " +
+						"version {} - verify it before reloading; a restore may be required.",
+					this.catalogName, failedCatalogVersion, servingCatalogVersion, failedCatalogVersion, cause
+				);
+			} else {
+				log.error(
+					"Catalog `{}` SUSPENDED after version {} failed to be written (serving version {}). Reads continue " +
+						"to be served from memory, writes are refused. Disk is intact at version {} - reloading the " +
+						"catalog replays the transaction from the WAL.",
+					this.catalogName, failedCatalogVersion, servingCatalogVersion, servingCatalogVersion, cause
+				);
+			}
+		}
+		// whether or not we won the race, no parked client may be left waiting on a pipeline that will never run again
+		this.pendingCommitProgressRegistry.failAllPending(
+			"the catalog has been suspended after a failed transaction incorporation"
+		);
+	}
+
+	/**
+	 * Returns the suspension that stopped this catalog's transaction processing, if any.
+	 *
+	 * @return the suspension, or empty while the catalog is healthy
+	 */
+	@Nonnull
+	public Optional<CatalogSuspension> getSuspension() {
+		return Optional.ofNullable(this.suspension.get());
+	}
+
+	/**
+	 * Tells whether the given catalog version had already reached disk — i.e. whether a failure struck AFTER the write
+	 * was durable (during the merge into the live catalog) or BEFORE it (during the write itself). The two are not
+	 * symmetric and the operator needs to tell them apart: a pre-durability failure leaves disk at the previous version
+	 * and reloading simply replays the transaction, whereas a post-durability failure leaves disk holding a version
+	 * whose incorporation did not pass, which a reload would land straight back on.
+	 *
+	 * @param catalogVersion the version whose incorporation failed
+	 * @return true when the version is already on disk
+	 */
+	private boolean isVersionPersisted(long catalogVersion) {
+		return getLastFinalizedCatalog().getLastPersistedCatalogVersion() >= catalogVersion;
+	}
+
+	/**
+	 * Describes why a catalog stopped processing transactions, and what an operator is left holding.
+	 *
+	 * @param cause                the flush/merge failure that forced the suspension
+	 * @param durable              whether {@link #failedCatalogVersion} had already reached disk when it failed; when
+	 *                             true the disk holds a SUSPECT version, when false the disk is intact at
+	 *                             {@link #servingCatalogVersion}
+	 * @param failedCatalogVersion the catalog version whose incorporation failed
+	 * @param servingCatalogVersion the version readers continue to be served from memory
+	 */
+	public record CatalogSuspension(
+		@Nonnull Throwable cause,
+		boolean durable,
+		long failedCatalogVersion,
+		long servingCatalogVersion
+	) {
 	}
 
 	/**
@@ -498,6 +597,20 @@ public class TransactionManager implements Closeable {
 		@Nonnull IsolatedWalPersistenceService walPersistenceService,
 		@Nonnull CommitProgressRecord commitProgress
 	) {
+		// a suspended catalog will never incorporate another transaction, so accepting this one would park the client
+		// on a pipeline that cannot run; refuse it here, at the point of acceptance, exactly as an overloaded queue does
+		final CatalogSuspension theSuspension = this.suspension.get();
+		if (theSuspension != null) {
+			commitProgress.completeExceptionally(
+				new TransactionException(
+					"Catalog `" + this.catalogName + "` is suspended after a failed transaction incorporation at " +
+						"version " + theSuspension.failedCatalogVersion() + " and accepts no further writes until it " +
+						"is reloaded. Reads are unaffected.",
+					theSuspension.cause()
+				)
+			);
+			return;
+		}
 		this.transactionalPipeline.offer(
 			new ConflictResolutionAndWalAppendingTransactionTask(
 				getCatalogName(),
@@ -1170,6 +1283,13 @@ public class TransactionManager implements Closeable {
 		boolean waitForLock,
 		@Nonnull LongConsumer progressCallback
 	) {
+		// Gate every drain of the WAL, before the trunk lock is taken or a single mutation is read. This is the point
+		// the suspension has to bite: a freshly appended transaction schedules the draining task on its own, entirely
+		// independently of the path that failed, so refusing commits alone would not stop the catalog from trying
+		// again. Returning empty (rather than throwing) is what makes the draining task PAUSE instead of rescheduling.
+		if (this.suspension.get() != null) {
+			return Optional.empty();
+		}
 		try {
 			final boolean locked;
 			if (waitForLock) {
@@ -1183,6 +1303,9 @@ public class TransactionManager implements Closeable {
 				TransactionMutation lastTransactionMutation;
 				Transaction lastTransaction = null;
 				final Catalog newCatalog;
+				// the version whose changes we got as far as collecting + writing, or -1 if we never got that far;
+				// see the catch below
+				long collectingVersion = -1;
 
 				int atomicMutationCount = 0;
 				int localMutationCount = 0;
@@ -1290,6 +1413,11 @@ public class TransactionManager implements Closeable {
 
 					// we've run out of mutation, or the timeout has been exceeded, create a new catalog version now
 					// and update the last finalized transaction ID and catalog version
+					// From here on the collect has begun: the flush pops every trapped change, advances every page
+					// baseline and writes, and the merge then publishes those baselines. A failure anywhere inside
+					// leaves the baselines describing a write that may never have landed, which is precisely the state
+					// no retry may run against - so the scope is POSITIONAL (where we failed), never by exception type.
+					collectingVersion = lastTransactionMutation.getVersion();
 					newCatalog = commitChangesToSharedCatalog(lastTransactionMutation, lastTransaction, transactionHandler);
 					updateLastFinalizedCatalog(
 						newCatalog,
@@ -1305,7 +1433,14 @@ public class TransactionManager implements Closeable {
 					final Catalog catalog = this.lastFinalizedCatalog.get();
 					this.changeObserver.forgetMutationsAfter(catalog, catalog.getVersion());
 
-					// rethrow the exception - we will have to re-try the transaction
+					if (collectingVersion >= 0) {
+						// a failed flush/merge: suspend rather than retry. The retry is what would diff the next flush
+						// against the baselines this one left behind, and it can never succeed by repetition anyway -
+						// a deterministic failure spins forever, a transient one corrupts.
+						suspend(ex, isVersionPersisted(collectingVersion), collectingVersion);
+					}
+					// rethrow the exception - a failure BEFORE the collect (an unreadable WAL tail, a replay error) is
+					// still safely retryable and keeps its bounded retry
 					throw ex;
 				} finally {
 					if (committedMutationStream != null) {

--- a/evita_engine/src/main/java/io/evitadb/index/HistogramIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/HistogramIndex.java
@@ -333,8 +333,11 @@ public abstract class HistogramIndex
 			inlineBuckets = HistogramIndexStoragePart.emptyHistogram();
 		} else {
 			// SINGLE shape (possibly just collapsed from PAGED): remove every prior leaf page BEFORE forgetting the
-			// stream, then carry the whole bucket array inline on the root
-			for (final int freedPageSequence : invertedIndex.livePageSequences()) {
+			// stream, then carry the whole bucket array inline on the root. Reclaim against the pages the previous flush
+			// left ON DISK: its STAGED set while it is still unpublished (a warm-up flush never reaches the commit-merge
+			// that publishes), else the published set. Reading only the published set reclaims nothing for a whole warm-up
+			// and leaks every page the collapsed stream ever wrote — the same set the drop path above already reclaims from.
+			for (final int freedPageSequence : invertedIndex.currentLeafPageSequences()) {
 				sink.addChangeToStore(
 					new HistogramIndexLeafPageRemoval(entityIndexPrimaryKey, name, locale, StreamKind.BUCKET, freedPageSequence)
 				);
@@ -375,8 +378,9 @@ public abstract class HistogramIndex
 			inlineRange = null;
 		} else {
 			if (rangeIndex != null) {
-				// SINGLE range that may have just collapsed from PAGED: remove prior leaf pages before forgetting
-				for (final int freedPageSequence : rangeIndex.livePageSequences()) {
+				// SINGLE range that may have just collapsed from PAGED: remove prior leaf pages before forgetting, against
+				// the staged-or-published set for the same reason as the bucket axis above
+				for (final int freedPageSequence : rangeIndex.currentLeafPageSequences()) {
 					sink.addChangeToStore(
 						new HistogramIndexLeafPageRemoval(entityIndexPrimaryKey, name, locale, StreamKind.RANGE, freedPageSequence)
 					);

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/ChainIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/ChainIndex.java
@@ -894,6 +894,45 @@ public class ChainIndex implements
 	}
 
 	/**
+	 * Promotes the page set staged by the PREVIOUS flush of the element-tree page stream to the live
+	 * change-detection baseline, so this flush's freed-page diff and `pageListChanged` verdict are taken against
+	 * what disk actually holds.
+	 *
+	 * The registry's live set answers "which leaf pages does this chain's element tree have on disk", and both the
+	 * pages a leaf drop freed (so the corresponding {@link ChainIndexLeafPageRemoval} is emitted instead of leaving an
+	 * unreferenced-but-never-removed record in the append-only OffsetIndex) and whether the ordered page list changed
+	 * at all (so the PAGED {@link ChainIndexStoragePart} root carrying it is re-emitted rather than skipped as
+	 * unchanged) are derived from it. It advances solely by publishing, which
+	 * {@link #createCopyWithMergedTransactionalMemory} does at the commit-merge.
+	 *
+	 * A WARM_UP (bulk) flush never reaches a commit-merge — {@link #appendStorageParts} is called directly, flush
+	 * after flush, and the merge that publishes only ever runs for a transaction. Left alone, the live set of a
+	 * freshly re-indexed chain would therefore stay EMPTY for the whole warm-up while disk moved on, so a leaf that a
+	 * mid-life shrink or rebalance drops without a fresh leaf being born would never be removed from storage and
+	 * would stay listed on a root skipped as "unchanged". The next cold load would then reassemble a stale, no
+	 * longer valid leaf-page sequence alongside its live neighbours.
+	 *
+	 * Publishing a staged set HERE — rather than only at the merge — is correct for every path, because of one
+	 * invariant: **a failed flush is never followed by another flush of the same data**. Note that this publish runs
+	 * at COLLECT time, before this flush has written anything (the baseline-capture pass re-enters this pipeline), so
+	 * it cannot lean on the previous flush's bytes having landed by now. It does not need to: a flush that fails
+	 * during trunk incorporation SUSPENDS the catalog's transaction processing ({@code TransactionManager.suspend}),
+	 * and a flush that fails on the warm-up path POISONS the collection's buffer
+	 * ({@code WarmUpDataStoreMemoryBuffer.poison}), so every later collect of it refuses deterministically. Those two
+	 * are the same invariant in different dresses: after a failed flush no later flush of that data ever runs, so
+	 * nothing can ever diff against the baselines it left behind. A flush that does NOT fail leaves `staged` holding
+	 * exactly the page set it wrote — the baseline the next flush must diff against — regardless of which path staged
+	 * it, and regardless of whether the commit-merge ever ran. (Should the process die instead,
+	 * {@link #fromPersistedPages} rebuilds the registry from disk on restart — page allocation is advance-only, so a
+	 * burnt id is harmless.) That is what makes this safe in its own right — not the fact that it happens to be a
+	 * no-op on the transactional path (where the merge published first, leaving nothing staged). The commit
+	 * handshake is untouched.
+	 */
+	private void publishPreviousFlush() {
+		this.pageStreamRegistry.publishStaged();
+	}
+
+	/**
 	 * Emits this (dirty) index's modified storage parts into `sink`. The SINGLE/PAGED decision mirrors
 	 * {@link OwnerSortIndex#doAppendStorageParts}: a multi-leaf element tree
 	 * ({@link TransactionalUnorderedIntArray#isRootInternal()}) persists granularly (one leaf page per changed leaf +
@@ -903,10 +942,14 @@ public class ChainIndex implements
 	 * collapse first removes every prior live leaf page and forgets the page stream (the registry AND the per-leaf
 	 * bookkeeping) so a later regrow into PAGED starts from a clean baseline and re-emits every leaf.
 	 *
+	 * Before deciding SINGLE vs PAGED, any set still staged by the PREVIOUS flush is promoted to live: see
+	 * {@link #publishPreviousFlush()} for why that is both necessary and safe.
+	 *
 	 * @param entityIndexPrimaryKey the owning entity index primary key
 	 * @param sink                  the trapped-changes accumulator for this commit
 	 */
 	private void doAppendStorageParts(int entityIndexPrimaryKey, @Nonnull TrappedChanges sink) {
+		publishPreviousFlush();
 		// every leaf page (and removal) carries the CHAIN-typed sub-index identity, so its stream id is disjoint from the
 		// FILTER / SORT streams of the same attribute and resolved store-side when the page's primary key is assigned
 		final AttributeKeyWithIndexType streamKey =
@@ -950,7 +993,9 @@ public class ChainIndex implements
 		// root no longer references them) BEFORE dropping the page bookkeeping, then forget the stream - both the registry
 		// live set / high-water AND the per-leaf page sequences + dirty flags - so a later regrow into PAGED starts from a
 		// clean baseline and re-emits every leaf
-		for (final int freedPageSequence : this.pageStreamRegistry.livePageSequences(ELEMENTS_PAGE_STREAM)) {
+		// Reclaim against the staged-or-published set, uniformly with every other paged index: this flush already
+		// published the previous one above, so the two coincide here.
+		for (final int freedPageSequence : this.pageStreamRegistry.pendingLivePageSequences(ELEMENTS_PAGE_STREAM)) {
 			sink.addChangeToStore(new ChainIndexLeafPageRemoval(entityIndexPrimaryKey, streamKey, freedPageSequence));
 		}
 		this.pageStreamRegistry.forget(ELEMENTS_PAGE_STREAM);
@@ -1114,11 +1159,15 @@ public class ChainIndex implements
 	) {
 		transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
 		// the merge runs only AFTER this commit's flush has durably written the changed leaf pages + root, so the live set
-		// staged by that flush now reflects what is on disk and may become the change-detection baseline for the next
+		// staged by that flush now reflects what is on disk and becomes the change-detection baseline for the next
 		// commit; publish it, then carry the registry BY REFERENCE into the committed copy so the surviving owner keeps it.
-		// A SINGLE flush stages nothing (it forgets the stream), so this is a no-op in that case. No discard counterpart is
-		// needed: a pre-flush abort never stages, a flush failure is fatal (restart rebuilds a clean registry) and a stale
-		// staged set is harmlessly replaced by the next commit's stage - mirrors InvertedIndex.
+		// A SINGLE flush stages nothing (it forgets the stream), so this is a no-op in that case. This is the EARLIEST
+		// publish point on the transactional path only; it is not the only one — a staged set that never reaches a merge
+		// (the warm-up path has no merge at all) is published by the next flush instead, see `publishPreviousFlush`. (No
+		// discard counterpart is needed: a pre-flush abort never stages, and a failed flush suspends this catalog's
+		// transaction processing — on the warm-up path it poisons the collection's buffer instead, the same invariant
+		// in another dress — so no later flush ever diffs against the baseline a failed one left behind; restart
+		// rebuilds a clean registry from disk.)
 		this.pageStreamRegistry.publishStaged();
 		return new ChainIndex(
 			this.referenceKey,

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/FilterIndex.java
@@ -1193,7 +1193,11 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 		// SINGLE shape: the index collapsed back to a single leaf. Remove every leaf page from its prior PAGED life
 		// (the SINGLE root no longer references them) BEFORE dropping the page bookkeeping, then forget the stream so a
 		// later regrow into PAGED starts from a clean baseline and re-emits every leaf.
-		for (final int freedPageSequence : this.invertedIndex.livePageSequences()) {
+		// Reclaim against what the previous flush left ON DISK: its staged set while still unpublished (a warm-up
+		// flush never reaches the commit-merge that publishes), else the published set. The published set alone lags a
+		// whole flush behind, so every page of the collapsed stream would leak — the append-only OffsetIndex never
+		// reclaims a record that is neither superseded nor explicitly removed.
+		for (final int freedPageSequence : this.invertedIndex.currentLeafPageSequences()) {
 			sink.addChangeToStore(new FilterIndexLeafPageRemoval(entityIndexPrimaryKey, streamKey, freedPageSequence));
 		}
 		this.invertedIndex.forgetPageStream();
@@ -1239,7 +1243,11 @@ public abstract sealed class FilterIndex implements IndexDataStructure, Serializ
 			// SINGLE range that may have just collapsed from PAGED: remove every prior leaf page (the inline root no
 			// longer references them) BEFORE dropping the bookkeeping, then forget the stream so a later regrow starts
 			// from a clean baseline and re-emits every leaf
-			for (final int freedPageSequence : this.rangeIndex.livePageSequences()) {
+			// Reclaim against what the previous flush left ON DISK: its staged set while still unpublished (a warm-up
+			// flush never reaches the commit-merge that publishes), else the published set. The published set alone lags a
+			// whole flush behind, so every page of the collapsed stream would leak — the append-only OffsetIndex never
+			// reclaims a record that is neither superseded nor explicitly removed.
+			for (final int freedPageSequence : this.rangeIndex.currentLeafPageSequences()) {
 				sink.addChangeToStore(new RangeIndexLeafPageRemoval(entityIndexPrimaryKey, streamKey, freedPageSequence));
 			}
 			this.rangeIndex.forgetPageStream();

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
@@ -628,7 +628,11 @@ public class GlobalUniqueIndex implements
 			// SINGLE shape: the index spans one leaf. If it just collapsed from PAGED, remove every prior leaf page (the
 			// inline root no longer references them) BEFORE dropping the bookkeeping, then forget the stream so a later
 			// regrow into PAGED starts from a clean baseline and re-emits every leaf.
-			for (final int freedPageSequence : this.pageStreamRegistry.livePageSequences(UNIQUE_PAGE_STREAM)) {
+			// Reclaim against what the previous flush left ON DISK: its staged set while still unpublished (a warm-up
+			// flush never reaches the commit-merge that publishes), else the published set. The published set alone lags a
+			// whole flush behind, so every page of the collapsed stream would leak — the append-only OffsetIndex never
+			// reclaims a record that is neither superseded nor explicitly removed.
+			for (final int freedPageSequence : this.pageStreamRegistry.pendingLivePageSequences(UNIQUE_PAGE_STREAM)) {
 				sink.addChangeToStore(new GlobalUniqueIndexLeafPageRemoval(this.scope, attribute, freedPageSequence));
 			}
 			this.pageStreamRegistry.forget(UNIQUE_PAGE_STREAM);
@@ -785,15 +789,58 @@ public class GlobalUniqueIndex implements
 	}
 
 	/**
+	 * Promotes the page set staged by the PREVIOUS flush to the live change-detection baseline, so this flush's freed
+	 * -page diff is taken against what disk actually holds.
+	 *
+	 * {@link #pageStreamRegistry}'s live set answers "which leaf pages does this stream have on disk". {@link
+	 * #collectChangedPages()} relies on it for exactly one thing: which pages a leaf merge dropped, so a {@link
+	 * GlobalUniqueIndexLeafPageRemoval} is emitted and the page is actually removed from storage — the ordered
+	 * leaf-page list carried by the `PAGED` root, by contrast, is read straight off the current tree leaves every time
+	 * (see {@link #appendStorageParts}, which re-emits that root unconditionally because it also carries the inline
+	 * locale map), so it is never stale regardless of this baseline. That live set only ever advances by {@link
+	 * PageStreamRegistry#publishStaged()}, which {@link #createCopyWithMergedTransactionalMemory} calls at the
+	 * transactional commit-merge.
+	 *
+	 * A WARM_UP (bulk) flush never reaches a commit-merge — it runs the same collect path but is never wrapped in a
+	 * transaction, so nothing ever calls {@code createCopyWithMergedTransactionalMemory} for it. Left alone, the live
+	 * set of a freshly re-indexed catalog would stay EMPTY for the whole warm-up while disk moved on underneath it. A
+	 * leaf MERGE (unlike a split) drops a page without creating one: the surviving leaf absorbs its sibling IN PLACE,
+	 * keeping its own page sequence and dirty flag, so nothing is freshly allocated. With an empty live baseline the
+	 * freed-page diff for that merge is vacuously empty, so the dropped page is never removed from storage — an
+	 * unreferenced leaf-page record that every future compaction copies forward forever even though the (always
+	 * correctly re-emitted) root no longer points at it.
+	 *
+	 * Publishing HERE, before every flush rather than only at the commit-merge, is safe for every path because a failed
+	 * flush is never followed by another flush of the same data. This call runs at COLLECT time, before this flush has
+	 * written anything (the baseline-capture pass re-enters the collect path), so it cannot rest on the previous
+	 * flush's bytes having landed — and it does not need to. A flush that fails during trunk incorporation SUSPENDS the
+	 * catalog's transaction processing ({@code TransactionManager.suspend}); a flush that fails during warm-up POISONS
+	 * the collection's buffer ({@code WarmUpDataStoreMemoryBuffer.poison}), so every later collect of it refuses
+	 * deterministically. The two are the same invariant in different dresses: after a failed flush nothing ever diffs
+	 * against the baseline it left behind, because no later flush of that data runs at all. Whatever a SUCCEEDING flush
+	 * leaves staged is exactly the page set it wrote, regardless of whether a commit-merge ever ran for it. (If the
+	 * process crashes instead, the registry itself is gone and gets rebuilt from disk on restart, where a burnt page
+	 * sequence is harmless since allocation is advance-only.) On the transactional path this call is simply a no-op
+	 * (the merge already published, so nothing is left staged) — that is a side effect, not the reason it is safe.
+	 */
+	private void publishPreviousFlush() {
+		this.pageStreamRegistry.publishStaged();
+	}
+
+	/**
 	 * Walks the value tree leaf-by-leaf and returns the granular write-path emission for this commit: the leaf pages that
 	 * changed since the last flush, the full ordered list of live leaf-page sequences (the `PAGED` root's leaf list), the
 	 * stream high-water, and the freed page sequences a leaf merge dropped. Mirrors
 	 * {@code OwnerUniqueIndex.collectChangedPages} with the slim value + packed-`long`-payload columns.
 	 *
+	 * Before staging, any set still staged by the PREVIOUS flush is promoted to live — see
+	 * {@link #publishPreviousFlush()} for why that is both necessary and safe.
+	 *
 	 * @return the changed leaf pages, the ordered live page-sequence list, the high-water, and the freed pages
 	 */
 	@Nonnull
 	private PageEmission<LeafPage> collectChangedPages() {
+		publishPreviousFlush();
 		// this.tree is a raw bucket tree, so the handle list and its cursors are raw too — bucket values are read as
 		// Object and cast to Serializable exactly as the whole-tree snapshot does
 		final List<LeafPageHandle> handles = this.tree.leafPageHandles();

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerSortIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerSortIndex.java
@@ -495,7 +495,11 @@ public final class OwnerSortIndex extends SortIndex {
 		// SINGLE shape (possibly just collapsed from PAGED): remove every leaf page from its prior PAGED life (the SINGLE
 		// root no longer references them) BEFORE dropping the page bookkeeping, then forget the stream so a later regrow
 		// into PAGED starts from a clean baseline and re-emits every leaf
-		for (final int freedPageSequence : this.ownedTree.livePageSequences()) {
+		// Reclaim against what the previous flush left ON DISK: its staged set while still unpublished (a warm-up
+		// flush never reaches the commit-merge that publishes), else the published set. The published set alone lags a
+		// whole flush behind, so every page of the collapsed stream would leak — the append-only OffsetIndex never
+		// reclaims a record that is neither superseded nor explicitly removed.
+		for (final int freedPageSequence : this.ownedTree.currentLeafPageSequences()) {
 			sink.addChangeToStore(new SortIndexLeafPageRemoval(entityIndexPrimaryKey, streamKey, freedPageSequence));
 		}
 		this.ownedTree.forgetPageStream();

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
@@ -375,7 +375,11 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 			// SINGLE shape: the index spans one leaf. If it just collapsed from PAGED, remove every prior leaf page (the
 			// inline root no longer references them) BEFORE dropping the bookkeeping, then forget the stream so a later
 			// regrow into PAGED starts from a clean baseline and re-emits every leaf.
-			for (final int freedPageSequence : this.pageStreamRegistry.livePageSequences(UNIQUE_PAGE_STREAM)) {
+			// Reclaim against what the previous flush left ON DISK: its staged set while still unpublished (a warm-up
+			// flush never reaches the commit-merge that publishes), else the published set. The published set alone lags a
+			// whole flush behind, so every page of the collapsed stream would leak — the append-only OffsetIndex never
+			// reclaims a record that is neither superseded nor explicitly removed.
+			for (final int freedPageSequence : this.pageStreamRegistry.pendingLivePageSequences(UNIQUE_PAGE_STREAM)) {
 				sink.addChangeToStore(new UniqueIndexLeafPageRemoval(entityIndexPrimaryKey, streamKey, freedPageSequence));
 			}
 			this.pageStreamRegistry.forget(UNIQUE_PAGE_STREAM);
@@ -474,15 +478,59 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 	}
 
 	/**
+	 * Promotes the page set staged by the PREVIOUS flush to the live change-detection baseline, so this flush's freed
+	 * -page diff and root re-emission decision are taken against what disk actually holds.
+	 *
+	 * {@link #pageStreamRegistry}'s live set answers "which leaf pages does this stream have on disk". {@link
+	 * #collectChangedPages()} derives two things from it: which pages a leaf merge freed (so a {@link
+	 * UniqueIndexLeafPageRemoval} is emitted and the page is actually dropped from storage, rather than left as an
+	 * unreferenced record the append-only OffsetIndex would copy forward forever) and whether the ordered leaf-page
+	 * list changed at all (so the `PAGED` root carrying it is re-emitted instead of skipped as unchanged). That live
+	 * set only ever advances by {@link PageStreamRegistry#publishStaged()}, which {@link
+	 * #createCopyWithMergedTransactionalMemory} calls at the transactional commit-merge.
+	 *
+	 * A WARM_UP (bulk) flush never reaches a commit-merge — it runs the same collect path but is never wrapped in a
+	 * transaction, so nothing ever calls {@code createCopyWithMergedTransactionalMemory} for it. Left alone, the live
+	 * set of a freshly re-indexed catalog would stay EMPTY for the whole warm-up while disk moved on underneath it. A
+	 * leaf MERGE (unlike a split) drops a page without creating one: the surviving leaf absorbs its sibling IN PLACE,
+	 * keeping its own page sequence and dirty flag, so nothing is freshly allocated. With an empty live baseline the
+	 * freed-page diff for that merge is vacuously empty and the list-changed check sees no change either, so the
+	 * dropped page is neither removed from storage nor dropped from the persisted root's leaf list. On the next cold
+	 * load the tree is assembled from the surviving leaf (holding the absorbed keys) followed by its stale,
+	 * still-listed sibling, whose first key no longer sorts after the survivor's last — the cross-leaf overlap check
+	 * then fails fast.
+	 *
+	 * Publishing HERE, before every flush rather than only at the commit-merge, is safe for every path because a failed
+	 * flush is never followed by another flush of the same data. This call runs at COLLECT time, before this flush has
+	 * written anything (the baseline-capture pass re-enters the collect path), so it cannot rest on the previous
+	 * flush's bytes having landed — and it does not need to. A flush that fails during trunk incorporation SUSPENDS the
+	 * catalog's transaction processing ({@code TransactionManager.suspend}); a flush that fails during warm-up POISONS
+	 * the collection's buffer ({@code WarmUpDataStoreMemoryBuffer.poison}), so every later collect of it refuses
+	 * deterministically. The two are the same invariant in different dresses: after a failed flush nothing ever diffs
+	 * against the baseline it left behind, because no later flush of that data runs at all. Whatever a SUCCEEDING flush
+	 * leaves staged is exactly the page set it wrote, regardless of whether a commit-merge ever ran for it. (If the
+	 * process crashes instead, the registry itself is gone and gets rebuilt from disk on restart, where a burnt page
+	 * sequence is harmless since allocation is advance-only.) On the transactional path this call is simply a no-op
+	 * (the merge already published, so nothing is left staged) — that is a side effect, not the reason it is safe.
+	 */
+	private void publishPreviousFlush() {
+		this.pageStreamRegistry.publishStaged();
+	}
+
+	/**
 	 * Walks the value tree leaf-by-leaf and returns the granular write-path emission for this commit: the leaf pages
 	 * that changed since the last flush, the full ordered list of live leaf-page sequences (the `PAGED` root's leaf
 	 * list), the stream high-water, and the freed page sequences a leaf merge dropped. Mirrors
 	 * {@code InvertedIndex.collectChangedPages} with the slim value+pk payload.
 	 *
+	 * Before staging, any set still staged by the PREVIOUS flush is promoted to live — see
+	 * {@link #publishPreviousFlush()} for why that is both necessary and safe.
+	 *
 	 * @return the changed leaf pages, the ordered live page-sequence list, the high-water, and the freed pages
 	 */
 	@Nonnull
 	private PageEmission<LeafPage> collectChangedPages() {
+		publishPreviousFlush();
 		// this.tree is a raw bucket tree, so the handle list and its cursors are raw too — bucket values are read as
 		// Object and cast to Serializable exactly as the whole-tree snapshot does
 		final List<LeafPageHandle> handles = this.tree.leafPageHandles();

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/AbstractTransactionalBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/AbstractTransactionalBPlusTree.java
@@ -39,6 +39,7 @@ import javax.annotation.Nullable;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -1386,6 +1387,55 @@ public abstract class AbstractTransactionalBPlusTree implements Serializable {
 			super(publicMessage);
 		}
 
+	}
+
+	/**
+	 * Builds the operator-facing diagnostic for an overlapping-leaf-page corruption detected while reassembling a paged
+	 * B+ tree from disk (the "stale leaf-page twin" class: a leaf whose key range overlaps the leaf listed after it).
+	 *
+	 * This is called ONLY once an overlap has already been detected — on the failure path — so it gathers the full
+	 * context a healthy cold load never pays for: the whole ordered leaf-page list (where in the layout the overlap
+	 * sits), both offending page sequences, and each leaf's key range and key count. The containment relationship is
+	 * reported as a raw fact (`successorRangeWithinPredecessorRange`) computed by the caller with its own comparator,
+	 * NOT as an interpreted verdict — the paged layout is new and the next corruption may not be the known twin, so the
+	 * shape is left for the reader to classify. Page/leaf versions are deliberately absent: they are not threaded down
+	 * to the reassembly layer, and the message says so rather than leaving their absence to look accidental.
+	 *
+	 * The shared shape is used identically by every tree that reassembles paged leaves; each passes its own keys as
+	 * plain objects so this method stays free of the trees' key-type generics.
+	 *
+	 * @param structureDescription         a full identification of the index for diagnostics
+	 * @param orderedPageSequences         the root's ordered leaf-page sequence list (the persisted layout)
+	 * @param predecessorPageSequence      the page sequence of the earlier (overlapping) leaf
+	 * @param predecessorFirstKey          the earlier leaf's first key
+	 * @param predecessorLastKey           the earlier leaf's last key (the one that fails to sort before the successor)
+	 * @param predecessorKeyCount          the number of keys in the earlier leaf
+	 * @param successorPageSequence        the page sequence of the next leaf in the list
+	 * @param successorFirstKey            the next leaf's first key (the one the predecessor's last key overran)
+	 * @param successorLastKey             the next leaf's last key
+	 * @param successorKeyCount            the number of keys in the next leaf
+	 * @param successorWithinPredecessor   whether the successor's key range lies entirely within the predecessor's
+	 * @return the full diagnostic message; never null
+	 */
+	@Nonnull
+	static String overlappingLeafPagesDiagnostic(
+		@Nonnull String structureDescription,
+		@Nonnull int[] orderedPageSequences,
+		int predecessorPageSequence, @Nonnull Object predecessorFirstKey, @Nonnull Object predecessorLastKey,
+		int predecessorKeyCount,
+		int successorPageSequence, @Nonnull Object successorFirstKey, @Nonnull Object successorLastKey,
+		int successorKeyCount,
+		boolean successorWithinPredecessor
+	) {
+		return "Corrupted persisted " + structureDescription + ": leaf-page sequence " + predecessorPageSequence +
+			" overlaps its successor leaf-page sequence " + successorPageSequence + " — its last key (" +
+			predecessorLastKey + ") does not sort before the first key (" + successorFirstKey + ") of the next leaf " +
+			"page. Overlap context: orderedLeafPageList=" + Arrays.toString(orderedPageSequences) +
+			", predecessorKeyRange=[" + predecessorFirstKey + " .. " + predecessorLastKey + "] (" + predecessorKeyCount +
+			" keys), successorKeyRange=[" + successorFirstKey + " .. " + successorLastKey + "] (" + successorKeyCount +
+			" keys), successorRangeWithinPredecessorRange=" + successorWithinPredecessor + "; page/leaf versions are " +
+			"not available at the reassembly layer. This is a stale leaf-page twin or other index corruption. Restore " +
+			"the catalog from a backup, or fully rebuild / reindex the affected catalog.";
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTree.java
@@ -1481,7 +1481,7 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 		}
 		// validate cross-leaf key order BEFORE assembly, so the corruption diagnostic fires ahead of any left-boundary
 		// separator invariant the spine builder would otherwise trip on with a less actionable message
-		assertCrossLeafBoundaries(leaves, structureDescription);
+		assertCrossLeafBoundaries(leaves, pageSequences, structureDescription);
 		return assembleFromLeaves(leaves);
 	}
 
@@ -1501,12 +1501,14 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 	 * remediation hint.
 	 *
 	 * @param leaves               the reassembled leaves in persisted list order
+	 * @param pageSequences        the root's ordered leaf-page sequence list, reported as overlap context on failure
 	 * @param structureDescription a full identification of the index for diagnostics (see
 	 *                             {@link #assembleFromSingleLeafTrees})
 	 * @throws GenericEvitaInternalError when a leaf's last key does not sort strictly before the next leaf's first key
 	 */
 	private void assertCrossLeafBoundaries(
 		@Nonnull List<BPlusLeafTreeNode<K>> leaves,
+		@Nonnull int[] pageSequences,
 		@Nonnull String structureDescription
 	) {
 		BPlusLeafTreeNode<K> previousKeyBearing = null;
@@ -1536,13 +1538,21 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 				final K previousLastKey = previousKeyBearing.getKeys()[previousKeyBearing.getPeek()];
 				final K currentFirstKey = keys[0];
 				if (compareKeys(previousLastKey, currentFirstKey, this.comparator) >= 0) {
+					// error path only: gather the full overlap context (ranges, counts, containment) here, never on a
+					// healthy load
+					final K predecessorFirstKey = previousKeyBearing.getKeys()[0];
+					final K successorLastKey = keys[peek];
+					final boolean successorWithinPredecessor =
+						compareKeys(currentFirstKey, predecessorFirstKey, this.comparator) >= 0 &&
+							compareKeys(successorLastKey, previousLastKey, this.comparator) <= 0;
 					throw new GenericEvitaInternalError(
-						"Corrupted persisted " + structureDescription + ": leaf-page sequence " +
-							previousKeyBearing.getPageSequence() + " overlaps its successor leaf-page sequence " +
-							leaf.getPageSequence() + " — its last key (" + previousLastKey + ") does not sort before the " +
-							"first key (" + currentFirstKey + ") of the next leaf page. This is a stale leaf-page twin or " +
-							"other index corruption. Restore the catalog from a backup, or fully rebuild / reindex the " +
-							"affected catalog."
+						AbstractTransactionalBPlusTree.overlappingLeafPagesDiagnostic(
+							structureDescription, pageSequences,
+							previousKeyBearing.getPageSequence(), predecessorFirstKey, previousLastKey,
+							previousKeyBearing.getPeek() + 1,
+							leaf.getPageSequence(), currentFirstKey, successorLastKey, peek + 1,
+							successorWithinPredecessor
+						)
 					);
 				}
 			}

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTree.java
@@ -329,7 +329,7 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 		}
 		// validate cross-leaf key order BEFORE assembly, so the corruption diagnostic fires ahead of any left-boundary
 		// separator invariant the spine builder would otherwise trip on with a less actionable message
-		assertCrossLeafBoundaries(leaves, structureDescription);
+		assertCrossLeafBoundaries(leaves, pageSequences, structureDescription);
 		return assembleFromLeaves(leaves);
 	}
 
@@ -349,12 +349,14 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 	 * remediation hint.
 	 *
 	 * @param leaves               the reassembled leaves in persisted list order
+	 * @param pageSequences        the root's ordered leaf-page sequence list, reported as overlap context on failure
 	 * @param structureDescription a full identification of the index for diagnostics (see
 	 *                             {@link #assembleFromSingleLeafTrees})
 	 * @throws GenericEvitaInternalError when a leaf's last key does not sort strictly before the next leaf's first key
 	 */
 	private void assertCrossLeafBoundaries(
 		@Nonnull List<BPlusLeafTreeNode<E>> leaves,
+		@Nonnull int[] pageSequences,
 		@Nonnull String structureDescription
 	) {
 		BPlusLeafTreeNode<E> previousKeyBearing = null;
@@ -389,13 +391,20 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 				);
 				final int currentFirstKey = leaf.getLeftBoundaryKey();
 				if (previousLastKey >= currentFirstKey) {
+					// error path only: gather the full overlap context (ranges, counts, containment) here, never on a
+					// healthy load
+					final int predecessorFirstKey = this.keyExtractor.applyAsInt(previousKeyBearing.getValues()[0]);
+					final int successorLastKey = this.keyExtractor.applyAsInt(values[peek]);
+					final boolean successorWithinPredecessor =
+						currentFirstKey >= predecessorFirstKey && successorLastKey <= previousLastKey;
 					throw new GenericEvitaInternalError(
-						"Corrupted persisted " + structureDescription + ": leaf-page sequence " +
-							previousKeyBearing.getPageSequence() + " overlaps its successor leaf-page sequence " +
-							leaf.getPageSequence() + " — its last key (" + previousLastKey + ") does not sort before the " +
-							"first key (" + currentFirstKey + ") of the next leaf page. This is a stale leaf-page twin or " +
-							"other index corruption. Restore the catalog from a backup, or fully rebuild / reindex the " +
-							"affected catalog."
+						AbstractTransactionalBPlusTree.overlappingLeafPagesDiagnostic(
+							structureDescription, pageSequences,
+							previousKeyBearing.getPageSequence(), predecessorFirstKey, previousLastKey,
+							previousKeyBearing.getPeek() + 1,
+							leaf.getPageSequence(), currentFirstKey, successorLastKey, peek + 1,
+							successorWithinPredecessor
+						)
 					);
 				}
 			}

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTree.java
@@ -439,7 +439,7 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 		}
 		// validate cross-leaf key order BEFORE assembly, so the corruption diagnostic fires ahead of any left-boundary
 		// separator invariant the spine builder would otherwise trip on with a less actionable message
-		assertCrossLeafBoundaries(leaves, structureDescription);
+		assertCrossLeafBoundaries(leaves, pageSequences, structureDescription);
 		return assembleFromLeaves(leaves);
 	}
 
@@ -458,12 +458,14 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 	 * remediation hint.
 	 *
 	 * @param leaves               the reassembled leaves in persisted list order
+	 * @param pageSequences        the root's ordered leaf-page sequence list, reported as overlap context on failure
 	 * @param structureDescription a full identification of the index for diagnostics (see
 	 *                             {@link #assembleFromSingleLeafTrees})
 	 * @throws GenericEvitaInternalError when a leaf's last key does not sort strictly before the next leaf's first key
 	 */
 	private void assertCrossLeafBoundaries(
 		@Nonnull List<BPlusLeafTreeNode<V>> leaves,
+		@Nonnull int[] pageSequences,
 		@Nonnull String structureDescription
 	) {
 		BPlusLeafTreeNode<V> previousKeyBearing = null;
@@ -493,13 +495,20 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 				final long previousLastKey = previousKeyBearing.getKeys()[previousKeyBearing.getPeek()];
 				final long currentFirstKey = keys[0];
 				if (previousLastKey >= currentFirstKey) {
+					// error path only: gather the full overlap context (ranges, counts, containment) here, never on a
+					// healthy load
+					final long predecessorFirstKey = previousKeyBearing.getKeys()[0];
+					final long successorLastKey = keys[peek];
+					final boolean successorWithinPredecessor =
+						currentFirstKey >= predecessorFirstKey && successorLastKey <= previousLastKey;
 					throw new GenericEvitaInternalError(
-						"Corrupted persisted " + structureDescription + ": leaf-page sequence " +
-							previousKeyBearing.getPageSequence() + " overlaps its successor leaf-page sequence " +
-							leaf.getPageSequence() + " — its last key (" + previousLastKey + ") does not sort before the " +
-							"first key (" + currentFirstKey + ") of the next leaf page. This is a stale leaf-page twin or " +
-							"other index corruption. Restore the catalog from a backup, or fully rebuild / reindex the " +
-							"affected catalog."
+						AbstractTransactionalBPlusTree.overlappingLeafPagesDiagnostic(
+							structureDescription, pageSequences,
+							previousKeyBearing.getPageSequence(), predecessorFirstKey, previousLastKey,
+							previousKeyBearing.getPeek() + 1,
+							leaf.getPageSequence(), currentFirstKey, successorLastKey, peek + 1,
+							successorWithinPredecessor
+						)
 					);
 				}
 			}

--- a/evita_engine/src/main/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndex.java
@@ -590,7 +590,11 @@ public class ReferenceTypeCardinalityIndex
 			// SINGLE shape: the index spans one leaf. If it just collapsed from PAGED, remove every prior leaf page (the
 			// inline root no longer references them) BEFORE dropping the bookkeeping, then forget the stream so a later
 			// regrow into PAGED starts from a clean baseline and re-emits every leaf.
-			for (final int freedPageSequence : this.pageStreamRegistry.livePageSequences(CARDINALITY_PAGE_STREAM)) {
+			// Reclaim against what the previous flush left ON DISK: its staged set while still unpublished (a warm-up
+			// flush never reaches the commit-merge that publishes), else the published set. The published set alone lags a
+			// whole flush behind, so every page of the collapsed stream would leak — the append-only OffsetIndex never
+			// reclaims a record that is neither superseded nor explicitly removed.
+			for (final int freedPageSequence : this.pageStreamRegistry.pendingLivePageSequences(CARDINALITY_PAGE_STREAM)) {
 				sink.addChangeToStore(
 					new ReferenceTypeCardinalityIndexLeafPageRemoval(entityIndexPrimaryKey, referenceName, freedPageSequence)
 				);
@@ -640,6 +644,12 @@ public class ReferenceTypeCardinalityIndex
 			// publish the page baseline staged by this commit's flush: the merge runs only AFTER the flush has durably
 			// written the changed leaf pages + root, so the staged live set now reflects what is on disk. The registry is
 			// then carried BY REFERENCE into the committed copy, so the surviving index keeps it (mirrors OwnerUniqueIndex).
+			// This is the EARLIEST publish point on the transactional path only; it is not the only one — a staged set
+			// that never reaches a merge (the warm-up path has no merge at all) is published by the next flush instead,
+			// see `publishPreviousFlush`. (No discard counterpart is needed: a pre-flush abort never stages, and a
+			// failed flush suspends this catalog's transaction processing — on the warm-up path it poisons the
+			// collection's buffer instead, the same invariant in another dress — so no later flush ever diffs against
+			// the baseline a failed one left behind; restart rebuilds a clean registry from disk.)
 			this.pageStreamRegistry.publishStaged();
 			return new ReferenceTypeCardinalityIndex(
 				committedTree,
@@ -720,15 +730,63 @@ public class ReferenceTypeCardinalityIndex
 	}
 
 	/**
+	 * Promotes the page set staged by the PREVIOUS flush to the live change-detection baseline, so this flush's
+	 * freed-page diff is taken against what disk actually holds.
+	 *
+	 * The registry's live set answers "which leaf pages does this stream have on disk", and the write path derives the
+	 * freed-page reclaim from it — which pages a leaf merge dropped from the `(key, count)` bucket tree, so a
+	 * {@link ReferenceTypeCardinalityIndexLeafPageRemoval} is emitted for each and their entries stop being copied
+	 * forward. It advances solely by publishing, which {@link #createCopyWithMergedTransactionalMemory} does at the
+	 * commit-merge.
+	 *
+	 * A WARM_UP (bulk) flush never reaches a commit-merge: it runs the very same collect pipeline as a transaction, but
+	 * the merge that publishes only ever runs for one. Left alone, the live set of a freshly re-indexed catalog would
+	 * therefore stay EMPTY for the whole warm-up while disk moved on, making the freed-page diff of every warm-up flush
+	 * of this cardinality tree vacuously empty. A leaf MERGE is the one structural event that drops a page without
+	 * creating one — the survivor absorbs its sibling IN PLACE, keeping its own page and dirty flag, so nothing is
+	 * allocated — which leaves the dropped page unremoved and therefore ORPHANED on disk. Unlike a pure page-list root
+	 * (Chain / OwnerUnique / OwnerSort / FilterIndex), this `PAGED` root can never go stale on a cold reload: it also
+	 * carries the inline {@link #referencedPrimaryKeysIndex}, so it is re-emitted every dirty commit regardless of
+	 * whether the leaf list changed, and its `leafPageSequences` is always derived from the CURRENT tree rather than the
+	 * registry — so {@link #fromPersistedPages} never re-reads the dropped page and no cross-leaf overlap can occur. The
+	 * observable failure here is therefore not a reload-time corruption but a silent storage LEAK: the orphaned leaf
+	 * page is unreferenced by the root yet was never explicitly removed, so the append-only OffsetIndex — which
+	 * reclaims space only for records it is told to remove, never by reachability — copies it forward at every future
+	 * compaction.
+	 *
+	 * Publishing a staged set HERE — rather than only at the merge — is correct for every path, because of one
+	 * invariant: **a failed flush is never followed by another flush of the same data**. Note that this publish runs at
+	 * COLLECT time, before this flush has written anything (the baseline-capture pass re-enters this pipeline), so it
+	 * cannot lean on the previous flush's bytes having landed by now. It does not need to: a flush that fails during
+	 * trunk incorporation SUSPENDS the catalog's transaction processing ({@code TransactionManager.suspend}), and a
+	 * flush that fails on the warm-up path POISONS the collection's buffer
+	 * ({@code WarmUpDataStoreMemoryBuffer.poison}), so every later collect of it refuses deterministically. Those two
+	 * are the same invariant in different dresses: after a failed flush no later flush of that data ever runs, so
+	 * nothing can ever diff against the baselines it left behind. A flush that does NOT fail leaves `staged` holding
+	 * exactly the page set it wrote — the baseline the next flush must diff against — regardless of which path staged
+	 * it, and regardless of whether a merge ever ran. (Should the process die instead, {@link #fromPersistedPages}
+	 * rebuilds the registry from disk on restart — page allocation is advance-only, so a burnt id is harmless.) That is
+	 * what makes this safe in its own right — not the fact that it happens to be a no-op on the transactional path
+	 * (where the merge published first, leaving nothing staged). The commit handshake is untouched.
+	 */
+	private void publishPreviousFlush() {
+		this.pageStreamRegistry.publishStaged();
+	}
+
+	/**
 	 * Walks the cardinality tree leaf-by-leaf and returns the granular write-path emission for this commit: the leaf
 	 * pages that changed since the last flush, the full ordered list of live leaf-page sequences (the `PAGED` root's leaf
 	 * list), the stream high-water, and the freed page sequences a leaf merge dropped. Mirrors
 	 * {@code OwnerUniqueIndex.collectChangedPages} with the slim `(key, count)` columns.
 	 *
+	 * Before staging, any set still staged by the PREVIOUS flush is promoted to live: see
+	 * {@link #publishPreviousFlush()} for why that is both necessary and safe.
+	 *
 	 * @return the changed leaf pages, the ordered live page-sequence list, the high-water, and the freed pages
 	 */
 	@Nonnull
 	private PageEmission<LeafPage> collectChangedPages() {
+		publishPreviousFlush();
 		// this.cardinalities is a raw bucket tree, so the handle list and its cursors are raw too — bucket keys are read
 		// as Object and cast to Long exactly as the whole-tree snapshot does
 		final List<LeafPageHandle> handles = this.cardinalities.leafPageHandles();

--- a/evita_engine/src/main/java/io/evitadb/index/invertedIndex/InvertedIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/invertedIndex/InvertedIndex.java
@@ -931,10 +931,14 @@ public class InvertedIndex implements
 				(TransactionalBucketBPlusTree) transactionalLayer.getStateCopyWithCommittedChanges(this.buckets);
 			// publish the page baseline staged by this commit's flush: the merge runs only AFTER the
 			// flush has durably written the changed leaf pages + root, so the staged `pageSequence -> nodeId` map now
-			// reflects what is on disk and may become the live change-detection baseline for the next commit. The
-			// registry is then carried BY REFERENCE into the committed copy, so the surviving owner keeps it. (No
-			// discard counterpart is needed: a pre-flush abort never stages, a flush failure is fatal — restart rebuilds
-			// a clean registry — and a stale staged map is harmlessly replaced by the next commit's stage.)
+			// reflects what is on disk and becomes the live change-detection baseline for the next commit. The
+			// registry is then carried BY REFERENCE into the committed copy, so the surviving owner keeps it. This is
+			// the EARLIEST publish point on the transactional path only; it is not the only one — a staged set that
+			// never reaches a merge (the warm-up path has no merge at all) is published by the next flush instead, see
+			// `publishPreviousFlush`. (No discard counterpart is needed: a pre-flush abort never stages, and a failed
+			// flush suspends this catalog's transaction processing — on the warm-up path it poisons the collection's
+			// buffer instead, the same invariant in another dress — so no later flush ever diffs against the baseline
+			// a failed one left behind; restart rebuilds a clean registry from disk.)
 			this.pageStreamRegistry.publishStaged();
 			return new InvertedIndex(
 				this.plainType,
@@ -971,11 +975,51 @@ public class InvertedIndex implements
 	/**
 	 * Drops this index's page bookkeeping (allocator, high-water, baseline). Called when the index falls back to the
 	 * inline `SINGLE` shape so a later regrow into `PAGED` starts from a clean baseline and re-emits every leaf. The
-	 * caller is expected to have already issued removals for the prior `PAGED` leaf pages (see {@link #livePageSequences()})
+	 * caller is expected to have already issued removals for the prior `PAGED` leaf pages (see
+	 * {@link #currentLeafPageSequences()})
 	 * BEFORE calling this — once the bookkeeping is forgotten those page sequences can no longer be enumerated.
 	 */
 	public void forgetPageStream() {
 		this.pageStreamRegistry.forget(BUCKET_PAGE_STREAM);
+	}
+
+	/**
+	 * Promotes the page set staged by the PREVIOUS flush to the live change-detection baseline, so this flush's
+	 * freed-page diff is taken against what disk actually holds.
+	 *
+	 * The registry's live set answers "which leaf pages does this stream have on disk", and everything the write path
+	 * derives from it — which pages a leaf merge freed (so their records are REMOVED, the append-only OffsetIndex never
+	 * reclaiming an unreferenced-but-never-removed record) and whether the ordered page list changed at all (so the
+	 * `PAGED` root carrying it is re-emitted) — is only as good as that baseline. It advances solely by publishing,
+	 * which {@link #createCopyWithMergedTransactionalMemory} does at the commit-merge.
+	 *
+	 * A WARM_UP (bulk) flush never reaches a commit-merge: it runs the very same collect pipeline
+	 * ({@code DataStoreChanges.popTrappedUpdates} -> {@code getModifiedStorageParts}) but the merge that publishes only
+	 * ever runs for a transaction. Left alone, the live set of a freshly re-indexed catalog would therefore stay EMPTY
+	 * for the whole warm-up while disk moved on, making the freed-page diff of every warm-up flush vacuously empty. A
+	 * leaf MERGE is the one structural event that drops a page without creating one — the survivor absorbs its sibling
+	 * IN PLACE, keeping its own page and dirty flag, so nothing is allocated — which leaves the dropped page both
+	 * unremoved on disk and still listed on a root that is skipped as "unchanged". The next cold load then assembles the
+	 * survivor (holding the absorbed keys) followed by its stale, still-listed sibling, whose first key no longer sorts
+	 * after the survivor's last — the overlapping-leaf-page corruption.
+	 *
+	 * Publishing a staged set HERE — rather than only at the merge — is correct for every path, because of one
+	 * invariant: **a failed flush is never followed by another flush of the same data**. Note that this publish runs at
+	 * COLLECT time, before this flush has written anything (the baseline-capture pass re-enters this pipeline), so it
+	 * cannot and does not lean on the previous flush's bytes having landed by now. It does not need to: a flush that
+	 * fails during trunk incorporation SUSPENDS the catalog's transaction processing ({@code TransactionManager.suspend}),
+	 * and a flush that fails on the warm-up path POISONS the collection's buffer
+	 * ({@code WarmUpDataStoreMemoryBuffer.poison}), so every later collect of it refuses deterministically. Those two are
+	 * the same invariant in different dresses: after a failed flush no later flush of that data ever runs, so nothing can
+	 * ever diff against the baselines it left behind. A flush that does NOT fail leaves `staged` holding exactly the page
+	 * set it wrote — the baseline the next flush must diff against — regardless of which path staged it, and regardless
+	 * of whether a merge ever ran. (Should the process die instead, {@link #fromPersistedPages} rebuilds the registry
+	 * from disk on restart — page allocation is advance-only, so a burnt id is harmless.) That is what makes this safe in
+	 * its own right — not the fact that it happens to be a no-op on the transactional path (where the merge published
+	 * first, leaving nothing staged). The commit handshake is untouched.
+	 */
+	private void publishPreviousFlush() {
+		this.pageStreamRegistry.publishStaged();
 	}
 
 	/**
@@ -989,10 +1033,14 @@ public class InvertedIndex implements
 	 * the registry here and becomes live only when the commit is published (see the commit handshake). A clean
 	 * (non-dirty) index must not call this — the caller gates on {@link #isDirty()}.
 	 *
+	 * Before staging, any set still staged by the PREVIOUS flush is promoted to live: see
+	 * {@link #publishPreviousFlush()} for why that is both necessary and safe.
+	 *
 	 * @return the changed leaf pages, the ordered live page-sequence list, and the high-water
 	 */
 	@Nonnull
 	public PageEmission<LeafPage> collectChangedPages() {
+		publishPreviousFlush();
 		// this.buckets is a raw tree, so the handle list and its cursors are raw too — bucket values are read as Object
 		// and cast to Serializable exactly as the whole-tree materializer does
 		final List<LeafPageHandle> handles = this.buckets.leafPageHandles();
@@ -1015,21 +1063,9 @@ public class InvertedIndex implements
 	}
 
 	/**
-	 * Returns the page sequences currently live in the published baseline — every leaf page this index has on disk. Used
-	 * by the `PAGED -> SINGLE` fallback to remove all prior leaf pages before the index collapses back to the inline
-	 * shape (after which {@link #forgetPageStream()} clears the bookkeeping).
-	 *
-	 * @return the live page sequences, or an empty array when the index has no leaf pages on disk
-	 */
-	@Nonnull
-	public int[] livePageSequences() {
-		return this.pageStreamRegistry.livePageSequences(BUCKET_PAGE_STREAM);
-	}
-
-	/**
 	 * Returns the leaf-page sequences this inverted index WILL have on disk once the in-flight commit is durable (the
 	 * staged set mid-flush, else the published live set), or an empty array when it is inline (SINGLE) / never paged.
-	 * Unlike {@link #livePageSequences()} (always the published set), this reflects the CURRENT tree shape at any point
+	 * The published set alone lags a whole flush behind, so this reflects the CURRENT tree shape at any point
 	 * of the flush, so the owning {@link io.evitadb.index.attribute.AttributeIndex} can snapshot "what disk holds after
 	 * this commit" and, when the sub-index is later emptied and dropped from its map — after which this index's own
 	 * flush never runs again — still reclaim the now-orphaned leaf pages instead of leaking them forever.

--- a/evita_engine/src/main/java/io/evitadb/index/page/PageStreamRegistry.java
+++ b/evita_engine/src/main/java/io/evitadb/index/page/PageStreamRegistry.java
@@ -58,12 +58,19 @@ import java.util.Set;
  *   transaction-aware dirty flag (`BPlusLeafTreeNode.isDirty()`), an exact signal that, unlike a content hash, can
  *   never miss a real change. The live set serves only the freed-page reclaim: pages present last commit but absent
  *   this commit were dropped by a leaf merge and must be removed from storage ({@link #freedPageSequences(int, Set)}).
+ * - the **ordered live-page list**, the same pages in ascending key order — the list the last published `PAGED` root
+ *   record carries. It is what decides whether the root must be re-emitted this commit: the root is rewritten iff the
+ *   list the flush collected differs from it. Kept alongside the set rather than derived from it because the set is
+ *   unordered and the root's list is not.
  *
- * **Commit handshake.** A flush stages the next live set for each touched stream ({@link #stage(int, Set)}); the
- * staged sets become live only when the commit is known durable ({@link #publishStaged()}), and are dropped wholesale
- * if the commit aborts after staging ({@link #discardStaged()}). The high-water, by contrast, advances *live* at
- * allocation time — an aborted transaction never reaches flush so it allocates nothing, while a flush that allocates
- * then crashes before its durable write merely burns an id harmlessly (advance-only).
+ * **Commit handshake.** A flush stages the next live set for each touched stream ({@link #stage(int, int[])}); the
+ * staged sets become live only when the commit is known durable ({@link #publishStaged()}). A failed flush is never
+ * followed by another flush of the same data — a failure during trunk incorporation suspends the catalog's transaction
+ * processing, and one on the warm-up path poisons the collection's buffer — so a staged set that never publishes is
+ * simply abandoned in memory and the registry is rebuilt from disk on restart; nothing ever diffs against it. The
+ * high-water, by contrast, advances *live* at allocation time — an aborted transaction never reaches flush so it
+ * allocates nothing, while a flush that allocates then crashes before its durable write merely burns an id harmlessly
+ * (advance-only).
  *
  * **Residence.** The registry is **owner-resident**: it lives on the committed owner
  * {@code InvertedIndex} (this engine module) and is carried by reference through the index's
@@ -124,22 +131,15 @@ public class PageStreamRegistry implements Serializable {
 	}
 
 	/**
-	 * Returns every page sequence currently live in the given stream's published set — all leaf pages the stream has on
-	 * disk — or an empty array when it has none. Used by the `PAGED -> SINGLE` fallback to remove all prior leaf pages
-	 * before a sub-index collapses back to its inline shape.
-	 *
-	 * @param streamId the stream to inspect
-	 * @return the live page sequences, or an empty array when the stream has no leaf pages
-	 */
-	@Nonnull
-	public int[] livePageSequences(int streamId) {
-		return liveSequencesExcluding(streamId, Collections.emptySet());
-	}
-
-	/**
 	 * Returns the page sequences live in the given stream's published set that are NOT among {@code liveSequences} — the
 	 * pages a leaf merge dropped this commit (freed pages, to be removed from storage). Reads the published set (not
 	 * the staged one), so the result is stable across the flush and merge passes of a single commit.
+	 *
+	 * Single pass: fill an upper-bound-sized buffer, then return it as-is or as a trimmed copy.
+	 *
+	 * Note this is the FREED-page difference only. A `PAGED -> SINGLE` collapse must not reclaim from the published set:
+	 * that set lags a whole flush behind for as long as nothing publishes, so the collapse would silently reclaim
+	 * nothing. It uses {@link #pendingLivePageSequences(int)} instead.
 	 *
 	 * @param streamId the stream to inspect
 	 * @param liveSequences the page sequences still live this commit
@@ -147,23 +147,6 @@ public class PageStreamRegistry implements Serializable {
 	 */
 	@Nonnull
 	public int[] freedPageSequences(int streamId, @Nonnull Set<Integer> liveSequences) {
-		return liveSequencesExcluding(streamId, liveSequences);
-	}
-
-	/**
-	 * Shared live-set difference: the published live page sequences of {@code streamId} with every sequence in
-	 * {@code excluded} removed, in the set's iteration order. The single helper behind {@link #livePageSequences(int)}
-	 * (empty exclusion) and {@link #freedPageSequences(int, Set)} (live-set exclusion).
-	 *
-	 * Single pass: fill an upper-bound-sized buffer, then return it as-is when nothing was excluded (the common
-	 * {@link #livePageSequences(int)} path) or a trimmed copy when a leaf merge dropped some pages.
-	 *
-	 * @param streamId the stream whose published live set is scanned
-	 * @param excluded the page sequences to omit from the result
-	 * @return the matching page sequences, or an empty array when none match
-	 */
-	@Nonnull
-	private int[] liveSequencesExcluding(int streamId, @Nonnull Set<Integer> excluded) {
 		final Set<Integer> publishedLive = livePages(streamId);
 		if (publishedLive.isEmpty()) {
 			return ArrayUtils.EMPTY_INT_ARRAY;
@@ -171,7 +154,7 @@ public class PageStreamRegistry implements Serializable {
 		final int[] result = new int[publishedLive.size()];
 		int count = 0;
 		for (final Integer sequence : publishedLive) {
-			if (!excluded.contains(sequence)) {
+			if (!liveSequences.contains(sequence)) {
 				result[count++] = sequence;
 			}
 		}
@@ -184,8 +167,8 @@ public class PageStreamRegistry implements Serializable {
 	/**
 	 * Returns the page sequences the given stream WILL have on disk once the in-flight flush is durable — its staged set
 	 * when a flush has already staged this commit, otherwise its published live set (and an empty array for an unknown /
-	 * page-less stream). Unlike {@link #livePageSequences(int)} (which always reads the published set and so lags behind
-	 * a flush that has staged but not yet published), this reflects the CURRENT tree shape at any point of the flush, so
+	 * page-less stream). Unlike the published live set alone ({@link #livePages(int)}, which lags behind a flush that has
+	 * staged but not yet published), this reflects the CURRENT tree shape at any point of the flush, so
 	 * an owner can snapshot "what disk holds after this commit" for a sub-index whose pages it must reclaim if the
 	 * sub-index is later dropped.
 	 *
@@ -215,15 +198,19 @@ public class PageStreamRegistry implements Serializable {
 	 * live-page set (rebuilt by the caller from the persisted leaf-page sequence list). Replaces any existing state for
 	 * the stream.
 	 *
+	 * The list is taken in the root's own order and seeds BOTH the live set and the ordered baseline the next flush
+	 * diffs against — a stream restored with only its set would leave the first post-load flush comparing its collected
+	 * list against an empty baseline and re-emitting a root that never changed.
+	 *
 	 * @param streamId  the stream to restore
 	 * @param highWater the persisted high-water ({@link #NO_PAGE} when the stream has no pages)
-	 * @param livePages the live page sequences on disk (copied defensively)
+	 * @param livePages the live page sequences on disk, in the persisted root's ascending key order (copied defensively)
 	 */
-	public void restore(int streamId, int highWater, @Nonnull Set<Integer> livePages) {
+	public void restore(int streamId, int highWater, @Nonnull int[] livePages) {
 		Assert.isPremiseValid(highWater >= NO_PAGE, "High-water must be >= " + NO_PAGE + ".");
 		final PageStream stream = new PageStream();
 		stream.highWater = highWater;
-		for (final Integer pageSequence : livePages) {
+		for (final int pageSequence : livePages) {
 			// every live page must be a real, allocated page: non-negative and within the high-water envelope
 			Assert.isPremiseValid(
 				pageSequence >= 0 && pageSequence <= highWater,
@@ -231,6 +218,12 @@ public class PageStreamRegistry implements Serializable {
 			);
 			stream.live.add(pageSequence);
 		}
+		// a page listed twice would silently shrink the set and desync it from the ordered list
+		Assert.isPremiseValid(
+			stream.live.size() == livePages.length,
+			"Restored live page list contains a duplicate page sequence."
+		);
+		stream.liveOrdered = Arrays.copyOf(livePages, livePages.length);
 		this.streams.put(streamId, stream);
 	}
 
@@ -238,7 +231,7 @@ public class PageStreamRegistry implements Serializable {
 	 * Read-path twin of {@link #collectChangedPages} and the single shared skeleton behind every paged index's reload:
 	 * builds a fresh registry seeded for a just-reassembled paged index. A tree rebuilt from its persisted leaf pages
 	 * has every leaf flagged dirty by the replaying inserts even though the leaves are byte-identical to what is already
-	 * on disk; this clears each leaf's dirty flag, collects the live-page set and {@link #restore(int, int, Set)
+	 * on disk; this clears each leaf's dirty flag, collects the live-page list and {@link #restore(int, int, int[])
 	 * restores} the stream, so the first post-load commit suppresses every untouched leaf. Like
 	 * {@link #collectChangedPages} it consumes the value-agnostic {@link PagedLeafHandle} contract rather than a concrete
 	 * tree, so it serves the bucket-, long- and element-keyed trees alike.
@@ -253,10 +246,12 @@ public class PageStreamRegistry implements Serializable {
 	public static <H extends PagedLeafHandle> PageStreamRegistry restoredFrom(
 		int streamId, int highWaterPageSequence, @Nonnull List<H> handles
 	) {
-		final Set<Integer> livePages = new HashSet<>(handles.size());
+		// the handles arrive in ascending key order, so collecting them in order yields the persisted root's own page list
+		final int[] livePages = new int[handles.size()];
+		int idx = 0;
 		for (final H handle : handles) {
 			handle.clearDirty();
-			livePages.add(handle.getPageSequence());
+			livePages[idx++] = handle.getPageSequence();
 		}
 		final PageStreamRegistry registry = new PageStreamRegistry();
 		registry.restore(streamId, highWaterPageSequence, livePages);
@@ -284,13 +279,16 @@ public class PageStreamRegistry implements Serializable {
 	 * to {@link #livePages(int)} until {@link #publishStaged()}. Staging again before publishing replaces the pending
 	 * set.
 	 *
+	 * The list is taken in ascending key order — the order the root record persists — and stages the set and the ordered
+	 * baseline together, so the two can never drift apart.
+	 *
 	 * @param streamId the stream being flushed
-	 * @param liveSequences the full next live-page set (copied defensively)
+	 * @param liveSequences the full next live-page list, in ascending key order (copied defensively)
 	 */
-	public void stage(int streamId, @Nonnull Set<Integer> liveSequences) {
+	public void stage(int streamId, @Nonnull int[] liveSequences) {
 		final PageStream stream = this.streams.computeIfAbsent(streamId, id -> new PageStream());
-		final Set<Integer> staged = new HashSet<>(liveSequences.size());
-		for (final Integer pageSequence : liveSequences) {
+		final Set<Integer> staged = new HashSet<>(liveSequences.length);
+		for (final int pageSequence : liveSequences) {
 			// a staged page must be a real, allocated page: non-negative and within this stream's high-water envelope
 			Assert.isPremiseValid(
 				pageSequence >= 0 && pageSequence <= stream.highWater,
@@ -298,7 +296,13 @@ public class PageStreamRegistry implements Serializable {
 			);
 			staged.add(pageSequence);
 		}
+		// a page listed twice would silently shrink the set and desync it from the ordered list
+		Assert.isPremiseValid(
+			staged.size() == liveSequences.length,
+			"Staged live page list contains a duplicate page sequence."
+		);
 		stream.staged = staged;
+		stream.stagedOrdered = Arrays.copyOf(liveSequences, liveSequences.length);
 	}
 
 	/**
@@ -309,7 +313,7 @@ public class PageStreamRegistry implements Serializable {
 	 * live-page list and the next live-page set. A leaf is (re)written — its {@code pageBuilder} payload collected and its
 	 * dirty flag cleared — iff it is brand new or its transaction-aware dirty flag is set, an exact signal a content hash
 	 * cannot match: every mutation site sets it, so a real change can never be suppressed. The complete next live-page set
-	 * is {@link #stage(int, Set) staged} here and becomes live only when the commit is published; the pages a leaf merge
+	 * is {@link #stage(int, int[]) staged} here and becomes live only when the commit is published; the pages a leaf merge
 	 * dropped are returned as {@link #freedPageSequences(int, Set) freed} so the caller can remove them from storage.
 	 *
 	 * A clean (non-dirty) index must not call this — the caller gates on its own dirty signal.
@@ -353,13 +357,80 @@ public class PageStreamRegistry implements Serializable {
 		// must be REMOVED from storage, not merely unreferenced — the append-only OffsetIndex never reclaims a record
 		// that is neither superseded (page ids are advance-only, never re-keyed) nor explicitly removed
 		final int[] freedPageSequences = freedPageSequences(streamId, nextLive);
-		stage(streamId, nextLive);
-		// the ordered live-page list is byte-identical to the persisted root iff no leaf was allocated (split/first page)
-		// and none was freed (merge); when unchanged a caller with a pure page-list root can skip re-emitting it (O(1))
-		final boolean pageListChanged = anyFreshLeaf || freedPageSequences.length > 0;
+		stage(streamId, orderedPageSequences);
+		// the root must be re-emitted iff the list this flush collected differs from the one the published root carries;
+		// when unchanged a caller with a pure page-list root can skip re-emitting it (O(1))
+		final PageStream stream = this.streams.get(streamId);
+		final boolean pageListChanged = !Arrays.equals(orderedPageSequences, stream.liveOrdered);
+		// `anyFreshLeaf` is reassigned in the collect loop above, so it is not effectively final; snapshot it into a
+		// final local the failure-path supplier can capture (the eager cross-check below still reads the loop variable)
+		final boolean anyFreshLeafSnapshot = anyFreshLeaf;
+		// the same predicate derived from the live-set bookkeeping instead: a leaf was allocated (split / first page) or
+		// one was dropped (merge). It cannot disagree with the direct comparison while the baseline is sound — leaves are
+		// key-ordered, and a steal/merge/split each either preserves that order or changes the membership, so there is no
+		// order-only change for the set-difference to miss. A disagreement therefore means the published baseline no
+		// longer describes what is on disk, and the freed-page difference silently under-reports against a stale baseline
+		// (`∅ - anything = ∅` reads as "nothing changed"), which would skip the root and strand the dropped page listed
+		// in it. Surface it here, at the flush that caused it, rather than let it reach storage and fail at cold load.
+		Assert.isPremiseValid(
+			pageListChanged == (anyFreshLeaf || freedPageSequences.length > 0),
+			// the whole diagnostic is built INSIDE the supplier: it runs only when the premise is already violated, so
+			// this branch pays for information gathering solely on the error path, never on a healthy flush
+			() -> "Page stream " + streamId + " has a stale published page baseline: the collected page list " +
+				Arrays.toString(orderedPageSequences) + " disagrees with the published baseline " +
+				Arrays.toString(stream.liveOrdered) + ". Cross-check inputs (why the disagreement was caught): " +
+				"pageListChanged=" + pageListChanged + ", anyFreshLeaf=" + anyFreshLeafSnapshot + ", freedPages=" +
+				Arrays.toString(freedPageSequences) + ", highWater=" + stream.highWater +
+				", pagesInCollectedNotBaseline=" +
+				Arrays.toString(pageSequenceDifference(orderedPageSequences, stream.liveOrdered)) +
+				", pagesInBaselineNotCollected=" +
+				Arrays.toString(pageSequenceDifference(stream.liveOrdered, orderedPageSequences)) +
+				". A collected list that differs from the baseline while the freed/fresh signals report no structural " +
+				"change means the published baseline no longer describes what is on disk — the known cause is a flush " +
+				"that failed after staging its next baseline, which a later flush then promoted before re-collecting."
+		);
 		return new PageEmission<>(
 			changedPages, orderedPageSequences, highWater(streamId), freedPageSequences, pageListChanged
 		);
+	}
+
+	/**
+	 * Returns the ascending set difference `from \ remove` — every value present in `from` but not in `remove`. Used
+	 * only to build the stale-baseline diagnostic on the failure path (see {@link #collectChangedPages}), so a plain
+	 * nested scan over the two short page-sequence lists is preferred to any allocation-heavier set machinery.
+	 *
+	 * A null `from` (the published baseline is null before the stream's first publish) yields an empty result; a null
+	 * `remove` excludes nothing. This keeps the failure-path diagnostic from throwing a second, less useful exception
+	 * that would mask the stale-baseline report it exists to produce.
+	 *
+	 * @param from   the source page-sequence list, or null
+	 * @param remove the page-sequence list whose members are excluded, or null
+	 * @return the ascending difference (never null)
+	 */
+	@Nonnull
+	private static int[] pageSequenceDifference(@Nullable int[] from, @Nullable int[] remove) {
+		if (from == null || from.length == 0) {
+			return ArrayUtils.EMPTY_INT_ARRAY;
+		}
+		final int[] result = new int[from.length];
+		int count = 0;
+		for (final int candidate : from) {
+			boolean present = false;
+			if (remove != null) {
+				for (final int excluded : remove) {
+					if (candidate == excluded) {
+						present = true;
+						break;
+					}
+				}
+			}
+			if (!present) {
+				result[count++] = candidate;
+			}
+		}
+		final int[] trimmed = Arrays.copyOf(result, count);
+		Arrays.sort(trimmed);
+		return trimmed;
 	}
 
 	/**
@@ -381,18 +452,10 @@ public class PageStreamRegistry implements Serializable {
 		for (final PageStream stream : this.streams.values()) {
 			if (stream.staged != null) {
 				stream.live = stream.staged;
+				stream.liveOrdered = stream.stagedOrdered;
 				stream.staged = null;
+				stream.stagedOrdered = null;
 			}
-		}
-	}
-
-	/**
-	 * Drops every pending staged live-page set, leaving each stream's live set intact — the commit-aborted half of the
-	 * handshake. The high-water is deliberately not rolled back (allocation is advance-only).
-	 */
-	public void discardStaged() {
-		for (final PageStream stream : this.streams.values()) {
-			stream.staged = null;
 		}
 	}
 
@@ -421,10 +484,20 @@ public class PageStreamRegistry implements Serializable {
 		 */
 		private Set<Integer> live = new HashSet<>();
 		/**
+		 * The published live-page list in ascending key order — the page list the root record on disk carries. Always the
+		 * ordered view of {@link #live}: both are written together, so they can never drift apart.
+		 */
+		@Nullable private int[] liveOrdered = ArrayUtils.EMPTY_INT_ARRAY;
+		/**
 		 * The pending live-page set staged by the in-flight flush; {@code null} when nothing is staged. Promoted to
-		 * {@link #live} on {@link PageStreamRegistry#publishStaged()}, dropped on
-		 * {@link PageStreamRegistry#discardStaged()}.
+		 * {@link #live} on {@link PageStreamRegistry#publishStaged()}; a staged set whose flush never completes is
+		 * abandoned when the catalog suspends and the registry is rebuilt from disk on restart.
 		 */
 		@Nullable private Set<Integer> staged;
+		/**
+		 * The ordered view of {@link #staged}; {@code null} exactly when {@link #staged} is. Promoted to
+		 * {@link #liveOrdered} in lockstep with it.
+		 */
+		@Nullable private int[] stagedOrdered;
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndex.java
@@ -319,7 +319,11 @@ public class PriceListAndCurrencyPriceSuperIndex
 			// SINGLE shape (possibly just collapsed from PAGED): remove every prior leaf page (the SINGLE root no longer
 			// references them) BEFORE dropping the page bookkeeping, then forget the stream so a later regrow into PAGED
 			// starts from a clean baseline and re-emits every leaf
-			for (final int freedPageSequence : this.pageStreamRegistry.livePageSequences(PRICE_PAGE_STREAM)) {
+			// Reclaim against what the previous flush left ON DISK: its staged set while still unpublished (a warm-up
+			// flush never reaches the commit-merge that publishes), else the published set. The published set alone lags a
+			// whole flush behind, so every page of the collapsed stream would leak — the append-only OffsetIndex never
+			// reclaims a record that is neither superseded nor explicitly removed.
+			for (final int freedPageSequence : this.pageStreamRegistry.pendingLivePageSequences(PRICE_PAGE_STREAM)) {
 				sink.addChangeToStore(
 					new PriceListAndCurrencySuperIndexLeafPageRemoval(
 						entityIndexPrimaryKey, this.priceIndexKey, freedPageSequence
@@ -336,6 +340,48 @@ public class PriceListAndCurrencyPriceSuperIndex
 	}
 
 	/**
+	 * Promotes the page set staged by the PREVIOUS flush to the live change-detection baseline, so this flush's
+	 * freed-page diff is taken against what disk actually holds.
+	 *
+	 * The registry's live set answers "which leaf pages does this stream have on disk", and the write path derives the
+	 * freed-page reclaim from it — which pages a leaf merge dropped, so a {@link PriceListAndCurrencySuperIndexLeafPageRemoval}
+	 * is emitted for each and their {@link PriceRecord}s stop being copied forward. It advances solely by publishing,
+	 * which {@link #createCopyWithMergedTransactionalMemory} does at the commit-merge.
+	 *
+	 * A WARM_UP (bulk) flush never reaches a commit-merge: it runs the very same collect pipeline as a transaction, but
+	 * the merge that publishes only ever runs for one. Left alone, the live set of a freshly re-indexed catalog would
+	 * therefore stay EMPTY for the whole warm-up while disk moved on, making the freed-page diff of every warm-up flush
+	 * of this price-record tree vacuously empty. A leaf MERGE is the one structural event that drops a page without
+	 * creating one — the survivor absorbs its sibling IN PLACE, keeping its own page and dirty flag, so nothing is
+	 * allocated — which leaves the dropped page unremoved and therefore ORPHANED on disk. Unlike a pure page-list root
+	 * (Chain / OwnerUnique / OwnerSort / FilterIndex), this `PAGED` root can never go stale on a cold reload: it also
+	 * carries the inline {@link #validityIndex}, so it is re-emitted every dirty commit regardless of whether the leaf
+	 * list changed, and its `leafPageSequences` is always derived from the CURRENT tree rather than the registry — so
+	 * {@link #fromPersistedPages} never re-reads the dropped page and no cross-leaf overlap can occur. The observable
+	 * failure here is therefore not a reload-time corruption but a silent storage LEAK: the orphaned leaf page is
+	 * unreferenced by the root yet was never explicitly removed, so the append-only OffsetIndex — which reclaims space
+	 * only for records it is told to remove, never by reachability — copies it forward at every future compaction.
+	 *
+	 * Publishing a staged set HERE — rather than only at the merge — is correct for every path, because of one
+	 * invariant: **a failed flush is never followed by another flush of the same data**. Note that this publish runs at
+	 * COLLECT time, before this flush has written anything (the baseline-capture pass re-enters this pipeline), so it
+	 * cannot lean on the previous flush's bytes having landed by now. It does not need to: a flush that fails during
+	 * trunk incorporation SUSPENDS the catalog's transaction processing ({@code TransactionManager.suspend}), and a
+	 * flush that fails on the warm-up path POISONS the collection's buffer
+	 * ({@code WarmUpDataStoreMemoryBuffer.poison}), so every later collect of it refuses deterministically. Those two
+	 * are the same invariant in different dresses: after a failed flush no later flush of that data ever runs, so
+	 * nothing can ever diff against the baselines it left behind. A flush that does NOT fail leaves `staged` holding
+	 * exactly the page set it wrote — the baseline the next flush must diff against — regardless of which path staged
+	 * it, and regardless of whether a merge ever ran. (Should the process die instead, {@link #fromPersistedPages}
+	 * rebuilds the registry from disk on restart — page allocation is advance-only, so a burnt id is harmless.) That is
+	 * what makes this safe in its own right — not the fact that it happens to be a no-op on the transactional path
+	 * (where the merge published first, leaving nothing staged). The commit handshake is untouched.
+	 */
+	private void publishPreviousFlush() {
+		this.pageStreamRegistry.publishStaged();
+	}
+
+	/**
 	 * Walks the price-record tree leaf-by-leaf and emits the granular `PAGED` write path for this commit: one
 	 * {@link PriceListAndCurrencySuperIndexLeafPagePart} per CHANGED leaf, a
 	 * {@link PriceListAndCurrencySuperIndexLeafPageRemoval} per leaf a merge dropped this commit, and the `PAGED` root
@@ -344,10 +390,14 @@ public class PriceListAndCurrencyPriceSuperIndex
 	 * leaf's transaction-aware dirty flag decides whether it is re-emitted, and is cleared once its page is collected.
 	 * The complete next live-page set is STAGED on the registry here and becomes live only when the commit is published.
 	 *
+	 * Before staging, any set still staged by the PREVIOUS flush is promoted to live: see
+	 * {@link #publishPreviousFlush()} for why that is both necessary and safe.
+	 *
 	 * @param entityIndexPrimaryKey the owning entity index pk
 	 * @param sink                  the trapped-changes accumulator for this commit
 	 */
 	private void appendPagedParts(int entityIndexPrimaryKey, @Nonnull TrappedChanges sink) {
+		publishPreviousFlush();
 		// the page-sequence reconciliation is shared; the builder materializes this index's leaf part per changed leaf
 		final PageEmission<PriceListAndCurrencySuperIndexLeafPagePart> emission =
 			this.pageStreamRegistry.collectChangedPages(
@@ -440,9 +490,13 @@ public class PriceListAndCurrencyPriceSuperIndex
 		if (isDirty) {
 			// the just-completed flush staged the next live-page set for the price-record stream; the commit is now known
 			// durable, so promote it to live. The registry is then carried BY REFERENCE into the committed copy so the
-			// surviving owner keeps the allocator + change-detection baseline the flush populated. (No discard counterpart
-			// is needed: a pre-flush abort never stages, a flush failure is fatal — restart rebuilds a clean registry —
-			// and a stale staged map is harmlessly replaced by the next commit's stage.)
+			// surviving owner keeps the allocator + change-detection baseline the flush populated. This is the EARLIEST
+			// publish point on the transactional path only; it is not the only one — a staged set that never reaches a
+			// merge (the warm-up path has no merge at all) is published by the next flush instead, see
+			// `publishPreviousFlush`. (No discard counterpart is needed: a pre-flush abort never stages, and a failed
+			// flush suspends this catalog's transaction processing — on the warm-up path it poisons the collection's
+			// buffer instead, the same invariant in another dress — so no later flush ever diffs against the baseline
+			// a failed one left behind; restart rebuilds a clean registry from disk.)
 			this.pageStreamRegistry.publishStaged();
 			final TransactionalElementBPlusTree<PriceRecordContract> newTriples =
 				transactionalLayer.getStateCopyWithCommittedChanges(this.priceRecords);

--- a/evita_engine/src/main/java/io/evitadb/index/range/RangeIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/range/RangeIndex.java
@@ -710,11 +710,49 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 	/**
 	 * Drops this index's page bookkeeping (allocator, high-water, baseline). Called when the range falls back to the
 	 * inline `SINGLE` shape so a later regrow into `PAGED` starts from a clean baseline and re-emits every leaf. The
-	 * caller is expected to have already issued removals for the prior `PAGED` leaf pages (see {@link #livePageSequences()})
+	 * caller is expected to have already issued removals for the prior `PAGED` leaf pages (see
+	 * {@link #currentLeafPageSequences()})
 	 * BEFORE calling this.
 	 */
 	public void forgetPageStream() {
 		this.pageStreamRegistry.forget(RANGE_PAGE_STREAM);
+	}
+
+	/**
+	 * Promotes the page set staged by the PREVIOUS flush to the live change-detection baseline, so this flush's
+	 * freed-page diff and `pageListChanged` verdict are taken against what disk actually holds.
+	 *
+	 * The registry's live set answers "which leaf pages does this threshold tree have on disk", and both the pages a
+	 * leaf merge freed (so their obsolete points are REMOVED from storage, not merely left unreferenced) and whether
+	 * the ordered page list changed at all (so the `PAGED` root carrying it is re-emitted rather than skipped as
+	 * unchanged) are derived from it. It advances solely by publishing, which
+	 * {@link #createCopyWithMergedTransactionalMemory} does at the commit-merge.
+	 *
+	 * A WARM_UP (bulk) flush never reaches a commit-merge — it calls this method directly, flush after flush, and
+	 * the merge that publishes only ever runs for a transaction. Left alone, the live set of a freshly re-indexed
+	 * range would therefore stay EMPTY for the whole warm-up while disk moved on, so a leaf MERGE (the survivor
+	 * absorbs its sibling IN PLACE, keeping its own page and dirty flag — nothing is allocated) would drop a page
+	 * that is never removed from storage and is still listed on a root skipped as "unchanged". The next cold load
+	 * then assembles the survivor (holding the absorbed points) followed by its stale, still-listed sibling, whose
+	 * first threshold no longer sorts after the survivor's last — the overlapping-leaf-page corruption.
+	 *
+	 * Publishing a staged set HERE — rather than only at the merge — is correct for every path, because of one
+	 * invariant: **a failed flush is never followed by another flush of the same data**. Note that this publish runs
+	 * at COLLECT time, before this flush has written anything (the baseline-capture pass re-enters this pipeline), so
+	 * it cannot lean on the previous flush's bytes having landed by now. It does not need to: a flush that fails
+	 * during trunk incorporation SUSPENDS the catalog's transaction processing ({@code TransactionManager.suspend}),
+	 * and a flush that fails on the warm-up path POISONS the collection's buffer
+	 * ({@code WarmUpDataStoreMemoryBuffer.poison}), so every later collect of it refuses deterministically. Those two
+	 * are the same invariant in different dresses: after a failed flush no later flush of that data ever runs, so
+	 * nothing can ever diff against the baselines it left behind. A flush that does NOT fail leaves `staged` holding
+	 * exactly the page set it wrote — the baseline the next flush must diff against — regardless of which path staged
+	 * it, and regardless of whether a merge ever ran. (Should the process die instead, {@link #fromPersistedPages}
+	 * rebuilds the registry from disk on restart — page allocation is advance-only, so a burnt id is harmless.) That
+	 * is what makes this safe in its own right — not the fact that it happens to be a no-op on the transactional path
+	 * (where the merge published first, leaving nothing staged). The commit handshake is untouched.
+	 */
+	private void publishPreviousFlush() {
+		this.pageStreamRegistry.publishStaged();
 	}
 
 	/**
@@ -727,10 +765,14 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 	 * complete next live-page set is STAGED here and becomes live only when the commit is published. A clean index must
 	 * not call this.
 	 *
+	 * Before staging, any set still staged by the PREVIOUS flush is promoted to live: see
+	 * {@link #publishPreviousFlush()} for why that is both necessary and safe.
+	 *
 	 * @return the changed leaf pages, the ordered live page-sequence list, the high-water and the freed page sequences
 	 */
 	@Nonnull
 	public PageEmission<RangePage> collectChangedPages() {
+		publishPreviousFlush();
 		return this.pageStreamRegistry.collectChangedPages(
 			RANGE_PAGE_STREAM, this.ranges.<TransactionalRangePoint>leafPageHandles(),
 			(pageSequence, handle) -> {
@@ -745,21 +787,9 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 	}
 
 	/**
-	 * Returns the page sequences currently live in the published set — every leaf page this index has on disk. Used
-	 * by the `PAGED -> SINGLE` fallback to remove all prior leaf pages before the index collapses back to the inline
-	 * shape (after which {@link #forgetPageStream()} clears the bookkeeping).
-	 *
-	 * @return the live page sequences, or an empty array when the index has no leaf pages on disk
-	 */
-	@Nonnull
-	public int[] livePageSequences() {
-		return this.pageStreamRegistry.livePageSequences(RANGE_PAGE_STREAM);
-	}
-
-	/**
 	 * Returns the leaf-page sequences this range index WILL have on disk once the in-flight commit is durable (the
 	 * staged set mid-flush, else the published live set), or an empty array when it is inline (SINGLE) / never paged.
-	 * Unlike {@link #livePageSequences()} (always the published set), this reflects the CURRENT tree shape at any point
+	 * The published set alone lags a whole flush behind, so this reflects the CURRENT tree shape at any point
 	 * of the flush, so the owning {@link io.evitadb.index.attribute.AttributeIndex} can snapshot "what disk holds after
 	 * this commit" and, when the range companion is later dropped with its emptied filter — after which this index's own
 	 * flush never runs again — still reclaim the now-orphaned leaf pages instead of leaking them forever.
@@ -840,10 +870,14 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 		if (isDirty) {
 			// publish the page baseline staged by this commit's flush: the merge runs only AFTER the
 			// flush has durably written the changed leaf pages + root, so the staged `pageSequence -> nodeId` map now
-			// reflects what is on disk and may become the live change-detection baseline for the next commit. The
-			// registry is then carried BY REFERENCE into the committed copy, so the surviving owner keeps it. (No discard
-			// counterpart is needed: a pre-flush abort never stages, a flush failure is fatal — restart rebuilds a clean
-			// registry — and a stale staged map is harmlessly replaced by the next commit's stage.)
+			// reflects what is on disk and becomes the live change-detection baseline for the next commit. The
+			// registry is then carried BY REFERENCE into the committed copy, so the surviving owner keeps it. This is
+			// the EARLIEST publish point on the transactional path only; it is not the only one — a staged set that
+			// never reaches a merge (the warm-up path has no merge at all) is published by the next flush instead, see
+			// `publishPreviousFlush`. (No discard counterpart is needed: a pre-flush abort never stages, and a failed
+			// flush suspends this catalog's transaction processing — on the warm-up path it poisons the collection's
+			// buffer instead, the same invariant in another dress — so no later flush ever diffs against the baseline
+			// a failed one left behind; restart rebuilds a clean registry from disk.)
 			this.pageStreamRegistry.publishStaged();
 			return new RangeIndex(
 				transactionalLayer.getStateCopyWithCommittedChanges(this.ranges),

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/storage/FilterIndexPagedPersistenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/storage/FilterIndexPagedPersistenceTest.java
@@ -38,6 +38,7 @@ import io.evitadb.index.EntityIndex;
 import io.evitadb.index.EntityIndexKey;
 import io.evitadb.index.EntityIndexType;
 import io.evitadb.index.attribute.FilterIndex;
+import io.evitadb.index.invertedIndex.InvertedIndex;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
 import io.evitadb.test.Entities;
 import io.evitadb.test.EvitaTestSupport;
@@ -48,7 +49,10 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Set;
 
 import static io.evitadb.api.query.Query.query;
 import static io.evitadb.api.query.QueryConstraints.attributeEquals;
@@ -90,6 +94,24 @@ class FilterIndexPagedPersistenceTest implements EvitaTestSupport {
 	 * thresholds per range, block size 512) becomes multi-leaf → range-PAGED.
 	 */
 	private static final String ATTRIBUTE_RANGE = "validity";
+	/**
+	 * A filterable {@link OffsetDateTime} attribute, one distinct strictly-ascending value per entity — the
+	 * near-unique timestamp shape a re-indexing job writes. Every bucket therefore holds a single record, so deleting
+	 * an entity drops its bucket outright and can shrink a leaf below its minimum occupancy into a merge.
+	 */
+	private static final String ATTRIBUTE_TIMESTAMP = "published";
+	/** Base of the ascending {@link #ATTRIBUTE_TIMESTAMP} stream. */
+	private static final OffsetDateTime BASE_TIMESTAMP = OffsetDateTime.of(
+		2026, 7, 16, 18, 20, 0, 0, ZoneOffset.UTC
+	);
+	/**
+	 * Distinct timestamps inserted during warm-up. With valueBlockSize=256 (split at 128) an ascending stream of 513
+	 * values lays the bucket tree out as four leaves — [1..128], [129..256], [257..384], [385..513] — which is the
+	 * smallest layout that can lose a leaf to a merge and still stay PAGED afterwards.
+	 */
+	private static final int TIMESTAMP_COUNT = 513;
+	/** The primary keys deleted to force the leaf merge; their timestamps must resolve to nothing afterwards. */
+	private static final Set<Integer> DELETED_TIMESTAMP_PKS = Set.of(1, 2, 129);
 	/** distinct values inserted during warm-up; > 256 so the InvertedIndex root becomes internal → PAGED. */
 	private static final int WARMUP_COUNT = 300;
 	/** additional distinct values inserted transactionally after go-live to exercise the merge/page-publish path. */
@@ -248,6 +270,76 @@ class FilterIndexPagedPersistenceTest implements EvitaTestSupport {
 		assertSurvivingRangesResolve();
 	}
 
+	@Test
+	@DisplayName("A leaf merge in a warm-up flush must not leave the dropped leaf page listed on the persisted root")
+	void shouldReloadAfterAWarmUpFlushMergedALeaf() {
+		// 1) FIRST warm-up flush: closing a warming-up session flushes synchronously (Catalog.flush ->
+		//    EntityCollection.createFlushFuture -> popTrappedChanges), so this lands pages 0..3 + the root on disk.
+		//    Ascending timestamps fill the leaves left to right, giving the deterministic layout asserted below.
+		this.evita.defineCatalog(TEST_CATALOG);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withAttribute(ATTRIBUTE_TIMESTAMP, OffsetDateTime.class, AttributeSchemaEditor::filterable)
+					.updateVia(session);
+				for (int pk = 1; pk <= TIMESTAMP_COUNT; pk++) {
+					session.upsertEntity(
+						session.createNewEntity(Entities.PRODUCT, pk)
+							.setAttribute(ATTRIBUTE_TIMESTAMP, timestamp(pk))
+					);
+				}
+			}
+		);
+		assertTrue(isTimestampIndexPaged(), "The timestamp index must be PAGED before the merge!");
+		assertEquals(
+			4, timestampIndexLeafPageCount(),
+			"The first warm-up flush must lay the bucket tree out as four leaf pages — the layout the deletes below " +
+				"are calibrated against!"
+		);
+
+		// 2) SECOND warm-up flush: delete exactly enough distinct values to force leaf 0 to merge its right sibling.
+		//    Each timestamp is unique, so its bucket holds a single record and deleting the entity drops the bucket
+		//    outright — the shrink that a low-cardinality attribute practically never sees. With valueBlockSize=256 /
+		//    minValueBlockSize=127 the leaves start out [1..128], [129..256], [257..384], [385..513]:
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				// leaf 1: 128 -> 127, so it sits exactly at the minimum and can no longer donate a key
+				session.deleteEntity(Entities.PRODUCT, 129);
+				// leaf 0: 128 -> 127 (still at the minimum, no underflow yet)
+				session.deleteEntity(Entities.PRODUCT, 1);
+				// leaf 0: 127 -> 126 -> underflow. It has no left sibling, the right sibling cannot donate
+				// (127 > 127 is false) and 127 + 126 = 253 < 256, so consolidate takes `mergeWithRight`: leaf 0
+				// absorbs leaf 1 IN PLACE — it keeps page 0 and is marked dirty, while leaf 1 is detached and its
+				// page 1 must be freed. No leaf is born, so nothing is allocated.
+				session.deleteEntity(Entities.PRODUCT, 2);
+			}
+		);
+		// pin that a leaf really was merged away: without this the test would still pass if the block-size constants
+		// ever drifted so the deletes no longer underflow a leaf — the tree would simply stay intact, reload cleanly
+		// and never exercise the defect at all
+		assertEquals(
+			3, timestampIndexLeafPageCount(),
+			"The deletes must have merged a leaf away (four leaf pages -> three); if this still reports four, no " +
+				"merge happened and the test is not exercising the freed-page path!"
+		);
+		// the tree must still span several leaves: had it collapsed to the inline SINGLE shape, that path force-emits
+		// the root (listChanged=true) and would mask the defect under test
+		assertTrue(isTimestampIndexPaged(), "The timestamp index must stay PAGED after the merge!");
+
+		// 3) reopen: the persisted root must no longer list the page the merge dropped, and that page's record must be
+		//    gone. Otherwise the cold load assembles leaf 0 (holding the absorbed keys) followed by the stale leaf 1,
+		//    whose first key now sorts *before* leaf 0's last key -> the cross-page overlap check fires.
+		this.evita.close();
+		this.evita = new Evita(configuration());
+		this.evita.waitUntilFullyInitialized();
+
+		assertTrue(isTimestampIndexPaged(), "The reloaded timestamp index must still be PAGED!");
+		assertSurvivingTimestampsResolve();
+	}
+
 	/**
 	 * Builds the per-test Evita configuration wired to the (stable across restarts) test path triplet.
 	 *
@@ -256,6 +348,81 @@ class FilterIndexPagedPersistenceTest implements EvitaTestSupport {
 	@Nonnull
 	private EvitaConfiguration configuration() {
 		return newTestEvitaConfigurationBuilder(this.paths).build();
+	}
+
+	/**
+	 * Produces a distinct, strictly ascending timestamp for the given primary key, mirroring the near-monotonic
+	 * near-unique timestamp stream a re-indexing job writes.
+	 *
+	 * @param pk the primary key (1-based)
+	 * @return a distinct timestamp; never null
+	 */
+	@Nonnull
+	private static OffsetDateTime timestamp(int pk) {
+		return BASE_TIMESTAMP.plusSeconds(pk);
+	}
+
+	/**
+	 * Reports whether the {@link io.evitadb.index.invertedIndex.InvertedIndex} backing {@link #ATTRIBUTE_TIMESTAMP}
+	 * currently uses the PAGED (granular) representation.
+	 *
+	 * @return {@code true} when the backing bucket tree is multi-leaf (PAGED)
+	 */
+	private boolean isTimestampIndexPaged() {
+		return timestampInvertedIndex().isPaged();
+	}
+
+	/**
+	 * Returns how many leaf pages the {@link #ATTRIBUTE_TIMESTAMP} bucket tree currently occupies on disk (the set the
+	 * last flush staged). A drop across a flush is the observable fingerprint of a leaf merge.
+	 *
+	 * @return the current on-disk leaf-page count
+	 */
+	private int timestampIndexLeafPageCount() {
+		return timestampInvertedIndex().currentLeafPageSequences().length;
+	}
+
+	/**
+	 * Resolves the {@link InvertedIndex} backing {@link #ATTRIBUTE_TIMESTAMP} in the global entity index.
+	 *
+	 * @return the backing inverted index; never null
+	 */
+	@Nonnull
+	private InvertedIndex timestampInvertedIndex() {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection = (EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		final EntityIndex globalIndex = collection.getIndexByKeyIfExists(new EntityIndexKey(EntityIndexType.GLOBAL));
+		assertNotNull(globalIndex, "Global entity index must exist!");
+		final FilterIndex filterIndex = globalIndex.getFilterIndex(new AttributeIndexKey(null, ATTRIBUTE_TIMESTAMP, null));
+		assertNotNull(filterIndex, "Filter index for the timestamp attribute must exist!");
+		return filterIndex.getInvertedIndex();
+	}
+
+	/**
+	 * Asserts that every timestamp that was not deleted still resolves to exactly the primary key it was written with,
+	 * and that the deleted ones resolve to nothing — the round-trip check across the merged leaf boundary.
+	 */
+	private void assertSurvivingTimestampsResolve() {
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				for (int pk = 1; pk <= TIMESTAMP_COUNT; pk++) {
+					final List<EntityReferenceContract> matches = session.queryListOfEntityReferences(
+						query(
+							collection(Entities.PRODUCT),
+							filterBy(attributeEquals(ATTRIBUTE_TIMESTAMP, timestamp(pk)))
+						)
+					);
+					if (DELETED_TIMESTAMP_PKS.contains(pk)) {
+						assertEquals(0, matches.size(), "Deleted timestamp of pk " + pk + " must match nothing!");
+					} else {
+						assertEquals(1, matches.size(), "Exactly one entity should match timestamp of pk " + pk);
+						assertEquals(pk, matches.get(0).getPrimaryKey(), "Wrong primary key for timestamp of pk " + pk);
+					}
+				}
+				return null;
+			}
+		);
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/storage/TransactionalMergeFlushFailureSuspendTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/storage/TransactionalMergeFlushFailureSuspendTest.java
@@ -1,0 +1,385 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.storage;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.SessionTraits;
+import io.evitadb.api.SessionTraits.SessionFlags;
+import io.evitadb.api.TransactionContract.CommitBehavior;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.requestResponse.data.EntityReferenceContract;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.core.Evita;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.exception.UnexpectedIOException;
+import io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.EntityIndexType;
+import io.evitadb.index.attribute.FilterIndex;
+import io.evitadb.index.invertedIndex.InvertedIndex;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.attributeEquals;
+import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.filterBy;
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.STORAGE;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The corruption-level counterpart to the mock-level {@code TransactionManagerSuspensionTest}: it drives the same
+ * merge-only flush the warm-up repro uses, but in the ALIVE (transactional) path, so a leaf merge is incorporated
+ * through a real trunk-incorporation flush against real persistence and then cold-reloaded from disk.
+ *
+ * The warm-up bug (a merge-only flush whose freed set is empty ⇒ the root is skipped over a stale page list) is fixed
+ * and covered. The remaining question this class exists to answer empirically is the transactional retry window: if a
+ * merge-only incorporation flush fails transiently, does a retry — running against the page baseline the failed flush
+ * left behind — reproduce the same overlapping-leaf-page corruption on disk, and does the suspend boundary close it?
+ *
+ * This first test pins the harness itself: a transactional leaf merge with NO injected failure must incorporate and
+ * cold-reload cleanly. Later tests build the injection on top of exactly this recipe.
+ *
+ * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(STORAGE)
+@Tag(ATTRIBUTE)
+@Tag(TRANSACTION)
+@DisplayName("Transactional merge-only flush failure must suspend, never corrupt the persisted page list")
+class TransactionalMergeFlushFailureSuspendTest implements EvitaTestSupport {
+
+	/** Filterable near-unique timestamp attribute — near-unique values give single-record buckets that a delete drops
+	 * outright, which is the shrink that forces a leaf merge (a low-cardinality attribute practically never merges). */
+	private static final String ATTRIBUTE_TIMESTAMP = "published";
+	/** Anchor for the strictly ascending timestamp stream a re-indexing job writes. */
+	private static final OffsetDateTime BASE_TIMESTAMP = OffsetDateTime.of(
+		2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC
+	);
+	/** 513 ascending values ⇒ four bucket-tree leaves [1..128], [129..256], [257..384], [385..513] at block size 256. */
+	private static final int TIMESTAMP_COUNT = 513;
+	/** The primary keys whose deletion forces leaf 0 to absorb leaf 1 via `mergeWithRight` (see the delete sequence). */
+	private static final Set<Integer> DELETED_TIMESTAMP_PKS = Set.of(1, 2, 129);
+
+	private TestPaths paths;
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() {
+		this.paths = createTestPaths("TransactionalMergeFlushFailureSuspend");
+		this.evita = new Evita(configuration());
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (this.evita != null && this.evita.isActive()) {
+			this.evita.close();
+		}
+		cleanupTestPaths(this.paths);
+	}
+
+	@Test
+	@DisplayName("a transactional leaf merge with no injected failure incorporates and cold-reloads cleanly")
+	void shouldIncorporateAndReloadATransactionalLeafMergeCleanly() {
+		warmUpToFourPagedLeavesAndGoLive();
+
+		// ALIVE now: force leaf 0 to merge leaf 1 through a real transaction, incorporated by the trunk-incorporation
+		// flush against real persistence (the warm-up repro does this same shrink, but on the warm-up path)
+		mergeLeafZeroTransactionally();
+
+		assertEquals(
+			3, timestampIndexLeafPageCount(),
+			"The transactional deletes must have merged a leaf away (four leaf pages -> three); if this still reports " +
+				"four, no merge happened and the test is not exercising the freed-page path."
+		);
+		assertTrue(isTimestampIndexPaged(), "The index must stay PAGED after the merge, not collapse to SINGLE.");
+		assertSurvivingTimestampsResolve();
+
+		// cold reload: the merged, now-three-leaf tree must reassemble from disk with no overlapping page and every
+		// surviving value resolving to its primary key
+		reopenEvita();
+		assertTrue(isTimestampIndexPaged(), "The reloaded index must still be PAGED after a cold load of the leaf pages.");
+		assertSurvivingTimestampsResolve();
+	}
+
+	@Test
+	@DisplayName("a transient flush failure on a transactional merge incorporation suspends, then recovers on reload")
+	void shouldSuspendThenRecoverWhenTransactionalMergeIncorporationFlushFailsTransiently() {
+		warmUpToFourPagedLeavesAndGoLive();
+
+		// arm the trunk-incorporation flush to fail exactly once at storeHeader: the point AFTER every collection has
+		// staged its next page baseline (collectChangedPages runs inside the preceding flushTrappedUpdates) but BEFORE
+		// the version is made durable - the "staged, not yet on disk" window the retry trace is about
+		final AtomicInteger storeHeaderAttempts = injectTransientStoreHeaderFailure();
+
+		// the merge transaction's incorporation now fails. Item 5 must suspend rather than retry, so the
+		// WAIT_FOR_CHANGES_VISIBLE commit completes exceptionally instead of hanging or spinning
+		assertThrows(
+			Exception.class,
+			this::mergeLeafZeroTransactionally,
+			"the merge commit must surface the failed incorporation, not hang or silently swallow it"
+		);
+		assertEquals(
+			1, storeHeaderAttempts.get(),
+			"the injected storeHeader failure must have fired exactly once (a transient failure, not a deterministic one)"
+		);
+
+		// reads keep being served from the last good version: the failed merge left the in-memory catalog at N-1, so
+		// every timestamp - including the ones the failed transaction tried to delete - still resolves
+		assertAllTimestampsPresent();
+
+		// reload: the delete transaction is durable in the WAL and replays on a fresh instance whose storeHeader is the
+		// real one (the injected failure lived only on the suspended instance), so the merge finally lands - and the
+		// persisted page list must be sound, NOT the overlapping-leaf-page corruption the retry trace warns about
+		reopenEvita();
+		assertEquals(3, timestampIndexLeafPageCount(), "the replayed merge must have dropped the tree to three leaves");
+		assertTrue(isTimestampIndexPaged(), "the reloaded index must still be PAGED, not collapsed or corrupt");
+		assertSurvivingTimestampsResolve();
+	}
+
+	/**
+	 * Warm-up bulk insert of {@link #TIMESTAMP_COUNT} ascending timestamps, flushed by go-live, leaving the timestamp
+	 * bucket tree laid out as four leaf pages before the catalog turns ALIVE.
+	 */
+	private void warmUpToFourPagedLeavesAndGoLive() {
+		this.evita.defineCatalog(TEST_CATALOG);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withAttribute(ATTRIBUTE_TIMESTAMP, OffsetDateTime.class, AttributeSchemaEditor::filterable)
+					.updateVia(session);
+				for (int pk = 1; pk <= TIMESTAMP_COUNT; pk++) {
+					session.upsertEntity(
+						session.createNewEntity(Entities.PRODUCT, pk)
+							.setAttribute(ATTRIBUTE_TIMESTAMP, timestamp(pk))
+					);
+				}
+				session.goLiveAndClose();
+			}
+		);
+		assertTrue(isTimestampIndexPaged(), "The timestamp index must be PAGED before the merge.");
+		assertEquals(
+			4, timestampIndexLeafPageCount(),
+			"Go-live must lay the bucket tree out as four leaf pages — the layout the deletes are calibrated against."
+		);
+	}
+
+	/**
+	 * Deletes exactly the three primary keys that force leaf 0 to underflow and absorb leaf 1 in place
+	 * (`mergeWithRight`) inside a single transaction, so the merge is incorporated by the trunk-incorporation flush.
+	 * The sequence mirrors the warm-up repro: bring the right sibling to the minimum so it cannot donate, then push
+	 * leaf 0 one below the minimum.
+	 */
+	private void mergeLeafZeroTransactionally() {
+		try (final EvitaSessionContract session = this.evita.createSession(
+			new SessionTraits(TEST_CATALOG, CommitBehavior.WAIT_FOR_CHANGES_VISIBLE, SessionFlags.READ_WRITE))) {
+			session.deleteEntity(Entities.PRODUCT, 129); // leaf 1: 128 -> 127 (== minimum, can no longer donate)
+			session.deleteEntity(Entities.PRODUCT, 1);   // leaf 0: 128 -> 127 (still at the minimum)
+			session.deleteEntity(Entities.PRODUCT, 2);   // leaf 0: 127 -> 126 -> underflow -> mergeWithRight
+		}
+	}
+
+	/**
+	 * Closes and reopens the whole Evita instance, forcing a cold load of the PAGED leaf pages from disk.
+	 */
+	private void reopenEvita() {
+		this.evita.close();
+		this.evita = new Evita(configuration());
+		this.evita.waitUntilFullyInitialized();
+	}
+
+	/**
+	 * Builds the per-test Evita configuration wired to the (stable across restarts) test path triplet.
+	 *
+	 * @return the configuration; never null
+	 */
+	@Nonnull
+	private EvitaConfiguration configuration() {
+		return newTestEvitaConfigurationBuilder(this.paths).build();
+	}
+
+	/**
+	 * Produces a distinct, strictly ascending timestamp for the given primary key.
+	 *
+	 * @param pk the primary key (1-based)
+	 * @return a distinct timestamp; never null
+	 */
+	@Nonnull
+	private static OffsetDateTime timestamp(int pk) {
+		return BASE_TIMESTAMP.plusSeconds(pk);
+	}
+
+	/**
+	 * Reports whether the {@link InvertedIndex} backing {@link #ATTRIBUTE_TIMESTAMP} currently uses the PAGED
+	 * representation.
+	 *
+	 * @return {@code true} when the backing bucket tree is multi-leaf (PAGED)
+	 */
+	private boolean isTimestampIndexPaged() {
+		return timestampInvertedIndex().isPaged();
+	}
+
+	/**
+	 * Returns how many leaf pages the {@link #ATTRIBUTE_TIMESTAMP} bucket tree currently occupies (the set the last
+	 * flush staged). A drop across a flush is the observable fingerprint of a leaf merge.
+	 *
+	 * @return the current live leaf-page count
+	 */
+	private int timestampIndexLeafPageCount() {
+		return timestampInvertedIndex().currentLeafPageSequences().length;
+	}
+
+	/**
+	 * Resolves the {@link InvertedIndex} backing {@link #ATTRIBUTE_TIMESTAMP} in the global entity index.
+	 *
+	 * @return the backing inverted index; never null
+	 */
+	@Nonnull
+	private InvertedIndex timestampInvertedIndex() {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection =
+			(EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		final EntityIndex globalIndex = collection.getIndexByKeyIfExists(new EntityIndexKey(EntityIndexType.GLOBAL));
+		assertNotNull(globalIndex, "Global entity index must exist!");
+		final FilterIndex filterIndex = globalIndex.getFilterIndex(new AttributeIndexKey(null, ATTRIBUTE_TIMESTAMP, null));
+		assertNotNull(filterIndex, "Filter index for the timestamp attribute must exist!");
+		return filterIndex.getInvertedIndex();
+	}
+
+	/**
+	 * Asserts that every timestamp that was not deleted still resolves to exactly the primary key it was written with,
+	 * and that the deleted ones resolve to nothing — the round-trip check across the merged leaf boundary.
+	 */
+	private void assertSurvivingTimestampsResolve() {
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				for (int pk = 1; pk <= TIMESTAMP_COUNT; pk++) {
+					final List<EntityReferenceContract> matches = session.queryListOfEntityReferences(
+						query(
+							collection(Entities.PRODUCT),
+							filterBy(attributeEquals(ATTRIBUTE_TIMESTAMP, timestamp(pk)))
+						)
+					);
+					if (DELETED_TIMESTAMP_PKS.contains(pk)) {
+						assertEquals(0, matches.size(), "Deleted timestamp of pk " + pk + " must match nothing!");
+					} else {
+						assertEquals(1, matches.size(), "Exactly one entity should match timestamp of pk " + pk);
+						assertEquals(pk, matches.get(0).getPrimaryKey(), "Wrong primary key for timestamp of pk " + pk);
+					}
+				}
+				return null;
+			}
+		);
+	}
+
+	/**
+	 * Asserts that every timestamp still resolves to its primary key — the read-side check that a suspended catalog
+	 * keeps serving the last good version, with the failed transaction's deletes never applied.
+	 */
+	private void assertAllTimestampsPresent() {
+		this.evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				for (int pk = 1; pk <= TIMESTAMP_COUNT; pk++) {
+					final List<EntityReferenceContract> matches = session.queryListOfEntityReferences(
+						query(
+							collection(Entities.PRODUCT),
+							filterBy(attributeEquals(ATTRIBUTE_TIMESTAMP, timestamp(pk)))
+						)
+					);
+					assertEquals(
+						1, matches.size(),
+						"A suspended catalog must still serve pk " + pk + " from the last good version."
+					);
+					assertEquals(pk, matches.get(0).getPrimaryKey(), "Wrong primary key for timestamp of pk " + pk);
+				}
+				return null;
+			}
+		);
+	}
+
+	/**
+	 * Wraps the live catalog's {@link CatalogPersistenceService} in a delegating proxy that throws once from
+	 * {@code storeHeader} — the trunk-incorporation write that follows every collection's page-baseline staging — and
+	 * delegates every other call to the real service. The proxy rides the persistence service by reference into the
+	 * next transactional catalog copy, so it is in force for the merge transaction incorporated next.
+	 *
+	 * @return the counter of {@code storeHeader} attempts that reached the proxy (one failure, then pass-through)
+	 */
+	@Nonnull
+	private AtomicInteger injectTransientStoreHeaderFailure() {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final AtomicInteger attempts = new AtomicInteger();
+		try {
+			final Field field = Catalog.class.getDeclaredField("persistenceService");
+			field.setAccessible(true);
+			final CatalogPersistenceService<?, ?, ?> real = (CatalogPersistenceService<?, ?, ?>) field.get(catalog);
+			final CatalogPersistenceService<?, ?, ?> poisoned = (CatalogPersistenceService<?, ?, ?>) Proxy.newProxyInstance(
+				CatalogPersistenceService.class.getClassLoader(),
+				new Class<?>[]{CatalogPersistenceService.class},
+				(proxy, method, args) -> {
+					if ("storeHeader".equals(method.getName()) && attempts.getAndIncrement() == 0) {
+						throw new UnexpectedIOException(
+							"Injected transient store-header failure", "The catalog header could not be written."
+						);
+					}
+					try {
+						return method.invoke(real, args);
+					} catch (InvocationTargetException ex) {
+						throw ex.getCause();
+					}
+				}
+			);
+			field.set(catalog, poisoned);
+		} catch (ReflectiveOperationException ex) {
+			throw new IllegalStateException("Failed to inject the transient storeHeader failure", ex);
+		}
+		return attempts;
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/buffer/WarmUpDataStoreMemoryBufferPoisonTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/buffer/WarmUpDataStoreMemoryBufferPoisonTest.java
@@ -1,0 +1,135 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.buffer;
+
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.spi.store.catalog.persistence.StorageDescriptor;
+import io.evitadb.spi.store.catalog.persistence.StoragePartPersistenceService;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.STORAGE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that a {@link WarmUpDataStoreMemoryBuffer} whose flush failed refuses to serve any later flush.
+ *
+ * A warm-up collect is DESTRUCTIVE: {@code popTrappedChanges} hands the trapped parts out and simultaneously advances
+ * every index's change-detection baseline, all BEFORE the write is attempted. If that write then fails, the popped
+ * parts are gone — no later flush will re-collect them, because every baseline already says "already persisted". A
+ * buffer that kept serving after such a failure would therefore silently write a catalog that is missing data it
+ * believes it stored. Poisoning makes that state refuse loudly instead.
+ *
+ * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(ENGINE)
+@Tag(STORAGE)
+@DisplayName("Warm-up data-store buffer poisoning after a failed flush")
+class WarmUpDataStoreMemoryBufferPoisonTest {
+
+	/**
+	 * Creates a throwaway persistence-service stub — the trapped-change paths under test never reach it.
+	 *
+	 * @return a Mockito stub of the persistence service
+	 */
+	@Nonnull
+	@SuppressWarnings("unchecked")
+	private static StoragePartPersistenceService<StorageDescriptor> mockPersistenceService() {
+		return Mockito.mock(StoragePartPersistenceService.class);
+	}
+
+	/**
+	 * Creates a {@link StoragePart} stub identified by the given primary key — the trapped-change map stores it purely
+	 * by reference and keys it by that pk.
+	 *
+	 * @param storagePartPk the primary key the stub reports
+	 * @return a {@link StoragePart} stub
+	 */
+	@Nonnull
+	private static StoragePart storagePartStub(long storagePartPk) {
+		final StoragePart part = Mockito.mock(StoragePart.class);
+		Mockito.when(part.getStoragePartPKOrElseThrowException()).thenReturn(storagePartPk);
+		return part;
+	}
+
+	@Test
+	@DisplayName("hands the trapped parts out exactly once, so a failed write can never re-collect them")
+	void shouldPopTrappedChangesDestructively() {
+		final WarmUpDataStoreMemoryBuffer buffer = new WarmUpDataStoreMemoryBuffer(mockPersistenceService());
+		buffer.trapUpdate(0L, storagePartStub(1L));
+
+		assertEquals(1, buffer.popTrappedChanges().getTrappedChangesCount(), "the flush must collect the trapped part");
+		assertEquals(
+			0, buffer.popTrappedChanges().getTrappedChangesCount(),
+			"pop is destructive — this is WHY a failed flush must poison the buffer: the parts it popped are gone, so " +
+				"a second flush would happily persist a catalog that silently lost them"
+		);
+	}
+
+	@Test
+	@DisplayName("refuses every later collect once a failed flush has poisoned it")
+	void shouldRefuseToPopOnceAFailedFlushHasPoisonedTheBuffer() {
+		final WarmUpDataStoreMemoryBuffer buffer = new WarmUpDataStoreMemoryBuffer(mockPersistenceService());
+		buffer.trapUpdate(0L, storagePartStub(1L));
+
+		// the flush collects the parts (destructively) and then its write fails
+		buffer.popTrappedChanges();
+		buffer.poison(new IOException("no space left on device"));
+
+		// a later session traps more changes and closes: the collect must refuse rather than persist a catalog whose
+		// baselines claim the lost parts were already written
+		buffer.trapUpdate(0L, storagePartStub(2L));
+		final GenericEvitaInternalError error = assertThrows(
+			GenericEvitaInternalError.class,
+			buffer::popTrappedChanges,
+			"a poisoned buffer must refuse to collect, never silently proceed"
+		);
+		assertSame(
+			IOException.class, error.getCause().getClass(),
+			"the refusal must carry the original flush failure as its cause, so the operator sees what actually broke"
+		);
+	}
+
+	@Test
+	@DisplayName("refuses deterministically — every subsequent collect fails the same way, never just the first")
+	void shouldRefuseDeterministicallyOnEveryLaterCollect() {
+		final WarmUpDataStoreMemoryBuffer buffer = new WarmUpDataStoreMemoryBuffer(mockPersistenceService());
+		buffer.poison(new IOException("no space left on device"));
+
+		assertThrows(GenericEvitaInternalError.class, buffer::popTrappedChanges, "the first later collect must refuse");
+		assertThrows(
+			GenericEvitaInternalError.class, buffer::popTrappedChanges,
+			"poisoning is terminal: a retry must never be allowed to slip through"
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/TransactionManagerSuspensionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/TransactionManagerSuspensionTest.java
@@ -1,0 +1,333 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.transaction;
+
+import io.evitadb.api.CommitProgress.CommitVersions;
+import io.evitadb.api.CommitProgressRecord;
+import io.evitadb.api.configuration.ChangeDataCaptureOptions;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.configuration.ServerOptions;
+import io.evitadb.api.requestResponse.mutation.CatalogBoundMutation;
+import io.evitadb.api.requestResponse.schema.SealedCatalogSchema;
+import io.evitadb.api.requestResponse.transaction.TransactionMutation;
+import io.evitadb.core.Evita;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.executor.ObservableExecutorService;
+import io.evitadb.core.executor.Scheduler;
+import io.evitadb.core.transaction.TransactionManager.CatalogSuspension;
+import io.evitadb.core.transaction.TransactionManager.ProcessResult;
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.exception.UnexpectedIOException;
+import io.evitadb.spi.store.catalog.wal.IsolatedWalPersistenceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pins the suspension contract of {@link TransactionManager}: once a trunk incorporation has failed at or after the
+ * point where it began collecting and writing, the catalog must stop processing transactions rather than retry.
+ *
+ * The failure is driven through a real thrown flush rather than by calling {@link TransactionManager#suspend} directly,
+ * because the behaviour that has to be pinned is not the existence of a suspension — it is that the catalog **does not
+ * try again**. A retry re-runs the flush against the page baselines the failed attempt already advanced, which is how
+ * a transient write failure turns into a corrupt catalog on disk; and when the failure is deterministic instead, the
+ * retry merely spins forever. The retry has no good case. Suspending stops the write path while leaving readers alone,
+ * which is the whole point: the in-memory catalog is still correct, only its persisted image is not.
+ *
+ * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("TransactionManager — suspension after a failed transaction incorporation")
+@Tag(ENGINE)
+@Tag(TRANSACTION)
+class TransactionManagerSuspensionTest {
+	private static final String CATALOG_NAME = "suspensionCatalog";
+	private static final long INITIAL_VERSION = 10L;
+	/** The version of the single transaction waiting in the WAL — the one whose incorporation is made to fail. */
+	private static final long FAILING_VERSION = INITIAL_VERSION + 1;
+
+	private Catalog catalog;
+	private TransactionManager transactionManager;
+
+	/**
+	 * Builds the transaction mutation the WAL hands out. It carries no mutations of its own: the replay loop is bounded
+	 * by {@code getMutationCount()}, so an empty transaction replays trivially and lets the drain reach the flush —
+	 * which is the only part of the pipeline these tests are about.
+	 *
+	 * @return a fresh, empty transaction mutation at {@link #FAILING_VERSION}
+	 */
+	@Nonnull
+	private static CatalogBoundMutation transactionMutation() {
+		return new TransactionMutation(UUID.randomUUID(), FAILING_VERSION, 0, 0L, OffsetDateTime.now());
+	}
+
+	@BeforeEach
+	void setUp() {
+		final SealedCatalogSchema catalogSchema = mock(SealedCatalogSchema.class);
+		when(catalogSchema.version()).thenReturn(1);
+		when(catalogSchema.getConflictResolution()).thenReturn(Optional.empty());
+
+		this.catalog = mock(Catalog.class);
+		when(this.catalog.getName()).thenReturn(CATALOG_NAME);
+		when(this.catalog.getVersion()).thenReturn(INITIAL_VERSION);
+		when(this.catalog.getSchema()).thenReturn(catalogSchema);
+		when(this.catalog.getLastCatalogVersionInMutationStream()).thenReturn(INITIAL_VERSION);
+		when(this.catalog.getFirstCatalogVersionInMutationStream()).thenReturn(INITIAL_VERSION);
+		when(this.catalog.getEntitySchema(anyString())).thenReturn(Optional.empty());
+		// a fresh stream per call - a Stream is single-use, and what happens on the SECOND drain is the whole subject
+		// of these tests, so handing out an already-consumed one would fake the very result being asserted
+		when(this.catalog.getCommittedLiveMutationStream(anyLong(), anyLong()))
+			.thenAnswer(invocation -> Stream.of(transactionMutation()));
+
+		final EvitaConfiguration configuration = EvitaConfiguration.builder()
+			.server(
+				ServerOptions.builder()
+					.changeDataCapture(ChangeDataCaptureOptions.builder().enabled(false).build())
+					.build()
+			)
+			.build();
+		final Evita evita = mock(Evita.class);
+		when(evita.getConfiguration()).thenReturn(configuration);
+
+		final ObservableExecutorService synchronousExecutor = mock(ObservableExecutorService.class);
+		doAnswer(invocation -> {
+			((Runnable) invocation.getArgument(0)).run();
+			return null;
+		}).when(synchronousExecutor).execute(any(Runnable.class));
+
+		this.transactionManager = new TransactionManager(
+			this.catalog,
+			evita,
+			mock(Scheduler.class),
+			synchronousExecutor,
+			synchronousExecutor,
+			newCatalog -> {
+			},
+			INITIAL_VERSION
+		);
+	}
+
+	/**
+	 * Drains the write-ahead log exactly the way the trunk-incorporation task does.
+	 *
+	 * @return the process result, empty when the drain did nothing
+	 */
+	@Nonnull
+	private Optional<ProcessResult> drain() {
+		return this.transactionManager.processTransactions(
+			FAILING_VERSION, 1_000L, true, false, version -> {
+			}
+		);
+	}
+
+	/**
+	 * Arms the catalog's flush to fail the way a full disk would, counting every attempt that reaches it.
+	 *
+	 * @return the counter of flush attempts
+	 */
+	@Nonnull
+	private AtomicInteger armFailingFlush() {
+		final AtomicInteger flushAttempts = new AtomicInteger();
+		doAnswer(invocation -> {
+			flushAttempts.incrementAndGet();
+			throw new UnexpectedIOException(
+				"no space left on device", "The catalog could not be written to disk."
+			);
+		}).when(this.catalog).flush(anyLong(), any());
+		return flushAttempts;
+	}
+
+	@Test
+	@DisplayName("never attempts an incorporation whose flush failed a second time")
+	void shouldNeverRetryTheIncorporationWhoseFlushFailed() {
+		final AtomicInteger flushAttempts = armFailingFlush();
+
+		assertThrows(
+			UnexpectedIOException.class, this::drain,
+			"self-check: the drain must get all the way to the flush and fail there, not somewhere earlier"
+		);
+		assertEquals(1, flushAttempts.get(), "self-check: the first drain must have reached the flush exactly once");
+
+		// the draining task is rescheduled by every freshly appended transaction, entirely independently of the path
+		// that just failed - so the gate has to stop the drain STARTING, and it has to do so by returning empty rather
+		// than throwing, or the task would reschedule itself forever instead of pausing
+		assertTrue(drain().isEmpty(), "a drain after a failed incorporation must do nothing at all");
+		assertEquals(
+			1, flushAttempts.get(),
+			"the failed incorporation must never be attempted again: the second flush would diff its page baselines " +
+				"against the ones the failed flush already advanced, which is exactly what corrupts the catalog"
+		);
+	}
+
+	@Test
+	@DisplayName("still retries a failure that happened before the collect began, and does not suspend")
+	void shouldKeepRetryingWhenTheFailureHappenedBeforeTheCollectBegan() {
+		// a replay failure strikes before a single byte is written and before any page baseline moves, so it leaves
+		// nothing behind for a later flush to diff against - it stays safely retryable, and taking the catalog down
+		// for it would turn a recoverable hiccup into an outage
+		doThrow(new GenericEvitaInternalError("the write-ahead log tail could not be read"))
+			.when(this.catalog).setVersion(anyLong());
+
+		assertThrows(GenericEvitaInternalError.class, this::drain);
+
+		assertTrue(
+			this.transactionManager.getSuspension().isEmpty(),
+			"a pre-collect failure must not suspend: the scope is positional (where it failed), never by exception type"
+		);
+		assertThrows(
+			GenericEvitaInternalError.class, this::drain,
+			"...and the catalog must still be willing to try again - the gate must not have closed on it"
+		);
+	}
+
+	@Test
+	@DisplayName("reports a pre-durability failure as leaving disk intact at the version still being served")
+	void shouldReportAPreDurabilityFailureWithTheVersionPair() {
+		armFailingFlush();
+		// nothing was ever persisted, so the flush threw before its bytes landed
+		when(this.catalog.getLastPersistedCatalogVersion()).thenReturn(INITIAL_VERSION);
+
+		assertThrows(UnexpectedIOException.class, this::drain);
+
+		final CatalogSuspension suspension = this.transactionManager.getSuspension().orElseThrow();
+		assertEquals(
+			FAILING_VERSION, suspension.failedCatalogVersion(),
+			"the operator needs the version whose incorporation failed"
+		);
+		assertEquals(
+			INITIAL_VERSION, suspension.servingCatalogVersion(),
+			"...paired with the version readers are still being served, which tells reload apart from restore"
+		);
+		assertFalse(
+			suspension.durable(),
+			"the write never landed, so disk is still at the serving version and a reload recovers cleanly"
+		);
+		assertInstanceOf(
+			UnexpectedIOException.class, suspension.cause(),
+			"the suspension must carry the failure that actually broke it, so the alert can name the cause"
+		);
+	}
+
+	@Test
+	@DisplayName("reports a post-durability failure as leaving a suspect version on disk")
+	void shouldReportAPostDurabilityFailureWithTheVersionPair() {
+		armFailingFlush();
+		// the failing version reached disk before the incorporation broke down - the asymmetric, worse case: memory
+		// serves N-1 while disk holds a suspect N, so a reload lands ON the suspect version rather than away from it
+		when(this.catalog.getLastPersistedCatalogVersion()).thenReturn(FAILING_VERSION);
+
+		assertThrows(UnexpectedIOException.class, this::drain);
+
+		final CatalogSuspension suspension = this.transactionManager.getSuspension().orElseThrow();
+		assertTrue(
+			suspension.durable(),
+			"the failing version is already on disk: this is restore/repair territory, not a reload"
+		);
+		assertEquals(FAILING_VERSION, suspension.failedCatalogVersion());
+		assertEquals(INITIAL_VERSION, suspension.servingCatalogVersion());
+	}
+
+	@Test
+	@DisplayName("keeps the first failure, because later ones are merely its consequence")
+	void shouldKeepTheFirstFailure() {
+		// suspend() is called directly here on purpose: once suspended the gate turns every later drain away, so
+		// a second failure can only ever arrive from a drain that was already in flight when the first one suspended
+		final IOException firstCause = new IOException("no space left on device");
+		this.transactionManager.suspend(firstCause, false, FAILING_VERSION);
+		this.transactionManager.suspend(new IOException("a later, derived failure"), true, FAILING_VERSION + 4);
+
+		final CatalogSuspension suspension = this.transactionManager.getSuspension().orElseThrow();
+		assertEquals(
+			firstCause, suspension.cause(),
+			"the FIRST failure is the one that describes what actually broke; later ones are its consequence"
+		);
+		assertEquals(
+			FAILING_VERSION, suspension.failedCatalogVersion(),
+			"the version pair must describe the original failure, not the derived one"
+		);
+	}
+
+	@Test
+	@DisplayName("refuses a fresh commit at acceptance instead of parking it on a pipeline that will never run")
+	void shouldRefuseFreshCommitsOnceSuspended() {
+		armFailingFlush();
+		assertThrows(UnexpectedIOException.class, this::drain);
+
+		final CommitProgressRecord commitProgress = new CommitProgressRecord();
+		this.transactionManager.commit(
+			INITIAL_VERSION,
+			UUID.randomUUID(),
+			0,
+			mock(IsolatedWalPersistenceService.class),
+			commitProgress
+		);
+
+		assertTrue(
+			commitProgress.onConflictResolved().toCompletableFuture().isCompletedExceptionally(),
+			"a suspended catalog must refuse a new write immediately, never leave the client waiting on it"
+		);
+	}
+
+	@Test
+	@DisplayName("fails a commit already parked on the pipeline when the catalog suspends, so no client hangs")
+	void shouldFailACommitAlreadyParkedOnThePipelineWhenSuspended() {
+		// a commit accepted before the failure sits parked on the visibility stage, waiting for an incorporation the
+		// pipeline will now never run - refusing fresh commits does not cover it, only draining the registry does
+		final CommitProgressRecord parked = new CommitProgressRecord();
+		this.transactionManager.registerPendingCommitProgress(
+			FAILING_VERSION, parked, new CommitVersions(FAILING_VERSION, 1)
+		);
+		assertFalse(
+			parked.onChangesVisible().toCompletableFuture().isDone(),
+			"self-check: the parked record must still be in flight before the suspension"
+		);
+
+		this.transactionManager.suspend(new IOException("no space left on device"), false, FAILING_VERSION);
+
+		assertTrue(
+			parked.onChangesVisible().toCompletableFuture().isCompletedExceptionally(),
+			"a commit parked on a pipeline that will never run again must be completed exceptionally in bounded time, " +
+				"never left waiting"
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/HistogramIndexLoaderPagingRoundTripTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/HistogramIndexLoaderPagingRoundTripTest.java
@@ -415,6 +415,89 @@ class HistogramIndexLoaderPagingRoundTripTest implements EvitaTestSupport {
 		}
 
 		@Test
+		@DisplayName("collapsing PAGED -> SINGLE across two warm-up flushes still removes every prior bucket leaf page")
+		void shouldRemovePriorLeafPagesWhenCollapsingAcrossTwoWarmUpFlushesWithoutAnIntermediateReload() {
+			// the sibling test above collapses a RELOADED index, whose page baseline the loader restored from disk. A
+			// warm-up catalog never reloads and never reaches a commit-merge — the only place the staged page set is
+			// published — so its collapse must reclaim against the set the previous flush STAGED, not the published one.
+			final SimpleHistogramIndex source = pagedSource();
+
+			// first warm-up flush: stages every bucket leaf page, publishes nothing
+			final List<StoragePart> firstEmission = emit(source);
+			final int priorLeafPageCount = leafPages(firstEmission).size();
+			assertTrue(priorLeafPageCount >= 3, "the source histogram must start paged across several leaves");
+
+			// collapse the SAME in-memory index: drop all but a handful of buckets so the survivors fit a single leaf
+			for (int i = COLLAPSE_KEEP + 1; i <= VALUE_COUNT; i++) {
+				source.removeValue(null, i, i);
+			}
+
+			final List<StoragePart> secondEmission = emit(source);
+			assertFalse(
+				histogramRoot(secondEmission).isPaged(),
+				"the collapsed histogram must emit a single inline (SINGLE) root"
+			);
+			assertEquals(
+				0, leafPages(secondEmission).size(),
+				"a collapsed histogram must not re-emit any bucket leaf page"
+			);
+			assertEquals(
+				priorLeafPageCount, leafPageRemovals(secondEmission).size(),
+				"the collapse must remove every leaf page the previous warm-up flush wrote — the append-only OffsetIndex " +
+					"never reclaims a record that is neither superseded nor explicitly removed, so a missed removal leaks " +
+					"the page forever"
+			);
+		}
+
+		@Test
+		@DisplayName("collapsing a range-typed PAGED -> SINGLE across two warm-up flushes removes every prior RANGE leaf page")
+		void shouldRemovePriorRangeLeafPagesWhenCollapsingAcrossTwoWarmUpFlushesWithoutAnIntermediateReload() {
+			// the bucket-axis sibling above pins this defect on the BUCKET page stream; a range-typed histogram pages a
+			// SECOND, independent stream (the RangeIndex threshold tree) whose collapse site must reclaim against the
+			// same staged-not-published set — a warm-up catalog never reloads and never reaches the commit-merge that
+			// publishes, so a published-set reclaim would free NOTHING and leak every range page ever written.
+			final SimpleHistogramIndex source = pagedRangeSource();
+
+			// first warm-up flush: stages every bucket AND range leaf page, publishes nothing
+			final List<StoragePart> firstEmission = emit(source);
+			final HistogramIndexStoragePart firstRoot = histogramRoot(firstEmission);
+			assertTrue(firstRoot.isPaged(), "the source histogram must start with a paged bucket axis");
+			assertTrue(firstRoot.isRangePaged(), "the source histogram must start with a paged range axis");
+			final int priorBucketPageCount = leafPages(firstEmission).size();
+			final int priorRangePageCount = rangeLeafPages(firstEmission).size();
+			assertTrue(priorBucketPageCount >= 3, "the bucket axis must start paged across several leaves");
+			assertTrue(priorRangePageCount >= 3, "the range axis must start paged across several leaves");
+			assertEquals(0, leafPageRemovals(firstEmission).size(), "a first flush frees no leaf page");
+
+			// collapse the SAME in-memory index: drop all but a handful of ranges. The survivors' values fit a single
+			// bucket leaf and their thresholds a single range leaf, so BOTH axes fall back to the inline SINGLE shape
+			// and NEITHER re-enters the paged branch (which would publish the staged set instead of reclaiming it).
+			for (int i = COLLAPSE_KEEP + 1; i <= VALUE_COUNT; i++) {
+				source.removeValue(null, IntegerNumberRange.between(i, i + 1), i);
+			}
+
+			final List<StoragePart> secondEmission = emit(source);
+			final HistogramIndexStoragePart collapsedRoot = histogramRoot(secondEmission);
+			assertFalse(collapsedRoot.isRangePaged(), "the collapsed range axis must be carried inline (SINGLE)");
+			assertFalse(collapsedRoot.isPaged(), "the collapsed bucket axis must be carried inline (SINGLE)");
+			assertEquals(
+				0, rangeLeafPages(secondEmission).size(),
+				"a collapsed range axis must not re-emit any range leaf page"
+			);
+			assertEquals(
+				priorRangePageCount, leafPageRemovalsOfKind(secondEmission, StreamKind.RANGE).size(),
+				"the collapse must remove every RANGE leaf page the previous warm-up flush wrote — the append-only " +
+					"OffsetIndex never reclaims a record that is neither superseded nor explicitly removed, so a missed " +
+					"removal leaks the page forever"
+			);
+			assertEquals(
+				priorBucketPageCount, leafPageRemovalsOfKind(secondEmission, StreamKind.BUCKET).size(),
+				"the same collapse must reclaim the bucket axis' own prior leaf pages — the two page streams are " +
+					"independent and each has to free its own"
+			);
+		}
+
+		@Test
 		@DisplayName("collapsing PAGED -> SINGLE removes every prior bucket leaf page and carries the buckets inline")
 		void shouldRemovePriorLeafPagesAndCarryInlineWhenCollapsingFromPagedToSingle() {
 			final OffsetIndex offsetIndex = openWritableOffsetIndex();
@@ -932,6 +1015,22 @@ class HistogramIndexLoaderPagingRoundTripTest implements EvitaTestSupport {
 		);
 		for (int i = 1; i <= VALUE_COUNT; i++) {
 			source.insertValue(null, i, i);
+		}
+		return source;
+	}
+
+	/**
+	 * Builds a fresh non-localized RANGE-typed histogram paged on BOTH axes: one distinct range per owner pages the
+	 * bucket axis, while each range's two thresholds page the range axis. Consecutive ranges deliberately abut
+	 * (`[i, i+1]`, `[i+1, i+2]`) so they share a threshold, exactly as the range-typed reload test's source does.
+	 */
+	@Nonnull
+	private static SimpleHistogramIndex pagedRangeSource() {
+		final SimpleHistogramIndex source = new SimpleHistogramIndex(
+			HISTOGRAM_NAME, REFERENCE_NAME, IntegerNumberRange.class, 0
+		);
+		for (int i = 1; i <= VALUE_COUNT; i++) {
+			source.insertValue(null, IntegerNumberRange.between(i, i + 1), i);
 		}
 		return source;
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ChainIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/ChainIndexTest.java
@@ -2710,6 +2710,52 @@ class ChainIndexTest {
 			assertZeroEmission(reloaded);
 		}
 
+		@Test
+		@DisplayName(
+			"a leaf dropped by one warm-up flush and never published before the next warm-up flush still reports " +
+				"the removal and re-emits the changed PAGED root"
+		)
+		void shouldReportFreedLeafPagesWhenTwoWarmUpFlushesRunBackToBackWithoutAnIntermediatePublish() {
+			// every other test in this nested class models a "commit" as flush + store.reload(...): the reload rebuilds
+			// the index via ChainIndex#fromPersistedPages, which reseeds the page-stream registry from scratch and so
+			// incidentally sidesteps the very bug this test targets. A warm-up (bulk-load) flush never goes through a
+			// reload or a transactional commit-merge (see ChainIndex#createCopyWithMergedTransactionalMemory, the only
+			// place that publishes a staged page set) - appendStorageParts() is simply called again, flush after flush,
+			// directly on the SAME instance. This test reproduces exactly that: two flushes back to back, no reload (and
+			// therefore no publish) in between.
+			final AttributeIndexKey key = new AttributeIndexKey(null, "warm-up-merge", null);
+			final ChainIndex big = new ChainIndex(key);
+			appendConsecutiveChain(big, 1, 3200); // > 3 leaves (leafCapacity = 1024)
+
+			final ChainStore store = new ChainStore();
+			// FIRST warm-up flush: stages the live leaf-page set (never published).
+			store.flush(big);
+			assertTrue(store.root.isPaged(), "a >3-page chain must persist as PAGED");
+			final int[] pagesBeforeShrink = store.root.getPageSequencesOrThrowException();
+			assertTrue(pagesBeforeShrink.length >= 3, "the chain must span at least three live leaf pages");
+
+			// shrink from the TAIL so the chain stays ONE consistent chain (1 -> 2 -> ... -> 1300) yet empties and drops
+			// its trailing leaf pages - the same mutation the mid-life-shrink test above uses, proven to free at least
+			// one leaf page while staying comfortably above one leaf (root stays PAGED); applied directly to `big`
+			// (not a reloaded copy) so nothing publishes the first flush's staged baseline in between
+			for (int pk = 3200; pk >= 1301; pk--) {
+				big.removePredecessor(pk);
+			}
+			// SECOND warm-up flush: collects again on the very same instance with the first flush's set still staged.
+			store.flush(big);
+
+			assertTrue(store.root.isPaged(), "1300 elements still span more than one leaf, so the root must stay PAGED");
+			assertTrue(
+				store.lastRemovalCount > 0,
+				"the leaf page the shrink dropped must be reported as freed, not silently kept on the persisted root!"
+			);
+			final int[] pagesAfterShrink = store.root.getPageSequencesOrThrowException();
+			assertTrue(
+				pagesAfterShrink.length < pagesBeforeShrink.length,
+				"the persisted root must be re-emitted to reflect the drop, not skipped as unchanged!"
+			);
+		}
+
 		/**
 		 * Appends a consecutive head-first chain `fromPk -> fromPk+1 -> … -> toPk` to `idx` (pk 1 is the head; every other
 		 * pk follows its immediate predecessor), one {@link ChainIndex#upsertPredecessor} per element.

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexPagedCollapseEmissionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/FilterIndexPagedCollapseEmissionTest.java
@@ -1,0 +1,299 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.attribute;
+
+import io.evitadb.core.buffer.TrappedChanges;
+import io.evitadb.dataType.IntegerNumberRange;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.FilterIndexLeafPagePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.FilterIndexLeafPageRemoval;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.FilterIndexStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.RangeIndexLeafPagePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.RangeIndexLeafPageRemoval;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.FILTER;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.STORAGE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the `PAGED -> SINGLE` collapse reclaim of {@link FilterIndex} in the WARM-UP shape — two consecutive flushes of
+ * the SAME in-memory index with NO intermediate reload.
+ *
+ * A large filter index persists as one storage-part record per bucket / range B+ tree leaf page (`PAGED`); a small one
+ * is carried inline on the root (`SINGLE`). When a `PAGED` axis shrinks enough to fall back to `SINGLE` it must emit a
+ * removal for EVERY leaf page it previously wrote: the append-only `OffsetIndex` never reclaims a record that is
+ * neither superseded nor explicitly removed, and the collapsed `SINGLE` root references none of them — so a missed
+ * removal leaks that page forever.
+ *
+ * The reclaim must therefore be computed against the set the previous flush left ON DISK
+ * ({@link io.evitadb.index.invertedIndex.InvertedIndex#currentLeafPageSequences()} /
+ * {@link io.evitadb.index.range.RangeIndex#currentLeafPageSequences()} — the staged-or-published set), NOT against the
+ * published live set alone. Publishing only happens at a transactional commit-merge, so in a warming-up catalog nothing
+ * ever publishes and a published-set reclaim frees NOTHING.
+ *
+ * This is the gap a reload-based collapse test cannot see: reassembling an index through the real loader seeds the
+ * live-page baseline from disk (`PageStreamRegistry.restoredFrom(...)`), so the published set happens to be correct
+ * there and such a test stays green either way. The warm-up shape below never reloads, which is exactly what makes it
+ * discriminating. Sibling coverage for the histogram page streams lives in `HistogramIndexLoaderPagingRoundTripTest`.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("FilterIndex PAGED -> SINGLE collapse reclaims every prior leaf page across two warm-up flushes")
+@Tag(INDEXING)
+@Tag(STORAGE)
+@Tag(ATTRIBUTE)
+@Tag(FILTER)
+class FilterIndexPagedCollapseEmissionTest {
+	private static final int ENTITY_INDEX_PK = 7;
+	/** > 1 leaf page on both axes, so the index pages out across several leaves (mirrors the histogram suite). */
+	private static final int VALUE_COUNT = 3200;
+	/** Survivors kept after the `PAGED -> SINGLE` collapse; a handful of values fit inside a single leaf. */
+	private static final int COLLAPSE_KEEP = 12;
+	private static final AttributeIndexKey BUCKET_ATTRIBUTE_KEY = new AttributeIndexKey(null, "code", null);
+	private static final AttributeIndexKey RANGE_ATTRIBUTE_KEY = new AttributeIndexKey(null, "validity", null);
+
+	@Nested
+	@DisplayName("Bucket axis")
+	class BucketAxisCollapse {
+
+		@Test
+		@DisplayName("collapsing across two warm-up flushes still removes every prior bucket leaf page")
+		void shouldRemovePriorBucketLeafPagesWhenCollapsingAcrossTwoWarmUpFlushesWithoutAnIntermediateReload() {
+			final OwnerFilterIndex index = pagedBucketSource();
+
+			// first warm-up flush: stages every bucket leaf page, publishes nothing (no commit-merge ever runs)
+			final List<StoragePart> firstEmission = emit(index);
+			final FilterIndexStoragePart firstRoot = filterRoot(firstEmission);
+			assertTrue(firstRoot.isPaged(), "the source filter index must start with a paged bucket axis");
+			final int priorLeafPageCount = bucketLeafPages(firstEmission).size();
+			assertTrue(priorLeafPageCount >= 3, "the bucket axis must start paged across several leaves");
+			assertEquals(
+				0, bucketLeafPageRemovals(firstEmission).size(), "a first flush frees no bucket leaf page"
+			);
+
+			// collapse the SAME in-memory index: drop all but a handful of values so the survivors fit a single leaf
+			for (int i = COLLAPSE_KEEP + 1; i <= VALUE_COUNT; i++) {
+				index.removeRecord(i, i);
+			}
+
+			final List<StoragePart> secondEmission = emit(index);
+			final FilterIndexStoragePart collapsedRoot = filterRoot(secondEmission);
+			assertFalse(collapsedRoot.isPaged(), "the collapsed filter index must emit an inline (SINGLE) root");
+			assertEquals(
+				COLLAPSE_KEEP, collapsedRoot.getHistogramPoints().length,
+				"the SINGLE root must carry every surviving bucket inline"
+			);
+			assertEquals(
+				0, bucketLeafPages(secondEmission).size(),
+				"a collapsed bucket axis must not re-emit any bucket leaf page"
+			);
+			assertEquals(
+				priorLeafPageCount, bucketLeafPageRemovals(secondEmission).size(),
+				"the collapse must remove every bucket leaf page the previous warm-up flush wrote — the append-only " +
+					"OffsetIndex never reclaims a record that is neither superseded nor explicitly removed, so a missed " +
+					"removal leaks the page forever"
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Range axis")
+	class RangeAxisCollapse {
+
+		@Test
+		@DisplayName("collapsing across two warm-up flushes still removes every prior range leaf page")
+		void shouldRemovePriorRangeLeafPagesWhenCollapsingAcrossTwoWarmUpFlushesWithoutAnIntermediateReload() {
+			// a range-typed attribute pages TWO independent streams — the value bucket tree and the RangeIndex threshold
+			// tree — each with its own collapse site; both must reclaim against what the previous flush staged
+			final OwnerFilterIndex index = pagedRangeSource();
+
+			// first warm-up flush: stages every bucket AND range leaf page, publishes nothing
+			final List<StoragePart> firstEmission = emit(index);
+			final FilterIndexStoragePart firstRoot = filterRoot(firstEmission);
+			assertTrue(firstRoot.isPaged(), "the source filter index must start with a paged bucket axis");
+			assertTrue(firstRoot.isRangePaged(), "the source filter index must start with a paged range axis");
+			final int priorBucketPageCount = bucketLeafPages(firstEmission).size();
+			final int priorRangePageCount = rangeLeafPages(firstEmission).size();
+			assertTrue(priorBucketPageCount >= 3, "the bucket axis must start paged across several leaves");
+			assertTrue(priorRangePageCount >= 3, "the range axis must start paged across several leaves");
+			assertEquals(0, rangeLeafPageRemovals(firstEmission).size(), "a first flush frees no range leaf page");
+
+			// collapse the SAME in-memory index: drop all but a handful of ranges. The survivors' values fit a single
+			// bucket leaf and their thresholds a single range leaf, so BOTH axes fall back to the inline SINGLE shape
+			// and NEITHER re-enters the paged branch (which would publish the staged set instead of reclaiming it).
+			for (int i = COLLAPSE_KEEP + 1; i <= VALUE_COUNT; i++) {
+				index.removeRecord(i, IntegerNumberRange.between(i, i + 1));
+			}
+
+			final List<StoragePart> secondEmission = emit(index);
+			final FilterIndexStoragePart collapsedRoot = filterRoot(secondEmission);
+			assertFalse(collapsedRoot.isRangePaged(), "the collapsed range axis must be carried inline (SINGLE)");
+			assertFalse(collapsedRoot.isPaged(), "the collapsed bucket axis must be carried inline (SINGLE)");
+			assertNotNull(collapsedRoot.getRangeIndex(), "the SINGLE root must carry the surviving range inline");
+			assertEquals(
+				0, rangeLeafPages(secondEmission).size(),
+				"a collapsed range axis must not re-emit any range leaf page"
+			);
+			assertEquals(
+				priorRangePageCount, rangeLeafPageRemovals(secondEmission).size(),
+				"the collapse must remove every RANGE leaf page the previous warm-up flush wrote — the append-only " +
+					"OffsetIndex never reclaims a record that is neither superseded nor explicitly removed, so a missed " +
+					"removal leaks the page forever"
+			);
+			assertEquals(
+				priorBucketPageCount, bucketLeafPageRemovals(secondEmission).size(),
+				"the same collapse must reclaim the bucket axis' own prior leaf pages — the two page streams are " +
+					"independent and each has to free its own"
+			);
+		}
+	}
+
+	/*
+		PRIVATE HELPERS
+	 */
+
+	/**
+	 * Builds a fresh non-range filter index paged across several bucket leaves (one distinct value per record).
+	 *
+	 * @return the paged source index; never null
+	 */
+	@Nonnull
+	private static OwnerFilterIndex pagedBucketSource() {
+		final OwnerFilterIndex index = new OwnerFilterIndex(BUCKET_ATTRIBUTE_KEY, Integer.class);
+		for (int i = 1; i <= VALUE_COUNT; i++) {
+			index.addRecord(i, i);
+		}
+		return index;
+	}
+
+	/**
+	 * Builds a fresh range-typed filter index paged on BOTH axes: one distinct range per record pages the value bucket
+	 * tree, while the ranges' two thresholds each page the {@link io.evitadb.index.range.RangeIndex} threshold tree.
+	 * Consecutive ranges deliberately abut (`[i, i+1]`, `[i+1, i+2]`), exactly as the histogram suite's range source.
+	 *
+	 * @return the paged source index; never null
+	 */
+	@Nonnull
+	private static OwnerFilterIndex pagedRangeSource() {
+		final OwnerFilterIndex index = new OwnerFilterIndex(RANGE_ATTRIBUTE_KEY, IntegerNumberRange.class);
+		for (int i = 1; i <= VALUE_COUNT; i++) {
+			index.addRecord(i, IntegerNumberRange.between(i, i + 1));
+		}
+		return index;
+	}
+
+	/**
+	 * Flushes the index and returns every emitted storage part, removals included — the warm-up flush seam.
+	 *
+	 * @param index the index to flush
+	 * @return every part the flush emitted; never null
+	 */
+	@Nonnull
+	private static List<StoragePart> emit(@Nonnull FilterIndex index) {
+		final TrappedChanges trappedChanges = new TrappedChanges();
+		index.appendStorageParts(ENTITY_INDEX_PK, trappedChanges);
+		final List<StoragePart> parts = new ArrayList<>();
+		final Iterator<StoragePart> iterator = trappedChanges.getTrappedChangesIterator();
+		while (iterator.hasNext()) {
+			parts.add(iterator.next());
+		}
+		return parts;
+	}
+
+	/**
+	 * Returns the single {@link FilterIndexStoragePart} root of a flush emission.
+	 *
+	 * @param parts the flush emission
+	 * @return the emitted root part; never null
+	 */
+	@Nonnull
+	private static FilterIndexStoragePart filterRoot(@Nonnull List<StoragePart> parts) {
+		for (final StoragePart part : parts) {
+			if (part instanceof FilterIndexStoragePart root) {
+				return root;
+			}
+		}
+		throw new IllegalStateException("The emission carries no FilterIndexStoragePart root!");
+	}
+
+	@Nonnull
+	private static List<FilterIndexLeafPagePart> bucketLeafPages(@Nonnull List<StoragePart> parts) {
+		final List<FilterIndexLeafPagePart> result = new ArrayList<>();
+		for (final StoragePart part : parts) {
+			if (part instanceof FilterIndexLeafPagePart leafPage) {
+				result.add(leafPage);
+			}
+		}
+		return result;
+	}
+
+	@Nonnull
+	private static List<FilterIndexLeafPageRemoval> bucketLeafPageRemovals(@Nonnull List<StoragePart> parts) {
+		final List<FilterIndexLeafPageRemoval> result = new ArrayList<>();
+		for (final StoragePart part : parts) {
+			if (part instanceof FilterIndexLeafPageRemoval removal) {
+				result.add(removal);
+			}
+		}
+		return result;
+	}
+
+	@Nonnull
+	private static List<RangeIndexLeafPagePart> rangeLeafPages(@Nonnull List<StoragePart> parts) {
+		final List<RangeIndexLeafPagePart> result = new ArrayList<>();
+		for (final StoragePart part : parts) {
+			if (part instanceof RangeIndexLeafPagePart leafPage) {
+				result.add(leafPage);
+			}
+		}
+		return result;
+	}
+
+	@Nonnull
+	private static List<RangeIndexLeafPageRemoval> rangeLeafPageRemovals(@Nonnull List<StoragePart> parts) {
+		final List<RangeIndexLeafPageRemoval> result = new ArrayList<>();
+		for (final StoragePart part : parts) {
+			if (part instanceof RangeIndexLeafPageRemoval removal) {
+				result.add(removal);
+			}
+		}
+		return result;
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexPagingRoundTripTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexPagingRoundTripTest.java
@@ -127,6 +127,16 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 	 */
 	private static final int MERGE_REMOVE_TO = 700;
 	/**
+	 * Enough distinct keys to page the value tree out across several leaves (the 256-entry block splits at 128, so an
+	 * ascending run of this many keys lays out as ~7 leaves) before the warm-up collapse scenario shrinks it back.
+	 */
+	private static final int COLLAPSE_KEY_COUNT = 900;
+	/**
+	 * Distinct keys kept after the collapse shrink — well within the 256-entry leaf, so the value tree collapses out of
+	 * the `PAGED` shape back to the inline `SINGLE` one.
+	 */
+	private static final int COLLAPSE_KEEP = 40;
+	/**
 	 * The catalog version the parts are flushed at (and reopened at).
 	 */
 	private static final long PERSISTED_VERSION = 1L;
@@ -435,6 +445,81 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 		}
 	}
 
+	@Test
+	@DisplayName("Collapsing PAGED -> SINGLE across two warm-up flushes still removes every prior leaf page")
+	void shouldRemovePriorLeafPagesWhenCollapsingAcrossTwoWarmUpFlushesWithoutAnIntermediateReload() {
+		// the sibling merge test above mutates a RELOADED index, whose page-stream live-set baseline the loader restored
+		// from disk. A WARM_UP (bulk) catalog never reloads and never reaches a commit-merge — the only place the staged
+		// page set is PUBLISHED — so its collapse must reclaim against the set the previous flush STAGED, not the
+		// published one, which stays empty for the whole warm-up and would silently reclaim NOTHING.
+		final AttributeKey attributeKey = new AttributeKey("url", Locale.ENGLISH);
+		final GlobalUniqueIndex index = new GlobalUniqueIndex(Scope.LIVE, attributeKey, String.class);
+		index.attachToCatalog(null, this.catalog);
+		for (int i = 0; i < COLLAPSE_KEY_COUNT; i++) {
+			index.registerUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1);
+		}
+		assertTrue(index.isPaged(), "the index must span multiple leaves to exercise the paged layout");
+
+		// first WARM_UP flush: allocates + STAGES one leaf page per leaf and publishes nothing (publishing happens only at
+		// the commit-merge, which a warm-up flush never reaches)
+		final TrappedChanges firstChanges = new TrappedChanges();
+		index.appendStorageParts(attributeKey, firstChanges);
+		final List<StoragePart> firstEmission = collectAllParts(firstChanges);
+		index.resetDirty();
+
+		// the prior page count is taken from the EMISSION (which the flush derives by walking the tree's leaves), never
+		// from the registry accessor under test — sourcing it there would make the removal assertion below `0 == 0` and
+		// leave this test green with or without the fix
+		final int priorLeafPageCount = (int) firstEmission.stream()
+			.filter(GlobalUniqueIndexLeafPagePart.class::isInstance).count();
+		assertTrue(priorLeafPageCount >= 3, "the source index must start paged across several leaf pages");
+		final GlobalUniqueIndexStoragePart firstRoot = firstEmission.stream()
+			.filter(GlobalUniqueIndexStoragePart.class::isInstance)
+			.map(GlobalUniqueIndexStoragePart.class::cast)
+			.findFirst()
+			.orElseThrow();
+		assertTrue(firstRoot.isPaged(), "the first warm-up flush must emit a PAGED root");
+		assertEquals(
+			priorLeafPageCount, firstRoot.getLeafPageSequences().length,
+			"the PAGED root must list exactly the leaf pages the first warm-up flush wrote"
+		);
+		assertEquals(
+			0, firstEmission.stream().filter(GlobalUniqueIndexLeafPageRemoval.class::isInstance).count(),
+			"a first warm-up flush frees no leaf page — nothing was on disk before it"
+		);
+
+		// collapse the SAME in-memory index — NO reload in between, exactly what a warm-up catalog does: drop all but a
+		// handful of keys so the survivors fit within a single leaf
+		for (int i = COLLAPSE_KEEP; i < COLLAPSE_KEY_COUNT; i++) {
+			index.unregisterUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1);
+		}
+		assertFalse(index.isPaged(), "an index that fits a single leaf must collapse out of the PAGED shape");
+
+		final TrappedChanges secondChanges = new TrappedChanges();
+		index.appendStorageParts(attributeKey, secondChanges);
+		final List<StoragePart> secondEmission = collectAllParts(secondChanges);
+		final GlobalUniqueIndexStoragePart collapsedRoot = secondEmission.stream()
+			.filter(GlobalUniqueIndexStoragePart.class::isInstance)
+			.map(GlobalUniqueIndexStoragePart.class::cast)
+			.findFirst()
+			.orElseThrow();
+		assertFalse(collapsedRoot.isPaged(), "the collapsed index must emit a single inline (SINGLE) root");
+		assertNotNull(collapsedRoot.getValues(), "a SINGLE root carries the value column inline");
+		assertEquals(
+			COLLAPSE_KEEP, collapsedRoot.getValues().length, "the SINGLE root must carry every surviving value inline"
+		);
+		assertEquals(
+			0, secondEmission.stream().filter(GlobalUniqueIndexLeafPagePart.class::isInstance).count(),
+			"a collapsed index must not re-emit any leaf page"
+		);
+		assertEquals(
+			priorLeafPageCount,
+			(int) secondEmission.stream().filter(GlobalUniqueIndexLeafPageRemoval.class::isInstance).count(),
+			"the collapse must remove every leaf page the previous warm-up flush wrote — the append-only OffsetIndex never " +
+				"reclaims a record that is neither superseded nor explicitly removed, so a missed removal leaks the page forever"
+		);
+	}
+
 	/*
 		PRIVATE HELPERS
 	 */
@@ -514,7 +599,7 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 	 * page-stream live-set baseline, so a later flush can detect (and remove) the pages a merge frees.
 	 */
 	@Nonnull
-	private GlobalUniqueIndex loadPagedIndex(
+	private static GlobalUniqueIndex loadPagedIndex(
 		@Nonnull OffsetIndex offsetIndex,
 		long catalogVersion,
 		@Nonnull AttributeKey attributeKey,
@@ -546,7 +631,9 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 	 * {@code put}, while each {@link DeferredRemovalStoragePart} resolves its store-side primary key against the live
 	 * read-only key compressor and is {@code remove}d — exactly what the production flush drain does.
 	 */
-	private void writeEmission(@Nonnull OffsetIndex offsetIndex, long catalogVersion, @Nonnull List<StoragePart> parts) {
+	private static void writeEmission(
+		@Nonnull OffsetIndex offsetIndex, long catalogVersion, @Nonnull List<StoragePart> parts
+	) {
 		for (final StoragePart part : parts) {
 			if (part instanceof DeferredRemovalStoragePart deferredRemoval) {
 				final long removedPartPK =
@@ -648,7 +735,7 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 	}
 
 	@Nonnull
-	private Function<VersionedKryoKeyInputs, VersionedKryo> createKryo() {
+	private static Function<VersionedKryoKeyInputs, VersionedKryo> createKryo() {
 		return keyInputs -> VersionedKryoFactory.createKryo(
 			keyInputs.version(),
 			SchemaKryoConfigurer.INSTANCE

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexWarmUpFlushMergeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexWarmUpFlushMergeTest.java
@@ -1,0 +1,168 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.attribute;
+
+import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
+import io.evitadb.core.buffer.TrappedChanges;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.dataType.Scope;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.GlobalUniqueIndexLeafPageRemoval;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.GlobalUniqueIndexStoragePart;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Reproduces the WARM_UP (bulk, non-transactional) flush sequence on {@link GlobalUniqueIndex}: a first flush pages
+ * the value tree out to disk WITHOUT publishing (a warm-up flush never reaches the commit-merge that would otherwise
+ * promote the staged page set to live), followed by a second flush whose deletes force a leaf MERGE. A merge drops a
+ * page without creating one, so the freed-page diff a leaf merge relies on depends on the flush being able to see
+ * what the FIRST flush actually wrote to disk — not on an empty baseline left behind by a commit-merge that, for a
+ * warm-up flush, never runs.
+ *
+ * Unlike {@link OwnerUniqueIndex}, the `PAGED` root of a {@link GlobalUniqueIndex} also carries the inline locale map
+ * and is therefore re-emitted unconditionally on every dirty flush (it cannot use the page-list-unchanged skip), so
+ * this index's manifestation of the defect is narrower: only the freed leaf page itself is left behind, never removed
+ * from storage and copied forward by every future compaction — the root always correctly lists the surviving leaves.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@DisplayName("A warm-up flush leaf merge must free its dropped page on GlobalUniqueIndex")
+class GlobalUniqueIndexWarmUpFlushMergeTest {
+
+	private static final String ENTITY_TYPE = "product";
+	private static final int ENTITY_TYPE_PK = 1;
+	private static final AttributeKey URL_KEY = new AttributeKey("code");
+	/**
+	 * With valueBlockSize=256 (split at 128) and minValueBlockSize=127, an ascending stream of 513 distinct values lays
+	 * the value tree out as four leaves — [1..128], [129..256], [257..384], [385..513] — the smallest layout that can
+	 * lose a leaf to a merge and still stay PAGED afterwards.
+	 */
+	private static final int VALUE_COUNT = 513;
+
+	private final Catalog catalog = Mockito.mock(Catalog.class);
+
+	@BeforeEach
+	void setUp() {
+		final EntityCollection productCollection = Mockito.mock(EntityCollection.class);
+		Mockito.when(productCollection.getEntityTypePrimaryKey()).thenReturn(ENTITY_TYPE_PK);
+		Mockito.when(this.catalog.getCollectionForEntityOrThrowException(ENTITY_TYPE)).thenReturn(productCollection);
+	}
+
+	@Test
+	@DisplayName("should free the merged-away leaf page after a second warm-up flush merges a leaf")
+	void shouldFreeStalePageAfterWarmUpFlushMerge() {
+		final GlobalUniqueIndex index = new GlobalUniqueIndex(Scope.LIVE, URL_KEY, Integer.class);
+		index.attachToCatalog(null, this.catalog);
+		for (int i = 1; i <= VALUE_COUNT; i++) {
+			index.registerUniqueKey(i, ENTITY_TYPE, null, i);
+		}
+
+		// first WARM_UP flush: allocates + stages 4 leaf pages, never publishes them - a warm-up flush never reaches
+		// the commit-merge (createCopyWithMergedTransactionalMemory), which is the only place that call runs
+		final TrappedChanges firstFlush = new TrappedChanges();
+		index.appendStorageParts(URL_KEY, firstFlush);
+		index.resetDirty();
+
+		assertTrue(index.isPaged(), "The index must be PAGED before the merge!");
+		final GlobalUniqueIndexStoragePart firstRoot = extractPagedRoot(firstFlush);
+		assertEquals(
+			4, firstRoot.getLeafPageSequences().length,
+			"The first warm-up flush must lay the tree out as four leaf pages -- the layout the deletes below are " +
+				"calibrated against!"
+		);
+
+		// second WARM_UP flush: drop exactly enough values to force leaf 0 to merge with leaf 1.
+		// leaves start out [1..128], [129..256], [257..384], [385..513]:
+		// - leaf 1: 128 -> 127, so it sits exactly at the minimum and can no longer donate a key
+		index.unregisterUniqueKey(129, ENTITY_TYPE, null, 129);
+		// - leaf 0: 128 -> 127 (still at the minimum, no underflow yet)
+		index.unregisterUniqueKey(1, ENTITY_TYPE, null, 1);
+		// - leaf 0: 127 -> 126 -> underflow. It has no left sibling, the right sibling cannot donate
+		//   (127 > 127 is false) and 127 + 126 = 253 < 256, so consolidate takes mergeWithRight: leaf 0 absorbs
+		//   leaf 1 IN PLACE - it keeps page 0 and is marked dirty, while leaf 1 is detached and its page must be freed
+		index.unregisterUniqueKey(2, ENTITY_TYPE, null, 2);
+
+		final TrappedChanges secondFlush = new TrappedChanges();
+		index.appendStorageParts(URL_KEY, secondFlush);
+
+		// pin that a leaf really was merged away: without this the test would still pass if the block-size constants
+		// ever drifted so the deletes no longer underflow a leaf - the tree would simply stay intact and never
+		// exercise the defect at all
+		final GlobalUniqueIndexStoragePart secondRoot = extractPagedRoot(secondFlush);
+		assertEquals(
+			3, secondRoot.getLeafPageSequences().length,
+			"The deletes must have merged a leaf away (four leaf pages -> three); if this still reports four, no " +
+				"merge happened and the test is not exercising the freed-page path!"
+		);
+		// the tree must still span several leaves: had it collapsed to the inline SINGLE shape, that path force-emits
+		// removals for every prior page unconditionally and would mask the defect under test
+		assertTrue(index.isPaged(), "The index must stay PAGED after the merge!");
+
+		int removalCount = 0;
+		final Iterator<StoragePart> emittedParts = secondFlush.getTrappedChangesIterator();
+		while (emittedParts.hasNext()) {
+			if (emittedParts.next() instanceof GlobalUniqueIndexLeafPageRemoval) {
+				removalCount++;
+			}
+		}
+
+		assertEquals(
+			1, removalCount,
+			"The leaf merge must free exactly the one dropped leaf page - a leaf-page removal must be emitted for " +
+				"it, or the freed page is never removed from storage and is copied forward by every compaction forever!"
+		);
+	}
+
+	/**
+	 * Finds the single re-emitted `PAGED` root part in a flush emission (the root is unconditionally re-emitted on
+	 * every dirty {@link GlobalUniqueIndex} flush, since it also carries the inline locale map).
+	 */
+	@Nonnull
+	private static GlobalUniqueIndexStoragePart extractPagedRoot(@Nonnull TrappedChanges changes) {
+		final Iterator<StoragePart> emittedParts = changes.getTrappedChangesIterator();
+		while (emittedParts.hasNext()) {
+			final StoragePart part = emittedParts.next();
+			if (part instanceof GlobalUniqueIndexStoragePart root && root.isPaged()) {
+				return root;
+			}
+		}
+		return fail("No PAGED root storage part was emitted by the flush!");
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/OwnerUniqueIndexPagingRoundTripTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/OwnerUniqueIndexPagingRoundTripTest.java
@@ -32,6 +32,7 @@ import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.spi.store.catalog.persistence.storageParts.DeferredRemovalStoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.KeyCompressor;
 import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AbstractLeafPagePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexStoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexStoragePart.AttributeIndexType;
@@ -128,6 +129,16 @@ class OwnerUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 	 */
 	private static final int MERGE_REMOVE_TO = 700;
 	/**
+	 * Enough distinct keys to page the value tree out across several leaves (the 256-entry block splits at 128, so an
+	 * ascending run of this many keys lays out as ~7 leaves) before the warm-up collapse scenario shrinks it back.
+	 */
+	private static final int COLLAPSE_KEY_COUNT = 900;
+	/**
+	 * Distinct keys kept after the collapse shrink — well within the 256-entry leaf, so the value tree collapses out of
+	 * the `PAGED` shape back to the inline `SINGLE` one.
+	 */
+	private static final int COLLAPSE_KEEP = 40;
+	/**
 	 * The catalog version the parts are flushed at (and reopened at).
 	 */
 	private static final long PERSISTED_VERSION = 1L;
@@ -206,7 +217,7 @@ class OwnerUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 			for (int i = 0; i < orderedPageSequences.length; i++) {
 				final UniqueIndexLeafPagePart leafPage = reloaded.get(
 					PERSISTED_VERSION,
-					UniqueIndexLeafPagePart.computeUniquePartId(streamId, orderedPageSequences[i]),
+					AbstractLeafPagePart.computeUniquePartId(streamId, orderedPageSequences[i]),
 					UniqueIndexLeafPagePart.class
 				);
 				assertNotNull(leafPage, "leaf page " + orderedPageSequences[i] + " must be readable after reload");
@@ -379,7 +390,7 @@ class OwnerUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 				assertNull(
 					reopened.get(
 						SECOND_VERSION,
-						UniqueIndexLeafPagePart.computeUniquePartId(streamId, freedSequence),
+						AbstractLeafPagePart.computeUniquePartId(streamId, freedSequence),
 						UniqueIndexLeafPagePart.class
 					),
 					"freed leaf page " + freedSequence + " must be removed from storage"
@@ -424,6 +435,80 @@ class OwnerUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 				IOUtils.closeQuietly(reopened::close);
 			}
 		}
+	}
+
+	@Test
+	@DisplayName("Collapsing PAGED -> SINGLE across two warm-up flushes still removes every prior leaf page")
+	void shouldRemovePriorLeafPagesWhenCollapsingAcrossTwoWarmUpFlushesWithoutAnIntermediateReload() {
+		// every other collapse test RELOADS the index before collapsing it, and the loader seeds the page-stream live-set
+		// baseline from disk — so the published set is correct there and the collapse reclaims correctly either way. A
+		// WARM_UP (bulk) catalog never reloads and never reaches a commit-merge — the only place the staged page set is
+		// PUBLISHED — so its collapse must reclaim against the set the previous flush STAGED, not the published one, which
+		// stays empty for the whole warm-up and would silently reclaim NOTHING.
+		final AttributeIndexKey attributeIndexKey = new AttributeIndexKey(null, "url", Locale.ENGLISH);
+		final OwnerUniqueIndex index = new OwnerUniqueIndex(ENTITY_TYPE, attributeIndexKey, String.class);
+		for (int i = 0; i < COLLAPSE_KEY_COUNT; i++) {
+			index.registerUniqueKey(keyForIndex(i), i + 1);
+		}
+		assertTrue(index.isPaged(), "the index must span multiple leaves to exercise the paged layout");
+
+		// first WARM_UP flush: allocates + STAGES one leaf page per leaf and publishes nothing (publishing happens only at
+		// the commit-merge, which a warm-up flush never reaches)
+		final TrappedChanges firstChanges = new TrappedChanges();
+		index.appendStorageParts(ENTITY_INDEX_PK, firstChanges);
+		final List<StoragePart> firstEmission = collectAllParts(firstChanges);
+		index.resetDirty();
+
+		// the prior page count is taken from the EMISSION (which the flush derives by walking the tree's leaves), never
+		// from the registry accessor under test — sourcing it there would make the removal assertion below `0 == 0` and
+		// leave this test green with or without the fix
+		final int priorLeafPageCount = (int) firstEmission.stream()
+			.filter(UniqueIndexLeafPagePart.class::isInstance).count();
+		assertTrue(priorLeafPageCount >= 3, "the source index must start paged across several leaf pages");
+		final UniqueIndexStoragePart firstRoot = firstEmission.stream()
+			.filter(UniqueIndexStoragePart.class::isInstance)
+			.map(UniqueIndexStoragePart.class::cast)
+			.findFirst()
+			.orElseThrow();
+		assertTrue(firstRoot.isPaged(), "the first warm-up flush must emit a PAGED root");
+		assertEquals(
+			priorLeafPageCount, firstRoot.getLeafPageSequences().length,
+			"the PAGED root must list exactly the leaf pages the first warm-up flush wrote"
+		);
+		assertEquals(
+			0, firstEmission.stream().filter(UniqueIndexLeafPageRemoval.class::isInstance).count(),
+			"a first warm-up flush frees no leaf page — nothing was on disk before it"
+		);
+
+		// collapse the SAME in-memory index — NO reload in between, exactly what a warm-up catalog does: drop all but a
+		// handful of keys so the survivors fit within a single leaf
+		for (int i = COLLAPSE_KEEP; i < COLLAPSE_KEY_COUNT; i++) {
+			index.unregisterUniqueKey(keyForIndex(i), i + 1);
+		}
+		assertFalse(index.isPaged(), "an index that fits a single leaf must collapse out of the PAGED shape");
+
+		final TrappedChanges secondChanges = new TrappedChanges();
+		index.appendStorageParts(ENTITY_INDEX_PK, secondChanges);
+		final List<StoragePart> secondEmission = collectAllParts(secondChanges);
+		final UniqueIndexStoragePart collapsedRoot = secondEmission.stream()
+			.filter(UniqueIndexStoragePart.class::isInstance)
+			.map(UniqueIndexStoragePart.class::cast)
+			.findFirst()
+			.orElseThrow();
+		assertFalse(collapsedRoot.isPaged(), "the collapsed index must emit a single inline (SINGLE) root");
+		assertNotNull(collapsedRoot.getValues(), "a SINGLE root carries the value column inline");
+		assertEquals(
+			COLLAPSE_KEEP, collapsedRoot.getValues().length, "the SINGLE root must carry every surviving value inline"
+		);
+		assertEquals(
+			0, secondEmission.stream().filter(UniqueIndexLeafPagePart.class::isInstance).count(),
+			"a collapsed index must not re-emit any leaf page"
+		);
+		assertEquals(
+			priorLeafPageCount, (int) secondEmission.stream().filter(UniqueIndexLeafPageRemoval.class::isInstance).count(),
+			"the collapse must remove every leaf page the previous warm-up flush wrote — the append-only OffsetIndex never " +
+				"reclaims a record that is neither superseded nor explicitly removed, so a missed removal leaks the page forever"
+		);
 	}
 
 	/*
@@ -506,7 +591,7 @@ class OwnerUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 	 * page-stream live-set baseline, so a later flush can detect (and remove) the pages a merge frees.
 	 */
 	@Nonnull
-	private OwnerUniqueIndex loadPagedIndex(
+	private static OwnerUniqueIndex loadPagedIndex(
 		@Nonnull OffsetIndex offsetIndex,
 		long catalogVersion,
 		@Nonnull AttributeIndexKey attributeIndexKey,
@@ -519,7 +604,7 @@ class OwnerUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 		for (int i = 0; i < orderedPageSequences.length; i++) {
 			final UniqueIndexLeafPagePart leafPage = offsetIndex.get(
 				catalogVersion,
-				UniqueIndexLeafPagePart.computeUniquePartId(streamId, orderedPageSequences[i]),
+				AbstractLeafPagePart.computeUniquePartId(streamId, orderedPageSequences[i]),
 				UniqueIndexLeafPagePart.class
 			);
 			assertNotNull(leafPage, "leaf page " + orderedPageSequences[i] + " must be readable");
@@ -537,7 +622,9 @@ class OwnerUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 	 * {@code put}, while each {@link DeferredRemovalStoragePart} resolves its store-side primary key against the live
 	 * read-only key compressor and is {@code remove}d — exactly what the production flush drain does.
 	 */
-	private void writeEmission(@Nonnull OffsetIndex offsetIndex, long catalogVersion, @Nonnull List<StoragePart> parts) {
+	private static void writeEmission(
+		@Nonnull OffsetIndex offsetIndex, long catalogVersion, @Nonnull List<StoragePart> parts
+	) {
 		for (final StoragePart part : parts) {
 			if (part instanceof DeferredRemovalStoragePart deferredRemoval) {
 				final long removedPartPK =
@@ -639,7 +726,7 @@ class OwnerUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 	}
 
 	@Nonnull
-	private Function<VersionedKryoKeyInputs, VersionedKryo> createKryo() {
+	private static Function<VersionedKryoKeyInputs, VersionedKryo> createKryo() {
 		return keyInputs -> VersionedKryoFactory.createKryo(
 			keyInputs.version(),
 			SchemaKryoConfigurer.INSTANCE

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/OwnerUniqueIndexWarmUpFlushMergeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/OwnerUniqueIndexWarmUpFlushMergeTest.java
@@ -1,0 +1,149 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.attribute;
+
+import io.evitadb.core.buffer.TrappedChanges;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.UniqueIndexLeafPageRemoval;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.UniqueIndexStoragePart;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Iterator;
+
+import static io.evitadb.test.TestTags.ATTRIBUTE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduces the WARM_UP (bulk, non-transactional) flush sequence on {@link OwnerUniqueIndex}: a first flush pages the
+ * value tree out to disk WITHOUT publishing (a warm-up flush never reaches the commit-merge that would otherwise
+ * promote the staged page set to live), followed by a second flush whose deletes force a leaf MERGE. A merge drops a
+ * page without creating one, so the freed-page diff and the `PAGED` root re-emission both depend on the flush being
+ * able to see what the FIRST flush actually wrote to disk — not on an empty baseline left behind by a commit-merge
+ * that, for a warm-up flush, never runs.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(INDEXING)
+@Tag(ATTRIBUTE)
+@DisplayName("A warm-up flush leaf merge must free its dropped page and re-emit the PAGED root on OwnerUniqueIndex")
+class OwnerUniqueIndexWarmUpFlushMergeTest {
+
+	private static final String ENTITY_TYPE = "product";
+	private static final AttributeIndexKey CODE_KEY = new AttributeIndexKey(null, "code", null);
+	private static final int ENTITY_INDEX_PK = 1;
+	/**
+	 * With valueBlockSize=256 (split at 128) and minValueBlockSize=127, an ascending stream of 513 distinct values lays
+	 * the value tree out as four leaves — [1..128], [129..256], [257..384], [385..513] — the smallest layout that can
+	 * lose a leaf to a merge and still stay PAGED afterwards.
+	 */
+	private static final int VALUE_COUNT = 513;
+
+	/**
+	 * Returns the record id owning the `i`-th distinct value (stable 1:1 mapping).
+	 */
+	private static int recordId(int i) {
+		return 500_000 + i;
+	}
+
+	@Test
+	@DisplayName("should free the merged-away leaf page and re-emit the PAGED root after a second warm-up flush merges a leaf")
+	void shouldFreeStalePageAndReemitRootAfterWarmUpFlushMerge() {
+		final OwnerUniqueIndex index = new OwnerUniqueIndex(ENTITY_TYPE, CODE_KEY, Integer.class);
+		for (int i = 1; i <= VALUE_COUNT; i++) {
+			index.registerUniqueKey(i, recordId(i));
+		}
+
+		// first WARM_UP flush: allocates + stages 4 leaf pages, never publishes them - a warm-up flush never reaches
+		// the commit-merge (createCopyWithMergedTransactionalMemory), which is the only place that call runs
+		final TrappedChanges firstFlush = new TrappedChanges();
+		index.appendStorageParts(ENTITY_INDEX_PK, firstFlush);
+		index.resetDirty();
+
+		assertTrue(index.isPaged(), "The index must be PAGED before the merge!");
+		assertEquals(
+			4, index.currentLeafPageSequences().length,
+			"The first warm-up flush must lay the tree out as four leaf pages -- the layout the deletes below are " +
+				"calibrated against!"
+		);
+
+		// second WARM_UP flush: drop exactly enough values to force leaf 0 to merge with leaf 1.
+		// leaves start out [1..128], [129..256], [257..384], [385..513]:
+		// - leaf 1: 128 -> 127, so it sits exactly at the minimum and can no longer donate a key
+		index.unregisterUniqueKey(129, recordId(129));
+		// - leaf 0: 128 -> 127 (still at the minimum, no underflow yet)
+		index.unregisterUniqueKey(1, recordId(1));
+		// - leaf 0: 127 -> 126 -> underflow. It has no left sibling, the right sibling cannot donate
+		//   (127 > 127 is false) and 127 + 126 = 253 < 256, so consolidate takes mergeWithRight: leaf 0 absorbs
+		//   leaf 1 IN PLACE - it keeps page 0 and is marked dirty, while leaf 1 is detached and its page must be freed
+		index.unregisterUniqueKey(2, recordId(2));
+
+		final TrappedChanges secondFlush = new TrappedChanges();
+		index.appendStorageParts(ENTITY_INDEX_PK, secondFlush);
+
+		// pin that a leaf really was merged away: without this the test would still pass if the block-size constants
+		// ever drifted so the deletes no longer underflow a leaf - the tree would simply stay intact and never
+		// exercise the defect at all
+		assertEquals(
+			3, index.currentLeafPageSequences().length,
+			"The deletes must have merged a leaf away (four leaf pages -> three); if this still reports four, no " +
+				"merge happened and the test is not exercising the freed-page path!"
+		);
+		// the tree must still span several leaves: had it collapsed to the inline SINGLE shape, that path force-emits
+		// the root unconditionally and would mask the defect under test
+		assertTrue(index.isPaged(), "The index must stay PAGED after the merge!");
+
+		int removalCount = 0;
+		UniqueIndexStoragePart rootPart = null;
+		final Iterator<StoragePart> emittedParts = secondFlush.getTrappedChangesIterator();
+		while (emittedParts.hasNext()) {
+			final StoragePart part = emittedParts.next();
+			if (part instanceof UniqueIndexLeafPageRemoval) {
+				removalCount++;
+			} else if (part instanceof UniqueIndexStoragePart uniquePart && uniquePart.isPaged()) {
+				rootPart = uniquePart;
+			}
+		}
+
+		assertEquals(
+			1, removalCount,
+			"The leaf merge must free exactly the one dropped leaf page - a leaf-page removal must be emitted for " +
+				"it, or the freed page is never removed from storage and is copied forward by every compaction forever!"
+		);
+		assertNotNull(
+			rootPart,
+			"The PAGED root must be re-emitted after a merge changed the ordered leaf-page list - otherwise a cold " +
+				"reload assembles the stale, still-listed dropped page back into the tree and the cross-leaf overlap " +
+				"check fires!"
+		);
+		assertEquals(
+			3, rootPart.getLeafPageSequences().length, "The re-emitted root must list only the three surviving leaves!"
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/SortIndexOwnerPagingRoundTripTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/SortIndexOwnerPagingRoundTripTest.java
@@ -380,6 +380,61 @@ class SortIndexOwnerPagingRoundTripTest implements EvitaTestSupport {
 	}
 
 	@Test
+	@DisplayName("Collapsing PAGED -> SINGLE across two warm-up flushes still removes every prior leaf page")
+	void shouldRemovePriorLeafPagesWhenCollapsingAcrossTwoWarmUpFlushesWithoutAnIntermediateReload() {
+		// the sibling collapse test above collapses a RELOADED owner, whose page-stream live-set baseline the loader
+		// restored from disk. A WARM_UP (bulk) catalog never reloads and never reaches a commit-merge — the only place the
+		// staged page set is PUBLISHED — so the collapse must reclaim against the set the previous flush STAGED, not the
+		// published one, which stays empty for the whole warm-up and would silently reclaim NOTHING. The owner holds no
+		// registry of its own: it delegates to its inner `ownedTree` InvertedIndex, so this pins that delegation too.
+		final OwnerSortIndex source = scalarOwner();
+		for (int i = 0; i < KEY_COUNT; i++) {
+			source.addRecord(valueForOrdinal(i), recordForOrdinal(i));
+		}
+
+		// first WARM_UP flush: allocates + STAGES one leaf page per leaf and publishes nothing (publishing happens only at
+		// the commit-merge, which a warm-up flush never reaches)
+		final List<StoragePart> firstEmission = emit(source);
+		source.resetDirty();
+
+		// the prior page count is taken from the EMISSION (which the flush derives by walking the tree's leaves), never
+		// from the registry accessor under test — sourcing it there would make the removal assertion below `0 == 0` and
+		// leave this test green with or without the fix
+		final int priorLeafPageCount = leafPages(firstEmission).size();
+		assertTrue(priorLeafPageCount >= 3, "the source owner must start paged across several leaf pages");
+		final SortIndexStoragePart firstRoot = root(firstEmission);
+		assertTrue(firstRoot.isPaged(), "the first warm-up flush must emit a PAGED root");
+		assertEquals(
+			priorLeafPageCount, firstRoot.getLeafPageSequences().length,
+			"the PAGED root must list exactly the leaf pages the first warm-up flush wrote"
+		);
+		assertTrue(
+			removals(firstEmission).isEmpty(),
+			"a first warm-up flush frees no leaf page — nothing was on disk before it"
+		);
+
+		// collapse the SAME in-memory owner — NO reload in between, exactly what a warm-up catalog does: drop all but a
+		// handful of values so the survivors fit within a single leaf
+		for (int i = COLLAPSE_KEEP; i < KEY_COUNT; i++) {
+			source.removeRecord(valueForOrdinal(i), recordForOrdinal(i));
+		}
+
+		final List<StoragePart> secondEmission = emit(source);
+		final SortIndexStoragePart collapsedRoot = root(secondEmission);
+		assertFalse(collapsedRoot.isPaged(), "the collapsed owner must emit an inline (SINGLE) root");
+		assertEquals(
+			COLLAPSE_KEEP, collapsedRoot.getSortedRecordsValues().length,
+			"the SINGLE root must carry every surviving distinct value inline"
+		);
+		assertTrue(leafPages(secondEmission).isEmpty(), "a collapsed owner must not re-emit any leaf page");
+		assertEquals(
+			priorLeafPageCount, removals(secondEmission).size(),
+			"the collapse must remove every leaf page the previous warm-up flush wrote — the append-only OffsetIndex never " +
+				"reclaims a record that is neither superseded nor explicitly removed, so a missed removal leaks the page forever"
+		);
+	}
+
+	@Test
 	@DisplayName("A sortable compound owner pages out and reloads identically (compound value leaf serializer)")
 	void shouldRoundTripCompoundPagedOwnerThroughOffsetIndex() {
 		final OwnerSortIndex source = compoundOwner();

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTreeTest.java
@@ -2280,9 +2280,80 @@ class TransactionalBucketBPlusTreeTest {
 				),
 				"Overlapping single-leaf trees must fail the cross-leaf-order validation."
 			);
+			final String message = ex.getMessage();
 			assertTrue(
-				ex.getMessage().contains("overlaps its successor leaf-page sequence"),
-				"The failure must be the cross-leaf-order corruption diagnostic, got: " + ex.getMessage()
+				message.contains("overlaps its successor leaf-page sequence"),
+				"The failure must be the cross-leaf-order corruption diagnostic, got: " + message
+			);
+			// the enriched diagnostic must carry the full error-path context: both page sequences, the ordered page
+			// list, both leaves' key ranges with counts, and the (partial-overlap) containment fact
+			assertTrue(
+				message.contains("leaf-page sequence 0 overlaps its successor leaf-page sequence 1"),
+				"Both offending page sequences must be named, got: " + message
+			);
+			assertTrue(
+				message.contains("orderedLeafPageList=[0, 1]"),
+				"The ordered leaf-page list must be reported as overlap context, got: " + message
+			);
+			assertTrue(
+				message.contains("predecessorKeyRange=[1 .. 3] (3 keys)"),
+				"The predecessor leaf's key range and count must be reported, got: " + message
+			);
+			assertTrue(
+				message.contains("successorKeyRange=[2 .. 4] (3 keys)"),
+				"The successor leaf's key range and count must be reported, got: " + message
+			);
+			assertTrue(
+				message.contains("successorRangeWithinPredecessorRange=false"),
+				"A successor that extends beyond the predecessor is a partial overlap, not a nested twin, got: " + message
+			);
+		}
+
+		@Test
+		@DisplayName("reports containment as a fact when the successor's range nests inside the predecessor's")
+		@Tag(INDEXING)
+		@Tag(SERIALIZATION)
+		void shouldReportContainmentWhenSuccessorRangeNestsInsidePredecessor() {
+			// predecessor page 0 spans [1..10]; successor page 1 spans [3..5], entirely inside it — the nested shape a
+			// stale-donor twin leaves behind. The overlap trigger still fires (10 does not sort before 3) but the
+			// containment fact must now read true, distinguishing this shape from a partial overlap
+			final TransactionalBucketBPlusTree<Integer> treeA = new TransactionalBucketBPlusTree<>(9, Integer.class);
+			treeA.addRecord(1, 10);
+			treeA.addRecord(2, 20);
+			treeA.addRecord(10, 100);
+			final TransactionalBucketBPlusTree<Integer> treeB = new TransactionalBucketBPlusTree<>(9, Integer.class);
+			treeB.addRecord(3, 30);
+			treeB.addRecord(4, 40);
+			treeB.addRecord(5, 50);
+
+			final TransactionalBucketBPlusTree<Integer> target = new TransactionalBucketBPlusTree<>(9, Integer.class);
+			final GenericEvitaInternalError ex = assertThrows(
+				GenericEvitaInternalError.class,
+				() -> target.assembleFromSingleLeafTrees(
+					List.of(treeA, treeB), new int[]{7, 9}, "bucket B+ tree containment test"
+				),
+				"A successor nested inside the predecessor must still fail the cross-leaf-order validation."
+			);
+			final String message = ex.getMessage();
+			assertTrue(
+				message.contains("leaf-page sequence 7 overlaps its successor leaf-page sequence 9"),
+				"Both offending page sequences must be named, got: " + message
+			);
+			assertTrue(
+				message.contains("orderedLeafPageList=[7, 9]"),
+				"The ordered leaf-page list must be reported, got: " + message
+			);
+			assertTrue(
+				message.contains("predecessorKeyRange=[1 .. 10] (3 keys)"),
+				"The predecessor's key range must be reported, got: " + message
+			);
+			assertTrue(
+				message.contains("successorKeyRange=[3 .. 5] (3 keys)"),
+				"The successor's key range must be reported, got: " + message
+			);
+			assertTrue(
+				message.contains("successorRangeWithinPredecessorRange=true"),
+				"A successor nested inside the predecessor must be reported as contained, got: " + message
 			);
 		}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndexPagingRoundTripTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndexPagingRoundTripTest.java
@@ -488,9 +488,110 @@ class ReferenceTypeCardinalityIndexPagingRoundTripTest implements EvitaTestSuppo
 		}
 	}
 
+	@Test
+	@DisplayName("A PAGED -> SINGLE collapse across two warm-up flushes still removes every prior leaf page")
+	void shouldRemovePriorLeafPagesWhenCollapsingAcrossTwoWarmUpFlushesWithoutAnIntermediateReload() {
+		// The sibling collapse test above shrinks a RELOADED index, whose page baseline `fromPersistedPages` seeded from
+		// disk — so it stays green whether the collapse reclaims the published live set or the staged one, and therefore
+		// cannot see this bug at all. A warm-up (bulk) catalog never reloads and never reaches the transactional
+		// commit-merge, the only place `publishStaged` runs; its collapse must consequently reclaim against the set the
+		// PREVIOUS flush staged. Reclaiming from the published set alone finds it still EMPTY here and frees NOTHING,
+		// leaking every prior leaf page forever — the append-only OffsetIndex never reclaims a record that is neither
+		// superseded nor explicitly removed. No reload happens anywhere below; that is the whole point.
+		final ReferenceTypeCardinalityIndex index = new ReferenceTypeCardinalityIndex();
+		for (int i = 0; i < KEY_COUNT; i++) {
+			index.addRecord(indexPkForOrdinal(i), refPkForOrdinal(i));
+		}
+		assertTrue(index.isPaged(), "the index must span multiple leaves to exercise the collapse");
+
+		// first warm-up flush: allocates and stages one page per fresh leaf, but publishes nothing
+		final TrappedChanges firstChanges = new TrappedChanges();
+		index.appendStorageParts(ENTITY_INDEX_PK, REFERENCE_NAME, firstChanges);
+		final List<StoragePart> firstEmission = collectAllParts(firstChanges);
+		final int priorLeafPageCount = countLeafPages(firstEmission);
+		assertTrue(priorLeafPageCount >= 2, "the source index must start paged across several leaves");
+		assertEquals(
+			priorLeafPageCount, singleRoot(firstEmission).getLeafPageSequences().length,
+			"a first flush writes every one of the live leaf pages its root lists (every leaf is brand new)"
+		);
+		assertEquals(0, countRemovals(firstEmission), "a first flush frees no leaf page");
+
+		// collapse the SAME in-memory index with NO reload in between: remove enough tuples that the survivors fit
+		// within a single leaf, so the leaves cascade-merge and the root falls back to that single surviving leaf
+		for (int i = COLLAPSE_KEEP; i < KEY_COUNT; i++) {
+			index.removeRecord(indexPkForOrdinal(i), refPkForOrdinal(i));
+		}
+		assertFalse(index.isPaged(), "the shrunken index must collapse to a single leaf (PAGED -> SINGLE)");
+
+		// an index built directly from only the surviving tuples is the oracle: it proves both that this survivor count
+		// is genuinely SINGLE-sized (independently of the shrink path) and that the collapsed index holds exactly it
+		final ReferenceTypeCardinalityIndex expected = new ReferenceTypeCardinalityIndex();
+		for (int i = 0; i < COLLAPSE_KEEP; i++) {
+			expected.addRecord(indexPkForOrdinal(i), refPkForOrdinal(i));
+		}
+		assertFalse(expected.isPaged(), "a " + COLLAPSE_KEEP + "-tuple index is genuinely SINGLE-sized");
+		assertSameCardinalityIndex(expected, index, "warm-up collapse survivors");
+
+		// second warm-up flush: the collapse must reclaim what the FIRST flush staged
+		final TrappedChanges secondChanges = new TrappedChanges();
+		index.appendStorageParts(ENTITY_INDEX_PK, REFERENCE_NAME, secondChanges);
+		final List<StoragePart> secondEmission = collectAllParts(secondChanges);
+		final ReferenceTypeCardinalityIndexStoragePart collapsedRoot = singleRoot(secondEmission);
+		assertFalse(collapsedRoot.isPaged(), "the collapsed index must emit an inline (SINGLE) root");
+		assertNotNull(collapsedRoot.getKeys(), "a SINGLE root carries the key column inline");
+		assertNotNull(collapsedRoot.getPayloads(), "a SINGLE root carries the count column inline");
+		assertEquals(0, countLeafPages(secondEmission), "a collapsed index must not re-emit any leaf page");
+		assertEquals(
+			priorLeafPageCount, countRemovals(secondEmission),
+			"the collapse must remove every leaf page the previous warm-up flush wrote — the append-only OffsetIndex " +
+				"never reclaims a record that is neither superseded nor explicitly removed, so a missed removal leaks " +
+				"the page forever"
+		);
+	}
+
 	/*
 		PRIVATE HELPERS
 	 */
+
+	/**
+	 * Extracts the single {@link ReferenceTypeCardinalityIndexStoragePart} root emitted by a flush, failing if none or
+	 * more than one is present.
+	 *
+	 * @param parts the emitted storage parts
+	 * @return the sole root part
+	 */
+	@Nonnull
+	private static ReferenceTypeCardinalityIndexStoragePart singleRoot(@Nonnull List<StoragePart> parts) {
+		ReferenceTypeCardinalityIndexStoragePart root = null;
+		for (final StoragePart part : parts) {
+			if (part instanceof ReferenceTypeCardinalityIndexStoragePart rootPart) {
+				assertNull(root, "a flush must emit exactly one root part");
+				root = rootPart;
+			}
+		}
+		assertNotNull(root, "a dirty flush must emit a root part");
+		return root;
+	}
+
+	/**
+	 * Counts the leaf pages ({@link ReferenceTypeCardinalityIndexLeafPagePart}) among the emitted parts.
+	 *
+	 * @param parts the emitted storage parts
+	 * @return the number of leaf pages
+	 */
+	private static int countLeafPages(@Nonnull List<StoragePart> parts) {
+		return (int) parts.stream().filter(ReferenceTypeCardinalityIndexLeafPagePart.class::isInstance).count();
+	}
+
+	/**
+	 * Counts the leaf-page removals ({@link ReferenceTypeCardinalityIndexLeafPageRemoval}) among the emitted parts.
+	 *
+	 * @param parts the emitted storage parts
+	 * @return the number of freed-page removal instructions
+	 */
+	private static int countRemovals(@Nonnull List<StoragePart> parts) {
+		return (int) parts.stream().filter(ReferenceTypeCardinalityIndexLeafPageRemoval.class::isInstance).count();
+	}
 
 	/**
 	 * The (never-zero) index primary key for the given 0-based ordinal — index PKs start at 1.

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndexWarmUpFlushLeafMergeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndexWarmUpFlushLeafMergeTest.java
@@ -1,0 +1,186 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.cardinality;
+
+import io.evitadb.core.buffer.TrappedChanges;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.ReferenceTypeCardinalityIndexLeafPagePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.ReferenceTypeCardinalityIndexLeafPageRemoval;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.ReferenceTypeCardinalityIndexStoragePart;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A warm-up (bulk) flush never reaches the transactional commit-merge — {@code publishStaged} runs only there — so two
+ * consecutive {@link ReferenceTypeCardinalityIndex#appendStorageParts} calls on the same live index, with a leaf merge
+ * of its composed-key `(key, count)` bucket tree happening in between, must still correctly detect and free the page
+ * the merge dropped even though nothing was ever published between the two flushes.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Tag(INDEXING)
+@Tag(REFERENCE)
+@DisplayName("A leaf merge between two warm-up flushes with no intermediate publish (ReferenceTypeCardinalityIndex)")
+class ReferenceTypeCardinalityIndexWarmUpFlushLeafMergeTest {
+
+	private static final int ENTITY_INDEX_PK = 1;
+	private static final String REFERENCE_NAME = "testReference";
+	/**
+	 * The single whole-index primary key used for every {@code addRecord}/{@code removeRecord} call. Reusing the same
+	 * index PK for every tuple means only the per-tuple composed key {@code -pack(indexPk, referencedEntityPrimaryKey)}
+	 * is a fresh tree key per call — the per-whole-index counter {@code +pack(indexPk, 0)} is created once and merely
+	 * incremented/decremented in place afterward — which keeps the tree's ascending key layout fully predictable.
+	 */
+	private static final int INDEX_PK = 777;
+	/** Cardinality bucket-tree leaf capacity ({@code VALUE_BLOCK_SIZE}); a full leaf splits into two 128-halves. */
+	private static final int VALUE_BLOCK_SIZE = 256;
+	/**
+	 * Three leaves of exactly half capacity (128) — the layout an ascending append of this many distinct referenced
+	 * primary keys produces (packing {@link #INDEX_PK} with `referencedEntityPrimaryKey` and negating yields a
+	 * monotonically ascending key stream when `referencedEntityPrimaryKey` descends from {@code TUPLE_COUNT} to 1).
+	 */
+	private static final int TUPLE_COUNT = 3 * (VALUE_BLOCK_SIZE / 2) - 1;
+
+	@Test
+	@DisplayName("the leaf page a merge drops between two warm-up flushes must still be reported as freed")
+	void shouldReportFreedLeafPageAcrossConsecutiveWarmUpFlushesWithoutAnIntermediatePublish() {
+		final ReferenceTypeCardinalityIndex index = new ReferenceTypeCardinalityIndex();
+		// descending referencedEntityPrimaryKey -> ascending -pack(INDEX_PK, referencedEntityPrimaryKey) key stream;
+		// the first call also creates the single +pack(INDEX_PK, 0) counter key, which — being positive — is always
+		// the global maximum and therefore always lands in (and stays in) the rightmost leaf
+		for (int referencedEntityPrimaryKey = TUPLE_COUNT; referencedEntityPrimaryKey >= 1; referencedEntityPrimaryKey--) {
+			index.addRecord(INDEX_PK, referencedEntityPrimaryKey);
+		}
+		assertTrue(
+			index.isPaged(),
+			"383 tuples (384 tree keys) must span three leaves (leaf 0 [256..383], 1 [128..255], 2 [1..127]+sentinel)."
+		);
+
+		// first warm-up flush: stages page sequences 0, 1, 2 for the three fresh leaves but — mirroring a real
+		// warm-up, which never reaches the transactional commit-merge — is never published
+		final List<StoragePart> firstFlush = flush(index);
+		assertEquals(
+			3, countLeafPages(firstFlush), "The first flush must write every one of the three fresh leaves."
+		);
+		assertEquals(
+			3, singleRoot(firstFlush).getLeafPageSequences().length,
+			"The first flush's root must list all three leaf pages."
+		);
+
+		// force leaf 0 [256..383] to merge with leaf 1 [128..255] while leaf 2 [1..127]+sentinel stays structurally
+		// untouched: bring leaf 1 down to exactly the minimum (127) first so it can no longer donate, then push
+		// leaf 0 one below the minimum (126) so it underflows and merges into leaf 1 (mergeWithRight)
+		index.removeRecord(INDEX_PK, 128); // leaf 1: 128 -> 127 (== minValueBlockSize, can no longer donate)
+		index.removeRecord(INDEX_PK, 383); // leaf 0: 128 -> 127 (still at the minimum, no underflow yet)
+		index.removeRecord(INDEX_PK, 382); // leaf 0: 127 -> 126 (< minValueBlockSize) -> merges with leaf 1
+
+		assertTrue(index.isPaged(), "The index must stay PAGED (two leaves) after the merge, not collapse to SINGLE.");
+
+		// second warm-up flush: without the fix, the freed-page diff is computed against the still-EMPTY published
+		// live set (nothing was ever published after the first flush), so the page the merge dropped is silently
+		// never reported and therefore never removed from storage
+		final List<StoragePart> secondFlush = flush(index);
+		assertEquals(
+			2, singleRoot(secondFlush).getLeafPageSequences().length,
+			"The merge must have dropped the tree to two live leaves."
+		);
+		assertEquals(
+			1, countRemovals(secondFlush),
+			"The leaf page the merge dropped must be reported as freed, or it leaks in storage forever."
+		);
+	}
+
+	/**
+	 * Flushes the index's modified storage parts into a captured list, mirroring what a real flush drains from
+	 * {@link TrappedChanges}.
+	 *
+	 * @param index the index to flush
+	 * @return the emitted parts, in emission order
+	 */
+	@Nonnull
+	private static List<StoragePart> flush(@Nonnull ReferenceTypeCardinalityIndex index) {
+		final TrappedChanges trappedChanges = new TrappedChanges();
+		index.appendStorageParts(ENTITY_INDEX_PK, REFERENCE_NAME, trappedChanges);
+		final List<StoragePart> parts = new ArrayList<>();
+		final Iterator<StoragePart> iterator = trappedChanges.getTrappedChangesIterator();
+		while (iterator.hasNext()) {
+			parts.add(iterator.next());
+		}
+		return parts;
+	}
+
+	/**
+	 * Extracts the single {@link ReferenceTypeCardinalityIndexStoragePart} root emitted by a flush, failing if none or
+	 * more than one is present.
+	 *
+	 * @param parts the emitted storage parts
+	 * @return the sole root part
+	 */
+	@Nonnull
+	private static ReferenceTypeCardinalityIndexStoragePart singleRoot(@Nonnull List<StoragePart> parts) {
+		ReferenceTypeCardinalityIndexStoragePart root = null;
+		for (final StoragePart part : parts) {
+			if (part instanceof ReferenceTypeCardinalityIndexStoragePart rootPart) {
+				assertNull(root, "A flush must emit exactly one root part.");
+				root = rootPart;
+			}
+		}
+		assertNotNull(root, "A dirty PAGED flush must emit a root part.");
+		return root;
+	}
+
+	/**
+	 * Counts the leaf pages ({@link ReferenceTypeCardinalityIndexLeafPagePart}) among the emitted parts.
+	 *
+	 * @param parts the emitted storage parts
+	 * @return the number of leaf pages
+	 */
+	private static long countLeafPages(@Nonnull List<StoragePart> parts) {
+		return parts.stream().filter(ReferenceTypeCardinalityIndexLeafPagePart.class::isInstance).count();
+	}
+
+	/**
+	 * Counts the leaf-page removals ({@link ReferenceTypeCardinalityIndexLeafPageRemoval}) among the emitted parts.
+	 *
+	 * @param parts the emitted storage parts
+	 * @return the number of freed-page removal instructions
+	 */
+	private static long countRemovals(@Nonnull List<StoragePart> parts) {
+		return parts.stream().filter(ReferenceTypeCardinalityIndexLeafPageRemoval.class::isInstance).count();
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/page/PageStreamRegistryTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/page/PageStreamRegistryTest.java
@@ -24,12 +24,13 @@
 package io.evitadb.index.page;
 
 import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.index.bPlusTree.PagedLeafHandle;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static io.evitadb.index.page.PageStreamRegistry.NO_PAGE;
@@ -56,17 +57,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PageStreamRegistryTest {
 
 	/**
-	 * Builds a mutable live-page set from the given page sequences.
+	 * Builds a live-page list from the given page sequences, in the order they are passed.
 	 *
-	 * @param pageSequences the page sequences
-	 * @return the assembled set
+	 * @param pageSequences the page sequences in ascending key order
+	 * @return the assembled list
 	 */
-	private static Set<Integer> liveSetOf(int... pageSequences) {
-		final Set<Integer> set = new HashSet<>();
-		for (final int pageSequence : pageSequences) {
-			set.add(pageSequence);
-		}
-		return set;
+	private static int[] livePagesOf(int... pageSequences) {
+		return pageSequences;
 	}
 
 	@Nested
@@ -99,7 +96,7 @@ class PageStreamRegistryTest {
 			registry.allocate(1); // 1
 			registry.allocate(1); // 2
 			// page 1 is freed: the next published live set simply omits it
-			registry.stage(1, liveSetOf(0, 2));
+			registry.stage(1, livePagesOf(0, 2));
 			registry.publishStaged();
 
 			assertFalse(registry.livePages(1).contains(1), "Freed page must drop out of the live set.");
@@ -133,7 +130,7 @@ class PageStreamRegistryTest {
 		void shouldHideStagedLiveSetUntilPublished() {
 			final PageStreamRegistry registry = new PageStreamRegistry();
 			registry.allocate(1); // 0
-			registry.stage(1, liveSetOf(0));
+			registry.stage(1, livePagesOf(0));
 
 			assertTrue(registry.hasStaged(1), "Stream must report a pending staged live set.");
 			assertTrue(registry.livePages(1).isEmpty(), "Staged page must not be visible before publish.");
@@ -144,27 +141,6 @@ class PageStreamRegistryTest {
 		}
 
 		@Test
-		@DisplayName("discards a staged live set on abort, leaving the live set and high-water intact")
-		@Tag(INDEXING)
-		@Tag(SERIALIZATION)
-		void shouldDiscardStagedLiveSetOnAbort() {
-			final PageStreamRegistry registry = new PageStreamRegistry();
-			registry.allocate(1); // 0
-			registry.stage(1, liveSetOf(0));
-			registry.publishStaged(); // first commit lands page 0
-
-			// a second flush stages a change and allocates a page, then the commit aborts
-			registry.allocate(1); // 1
-			registry.stage(1, liveSetOf(0, 1));
-			registry.discardStaged();
-
-			assertFalse(registry.hasStaged(1), "Discard must clear the pending flag.");
-			assertTrue(registry.livePages(1).contains(0), "Live set must survive an aborted commit.");
-			assertFalse(registry.livePages(1).contains(1), "The aborted page must not enter the live set.");
-			assertEquals(1, registry.highWater(1), "High-water must not roll back on abort (advance-only).");
-		}
-
-		@Test
 		@DisplayName("replaces a pending staged live set when staged again before publishing")
 		@Tag(INDEXING)
 		@Tag(SERIALIZATION)
@@ -172,8 +148,8 @@ class PageStreamRegistryTest {
 			final PageStreamRegistry registry = new PageStreamRegistry();
 			registry.allocate(1); // 0
 			registry.allocate(1); // 1
-			registry.stage(1, liveSetOf(0, 1));
-			registry.stage(1, liveSetOf(0));
+			registry.stage(1, livePagesOf(0, 1));
+			registry.stage(1, livePagesOf(0));
 			registry.publishStaged();
 
 			assertEquals(Set.of(0), registry.livePages(1), "The last staged set must win.");
@@ -187,8 +163,8 @@ class PageStreamRegistryTest {
 			final PageStreamRegistry registry = new PageStreamRegistry();
 			registry.allocate(1); // stream 1, page 0
 			registry.allocate(2); // stream 2, page 0
-			registry.stage(1, liveSetOf(0));
-			registry.stage(2, liveSetOf(0));
+			registry.stage(1, livePagesOf(0));
+			registry.stage(2, livePagesOf(0));
 
 			registry.publishStaged();
 			assertEquals(Set.of(0), registry.livePages(1));
@@ -196,14 +172,13 @@ class PageStreamRegistryTest {
 		}
 
 		@Test
-		@DisplayName("treats publish and discard as no-ops when nothing is staged")
+		@DisplayName("treats publish as a no-op when nothing is staged")
 		@Tag(INDEXING)
 		@Tag(SERIALIZATION)
 		void shouldTreatEmptyHandshakeAsNoOp() {
 			final PageStreamRegistry registry = new PageStreamRegistry();
 			registry.allocate(1);
 			registry.publishStaged();
-			registry.discardStaged();
 			assertTrue(registry.livePages(1).isEmpty(), "No staging means the live set stays empty.");
 			assertEquals(0, registry.highWater(1), "Empty handshake must not touch the high-water.");
 		}
@@ -217,7 +192,7 @@ class PageStreamRegistryTest {
 			registry.allocate(1); // high-water 0
 			assertThrows(
 				GenericEvitaInternalError.class,
-				() -> registry.stage(1, liveSetOf(5)),
+				() -> registry.stage(1, livePagesOf(5)),
 				"Staging an unallocated page sequence must fail."
 			);
 		}
@@ -233,7 +208,7 @@ class PageStreamRegistryTest {
 		@Tag(SERIALIZATION)
 		void shouldRestoreAndContinue() {
 			final PageStreamRegistry registry = new PageStreamRegistry();
-			registry.restore(1, 4, liveSetOf(0, 2, 4));
+			registry.restore(1, 4, livePagesOf(0, 2, 4));
 
 			assertTrue(registry.isKnown(1));
 			assertEquals(4, registry.highWater(1));
@@ -249,7 +224,7 @@ class PageStreamRegistryTest {
 		@Tag(SERIALIZATION)
 		void shouldRestoreEmptyStream() {
 			final PageStreamRegistry registry = new PageStreamRegistry();
-			registry.restore(1, NO_PAGE, liveSetOf());
+			registry.restore(1, NO_PAGE, livePagesOf());
 			assertEquals(NO_PAGE, registry.highWater(1));
 			assertEquals(0, registry.allocate(1), "First allocation after an empty restore must be zero.");
 		}
@@ -262,8 +237,115 @@ class PageStreamRegistryTest {
 			final PageStreamRegistry registry = new PageStreamRegistry();
 			assertThrows(
 				GenericEvitaInternalError.class,
-				() -> registry.restore(1, 2, liveSetOf(3)),
+				() -> registry.restore(1, 2, livePagesOf(3)),
 				"A live page above the high-water is impossible and must fail."
+			);
+		}
+	}
+
+	/**
+	 * Minimal {@link PagedLeafHandle} double: a leaf carrying a page sequence and a dirty flag, with no tree behind it.
+	 */
+	private static final class TestLeafHandle implements PagedLeafHandle {
+		private int pageSequence;
+		private boolean dirty;
+
+		private TestLeafHandle(int pageSequence, boolean dirty) {
+			this.pageSequence = pageSequence;
+			this.dirty = dirty;
+		}
+
+		@Override
+		public int getPageSequence() {
+			return this.pageSequence;
+		}
+
+		@Override
+		public void setPageSequence(int pageSequence) {
+			this.pageSequence = pageSequence;
+		}
+
+		@Override
+		public boolean isDirty() {
+			return this.dirty;
+		}
+
+		@Override
+		public void clearDirty() {
+			this.dirty = false;
+		}
+	}
+
+	@Nested
+	@DisplayName("Page-list change detection")
+	class ChangeDetection {
+
+		@Test
+		@DisplayName("throws when the published baseline disagrees with the collected page list")
+		@Tag(INDEXING)
+		@Tag(SERIALIZATION)
+		void shouldThrowWhenPublishedBaselineDesyncsFromCollectedPageList() {
+			final PageStreamRegistry registry = new PageStreamRegistry();
+			// a previous flush allocated pages 0 and 1 and wrote them to disk, but never published its staged set —
+			// the exact warm-up baseline desync: the pages are on disk while the live set still claims the stream is empty
+			registry.allocate(1); // 0
+			registry.allocate(1); // 1
+			registry.stage(1, livePagesOf(0, 1));
+
+			// the next flush finds a merged tree: page 1 was merged away and page 0 absorbed its keys. Against the stale
+			// (empty) baseline the freed-page proxy computes `∅ - {0} = ∅` and reports "page list unchanged" — which would
+			// skip the root and leave it listing the dropped page 1. The direct comparison sees [0] != [] and disagrees:
+			// a disagreement is only possible when a baseline is wrong, so it must surface here rather than on disk.
+			final List<TestLeafHandle> handles = List.of(new TestLeafHandle(0, true));
+			assertThrows(
+				GenericEvitaInternalError.class,
+				() -> registry.collectChangedPages(1, handles, (pageSequence, handle) -> pageSequence),
+				"A page list that disagrees with the published baseline must fail the flush, never reach storage."
+			);
+		}
+
+		@Test
+		@DisplayName("agrees with the freed-page proxy across a merge, a split and an untouched flush")
+		@Tag(INDEXING)
+		@Tag(SERIALIZATION)
+		void shouldAgreeWithProxyAcrossMergeSplitAndUntouchedFlush() {
+			final PageStreamRegistry registry = new PageStreamRegistry();
+			registry.restore(1, 1, livePagesOf(0, 1));
+
+			// an untouched flush re-collects the same pages: nothing allocated, nothing freed, list identical
+			assertFalse(
+				registry.collectChangedPages(
+					1,
+					List.of(new TestLeafHandle(0, false), new TestLeafHandle(1, false)),
+					(pageSequence, handle) -> pageSequence
+				).pageListChanged(),
+				"An untouched flush must not re-emit the root."
+			);
+			registry.publishStaged();
+
+			// a split adds a fresh leaf: the allocator stamps it and the list grows
+			assertTrue(
+				registry.collectChangedPages(
+					1,
+					List.of(
+						new TestLeafHandle(0, true),
+						new TestLeafHandle(PagedLeafHandle.UNASSIGNED_PAGE_SEQUENCE, true),
+						new TestLeafHandle(1, false)
+					),
+					(pageSequence, handle) -> pageSequence
+				).pageListChanged(),
+				"A split must re-emit the root."
+			);
+			registry.publishStaged();
+
+			// a merge drops page 1: nothing is allocated, so only the freed page makes the list change
+			assertTrue(
+				registry.collectChangedPages(
+					1,
+					List.of(new TestLeafHandle(0, true), new TestLeafHandle(2, false)),
+					(pageSequence, handle) -> pageSequence
+				).pageListChanged(),
+				"A merge must re-emit the root."
 			);
 		}
 	}
@@ -279,7 +361,7 @@ class PageStreamRegistryTest {
 		void shouldForgetStream() {
 			final PageStreamRegistry registry = new PageStreamRegistry();
 			registry.allocate(1);
-			registry.stage(1, liveSetOf(0));
+			registry.stage(1, livePagesOf(0));
 			registry.publishStaged();
 
 			registry.forget(1);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/page/PageStreamRegistryTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/page/PageStreamRegistryTest.java
@@ -30,12 +30,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
 import static io.evitadb.index.page.PageStreamRegistry.NO_PAGE;
 import static io.evitadb.test.TestTags.INDEXING;
 import static io.evitadb.test.TestTags.SERIALIZATION;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -60,7 +62,7 @@ class PageStreamRegistryTest {
 	 * Builds a live-page list from the given page sequences, in the order they are passed.
 	 *
 	 * @param pageSequences the page sequences in ascending key order
-	 * @return the assembled list
+	 * @return the same page sequences as an ordered {@code int[]} live-page list
 	 */
 	private static int[] livePagesOf(int... pageSequences) {
 		return pageSequences;
@@ -196,6 +198,48 @@ class PageStreamRegistryTest {
 				"Staging an unallocated page sequence must fail."
 			);
 		}
+
+		@Test
+		@DisplayName("reports the staged set for a collapse reclaim before any publish, then the published set after")
+		@Tag(INDEXING)
+		@Tag(SERIALIZATION)
+		void shouldReportPendingLiveSetFromStagedSetBeforePublish() {
+			final PageStreamRegistry registry = new PageStreamRegistry();
+			assertArrayEquals(
+				new int[0], registry.pendingLivePageSequences(1),
+				"An unknown stream must report no pending live pages."
+			);
+
+			registry.allocate(1); // 0
+			registry.allocate(1); // 1
+			registry.stage(1, livePagesOf(0, 1));
+
+			// a PAGED -> SINGLE collapse reclaims against what THIS flush staged, before it publishes: the published
+			// live set still lags a whole flush behind (empty here), so only the staged set names the pages to remove
+			assertTrue(registry.livePages(1).isEmpty(), "The staged set must stay invisible to the published live set.");
+			assertArrayEquals(
+				new int[]{0, 1}, sorted(registry.pendingLivePageSequences(1)),
+				"Before publish, the pending live set must be the staged set, not the lagging published set."
+			);
+
+			registry.publishStaged();
+			assertArrayEquals(
+				new int[]{0, 1}, sorted(registry.pendingLivePageSequences(1)),
+				"After publish, the pending live set must fall back to the now-current published set."
+			);
+		}
+	}
+
+	/**
+	 * Sorts a page-sequence array in place and returns it, so assertions can ignore the {@link java.util.HashSet}
+	 * iteration order behind {@link PageStreamRegistry#pendingLivePageSequences(int)}.
+	 *
+	 * @param pageSequences the page sequences to sort
+	 * @return the same array, sorted ascending
+	 */
+	private static int[] sorted(int[] pageSequences) {
+		Arrays.sort(pageSequences);
+		return pageSequences;
 	}
 
 	@Nested

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndexPagingTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndexPagingTest.java
@@ -30,8 +30,10 @@ import io.evitadb.index.price.model.priceRecord.PriceRecord;
 import io.evitadb.index.price.model.priceRecord.PriceRecordContract;
 import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.PriceListAndCurrencySuperIndexLeafPagePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.PriceListAndCurrencySuperIndexLeafPageRemoval;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.PriceListAndCurrencySuperIndexStoragePart;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -242,6 +244,220 @@ class PriceListAndCurrencyPriceSuperIndexPagingTest {
 		final PriceListAndCurrencySuperIndexStoragePart root = (PriceListAndCurrencySuperIndexStoragePart) parts.get(0);
 		assertFalse(root.isPaged(), "the root is the inline SINGLE shape");
 		assertEquals(10, root.getPriceRecords().length, "a SINGLE root carries every record inline");
+	}
+
+	/**
+	 * A warm-up (bulk) flush never reaches the transactional commit-merge — {@code publishStaged} runs only there — so
+	 * two consecutive {@link PriceListAndCurrencyPriceSuperIndex#appendStorageParts} calls on the same live index, with a
+	 * leaf merge happening in between, must still correctly detect and free the page the merge dropped even though
+	 * nothing was ever published between the two flushes.
+	 */
+	@Nested
+	@DisplayName("A leaf merge between two warm-up flushes with no intermediate publish")
+	class WarmUpFlushLeafMergeTest {
+
+		/** Default element-tree block size ({@code DEFAULT_VALUE_BLOCK_SIZE}); a full leaf splits into two 32-halves. */
+		private static final int VALUE_BLOCK_SIZE = 64;
+		/** Three leaves of exactly half capacity (32) — the layout an ascending append of this many records produces. */
+		private static final int MERGE_RECORD_COUNT = 3 * (VALUE_BLOCK_SIZE / 2);
+
+		@Test
+		@DisplayName("the leaf page a merge drops between two warm-up flushes must still be reported as freed")
+		void shouldReportFreedLeafPageAcrossConsecutiveWarmUpFlushesWithoutAnIntermediatePublish() {
+			final PriceListAndCurrencyPriceSuperIndex index = new PriceListAndCurrencyPriceSuperIndex(PRICE_INDEX_KEY);
+			for (int internalPriceId = 1; internalPriceId <= MERGE_RECORD_COUNT; internalPriceId++) {
+				index.addPrice(rec(internalPriceId), null);
+			}
+			assertTrue(index.isPaged(), "96 ascending records must span three leaves (leaf 0 [1..32], 1 [33..64], 2 [65..96]).");
+
+			// first warm-up flush: stages page sequences 0, 1, 2 for the three fresh leaves but — mirroring a real
+			// warm-up, which never reaches the transactional commit-merge — is never published
+			final List<StoragePart> firstFlush = flush(index);
+			assertEquals(
+				3, countLeafPages(firstFlush), "The first flush must write every one of the three fresh leaves."
+			);
+			assertEquals(
+				3, singleRoot(firstFlush).getLeafPageSequences().length,
+				"The first flush's root must list all three leaf pages."
+			);
+
+			// force leaf 0 [1..32] to merge with leaf 1 [33..64] while leaf 2 [65..96] stays untouched: bring leaf 1
+			// down to exactly the minimum (31) first so it can no longer donate, then push leaf 0 one below the
+			// minimum (30) so it underflows and merges into leaf 1 (mergeWithRight)
+			index.removePrice(33, 33, null); // leaf 1: 32 -> 31 (== minValueBlockSize, can no longer donate)
+			index.removePrice(1, 1, null);   // leaf 0: 32 -> 31 (still at the minimum, no underflow yet)
+			index.removePrice(2, 2, null);   // leaf 0: 31 -> 30 (< minValueBlockSize) -> merges with leaf 1
+
+			assertTrue(index.isPaged(), "The index must stay PAGED (two leaves) after the merge, not collapse to SINGLE.");
+
+			// second warm-up flush: without the fix, the freed-page diff is computed against the still-EMPTY published
+			// live set (nothing was ever published after the first flush), so the page the merge dropped is silently
+			// never reported and therefore never removed from storage
+			final List<StoragePart> secondFlush = flush(index);
+			assertEquals(
+				2, singleRoot(secondFlush).getLeafPageSequences().length,
+				"The merge must have dropped the tree to two live leaves."
+			);
+			assertEquals(
+				1, countRemovals(secondFlush),
+				"The leaf page the merge dropped must be reported as freed, or it leaks in storage forever."
+			);
+		}
+
+		/**
+		 * Extracts the single {@link PriceListAndCurrencySuperIndexStoragePart} root emitted by a flush, failing if none
+		 * or more than one is present.
+		 *
+		 * @param parts the emitted storage parts
+		 * @return the sole root part
+		 */
+		@Nonnull
+		private static PriceListAndCurrencySuperIndexStoragePart singleRoot(@Nonnull List<StoragePart> parts) {
+			PriceListAndCurrencySuperIndexStoragePart root = null;
+			for (final StoragePart part : parts) {
+				if (part instanceof PriceListAndCurrencySuperIndexStoragePart rootPart) {
+					assertNull(root, "A flush must emit exactly one root part.");
+					root = rootPart;
+				}
+			}
+			assertNotNull(root, "A dirty PAGED flush must emit a root part.");
+			return root;
+		}
+
+		/**
+		 * Counts the leaf pages ({@link PriceListAndCurrencySuperIndexLeafPagePart}) among the emitted parts.
+		 *
+		 * @param parts the emitted storage parts
+		 * @return the number of leaf pages
+		 */
+		private static long countLeafPages(@Nonnull List<StoragePart> parts) {
+			return parts.stream().filter(PriceListAndCurrencySuperIndexLeafPagePart.class::isInstance).count();
+		}
+
+		/**
+		 * Counts the leaf-page removals ({@link PriceListAndCurrencySuperIndexLeafPageRemoval}) among the emitted parts.
+		 *
+		 * @param parts the emitted storage parts
+		 * @return the number of freed-page removal instructions
+		 */
+		private static long countRemovals(@Nonnull List<StoragePart> parts) {
+			return parts.stream().filter(PriceListAndCurrencySuperIndexLeafPageRemoval.class::isInstance).count();
+		}
+
+	}
+
+	/**
+	 * A `PAGED -> SINGLE` collapse in the WARM-UP shape: two consecutive
+	 * {@link PriceListAndCurrencyPriceSuperIndex#appendStorageParts} calls on the SAME live index with NO reload in
+	 * between. When the price-record tree shrinks back inside a single leaf, the inline `SINGLE` root references none of
+	 * the leaf pages the index previously wrote, so the collapse must emit a removal for EVERY one of them — the
+	 * append-only `OffsetIndex` never reclaims a record that is neither superseded nor explicitly removed, so a missed
+	 * removal leaks that page forever.
+	 *
+	 * The reclaim must therefore be taken against the page set the PREVIOUS flush left ON DISK (its staged set), not
+	 * against the published live set: publishing only ever happens at a transactional commit-merge, which a warming-up
+	 * catalog never reaches, so a published-set reclaim would free NOTHING here.
+	 *
+	 * This is precisely the gap a reload-based collapse test cannot see — reassembling an index through
+	 * {@link PriceListAndCurrencyPriceSuperIndex#fromPersistedPages} seeds the live-page baseline from disk, so the
+	 * published set happens to be correct there and such a test stays green either way. The shape below never reloads,
+	 * which is what makes it discriminating. Note this index re-emits its `PAGED` root unconditionally (the root carries
+	 * the inline validity index), so a missed reclaim can never CORRUPT a reload here — it is a pure storage LEAK, which
+	 * is why this pins removal counts rather than reload correctness.
+	 */
+	@Nested
+	@DisplayName("A PAGED -> SINGLE collapse between two warm-up flushes with no intermediate publish")
+	class WarmUpFlushCollapseTest {
+
+		/**
+		 * Price records kept after the collapse. Ten records fit comfortably inside a single 64-entry leaf — the same
+		 * count the sibling small-index test uses to prove a ten-record index persists as the inline SINGLE shape — so
+		 * the shrunken tree cannot retain an internal root and must fall back to a single leaf.
+		 */
+		private static final int COLLAPSE_KEEP = 10;
+
+		@Test
+		@DisplayName("every leaf page the previous warm-up flush wrote must be removed when the index collapses to SINGLE")
+		void shouldRemovePriorLeafPagesWhenCollapsingAcrossTwoWarmUpFlushesWithoutAnIntermediateReload() {
+			final PriceListAndCurrencyPriceSuperIndex index = buildLargeSuperIndex();
+			assertTrue(index.isPaged(), RECORD_COUNT + " records must span multiple leaves -> PAGED");
+
+			// first warm-up flush: allocates and stages one page per fresh leaf but — mirroring a real warm-up, which
+			// never reaches the transactional commit-merge — never publishes them
+			final List<StoragePart> firstFlush = flush(index);
+			final int priorLeafPageCount = countLeafPages(firstFlush);
+			assertTrue(priorLeafPageCount >= 3, "The source index must start paged across several leaves.");
+			assertEquals(
+				priorLeafPageCount, singleRoot(firstFlush).getLeafPageSequences().length,
+				"A first flush writes every one of the live leaf pages its root lists (every leaf is brand new)."
+			);
+			assertEquals(0, countRemovals(firstFlush), "A first flush frees no leaf page.");
+
+			// collapse the SAME in-memory index, with NO reload in between: drop all but a handful of records so the
+			// survivors fit one leaf — the leaves cascade-merge and the root falls back to that single surviving leaf
+			for (int internalPriceId = COLLAPSE_KEEP + 1; internalPriceId <= RECORD_COUNT; internalPriceId++) {
+				index.removePrice(internalPriceId, internalPriceId, null);
+			}
+			assertFalse(index.isPaged(), "The shrunken index must collapse to a single leaf (PAGED -> SINGLE).");
+
+			// second warm-up flush: the collapse must reclaim what the FIRST flush staged. Reading the published live
+			// set instead finds it still EMPTY — nothing published between the two flushes — and silently frees nothing.
+			final List<StoragePart> secondFlush = flush(index);
+			final PriceListAndCurrencySuperIndexStoragePart collapsedRoot = singleRoot(secondFlush);
+			assertFalse(collapsedRoot.isPaged(), "The collapsed index must emit the inline (SINGLE) root.");
+			assertEquals(
+				COLLAPSE_KEEP, collapsedRoot.getPriceRecords().length,
+				"The SINGLE root must carry every surviving price record inline."
+			);
+			assertEquals(0, countLeafPages(secondFlush), "A collapsed index must not re-emit any leaf page.");
+			assertEquals(
+				priorLeafPageCount, countRemovals(secondFlush),
+				"The collapse must remove every leaf page the previous warm-up flush wrote — the append-only " +
+					"OffsetIndex never reclaims a record that is neither superseded nor explicitly removed, so a " +
+					"missed removal leaks the page forever."
+			);
+		}
+
+		/**
+		 * Extracts the single {@link PriceListAndCurrencySuperIndexStoragePart} root emitted by a flush, failing if none
+		 * or more than one is present.
+		 *
+		 * @param parts the emitted storage parts
+		 * @return the sole root part
+		 */
+		@Nonnull
+		private static PriceListAndCurrencySuperIndexStoragePart singleRoot(@Nonnull List<StoragePart> parts) {
+			PriceListAndCurrencySuperIndexStoragePart root = null;
+			for (final StoragePart part : parts) {
+				if (part instanceof PriceListAndCurrencySuperIndexStoragePart rootPart) {
+					assertNull(root, "A flush must emit exactly one root part.");
+					root = rootPart;
+				}
+			}
+			assertNotNull(root, "A dirty flush must emit a root part.");
+			return root;
+		}
+
+		/**
+		 * Counts the leaf pages ({@link PriceListAndCurrencySuperIndexLeafPagePart}) among the emitted parts.
+		 *
+		 * @param parts the emitted storage parts
+		 * @return the number of leaf pages
+		 */
+		private static int countLeafPages(@Nonnull List<StoragePart> parts) {
+			return (int) parts.stream().filter(PriceListAndCurrencySuperIndexLeafPagePart.class::isInstance).count();
+		}
+
+		/**
+		 * Counts the leaf-page removals ({@link PriceListAndCurrencySuperIndexLeafPageRemoval}) among the emitted parts.
+		 *
+		 * @param parts the emitted storage parts
+		 * @return the number of freed-page removal instructions
+		 */
+		private static int countRemovals(@Nonnull List<StoragePart> parts) {
+			return (int) parts.stream().filter(PriceListAndCurrencySuperIndexLeafPageRemoval.class::isInstance).count();
+		}
+
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/range/RangeIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/range/RangeIndexTest.java
@@ -1573,6 +1573,22 @@ class RangeIndexTest {
 			return index;
 		}
 
+		/**
+		 * Builds a range index with one distinct threshold per record: `addRecord(v, v, v)` upserts the same
+		 * threshold twice, so the second upsert finds the point the first one just created and adds the end to it
+		 * instead of inserting a second point — a single point carries both the start and the end for record `v`.
+		 * This makes the leaf boundaries fall on exact record counts, which the split/merge arithmetic in
+		 * `shouldReportFreedPagesWhenLeafMergesAwayBetweenTwoUnpublishedWarmUpFlushes` depends on.
+		 */
+		@Nonnull
+		private static RangeIndex denseSingleThresholdRange(int recordCount) {
+			final RangeIndex index = new RangeIndex();
+			for (int i = 1; i <= recordCount; i++) {
+				index.addRecord(i, i, i);
+			}
+			return index;
+		}
+
 		@Test
 		@Tag(INDEXING)
 		@Tag(ATTRIBUTE)
@@ -1709,6 +1725,77 @@ class RangeIndexTest {
 			for (final int freed : afterShrink.freedPageSequences()) {
 				assertFalse(live.contains(freed), "A freed page must not be live.");
 				assertTrue(baseline.contains(freed), "A freed page must have been live in the prior baseline.");
+			}
+		}
+
+		@Test
+		@Tag(INDEXING)
+		@Tag(ATTRIBUTE)
+		@DisplayName(
+			"a leaf merge staged by one warm-up flush and never published before the next warm-up flush still " +
+				"reports the dropped page as freed and re-emits the changed page list"
+		)
+		void shouldReportFreedPagesWhenLeafMergesAwayBetweenTwoUnpublishedWarmUpFlushes() {
+			// a warm-up (bulk-load) flush never runs the transactional commit-merge that publishes the staged
+			// baseline (see RangeIndex#createCopyWithMergedTransactionalMemory) - collectChangedPages() is called
+			// directly, flush after flush, with nothing in between to publish it. This reproduces exactly that:
+			// two collectChangedPages() calls back to back, no publishStaged() in between.
+			//
+			// valueBlockSize = 512, split mid = 256: growing the empty tree's two border sentinels (MIN, MAX) with
+			// an ascending stream of 1022 single-threshold records (see denseSingleThresholdRange) lays the tree
+			// out as four leaves of 256 keys each:
+			//   leaf0 = {MIN, 1..255}     (256 keys)
+			//   leaf1 = {256..511}        (256 keys)
+			//   leaf2 = {512..767}        (256 keys)
+			//   leaf3 = {768..1022, MAX}  (256 keys)
+			final RangeIndex index = denseSingleThresholdRange(1022);
+			assertTrue(index.isPaged(), "The threshold tree must be PAGED before the merge!");
+
+			// FIRST warm-up flush: stages the four-leaf layout. A warm-up flush never publishes it.
+			final int[] pagesBeforeMerge = index.collectChangedPages().orderedPageSequences();
+			assertEquals(4, pagesBeforeMerge.length, "The tree must start out as four leaf pages!");
+
+			// SECOND warm-up flush: minValueBlockSize = 255. Force leaf0 to merge its right sibling (leaf1) while
+			// both stay far below their own capacity, so no further split can mask the defect under test:
+			// - leaf1: 256 -> 255 keys, exactly at the minimum, so it can no longer donate to a neighbor
+			index.removeRecord(256, 256, 256);
+			// - leaf0: 256 -> 255 keys, still exactly at the minimum, not yet an underflow
+			index.removeRecord(1, 1, 1);
+			// - leaf0: 255 -> 254 keys, underflow. leaf0 has no left sibling and leaf1 sits at the minimum (cannot
+			//   donate), but leaf1's 255 + leaf0's 254 = 509 < 512, so they merge: leaf0 absorbs leaf1 IN PLACE
+			//   (keeps its own page, is marked dirty), leaf1 is detached. No leaf is born, so nothing is allocated.
+			index.removeRecord(2, 2, 2);
+
+			// the tree must still span several leaves: a further collapse would force-emit the root and mask the
+			// defect under test
+			assertTrue(index.isPaged(), "The threshold tree must stay PAGED after the merge!");
+
+			final PageEmission<RangeIndex.RangePage> afterMerge = index.collectChangedPages();
+			assertEquals(
+				3, afterMerge.orderedPageSequences().length,
+				"The merge must have dropped exactly one leaf page (four leaves -> three)!"
+			);
+			assertTrue(
+				afterMerge.freedPageSequences().length > 0,
+				"The page the merge dropped must be reported as freed, not silently kept on the persisted root!"
+			);
+			assertTrue(
+				afterMerge.pageListChanged(),
+				"The ordered leaf-page list changed (a page was dropped) - the PAGED root must be re-emitted!"
+			);
+
+			// every freed page must have been live before the merge and must not be live afterwards
+			final Set<Integer> before = new HashSet<>();
+			for (final int sequence : pagesBeforeMerge) {
+				before.add(sequence);
+			}
+			final Set<Integer> afterwards = new HashSet<>();
+			for (final int sequence : afterMerge.orderedPageSequences()) {
+				afterwards.add(sequence);
+			}
+			for (final int freed : afterMerge.freedPageSequences()) {
+				assertTrue(before.contains(freed), "A freed page must have been live before the merge!");
+				assertFalse(afterwards.contains(freed), "A freed page must not still be live after the merge!");
 			}
 		}
 


### PR DESCRIPTION
## What & why

Fixes the overlapping-leaf-page ("stale leaf-page twin") corruption on paged indexes,
root-caused to warm-up flushes never publishing the `PageStreamRegistry` page baseline: a
leaf merge left the dropped page unremoved and still listed on a skipped `PAGED` root, so a
cold load reassembled overlapping leaves.

## Changes

**Core fix (seam A):** every paged index publishes the previous flush's staged page
baseline before collecting the next, so freed-page reclaim and root-rewrite are decided
against what disk holds. Rolled out to all 7 paged indexes.

**Hardening / fail-fast:**
- Registry stale-baseline tripwire (collected list vs the freed/fresh signals).
- `PAGED->SINGLE` collapse reclaims from the staged-or-published set.
- Warm-up buffer poison on a failed warm-up flush (no silent data loss).
- Transactional suspend boundary replacing the unbounded in-place retry; readers stay
  served from the last durable version and the WAL replays on a clean reload.

**Diagnostics (report, do not repair — SNAPSHOT phase):** load-time overlap detectors and
the registry tripwire now emit rich, error-path-only reports (ordered page list, key
ranges/counts, raw containment fact, cross-check inputs).

## Testing

Per-index warm-up-flush merge repros, a transactional merge-flush-failure suspend test, a
mock-level suspension test, and tree-level overlap-diagnostic assertions. Targeted suites
green (trees 278/0/0, PageStreamRegistry 14/0/0, reload-path twin tests 10/0/0). The full
gate was not re-run because the checkout is being built concurrently by another process.
