### PR TITLE
feat: support distance(0) in hierarchy stopAt

### DIFF
--- a/documentation/user/en/query/requirements/hierarchy.md
+++ b/documentation/user/en/query/requirements/hierarchy.md
@@ -953,7 +953,10 @@ The `distance` constraint can only be used within the `stopAt`
 and limits the hierarchy traversal to stop when
 the number of levels traversed reaches the specified constant. The distance is always relative to the pivot node
 (the node where the hierarchy traversal starts) and is the same whether we are traversing the hierarchy top-down or
-bottom-up. The distance between any two nodes in the hierarchy can be calculated as `abs(level(nodeA) - level(nodeB))`.
+bottom-up. Along a direct ancestor/descendant line, distance equals `abs(level(node) - level(pivot))` - but it is
+not a general distance between two arbitrary nodes in the tree (siblings, for example, sit in different branches
+and are two edges apart despite sharing the same level). In a `siblings` traversal, distance is measured from each
+sibling as its own local pivot, not from the original one.
 See the following figure when the pivot node is *Audio*:
 
 <Note type="info">

--- a/documentation/user/en/query/requirements/hierarchy.md
+++ b/documentation/user/en/query/requirements/hierarchy.md
@@ -943,7 +943,8 @@ distance(
     <dd>
         defines a maximum relative distance from the pivot node that can be traversed;
         the pivot node itself is at distance zero, its direct child or direct parent is at distance one, each additional
-        step adds a one to the distance
+        step adds a one to the distance. A distance of `0` is allowed and stops the traversal right at the pivot node -
+        the pivot (or, in a `siblings` traversal, each sibling) is returned without any of its descendants.
     </dd>
 </dl>
 
@@ -1019,6 +1020,32 @@ That returns simply:
 <MDInclude sourceVariable="extraResults.hierarchy.categories.parent">[Direct parent](/documentation/user/en/query/requirements/examples/hierarchy/hierarchy-parent.rest.json.md)</MDInclude>
 
 </LS>
+
+</Note>
+
+<Note type="info">
+
+<NoteTitle toggles="true">
+
+##### Why would I use `distance(0)`?
+</NoteTitle>
+
+Because `distance` limits how deep the traversal expands, `distance(0)` stops right at the pivot - you get the focused
+node itself with no descendants. Combined with [`statistics`](#statistics) (whose counts still reflect the whole
+subtree), it is the way to render the current node on its own - e.g. as a menu header or breadcrumb showing how many
+items sit below it - without listing its children:
+
+```evitaql
+children(
+    "currentCategory",
+    entityFetch(attributeContent("code")),
+    stopAt(distance(0)),
+    statistics(CHILDREN_COUNT, QUERIED_ENTITY_COUNT)
+)
+```
+
+Inside a [`siblings`](#siblings) traversal `distance(0)` means "the sibling row only, unexpanded" - the explicit
+equivalent of omitting `stopAt` there.
 
 </Note>
 

--- a/evita_query/src/main/java/io/evitadb/api/query/QueryConstraints.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/QueryConstraints.java
@@ -3516,7 +3516,7 @@ public interface QueryConstraints {
 	}
 
 	/**
-	 * Limits hierarchy traversal to nodes within the specified number of edge hops from the pivot node, regardless of traversal direction. Use this to fetch relatives at a distance relative to the pivot's position (e.g., direct children with distance 1). Must be used as the sole inner constraint of `HierarchyStopAt`. Distance must be greater than zero.
+	 * Limits hierarchy traversal to nodes within the specified number of edge hops from the pivot node, regardless of traversal direction. Use this to fetch relatives at a distance relative to the pivot's position (e.g., direct children with distance 1, or just the pivot itself with distance 0). Must be used as the sole inner constraint of `HierarchyStopAt`. Distance must be zero or greater.
 	 *
 	 * ```evitaql
 	 * stopAt(distance(1))

--- a/evita_query/src/main/java/io/evitadb/api/query/require/HierarchyDistance.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/require/HierarchyDistance.java
@@ -45,8 +45,9 @@ import java.io.Serializable;
  * - Distance N: nodes N hops away from the pivot
  *
  * The distance between any two nodes in the hierarchy can be computed as `abs(level(nodeA) - level(nodeB))`.
- * The distance value must be greater than zero (a distance of zero would include only the pivot node itself,
- * which is always included automatically).
+ * The distance value must be zero or greater. A distance of zero stops the traversal right at the pivot node:
+ * the pivot (or, in a `siblings` traversal, each sibling) is returned without any of its descendants — handy
+ * when you want just the focused node, optionally accompanied by its statistics, but none of its children.
  *
  * This constraint can only be used as the single inner constraint of a {@link HierarchyStopAt} container.
  * It is the right choice when you need a traversal depth that is _relative_ to wherever the pivot sits in the
@@ -102,7 +103,7 @@ public class HierarchyDistance extends AbstractRequireConstraintLeaf implements 
 		// because this query can be used only within some other hierarchy query, it would be
 		// unnecessary to duplicate the hierarchy prefix
 		super(CONSTRAINT_NAME, distance);
-		Assert.isTrue(distance > 0, () -> new EvitaInvalidUsageException("Distance must be greater than zero."));
+		Assert.isTrue(distance >= 0, () -> new EvitaInvalidUsageException("Distance must be zero or greater."));
 	}
 
 	/**

--- a/evita_query/src/main/java/io/evitadb/api/query/require/HierarchyDistance.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/require/HierarchyDistance.java
@@ -44,7 +44,10 @@ import java.io.Serializable;
  * - Distance 2: grandchildren (or grandparent) of the pivot node
  * - Distance N: nodes N hops away from the pivot
  *
- * The distance between any two nodes in the hierarchy can be computed as `abs(level(nodeA) - level(nodeB))`.
+ * Along a direct ancestor/descendant line, distance equals `abs(level(node) - level(pivot))` — but it is not
+ * a general shortest-path distance between two arbitrary nodes in the tree (siblings, for example, sit in
+ * different branches and are two edges apart despite sharing a level). In a `siblings` traversal, distance is
+ * measured from each sibling as its own local pivot, not from the original one.
  * The distance value must be zero or greater. A distance of zero stops the traversal right at the pivot node:
  * the pivot (or, in a `siblings` traversal, each sibling) is returned without any of its descendants — handy
  * when you want just the focused node, optionally accompanied by its statistics, but none of its children.

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/hierarchy/EntityByHierarchyFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/hierarchy/EntityByHierarchyFilteringFunctionalTest.java
@@ -1713,6 +1713,71 @@ public class EntityByHierarchyFilteringFunctionalTest extends AbstractHierarchyT
 		);
 	}
 
+	@DisplayName("Should return requested category itself in distance 0 (without its children)")
+	@UseDataSet(THOUSAND_CATEGORIES)
+	@ParameterizedTest
+	@MethodSource("statisticTypeVariants")
+	void shouldReturnCardinalitiesForRequestedCategoriesInDistanceZero(EnumSet<StatisticsType> statisticsType, Evita evita, Map<Integer, SealedEntity> originalCategoryIndex, one.edee.oss.pmptt.model.Hierarchy categoryHierarchy) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.CATEGORY),
+						filterBy(
+							and(
+								entityLocaleEquals(CZECH_LOCALE),
+								hierarchyWithinSelf(entityPrimaryKeyInSet(1))
+							)
+						),
+						require(
+							// we don't need the results whatsoever
+							page(1, 0),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES),
+							// we need only data about cardinalities
+							hierarchyOfSelf(
+								children(
+									"megaMenu",
+									entityFetch(attributeContentAll()),
+									stopAt(distance(0)),
+									statisticsType.isEmpty() ? null : statistics(statisticsType.toArray(StatisticsType[]::new))
+								)
+							)
+						)
+					),
+					EntityReference.class
+				);
+
+				final TestHierarchyPredicate languagePredicate = (entity, parentItems) -> entity.getLocales().contains(CZECH_LOCALE);
+				// distance 0 stops the traversal right at the pivot: only category 1 itself is part of the returned
+				// tree (no children), yet its childrenCount / queriedEntityCount still reflect the whole subtree below it
+				final TestHierarchyPredicate treePredicate = (sealedEntity, parentItems) ->
+					languagePredicate.test(sealedEntity, parentItems) && sealedEntity.getPrimaryKey() == 1;
+
+				final Hierarchy expectedStatistics = computeExpectedStatistics(
+					categoryHierarchy, originalCategoryIndex,
+					languagePredicate, treePredicate,
+					categoryCardinalities -> new HierarchyStatisticsTuple(
+						"megaMenu",
+						computeChildren(
+							session, 1, categoryHierarchy,
+							categoryCardinalities, false,
+							statisticsType.contains(StatisticsType.CHILDREN_COUNT),
+							statisticsType.contains(StatisticsType.QUERIED_ENTITY_COUNT),
+							1
+						)
+					)
+				);
+
+				final Hierarchy statistics = result.getExtraResult(Hierarchy.class);
+				assertNotNull(statistics);
+				assertEquals(expectedStatistics, statistics);
+
+				return null;
+			}
+		);
+	}
+
 	@DisplayName("Should return children for requested category siblings in distance 1")
 	@UseDataSet(THOUSAND_CATEGORIES)
 	@ParameterizedTest

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/query/require/HierarchyDistanceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/query/require/HierarchyDistanceTest.java
@@ -71,9 +71,11 @@ class HierarchyDistanceTest {
 		}
 
 		@Test
-		@DisplayName("should fail to create with zero distance")
-		void shouldFailToCreateDistanceWithZero() {
-			assertThrows(EvitaInvalidUsageException.class, () -> distance(0));
+		@DisplayName("should create with zero distance (stops at the pivot node)")
+		void shouldCreateDistanceWithZero() {
+			final HierarchyDistance hierarchyDistance = distance(0);
+
+			assertEquals(0, hierarchyDistance.getDistance());
 		}
 	}
 


### PR DESCRIPTION
Closes #499

## Summary

Allows `stopAt(distance(0))` in hierarchy requirements. A distance of zero stops traversal right at the pivot node: the pivot (or, in a `siblings` traversal, each sibling) is returned **without any of its descendants**.

## Why

`distance` limits how *deep* a traversal expands. Blocking `0` left a real gap: for `children` / `fromRoot` / `fromNode` there was no way to request just the focused node on its own — omitting `stopAt` expands the full subtree, and `distance(1)` adds the direct children. `distance(0)` combined with `statistics(...)` — whose counts still reflect the whole subtree via the omission block — is the natural way to render the current node alone (e.g. a menu header / breadcrumb showing how many items sit below it).

The engine already modelled distance 0 internally: `stopAtConstraintToPredicate` computes `distance > -1 && distance <= N` (correct for `N = 0`), and `HierarchyTraversalPredicate.ONLY_SELF = distance < 1` already exists. The sole barrier was the `HierarchyDistance` constructor's `distance > 0` assertion, through which **every transport funnels** — the EvitaQL parser, gRPC (the query travels as EvitaQL text and is re-parsed), and GraphQL/REST descriptor construction (no `minimum` schema bound). So one relaxation unblocks all four APIs.

## Semantics of `distance(0)` by context

| Context | `distance(0)` result |
|---|---|
| `children` / `fromRoot` / `fromNode` | the start node(s) only, no descendants — genuinely new scope |
| `parents` | the pivot only, no ancestors |
| `siblings` (standalone or within `parents`) | the sibling row, unexpanded — the explicit equivalent of omitting `stopAt` (default is already `ONLY_SELF` / `distance == 0`) |
| `hierarchyContent` | the entity's placement with zero ancestors |

## Changes

- `HierarchyDistance` constructor: `distance > 0` → `distance >= 0` (negatives still rejected); JavaDoc corrected.
- `QueryConstraints.distance(...)` factory JavaDoc corrected.
- `HierarchyDistanceTest`: zero now constructs (negative still throws).
- New `EntityByHierarchyFilteringFunctionalTest` case: `children(stopAt(distance(0)))` returns pivot-only while `childrenCount` / `queriedEntityCount` still reflect the full subtree — verified against a `distance(1)` control.
- Docs `hierarchy.md` §Distance: one clarifying sentence + a compact collapsed note.

## Notes

- `distance(0)` in `parents` / `fromRoot` / `fromNode` / `hierarchyContent` shares the same predicate path proven by the `children` test, but is not each individually covered by a new test.
- The `@SourceHash` on the `distance()` factory regenerates on the next `mvn -Pgenerate-javadoc` run; the now-correct one-liner was hand-updated in the meantime.
- The C# client mirrors this `distance > 0` guard in its own repo — a follow-up there.
