### PR TITLE
Fix catalog-init race, B+ tree dirty-scope validation, index reclaim leak, span-name laziness

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/observability/trace/DefaultTracingBlockReference.java
+++ b/evita_api/src/main/java/io/evitadb/api/observability/trace/DefaultTracingBlockReference.java
@@ -47,6 +47,13 @@ import javax.annotation.Nonnull;
 public class DefaultTracingBlockReference implements TracingBlockReference {
 
 	/**
+	 * Reusable no-op block reference. Because this class carries no state and every method is a
+	 * no-op, a single shared instance serves all callers — there is no reason to allocate a fresh
+	 * object per span on the disabled path, where span creation happens on every traced call site.
+	 */
+	public static final TracingBlockReference INSTANCE = new DefaultTracingBlockReference();
+
+	/**
 	 * No-op implementation that does nothing. The error is not recorded anywhere.
 	 *
 	 * @param error the exception to record (ignored in this implementation)

--- a/evita_api/src/main/java/io/evitadb/api/observability/trace/TracingContext.java
+++ b/evita_api/src/main/java/io/evitadb/api/observability/trace/TracingContext.java
@@ -30,6 +30,7 @@ import org.slf4j.MDC;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -348,7 +349,38 @@ public interface TracingContext {
 	@Nonnull
 	default TracingBlockReference createAndActivateBlock(
 		@Nonnull String taskName, @Nullable SpanAttribute... attributes) {
-		return new DefaultTracingBlockReference();
+		return DefaultTracingBlockReference.INSTANCE;
+	}
+
+	/**
+	 * Creates and activates a new trace span whose name is derived from `subject` only if the span
+	 * is actually recorded. Attributes are set immediately when the span is created.
+	 *
+	 * **Use Case:**
+	 * A span name is an ordinary method argument, so Java composes it eagerly — even when the
+	 * receiving implementation is the no-op one that throws it away unread. Use this variant when
+	 * the name is expensive to build (string concatenation over a whole mutation, a `toString()`
+	 * that walks a collection) and the call site is hot.
+	 *
+	 * **Why not a `Supplier<String>`:**
+	 * A supplier that closes over the value to be named is a *capturing* lambda, so the JVM
+	 * allocates one instance per call — before the implementation gets to decide not to invoke it.
+	 * Passing the subject separately keeps `taskNamer` free of captured state, which lets the
+	 * compiler hoist it into a constant and makes the disabled path allocation-free. Hold the namer
+	 * in a `static final` field for that to hold.
+	 *
+	 * @param subject    the value the span name is derived from
+	 * @param taskNamer  composes the span name from `subject`; invoked only when spans are recorded
+	 * @param attributes optional key-value pairs to attach to the span
+	 * @param <T>        type of the value the name is derived from
+	 * @return a reference to the active span (must be closed by caller)
+	 */
+	@Nonnull
+	default <T> TracingBlockReference createAndActivateBlock(
+		@Nonnull T subject, @Nonnull Function<? super T, String> taskNamer,
+		@Nullable SpanAttribute... attributes
+	) {
+		return DefaultTracingBlockReference.INSTANCE;
 	}
 
 	/**
@@ -370,7 +402,7 @@ public interface TracingContext {
 	@Nonnull
 	default TracingBlockReference createAndActivateBlock(
 		@Nonnull String taskName, @Nullable Supplier<SpanAttribute[]> attributes) {
-		return new DefaultTracingBlockReference();
+		return DefaultTracingBlockReference.INSTANCE;
 	}
 
 	/**
@@ -381,7 +413,7 @@ public interface TracingContext {
 	 */
 	@Nonnull
 	default TracingBlockReference createAndActivateBlock(@Nonnull String taskName) {
-		return new DefaultTracingBlockReference();
+		return DefaultTracingBlockReference.INSTANCE;
 	}
 
 	/**
@@ -489,7 +521,7 @@ public interface TracingContext {
 		@Nonnull TracingContextReference<?> contextHolderToUse, @Nonnull String taskName,
 		@Nullable SpanAttribute... attributes
 	) {
-		return new DefaultTracingBlockReference();
+		return DefaultTracingBlockReference.INSTANCE;
 	}
 
 	/**
@@ -506,7 +538,7 @@ public interface TracingContext {
 		@Nonnull TracingContextReference<?> contextHolderToUse, @Nonnull String taskName,
 		@Nullable Supplier<SpanAttribute[]> attributes
 	) {
-		return new DefaultTracingBlockReference();
+		return DefaultTracingBlockReference.INSTANCE;
 	}
 
 	/**
@@ -520,7 +552,7 @@ public interface TracingContext {
 	@Nonnull
 	default TracingBlockReference createAndActivateBlockWithParentContext(
 		@Nonnull TracingContextReference<?> contextHolderToUse, @Nonnull String taskName) {
-		return new DefaultTracingBlockReference();
+		return DefaultTracingBlockReference.INSTANCE;
 	}
 
 	/**
@@ -717,6 +749,34 @@ public interface TracingContext {
 	 */
 	<T> T executeWithinBlockIfParentContextAvailable(
 		@Nonnull String taskName, @Nonnull Supplier<T> lambda, @Nullable Supplier<SpanAttribute[]> attributes);
+
+	/**
+	 * Executes a supplier within a new child trace span only if a parent span is already active,
+	 * deriving the span name from `subject` only when the span is actually recorded. Attributes
+	 * are computed lazily when the span closes.
+	 *
+	 * **Use Case:**
+	 * The lazily-named counterpart of
+	 * {@link #executeWithinBlockIfParentContextAvailable(String, Supplier, Supplier)}, for hot call
+	 * sites whose span name is expensive to compose. See
+	 * {@link #createAndActivateBlock(Object, Function, SpanAttribute...)} for why the subject is
+	 * passed separately instead of wrapping the name in a `Supplier`.
+	 *
+	 * @param subject    the value the span name is derived from
+	 * @param taskNamer  composes the span name from `subject`; invoked only when spans are recorded
+	 * @param lambda     the code to trace (or execute untraced)
+	 * @param attributes supplier invoked after lambda completes to produce attributes (not invoked
+	 *                   if no parent span exists)
+	 * @param <S>        type of the value the name is derived from
+	 * @param <T>        return type
+	 * @return the result of invoking the supplier
+	 */
+	default <S, T> T executeWithinBlockIfParentContextAvailable(
+		@Nonnull S subject, @Nonnull Function<? super S, String> taskNamer, @Nonnull Supplier<T> lambda,
+		@Nullable Supplier<SpanAttribute[]> attributes
+	) {
+		return lambda.get();
+	}
 
 	/**
 	 * Executes a runnable within a new child trace span only if a parent span is already active,

--- a/evita_engine/src/main/java/io/evitadb/core/buffer/DataStoreChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/core/buffer/DataStoreChanges.java
@@ -33,14 +33,18 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import io.evitadb.core.collection.EntityCollection;
 import io.evitadb.core.transaction.memory.Snapshotable;
 import io.evitadb.core.transaction.memory.UndoJournal;
+import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.EntityIndex;
 import io.evitadb.index.Index;
 import io.evitadb.index.IndexKey;
 import io.evitadb.spi.store.catalog.persistence.StorageDescriptor;
 import io.evitadb.spi.store.catalog.persistence.StoragePartPersistenceService;
+import io.evitadb.spi.store.catalog.persistence.storageParts.DeferredRemovalStoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.KeyCompressor;
 import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePartKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.EntityIdsStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.EntityIndexStoragePart;
 import io.evitadb.utils.Assert;
 import lombok.RequiredArgsConstructor;
 
@@ -48,8 +52,10 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Serial;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -83,6 +89,16 @@ public class DataStoreChanges implements Snapshotable<DataStoreChanges.DataStore
 	 * store some of them in memory and flush them once in a while to the persistent storage.
 	 */
 	@Nullable private Map<Class<? extends StoragePart>, LongObjectMap<StoragePart>> trappedChanges;
+	/**
+	 * Deferred-removal parts accumulated when a whole {@link EntityIndex} is dropped via {@link #removeIndex}: one
+	 * removal per persisted sub-index root and per persisted leaf page of that index. Unlike {@link #trappedChanges},
+	 * these are {@link DeferredRemovalStoragePart}s whose primary
+	 * key is resolved store-side at drain time, so they carry no resolvable key here and cannot ride the per-type
+	 * primary-key map. They are drained into the {@link TrappedChanges} returned by {@link #popTrappedUpdates()} and
+	 * truncated back on a savepoint rollback through the {@link #undoJournal} (mirroring how a removed dirty index is
+	 * reinstated). Lazily allocated; {@code null} until the first index drop.
+	 */
+	@Nullable private List<StoragePart> pendingIndexRemovalParts;
 	/**
 	 * Contains reference to the I/O service, that allows reading/writing records to the persistent storage.
 	 */
@@ -224,6 +240,15 @@ public class DataStoreChanges implements Snapshotable<DataStoreChanges.DataStore
 			for (LongObjectMap<StoragePart> changesIndex : theTrappedChanges.values()) {
 				final ObjectContainer<StoragePart> values = changesIndex.values();
 				trappedChanges.addIterator(new LongObjectIterator<>(values.iterator()), values.size());
+			}
+		}
+
+		// deferred removals staged by dropping whole indexes (sub-index roots + leaf pages) — resolved store-side at drain
+		if (this.pendingIndexRemovalParts != null) {
+			final List<StoragePart> removals = this.pendingIndexRemovalParts;
+			this.pendingIndexRemovalParts = null;
+			for (final StoragePart removal : removals) {
+				trappedChanges.addChangeToStore(removal);
 			}
 		}
 
@@ -502,20 +527,80 @@ public class DataStoreChanges implements Snapshotable<DataStoreChanges.DataStore
 	/**
 	 * Removes {@link EntityIndex} from the change set. After removal (either successfully or unsuccessful)
 	 * `removalPropagation` function is called to propagate deletion to the origin collection.
+	 *
+	 * @return the removed index — the dirty one when it was in the change set, otherwise whatever
+	 * `removalPropagation` yielded from the origin collection; `null` when the index was found in neither, which
+	 * callers must treat as "nothing was removed"
 	 */
-	@Nonnull
+	@Nullable
 	public <IK extends IndexKey, I extends Index<IK>> I removeIndex(
+		long catalogVersion,
 		@Nonnull IK entityIndexKey,
 		@Nonnull Function<IK, I> removalPropagation
 	) {
 		//noinspection unchecked
 		final I dirtyIndexesRemoval = (I) this.dirtyEntityIndexes.remove(entityIndexKey);
 		if (dirtyIndexesRemoval != null && this.undoJournal != null) {
-			// removeIndex only drops the by-key entry (never the by-pk one); a savepoint rollback re-inserts exactly it
+			// removeIndex only drops the by-key entry (never the by-pk one); a savepoint rollback re-inserts exactly it.
+			// Re-inserting the SAME instance is what keeps the reclaim symmetric on rollback: the reclaim baselines
+			// (the persisted leaf-page sets and the `original*` manifest sets) live on the index object itself, and the
+			// surrounding diff-layer savepoint reverts that object's content in lockstep — so a rolled-back drop rewinds
+			// index state and reclaim state together, and the next flush diffs against the pre-drop baseline.
 			this.undoJournal.push(() -> this.dirtyEntityIndexes.put(entityIndexKey, dirtyIndexesRemoval));
 		}
 		final I baseIndexesRemoval = removalPropagation.apply(entityIndexKey);
-		return ofNullable(dirtyIndexesRemoval).orElse(baseIndexesRemoval);
+		final I removed = ofNullable(dirtyIndexesRemoval).orElse(baseIndexesRemoval);
+		if (removed instanceof EntityIndex entityIndex) {
+			// The append-only store reclaims a record only when it is superseded or explicitly removed. A dropped
+			// index is never re-flushed, so its manifest, membership bitmaps, every sub-index root and every leaf
+			// page it persisted would be copied forward by every compaction forever. Emit the removals here, while
+			// the index's persisted baselines are still intact and before the caller discards its transactional
+			// layers.
+			reclaimRemovedIndexFootprint(catalogVersion, entityIndex);
+		} else if (removed != null) {
+			// every present-day caller drops an EntityIndex; any other index type would silently reintroduce the
+			// permanent-orphan leak the branch above exists to prevent, so it must be taught to reclaim its own
+			// persisted footprint before it may be routed here
+			throw new GenericEvitaInternalError(
+				"Removal of index type `" + removed.getClass().getName() + "` does not reclaim its persisted " +
+					"footprint - implement the reclaim before removing indexes of this type!"
+			);
+		}
+		return removed;
+	}
+
+	/**
+	 * Emits the removal instructions that reclaim, from the append-only storage, the complete persisted footprint of a
+	 * dropped {@link EntityIndex}. The sub-index roots and leaf pages are {@link DeferredRemovalStoragePart}s
+	 * (store-side primary-key resolution) collected into {@link #pendingIndexRemovalParts}; the manifest and membership
+	 * bitmaps are plain primary-key removals routed through {@link #trapRemoveStoragePart} (which self-skips a
+	 * never-persisted part via its {@code containsStoragePart} gate and is reverted by a savepoint rollback).
+	 *
+	 * @param catalogVersion the version whose existence view gates the manifest/bitmaps removal
+	 * @param entityIndex    the index being dropped
+	 */
+	private void reclaimRemovedIndexFootprint(long catalogVersion, @Nonnull EntityIndex entityIndex) {
+		final TrappedChanges footprint = new TrappedChanges();
+		entityIndex.emitFootprintRemovals(footprint);
+		final int count = footprint.getTrappedChangesCount();
+		if (count > 0) {
+			if (this.pendingIndexRemovalParts == null) {
+				this.pendingIndexRemovalParts = new ArrayList<>(count);
+			}
+			final List<StoragePart> pending = this.pendingIndexRemovalParts;
+			final int mark = pending.size();
+			final Iterator<StoragePart> it = footprint.getTrappedChangesIterator();
+			while (it.hasNext()) {
+				pending.add(it.next());
+			}
+			if (this.undoJournal != null) {
+				// a savepoint rollback must drop exactly the removals this drop staged (mirrors the dirty-index reinstate)
+				this.undoJournal.push(() -> pending.subList(mark, pending.size()).clear());
+			}
+		}
+		final long indexPrimaryKey = entityIndex.getPrimaryKey();
+		trapRemoveStoragePart(catalogVersion, indexPrimaryKey, EntityIndexStoragePart.class);
+		trapRemoveStoragePart(catalogVersion, indexPrimaryKey, EntityIdsStoragePart.class);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/buffer/DataStoreMemoryBuffer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/buffer/DataStoreMemoryBuffer.java
@@ -30,6 +30,7 @@ import io.evitadb.index.IndexKey;
 import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 
@@ -64,9 +65,11 @@ public interface DataStoreMemoryBuffer extends DataStoreReader {
 	/**
 	 * Removes {@link EntityIndex} from the change set. After removal (either successfully or unsuccessful)
 	 * `removalPropagation` function is called to propagate deletion to the origin collection.
+	 *
+	 * @return the removed index, or `null` when no index existed under the given key
 	 */
-	@Nonnull
-	<IK extends IndexKey, I extends Index<IK>> I removeIndex(@Nonnull IK entityIndexKey, @Nonnull Function<IK, I> removalPropagation);
+	@Nullable
+	<IK extends IndexKey, I extends Index<IK>> I removeIndex(long catalogVersion, @Nonnull IK entityIndexKey, @Nonnull Function<IK, I> removalPropagation);
 
 	/**
 	 * Removes container from the target storage. If transaction is open, it just marks the container as removed but

--- a/evita_engine/src/main/java/io/evitadb/core/buffer/TransactionalDataStoreMemoryBuffer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/buffer/TransactionalDataStoreMemoryBuffer.java
@@ -114,13 +114,13 @@ public class TransactionalDataStoreMemoryBuffer implements DataStoreMemoryBuffer
 			.getIndexIfExists(entityIndexPrimaryKey, accessorWhenMissing);
 	}
 
-	@Nonnull
+	@Nullable
 	@Override
-	public <IK extends IndexKey, I extends Index<IK>> I removeIndex(@Nonnull IK entityIndexKey, @Nonnull Function<IK, I> removalPropagation) {
+	public <IK extends IndexKey, I extends Index<IK>> I removeIndex(long catalogVersion, @Nonnull IK entityIndexKey, @Nonnull Function<IK, I> removalPropagation) {
 		// removal MUTATES the layer, so the write-variant fetch is required: it records the layer's pre-mutation
 		// snapshot into an open savepoint on first touch (a read-path fetch would leave the removal unrevertable)
 		final DataStoreChanges layer = Transaction.getTransactionalMemoryLayerForWriteIfExists(this.transactionalMemoryDataSource);
-		return Objects.requireNonNullElse(layer, this.dataStoreChanges).removeIndex(entityIndexKey, removalPropagation);
+		return Objects.requireNonNullElse(layer, this.dataStoreChanges).removeIndex(catalogVersion, entityIndexKey, removalPropagation);
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/core/buffer/WarmUpDataStoreMemoryBuffer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/buffer/WarmUpDataStoreMemoryBuffer.java
@@ -104,10 +104,10 @@ public class WarmUpDataStoreMemoryBuffer implements DataStoreMemoryBuffer {
 		return this.dataStoreChanges.getIndexForModification(entityIndexPrimaryKey, accessorWhenMissing);
 	}
 
-	@Nonnull
+	@Nullable
 	@Override
-	public <IK extends IndexKey, I extends Index<IK>> I removeIndex(@Nonnull IK entityIndexKey, @Nonnull Function<IK, I> removalPropagation) {
-		return this.dataStoreChanges.removeIndex(entityIndexKey, removalPropagation);
+	public <IK extends IndexKey, I extends Index<IK>> I removeIndex(long catalogVersion, @Nonnull IK entityIndexKey, @Nonnull Function<IK, I> removalPropagation) {
+		return this.dataStoreChanges.removeIndex(catalogVersion, entityIndexKey, removalPropagation);
 	}
 
 	@Override
@@ -184,11 +184,12 @@ public class WarmUpDataStoreMemoryBuffer implements DataStoreMemoryBuffer {
 		// created / removed / replaced, going live or terminating - so this is the single point at which a warm-up
 		// buffer whose flush failed can be stopped before it writes again (this buffer backs both an entity collection
 		// and the catalog, so the refusal is phrased for either)
-		if (this.flushFailure != null) {
+		final Throwable theFlushFailure = this.flushFailure;
+		if (theFlushFailure != null) {
 			throw new GenericEvitaInternalError(
 				"Cannot collect changes: a previous warm-up flush failed, so the changes it had already collected are " +
 					"lost and the persisted state is incomplete. Reload the catalog from disk to recover.",
-				this.flushFailure
+				theFlushFailure
 			);
 		}
 		return this.dataStoreChanges.popTrappedUpdates();

--- a/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
@@ -594,6 +594,19 @@ public final class EntityCollection implements
 		return this.dataStoreReader;
 	}
 
+	/**
+	 * Returns the service this collection persists its storage parts through. Unlike {@link #getDataStoreReader()},
+	 * which resolves single parts by key, this exposes the store itself — the only way to enumerate the collection's
+	 * live record set, which diagnostics and storage-reclaim tests need in order to assert the ABSENCE of records they
+	 * cannot name in advance. Read-only use only; mutating the store behind the collection's back corrupts it.
+	 *
+	 * @return the storage-part persistence service backing this collection
+	 */
+	@Nonnull
+	public StoragePartPersistenceService<StorageDescriptor> getStoragePartPersistenceService() {
+		return this.persistenceService.getStoragePartPersistenceService();
+	}
+
 	@Override
 	@Nonnull
 	public <S extends Serializable, T extends EvitaResponse<S>> T getEntities(@Nonnull EvitaRequest evitaRequest, @Nonnull EvitaSessionContract session) {
@@ -2915,7 +2928,9 @@ public final class EntityCollection implements
 		@Override
 		public void removeIndex(@Nonnull EntityIndexKey entityIndexKey) {
 			final EntityIndex removedIndex = EntityCollection.this.dataStoreBuffer.removeIndex(
-				entityIndexKey, eik -> {
+				EntityCollection.this.catalog.getVersion(),
+				entityIndexKey,
+				eik -> {
 					final EntityIndex index = Objects.requireNonNull(EntityCollection.this.indexes.remove(eik));
 					final EntityIndex indexByPk = EntityCollection.this.indexesByPrimaryKey.remove(index.getPrimaryKey());
 					Assert.isPremiseValid(

--- a/evita_engine/src/main/java/io/evitadb/core/session/EvitaSessionProxy.java
+++ b/evita_engine/src/main/java/io/evitadb/core/session/EvitaSessionProxy.java
@@ -58,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -87,6 +88,13 @@ final class EvitaSessionProxy implements InvocationHandler {
 	);
 	private static final Method INACTIVITY_IN_SECONDS = resolveMethod("getInactivityDurationInSeconds");
 	private static final Method IS_INACTIVE_AND_IDLE = resolveMethod("isInactiveAndIdle", long.class);
+	/**
+	 * Composes the span name for a proxied session call. Every single call through this proxy would
+	 * otherwise concatenate a string that no-one reads while tracing is off. Held in a constant so
+	 * the lambda captures nothing and the disabled path stays allocation-free.
+	 */
+	private static final Function<Method, String> SESSION_CALL_SPAN_NAMER =
+		method -> "session call - " + method.getName();
 
 	private final EvitaSession evitaSession;
 	private final TracingContext tracingContext;
@@ -380,7 +388,8 @@ final class EvitaSessionProxy implements InvocationHandler {
 		@Nonnull Supplier<Object> invocation
 	) {
 		return this.tracingContext.executeWithinBlockIfParentContextAvailable(
-			"session call - " + method.getName(),
+			method,
+			SESSION_CALL_SPAN_NAMER,
 			invocation,
 			() -> buildSpanAttributes(method, args, session)
 		);

--- a/evita_engine/src/main/java/io/evitadb/core/traffic/TrafficRecordingEngine.java
+++ b/evita_engine/src/main/java/io/evitadb/core/traffic/TrafficRecordingEngine.java
@@ -72,6 +72,7 @@ import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -93,6 +94,36 @@ public class TrafficRecordingEngine implements TrafficRecordingReader {
 	public static final String LABEL_CLIENT_ID = "client-id";
 	public static final String LABEL_IP_ADDRESS = "ip-address";
 	public static final String LABEL_URI = "uri";
+	/**
+	 * Composes the span name for a single mutation application. `Mutation.toString()` walks the
+	 * whole mutation (`EntityUpsertMutation` joins every local mutation into a human-readable
+	 * string) and this runs once per mutation of every commit, so the name must not be built when
+	 * no tracing backend will read it. Held in a constant so the lambda captures nothing and the
+	 * disabled path stays allocation-free.
+	 */
+	private static final Function<Mutation, String> MUTATION_SPAN_NAMER =
+		mutation -> "mutation - " + mutation;
+	/**
+	 * Composes the span name for a fetch. `Arrays.toString` over the requested primary keys is the
+	 * expensive part, and this runs once per fetch. Held in a constant so the lambda captures
+	 * nothing and the disabled path stays allocation-free.
+	 */
+	private static final Function<EvitaRequest, String> FETCH_SPAN_NAMER =
+		request -> "enrich - " + request.getEntityType() +
+			" (pk: " + Arrays.toString(request.getPrimaryKeys()) + ")";
+	/**
+	 * Composes the span name for an enrichment, which runs once per enriched entity. The entity is
+	 * the sole subject so the lambda stays capture-free — it carries both its type and its primary
+	 * key, and its own type is the more faithful label for a span describing it.
+	 */
+	private static final Function<EntityContract, String> ENRICHMENT_SPAN_NAMER =
+		entity -> "enrich - " + entity.getType() +
+			" (pk: " + entity.getPrimaryKeyOrThrowException() + ")";
+	/**
+	 * Attribute supplier for spans that carry no attributes. Captures nothing, so it is allocated
+	 * once rather than per traced call.
+	 */
+	private static final Supplier<SpanAttribute[]> EMPTY_ATTRIBUTES = () -> SpanAttribute.EMPTY_ARRAY;
 	private final AtomicReference<CatalogInfo> catalogInfo;
 	private final StorageOptions storageOptions;
 	@Getter private final TrafficRecordingOptions trafficOptions;
@@ -377,9 +408,7 @@ public class TrafficRecordingEngine implements TrafficRecordingReader {
 		String finishedWithError = null;
 		try {
 			result = this.tracingContext.executeWithinBlockIfParentContextAvailable(
-				"enrich - " + evitaRequest.getEntityType() + " (pk: " + Arrays.toString(evitaRequest.getPrimaryKeys()) + ")",
-				lambda,
-				() -> SpanAttribute.EMPTY_ARRAY
+				evitaRequest, FETCH_SPAN_NAMER, lambda, EMPTY_ATTRIBUTES
 			);
 			return result;
 		} catch (RuntimeException ex) {
@@ -417,9 +446,7 @@ public class TrafficRecordingEngine implements TrafficRecordingReader {
 		String finishedWithError = null;
 		try {
 			result = this.tracingContext.executeWithinBlockIfParentContextAvailable(
-				"enrich - " + evitaRequest.getEntityType() + " (pk: " + entity.getPrimaryKeyOrThrowException() + ")",
-				lambda,
-				() -> SpanAttribute.EMPTY_ARRAY
+				entity, ENRICHMENT_SPAN_NAMER, lambda, EMPTY_ATTRIBUTES
 			);
 			return result;
 		} catch (RuntimeException ex) {
@@ -470,8 +497,7 @@ public class TrafficRecordingEngine implements TrafficRecordingReader {
 	) {
 		return new MutationApplicationRecord(
 			this.tracingContext.createAndActivateBlock(
-				"mutation - " + mutation,
-				SpanAttribute.EMPTY_ARRAY
+				mutation, MUTATION_SPAN_NAMER, SpanAttribute.EMPTY_ARRAY
 			),
 			this.trafficRecorder.get(),
 			sessionId,

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/DirtyScopeValidator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/DirtyScopeValidator.java
@@ -32,18 +32,22 @@ import java.util.Collection;
  * Contract implemented by any transactional data structure that participates in commit-time structural integrity
  * validation, in two phases:
  *
- * (a) A participant registers opaque *tokens* at its invariant-changing mutation seams via
- * {@link TransactionalLayerMaintainer#registerDirtyScopeToken}. Tokens and participants are both compared by
- * identity.
+ * (a) A participant registers a *probe key* at its invariant-changing mutation seams via
+ * {@link TransactionalLayerMaintainer#registerDirtyScopeToken}. Participants are compared by identity; probe keys by
+ * value, so an unchanged boundary touched by successive ops registers once.
  *
  * (b) The receiver decides the view: the same {@link #validateDirtyScope(Collection)} method serves the pre-commit
  * pass — called on the live baseline instance, so it validates through the transactional diff-layered view, before
  * the mutations reach the shared write-ahead log — and the post-replay pass — called on the freshly merged copy, so
  * it validates plain merged state, before that copy propagates to the live view.
  *
- * (c) Tokens are hints only, never validated in place — the participant must re-locate the current state they point
- * at. A stale token (e.g. one pointing at a savepoint-reverted layer, or an element merged away since registration)
- * at worst causes a redundant check; it can never cause a false positive.
+ * (c) Keys are relocation hints only — the participant descends its current tree to the leaf the key routes to and
+ * validates that leaf's own re-derived boundaries. A stale key (e.g. one captured before a savepoint-reverted layer,
+ * or before the leaf it named was merged away) at worst routes the descent to a real current leaf that is checked
+ * redundantly; a sound tree cannot fail that check, so it can never cause a false positive. Registering keys rather
+ * than node objects is deliberate: it keeps no leaf, array or element pinned to the registry until commit, and makes
+ * the "registered token whose backing array was blanked in place by an aliasing holder" failure class
+ * unrepresentable.
  *
  * (d) Validation must be read-only with respect to transactional memory — it must not create new diff layers,
  * because the post-replay pass runs with layer creation already disabled.
@@ -58,12 +62,12 @@ import java.util.Collection;
 public interface DirtyScopeValidator {
 
 	/**
-	 * Validates this participant's dirty scope against the tokens it (or its predecessor, for the post-replay pass)
-	 * registered during the transaction. Each implementation defines what a token is and how it is relocated; see the
-	 * concrete overrides (e.g. the B+ tree variants) for structure-specific detail.
+	 * Validates this participant's dirty scope against the probe keys it (or its predecessor, for the post-replay pass)
+	 * registered during the transaction. Each implementation defines its key type and how it relocates a leaf by it; see
+	 * the concrete overrides (e.g. the B+ tree variants) for structure-specific detail.
 	 *
-	 * @param dirtyScopeTokens the tokens registered for this participant; never validated in place, only used to
-	 *                         relocate the current state to check
+	 * @param dirtyScopeTokens the probe keys registered for this participant; never validated in place, only used to
+	 *                         relocate the current leaf to check
 	 * @throws DataStructureCorruptedException when the relocated state violates the participant's invariants
 	 */
 	void validateDirtyScope(@Nonnull Collection<Object> dirtyScopeTokens);

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerMaintainer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerMaintainer.java
@@ -35,6 +35,7 @@ import java.io.Closeable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -91,11 +92,12 @@ public class TransactionalLayerMaintainer {
 	@Nullable private Savepoint currentSavepoint;
 	/**
 	 * Per-transaction dirty-scope registry feeding the pre-commit (pre-WAL) and post-replay (merge-time) structural
-	 * integrity validation. Maps each participant (a {@link DirtyScopeValidator}) to the identity set of opaque tokens
-	 * it registered at its invariant-changing mutation seams during this transaction. Both axes are identity-keyed and
-	 * the whole structure is lazily instantiated on first registration (a transaction that touches no participant
-	 * pays nothing). Registration feeds both the pre-commit and post-replay validation passes, which each run
-	 * unconditionally whenever at least one participant was dirtied.
+	 * integrity validation. Maps each participant (a {@link DirtyScopeValidator}) to the set of probe keys it registered
+	 * at its invariant-changing mutation seams during this transaction. The participant axis is identity-keyed (the
+	 * validators are per-tree singletons), while the probe-key axis uses value semantics so equal keys registered by
+	 * successive ops on the same boundary dedup. The whole structure is lazily instantiated on first registration (a
+	 * transaction that touches no participant pays nothing). Registration feeds both the pre-commit and post-replay
+	 * validation passes, which each run unconditionally whenever at least one participant was dirtied.
 	 */
 	@Nullable private Map<DirtyScopeValidator, Set<Object>> dirtyScopes;
 
@@ -107,21 +109,22 @@ public class TransactionalLayerMaintainer {
 	}
 
 	/**
-	 * Registers an opaque scope token as dirtied by the given participant during this transaction, so the pre-commit
-	 * (pre-WAL) and post-replay (merge-time) validation can re-derive its invariants at commit. Called unconditionally
-	 * from the participant's invariant-changing mutation seams; the registered object is used only as a scope token
-	 * (see {@link DirtyScopeValidator}).
+	 * Registers a probe key as dirtied by the given participant during this transaction, so the pre-commit (pre-WAL)
+	 * and post-replay (merge-time) validation can relocate the affected leaf and re-derive its invariants at commit.
+	 * Called unconditionally from the participant's invariant-changing mutation seams; the registered object is the
+	 * boundary key of the dirtied leaf, captured at op time (see {@link DirtyScopeValidator}). Equal keys dedup by
+	 * value — validation is idempotent, so a boundary touched by several ops is validated once.
 	 *
-	 * @param owner      the participant the token belongs to
-	 * @param scopeToken the dirtied scope token
+	 * @param owner    the participant the key belongs to
+	 * @param probeKey the boundary key of the dirtied leaf
 	 */
-	public void registerDirtyScopeToken(@Nonnull DirtyScopeValidator owner, @Nonnull Object scopeToken) {
+	public void registerDirtyScopeToken(@Nonnull DirtyScopeValidator owner, @Nonnull Object probeKey) {
 		if (this.dirtyScopes == null) {
 			this.dirtyScopes = new IdentityHashMap<>(64);
 		}
 		this.dirtyScopes
-			.computeIfAbsent(owner, it -> Collections.newSetFromMap(new IdentityHashMap<>(64)))
-			.add(scopeToken);
+			.computeIfAbsent(owner, it -> new HashSet<>(64))
+			.add(probeKey);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/AbstractReducedEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/AbstractReducedEntityIndex.java
@@ -56,6 +56,8 @@ import io.evitadb.index.map.TransactionalMap;
 import io.evitadb.index.price.PriceIndexReadContract;
 import io.evitadb.index.price.PriceRefIndex;
 import io.evitadb.index.price.model.PriceIndexKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.PriceListAndCurrencyRefIndexStoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexStorageKey;
 import io.evitadb.utils.Assert;
 import lombok.Getter;
@@ -237,6 +239,12 @@ public abstract class AbstractReducedEntityIndex extends EntityIndex
 	@Override
 	public boolean isEmpty() {
 		return super.isEmpty() && this.priceIndex.isPriceIndexEmpty();
+	}
+
+	@Nonnull
+	@Override
+	protected Class<? extends StoragePart> getPriceRootStoragePartType() {
+		return PriceListAndCurrencyRefIndexStoragePart.class;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/index/EntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/EntityIndex.java
@@ -59,7 +59,12 @@ import io.evitadb.index.map.TransactionalMap;
 import io.evitadb.index.price.PriceIndexContract;
 import io.evitadb.index.price.model.PriceIndexKey;
 import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexRootRemoval;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexStorageKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.FacetIndexRootRemoval;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.HierarchyIndexRootRemoval;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.HistogramRootRemoval;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.PriceIndexRootRemoval;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.EntityIdsStoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.EntityIndexStoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.HistogramIndexStorageKey;
@@ -900,7 +905,94 @@ public abstract class EntityIndex implements
 				trappedChanges.addChangeToStore(createBitmapsPart());
 			}
 		}
+
+		// Reclaim the roots of sub-indexes that vanished this commit (churn-vanish): when a sub-index is emptied
+		// out of its family while this entity index survives, its leaf pages are reclaimed by that family's own
+		// page reclaim, but its stable-keyed root part is neither superseded (never re-flushed) nor removed, so it
+		// would be copied forward by every compaction forever. The manifest baseline is the only place that tracks
+		// SINGLE-shaped roots (which own no leaf pages), so the diff must run here, not in the leaf-page reclaim.
+		emitVanishedRootRemovals(
+			attributeIndexStorageKeys, priceIndexKeys, facetIndexReferencedEntities,
+			histogramIndexStorageKeys, !hierarchyIndexEmpty, trappedChanges
+		);
 	}
+
+	/**
+	 * Emits a root-part removal for every persisted sub-index whose manifest key is in the change-detection
+	 * baseline ({@code original*}) but not in the passed surviving set — i.e. a sub-index that was on disk and has
+	 * now vanished. Called two ways: from {@link #getModifiedStorageParts(TrappedChanges)} with the freshly
+	 * collected manifest sets (churn-vanish of one sub-index while the index survives) and from
+	 * {@link #emitFootprintRemovals(TrappedChanges)} with empty surviving sets (the whole index is dropped, so
+	 * every persisted root vanishes). Reads only the persisted baseline, never live/transactional state.
+	 *
+	 * @param survivingAttributes the attribute sub-index keys that remain after this commit
+	 * @param survivingPrices     the price sub-index keys that remain
+	 * @param survivingFacets     the facet referenced-entity types that remain
+	 * @param survivingHistograms the histogram sub-index keys that remain
+	 * @param hierarchyPresent    whether a hierarchy is still present
+	 * @param sink                the accumulator collecting the removal instructions
+	 */
+	private void emitVanishedRootRemovals(
+		@Nonnull Set<AttributeIndexStorageKey> survivingAttributes,
+		@Nonnull Set<PriceIndexKey> survivingPrices,
+		@Nonnull Set<String> survivingFacets,
+		@Nonnull Set<HistogramIndexStorageKey> survivingHistograms,
+		boolean hierarchyPresent,
+		@Nonnull TrappedChanges sink
+	) {
+		for (final AttributeIndexStorageKey key : this.originalAttributeIndexes) {
+			if (!survivingAttributes.contains(key)) {
+				sink.addChangeToStore(new AttributeIndexRootRemoval(this.primaryKey, key.attribute(), key.indexType()));
+			}
+		}
+		for (final PriceIndexKey key : this.originalPriceIndexes) {
+			if (!survivingPrices.contains(key)) {
+				sink.addChangeToStore(new PriceIndexRootRemoval(this.primaryKey, key, getPriceRootStoragePartType()));
+			}
+		}
+		for (final String referencedEntityType : this.originalFacetIndexes) {
+			if (!survivingFacets.contains(referencedEntityType)) {
+				sink.addChangeToStore(new FacetIndexRootRemoval(this.primaryKey, referencedEntityType));
+			}
+		}
+		for (final HistogramIndexStorageKey key : this.originalHistogramKeys) {
+			if (!survivingHistograms.contains(key)) {
+				sink.addChangeToStore(new HistogramRootRemoval(this.primaryKey, key.histogramName(), key.locale()));
+			}
+		}
+		// a hierarchy root was persisted (baseline non-empty) and is now gone
+		if (!this.originalHierarchyIndexEmpty && !hierarchyPresent) {
+			sink.addChangeToStore(new HierarchyIndexRootRemoval(this.primaryKey));
+		}
+	}
+
+	/**
+	 * Emits removal instructions reclaiming the ENTIRE persisted footprint of this index when it is dropped: every
+	 * persisted sub-index root (via {@link #emitVanishedRootRemovals} against empty surviving sets) plus every
+	 * persisted leaf page and every non-manifest sub-index root (e.g. reference-type cardinality) via each
+	 * {@link IndexComponent#emitPersistedFootprintRemovals(int, TrappedChanges)}. The manifest and membership
+	 * bitmaps are reclaimed separately by the caller (they are primary-key-addressable). Reads only persisted
+	 * baselines, so it is safe whether or not the transactional layers are still attached.
+	 *
+	 * @param sink the accumulator collecting the removal instructions
+	 */
+	public final void emitFootprintRemovals(@Nonnull TrappedChanges sink) {
+		emitVanishedRootRemovals(
+			Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
+			Collections.emptySet(), false, sink
+		);
+		for (final IndexComponent component : this.components) {
+			component.emitPersistedFootprintRemovals(this.primaryKey, sink);
+		}
+	}
+
+	/**
+	 * @return the concrete price root storage-part class this index persists its price sub-indexes under (the super
+	 * variant for the global index, the reference variant for reduced indexes). Consulted only to target the correct
+	 * record type when reclaiming a dropped price sub-index, so it is never called on an index that persisted none.
+	 */
+	@Nonnull
+	protected abstract Class<? extends StoragePart> getPriceRootStoragePartType();
 
 	/**
 	 * Advances the change-detection baseline to the state that was just persisted. Invoked by the flush

--- a/evita_engine/src/main/java/io/evitadb/index/GlobalEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/GlobalEntityIndex.java
@@ -47,6 +47,8 @@ import io.evitadb.index.facet.FacetIndex;
 import io.evitadb.index.hierarchy.HierarchyIndex;
 import io.evitadb.index.price.PriceIndexContract;
 import io.evitadb.index.price.PriceSuperIndex;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.PriceListAndCurrencySuperIndexStoragePart;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Delegate;
@@ -156,6 +158,12 @@ public class GlobalEntityIndex extends EntityIndex
 	 */
 	@Delegate(types = PriceIndexContract.class)
 	@Getter private final PriceSuperIndex priceIndex;
+
+	@Nonnull
+	@Override
+	protected Class<? extends StoragePart> getPriceRootStoragePartType() {
+		return PriceListAndCurrencySuperIndexStoragePart.class;
+	}
 
 	/**
 	 * Creates a proxy instance of {@link GlobalEntityIndex} that throws a {@link EntityNotManagedException}

--- a/evita_engine/src/main/java/io/evitadb/index/ReferencedTypeEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/ReferencedTypeEntityIndex.java
@@ -30,6 +30,7 @@ import io.evitadb.api.requestResponse.schema.SortableAttributeCompoundSchemaCont
 import io.evitadb.core.exception.ReferenceNotIndexedException;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer;
+import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.attribute.ReferenceAttributeIndex;
 import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.bitmap.Bitmap;
@@ -54,6 +55,7 @@ import io.evitadb.index.map.TransactionalMap;
 import io.evitadb.core.expression.trigger.DependencyType;
 import io.evitadb.index.price.PriceIndexContract;
 import io.evitadb.index.price.VoidPriceIndex;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
 import io.evitadb.index.result.CardinalityChange;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
 import io.evitadb.utils.Assert;
@@ -362,6 +364,18 @@ public class ReferencedTypeEntityIndex extends EntityIndex implements
 	public boolean isEmpty() {
 		// null check required: parent constructor calls isEmpty() before subclass fields are initialized
 		return super.isEmpty() && this.indexPrimaryKeyCardinality.isEmpty() && this.histogramIndexes.isEmpty();
+	}
+
+	@Nonnull
+	@Override
+	protected Class<? extends StoragePart> getPriceRootStoragePartType() {
+		// a referenced-type index carries a VoidPriceIndex, so its persisted price baseline is always empty and no
+		// price-root removal can ever be emitted for it — reaching this point means that invariant broke, and silently
+		// answering with a plausible container type would target the wrong record on removal
+		throw new GenericEvitaInternalError(
+			"Referenced type entity index never persists a price sub-index, so its price root storage part type " +
+				"must never be requested!"
+		);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/AttributeIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/AttributeIndex.java
@@ -1324,6 +1324,47 @@ public abstract sealed class AttributeIndex implements AttributeIndexContract,
 		this.persistedSortLeafPages = snapshotLeafPages(this.sortIndex, SortIndex::currentLeafPageSequences);
 	}
 
+	/**
+	 * Whole-index-drop reclaim: emits a leaf-page removal for EVERY persisted page of all five paged families
+	 * (CHAIN, owner UNIQUE, owner SORT, and both FILTER axes — shared value tree + range companion), as if nothing
+	 * survives. Called when the owning {@link io.evitadb.index.EntityIndex} is dropped: no sub-index flush will run
+	 * again, so the append-only OffsetIndex would copy every orphaned leaf page forward forever unless each is removed
+	 * explicitly. Reuses the same {@link #emitDroppedLeafPageRemovals} helper as the per-commit empty-drop reclaim, but
+	 * with a `stillPresent` predicate that always returns `false` so every persisted key is treated as vanished.
+	 *
+	 * The paged FILTER / SORT / UNIQUE / CHAIN roots themselves are manifest-listed and reclaimed by
+	 * `EntityIndex.emitVanishedRootRemovals`, so this method emits only leaf pages — never roots. It reads exclusively
+	 * the persisted baselines (the `persisted*LeafPages` fields) and has NO side effects: no `forget`, no baseline
+	 * mutation.
+	 *
+	 * @param entityIndexPrimaryKey the owning entity index pk
+	 * @param sink                  the trapped-changes accumulator collecting the removal instructions
+	 */
+	public void emitPersistedLeafPageRemovals(int entityIndexPrimaryKey, @Nonnull TrappedChanges sink) {
+		// nothing survives — treat every persisted key of every family as vanished
+		final Predicate<AttributeIndexKey> nothingSurvives = key -> false;
+		emitDroppedLeafPageRemovals(
+			entityIndexPrimaryKey, this.persistedChainLeafPages, nothingSurvives,
+			AttributeIndexType.CHAIN, sink, ChainIndexLeafPageRemoval::new
+		);
+		emitDroppedLeafPageRemovals(
+			entityIndexPrimaryKey, this.persistedUniqueLeafPages, nothingSurvives,
+			AttributeIndexType.UNIQUE, sink, UniqueIndexLeafPageRemoval::new
+		);
+		emitDroppedLeafPageRemovals(
+			entityIndexPrimaryKey, this.persistedSortLeafPages, nothingSurvives,
+			AttributeIndexType.SORT, sink, SortIndexLeafPageRemoval::new
+		);
+		emitDroppedLeafPageRemovals(
+			entityIndexPrimaryKey, this.persistedFilterInvertedLeafPages, nothingSurvives,
+			AttributeIndexType.FILTER, sink, FilterIndexLeafPageRemoval::new
+		);
+		emitDroppedLeafPageRemovals(
+			entityIndexPrimaryKey, this.persistedFilterRangeLeafPages, nothingSurvives,
+			AttributeIndexType.FILTER, sink, RangeIndexLeafPageRemoval::new
+		);
+	}
+
 	@Nullable
 	public UniqueIndex getUniqueIndex(
 		@Nullable ReferenceSchemaContract referenceSchema,

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/AbstractTransactionalBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/AbstractTransactionalBPlusTree.java
@@ -392,32 +392,14 @@ public abstract class AbstractTransactionalBPlusTree implements Serializable {
 	protected abstract BPlusTreeNode<?> newEmptyLeaf();
 
 	/**
-	 * Registers a leaf as dirtied for the current transaction's pre-commit / post-replay dirty-scope validation. A
-	 * no-op when no transaction is active — warm-up bulk load and other non-transactional mutations have neither a
-	 * registry nor a WAL, so the validation does not apply and pays nothing. The registered object is the leaf's write
-	 * LAYER when one exists (it holds the effective in-transaction keys and survives the layer discard the trunk merge
-	 * performs), otherwise the leaf itself (a split-born leaf holds its keys directly). Registered objects are key
-	 * sources only, so registering a not-strictly-current object cannot cause a false positive (see
-	 * {@link DirtyScopeValidator}).
-	 *
-	 * @param tree the owner tree the leaf belongs to
-	 * @param leaf the dirtied leaf node
-	 */
-	static void registerDirtyLeafInScope(@Nonnull DirtyScopeValidator tree, @Nonnull BPlusTreeNode<?> leaf) {
-		final TransactionalLayerMaintainer maintainer = Transaction.getTransactionalLayerMaintainer();
-		if (maintainer == null) {
-			return;
-		}
-		final Object writable = Transaction.getTransactionalMemoryLayerIfExists(leaf);
-		maintainer.registerDirtyScopeToken(tree, writable != null ? writable : leaf);
-	}
-
-	/**
 	 * Hook invoked by {@link #consolidate(Cursor)} for each leaf whose boundary keys a rebalance (steal / merge)
 	 * changed, so the concrete tree can register it in the transaction's dirty-scope validation. The default is a
 	 * no-op: the out-of-scope trees ({@code TransactionalObjectBPlusTree}, {@code TransactionalIntToLongBPlusTree}) do
-	 * not participate in the dirty-leaf validation. The in-scope paged trees override it to call
-	 * {@link #registerDirtyLeafInScope(DirtyScopeValidator, BPlusTreeNode)}.
+	 * not participate in the dirty-leaf validation. The in-scope paged trees override it to register the leaf's current
+	 * boundary key with {@link TransactionalLayerMaintainer#registerDirtyScopeToken}. Registration is a no-op outside a
+	 * transaction — warm-up bulk load and other non-transactional mutations have neither a registry nor a WAL — and the
+	 * registry keeps the key, not the leaf, so nothing pins the leaf, its array or its elements until commit (see
+	 * {@link DirtyScopeValidator}).
 	 *
 	 * @param leaf the rebalanced leaf node
 	 */

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTree.java
@@ -1185,7 +1185,8 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 		// post-replay (merge-time): before this merged version can propagate to the live view, re-derive the cross-leaf boundary
 		// invariants for every leaf this transaction dirtied — against the freshly merged structure (plain reads;
 		// the merged nodes are fresh or unchanged-and-layer-free, so the descent never consults a diff layer).
-		// Registered objects are key sources only; each is relocated by its current key in the merged tree.
+		// The registry holds boundary keys, not nodes; each key routes to whatever leaf currently owns it in the
+		// merged tree, and that landed leaf is validated on its own re-derived boundaries.
 		final Set<Object> dirtyScope = transactionalLayer.getDirtyScopeTokens(this);
 		if (!dirtyScope.isEmpty()) {
 			merged.validateDirtyScope(dirtyScope);
@@ -1706,49 +1707,45 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 	}
 
 	/**
-	 * Registers a dirtied leaf as a dirty-scope token for this transaction. This standalone tree does
-	 * not extend {@link AbstractTransactionalBPlusTree}, so it cannot reuse the base's static registration helper (whose
-	 * parameter is the base-package leaf type this tree's nested leaf does not implement); it inlines the same semantics
-	 * instead. A no-op when no transaction is active — warm-up bulk load and other non-transactional mutations have
-	 * neither a registry nor a WAL, so the pre-commit (pre-WAL) and post-replay (merge-time) validations do not apply and pay nothing. The registered object is the leaf's write
-	 * LAYER when one exists (it holds the effective in-transaction keys and survives the layer discard the trunk merge
-	 * performs), otherwise the leaf itself (a split-born leaf holds its keys directly). Registered objects are key
-	 * sources only, so registering a not-strictly-current object cannot cause a false positive.
+	 * Registers the dirtied leaf's CURRENT first key as a dirty-scope probe key for this transaction. This standalone
+	 * tree does not extend {@link AbstractTransactionalBPlusTree}, so it cannot reuse the base's static registration
+	 * helper; it inlines the same semantics instead. A no-op when no transaction is active — warm-up bulk load and other
+	 * non-transactional mutations have neither a registry nor a WAL, so the pre-commit (pre-WAL) and post-replay
+	 * (merge-time) validations do not apply and pay nothing. Reads the key through the transaction-aware
+	 * {@link BPlusLeafTreeNode#keyAt(int)}, so it captures the post-mutation boundary; an emptied leaf carries no
+	 * boundary key and is skipped — nothing needs relocating by a key that no longer exists. Keeping the key rather than
+	 * the leaf means nothing pins the leaf or its columns to the registry until commit.
 	 *
 	 * @param leaf the dirtied leaf node
 	 */
 	private void registerDirtyLeafInScope(@Nonnull BPlusLeafTreeNode<K> leaf) {
 		final TransactionalLayerMaintainer maintainer = Transaction.getTransactionalLayerMaintainer();
-		if (maintainer == null) {
+		// gate on the cheap checks before deriving (and boxing) the probe key: outside a transaction there is no
+		// registry (warm-up bulk load pays nothing), and an emptied leaf has no boundary key to relocate by
+		if (maintainer == null || leaf.getPeek() < 0) {
 			return;
 		}
-		final Object writable = Transaction.getTransactionalMemoryLayerIfExists(leaf);
-		maintainer.registerDirtyScopeToken(this, writable != null ? writable : leaf);
+		maintainer.registerDirtyScopeToken(this, leaf.keyAt(0));
 	}
 
 	/**
-	 * Dirty-scope validation for this tree. For each registered key source (a writable leaf
-	 * this transaction dirtied) it reads the current first key, descends from this tree's root to the leaf that key
-	 * routes to, and re-derives both cross-leaf half-invariants on the leaf the descent actually landed on — reusing
-	 * the op-time machinery with the leaf's ACTUAL boundary keys ({@link #assertTailBoundary} against the successor
-	 * fence, {@link #assertHeadBoundary} against the predecessor's last key). Empty key sources and descents that land
-	 * on an empty leaf are skipped (nothing to relocate by / assert). Called on the live baseline tree for the
-	 * pre-commit (pre-WAL) pass (the descent resolves diff layers) and on a freshly merged tree for the post-replay
-	 * (merge-time) pass (plain reads); both use read-path accessors only.
+	 * Dirty-scope validation for this tree. For each registered probe key (the first key of a leaf this transaction
+	 * dirtied, captured at op time) it descends from this tree's root to the leaf that key routes to, and re-derives
+	 * both cross-leaf half-invariants on the leaf the descent actually landed on — reusing the op-time machinery with
+	 * the leaf's ACTUAL boundary keys ({@link #assertTailBoundary} against the successor fence,
+	 * {@link #assertHeadBoundary} against the predecessor's last key). Descents that land on an empty leaf are skipped
+	 * (nothing to assert). Called on the live baseline tree for the pre-commit (pre-WAL) pass (the descent resolves diff
+	 * layers) and on a freshly merged tree for the post-replay (merge-time) pass (plain reads); both use read-path
+	 * accessors only.
 	 *
-	 * @param registeredLeafKeySources the writable leaf objects registered for this tree; used only as key sources
+	 * @param registeredProbeKeys the first keys registered for this tree; used only to relocate the leaf to check
 	 * @throws AbstractTransactionalBPlusTree.BPlusTreeCorruptedException when a relocated leaf overlaps an adjacent leaf
 	 */
 	@Override
-	public void validateDirtyScope(@Nonnull Collection<Object> registeredLeafKeySources) {
-		for (final Object keySource : registeredLeafKeySources) {
+	public void validateDirtyScope(@Nonnull Collection<Object> registeredProbeKeys) {
+		for (final Object token : registeredProbeKeys) {
 			//noinspection unchecked
-			final BPlusLeafTreeNode<K> registered = (BPlusLeafTreeNode<K>) keySource;
-			if (registered.getPeek() < 0) {
-				// empty key source — nothing to relocate by (key-source-only rule)
-				continue;
-			}
-			final K probeKey = registered.keyAt(0);
+			final K probeKey = (K) token;
 			final Cursor<K> cursor = createCursor(probeKey);
 			final BPlusLeafTreeNode<K> leaf = cursor.leafNode();
 			final int peek = leaf.getPeek();

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTree.java
@@ -539,9 +539,10 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 
 	/**
 	 * Builds the typed, diagnosable error raised when a leaf a dirty-scope descent landed on reports a non-negative peek
-	 * yet carries no element to derive its boundary key from. Without it, that state surfaces as a bare
-	 * {@link NullPointerException} from inside the key extractor, telling the operator nothing about which tree, which
-	 * leaf, or which slot went wrong.
+	 * yet carries no element to derive one of its boundary keys from — either the head (slot 0) or the tail (the peek
+	 * slot), including a peek that points past the end of the value array. Without it, that state surfaces as a bare
+	 * {@link NullPointerException} from inside the key extractor (or an {@link ArrayIndexOutOfBoundsException} from the
+	 * array read), telling the operator nothing about which tree, which leaf, or which slot went wrong.
 	 *
 	 * Composed only on the failure path — the caller's guard is a plain array read it needed anyway, so the healthy
 	 * path pays nothing for this belt.
@@ -551,16 +552,17 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 	 * value array was still shared with the base, or an array truncated by a decouple that copied the wrong length.
 	 *
 	 * @param leaf the leaf whose boundary key could not be derived
+	 * @param slot the value slot that could not be read (`0` for the head key, the peek slot for the tail key)
 	 * @return the typed corruption error to throw
 	 */
 	@Nonnull
-	private BPlusTreeCorruptedException boundaryKeyUnreadableError(@Nonnull BPlusLeafTreeNode<E> leaf) {
+	private BPlusTreeCorruptedException boundaryKeyUnreadableError(@Nonnull BPlusLeafTreeNode<E> leaf, int slot) {
 		final E[] values = leaf.getValues();
 		final BPlusLeafTreeNode<E> layer = Transaction.getTransactionalMemoryLayerIfExists(leaf);
 		//noinspection ArrayEquality
 		final String sb = "Corrupted in-memory B+ tree: a live leaf reached by a dirty-scope descent reports peek " +
-			leaf.getPeek() + " but carries no element at slot 0, so its boundary key cannot be " +
-			"derived. Leaf id: " + leaf.getId() +
+			leaf.getPeek() + " but carries no readable element at slot " + slot + ", so its " +
+			(slot == 0 ? "head" : "tail") + " boundary key cannot be derived. Leaf id: " + leaf.getId() +
 			", base peek: " + leaf.peek +
 			", layer peek: " + (layer == null ? "<no layer>" : String.valueOf(layer.peek)) +
 			", base values: " + (leaf.values == null ? "null" : "length " + leaf.values.length) +
@@ -647,11 +649,19 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 				// the descent landed on an empty leaf — validating it is sound and vacuous
 				continue;
 			}
-			// a live leaf reached by a descent must carry its head element; a null head is genuine corruption, so raise
-			// a typed, diagnosable error rather than let the key extractor throw a bare NullPointerException
+			// a live leaf reached by a descent must carry both of its boundary elements; a peek pointing past the value
+			// array, or a null head / tail element, is genuine corruption - raise a typed, diagnosable error naming the
+			// unreadable slot rather than let the key extractor throw a bare NullPointerException (or the array read an
+			// ArrayIndexOutOfBoundsException)
 			final E[] values = leaf.getValues();
-			if (values.length == 0 || values[0] == null) {
-				throw boundaryKeyUnreadableError(leaf);
+			if (peek >= values.length) {
+				throw boundaryKeyUnreadableError(leaf, peek);
+			}
+			if (values[0] == null) {
+				throw boundaryKeyUnreadableError(leaf, 0);
+			}
+			if (values[peek] == null) {
+				throw boundaryKeyUnreadableError(leaf, peek);
 			}
 			final int firstKey = this.keyExtractor.applyAsInt(values[0]);
 			final int lastKey = this.keyExtractor.applyAsInt(values[peek]);

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTree.java
@@ -429,7 +429,7 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 	 * @param newLastKey the leaf's new last key after the mutation
 	 * @throws GenericEvitaInternalError when the new last key does not sort strictly before the successor fence
 	 */
-	void assertTailBoundary(@Nonnull Cursor cursor, int newLastKey) {
+	static void assertTailBoundary(@Nonnull Cursor cursor, int newLastKey) {
 		final List<CursorLevel> path = cursor.path();
 		for (int level = path.size() - 1; level >= 1; level--) {
 			final CursorLevel cursorLevel = path.get(level);
@@ -527,7 +527,7 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 	 * @return the corruption error to throw
 	 */
 	@Nonnull
-	private BPlusTreeCorruptedException boundaryMutationError(
+	private static BPlusTreeCorruptedException boundaryMutationError(
 		@Nonnull String side, int boundaryKey, @Nonnull String relation, int neighborKey) {
 		return new BPlusTreeCorruptedException(
 			"Corrupted in-memory B+ tree: a leaf's " + side + " boundary key " + boundaryKey + " does not sort " +
@@ -538,41 +538,108 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 	}
 
 	/**
-	 * Registers a rebalanced leaf as a dirty-scope token for this transaction. Invoked by the base
-	 * {@link #consolidate(Cursor)} for each leaf whose boundary keys a steal / merge shifted.
+	 * Builds the typed, diagnosable error raised when a leaf a dirty-scope descent landed on reports a non-negative peek
+	 * yet carries no element to derive its boundary key from. Without it, that state surfaces as a bare
+	 * {@link NullPointerException} from inside the key extractor, telling the operator nothing about which tree, which
+	 * leaf, or which slot went wrong.
+	 *
+	 * Composed only on the failure path — the caller's guard is a plain array read it needed anyway, so the healthy
+	 * path pays nothing for this belt.
+	 *
+	 * The state is reported from both sides of the transactional layer, because the interesting failures in this seam
+	 * are disagreements between a leaf's committed state and its diff layer: a peek that grew in the layer while the
+	 * value array was still shared with the base, or an array truncated by a decouple that copied the wrong length.
+	 *
+	 * @param leaf the leaf whose boundary key could not be derived
+	 * @return the typed corruption error to throw
+	 */
+	@Nonnull
+	private BPlusTreeCorruptedException boundaryKeyUnreadableError(@Nonnull BPlusLeafTreeNode<E> leaf) {
+		final E[] values = leaf.getValues();
+		final BPlusLeafTreeNode<E> layer = Transaction.getTransactionalMemoryLayerIfExists(leaf);
+		//noinspection ArrayEquality
+		final String sb = "Corrupted in-memory B+ tree: a live leaf reached by a dirty-scope descent reports peek " +
+			leaf.getPeek() + " but carries no element at slot 0, so its boundary key cannot be " +
+			"derived. Leaf id: " + leaf.getId() +
+			", base peek: " + leaf.peek +
+			", layer peek: " + (layer == null ? "<no layer>" : String.valueOf(layer.peek)) +
+			", base values: " + (leaf.values == null ? "null" : "length " + leaf.values.length) +
+			", layer values: " +
+			(layer == null ? "<no layer>" : (layer.values == null ? "null" : "length " + layer.values.length)) +
+			", arrays shared: " + (layer != null && layer.values == leaf.values) +
+			", first null slot: " + firstNullSlot(values) +
+			". This indicates a transactional layer that was left partially populated (a decouple that copied " +
+			"the wrong length, or a peek advanced without the matching values). Restore the catalog from a backup, " +
+			"or fully rebuild / reindex the affected catalog.";
+		return new BPlusTreeCorruptedException(sb);
+	}
+
+	/**
+	 * Returns the index of the first `null` slot in the passed array, or `-1` when the array is fully populated. Used
+	 * only to enrich a corruption report.
+	 *
+	 * @param values the value array to scan
+	 * @return index of the first `null` element, or `-1`
+	 */
+	private int firstNullSlot(@Nonnull E[] values) {
+		for (int i = 0; i < values.length; i++) {
+			if (values[i] == null) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * Registers a rebalanced leaf's current boundary key as a dirty-scope probe key for this transaction. Invoked by the
+	 * base {@link #consolidate(Cursor)} for each leaf whose boundary keys a steal / merge shifted (always a leaf — the
+	 * base guards the call with {@code !isInternal}).
 	 *
 	 * @param leaf the rebalanced leaf node
 	 */
 	@Override
 	protected void registerConsolidatedLeaf(@Nonnull BPlusTreeNode<?> leaf) {
-		registerDirtyLeafInScope(this, leaf);
+		//noinspection unchecked
+		registerDirtyLeafInScope((BPlusLeafTreeNode<E>) leaf);
 	}
 
 	/**
-	 * Dirty-scope validation for this tree. For each registered key source (a writable leaf
-	 * this transaction dirtied) it reads the current first key, descends from this tree's root to the leaf that key
-	 * routes to, and re-derives both cross-leaf half-invariants on the leaf the descent actually landed on — reusing
-	 * the op-time machinery with the leaf's ACTUAL boundary keys ({@link #assertTailBoundary} against the successor
-	 * fence, {@link #assertHeadBoundary} against the predecessor's last key). This tree keeps no parallel key array,
-	 * so the boundary keys are re-derived on demand: the first key via {@link BPlusLeafTreeNode#getLeftBoundaryKey()},
-	 * the last via the key extractor over the peek slot. Empty key sources and descents that land on an empty leaf are
-	 * skipped (nothing to relocate by / assert). Called on the live baseline tree for the pre-commit (pre-WAL) pass,
+	 * Registers the dirtied leaf's CURRENT left boundary key as a dirty-scope probe key for this transaction. Called
+	 * from every boundary-changing seam (insert, delete, split, steal / merge). Derives the key from the
+	 * transaction-aware read-your-writes state, so it captures the post-mutation boundary; an emptied leaf carries no
+	 * boundary key and is skipped — nothing needs relocating by a key that no longer exists, and the leaf that key would
+	 * have named is validated on its own merits when a surviving sibling op registers it.
+	 *
+	 * @param leaf the dirtied leaf node
+	 */
+	private void registerDirtyLeafInScope(@Nonnull BPlusLeafTreeNode<E> leaf) {
+		final TransactionalLayerMaintainer maintainer = Transaction.getTransactionalLayerMaintainer();
+		// gate on the cheap checks before deriving (and boxing) the probe key: outside a transaction there is no
+		// registry (warm-up bulk load pays nothing), and an emptied leaf has no boundary key to relocate by
+		if (maintainer == null || leaf.getPeek() < 0) {
+			return;
+		}
+		maintainer.registerDirtyScopeToken(this, leaf.getLeftBoundaryKey());
+	}
+
+	/**
+	 * Dirty-scope validation for this tree. For each registered probe key (the boundary key of a leaf this transaction
+	 * dirtied, captured at op time) it descends from this tree's root to the leaf that key routes to, and re-derives
+	 * both cross-leaf half-invariants on the leaf the descent actually landed on — reusing the op-time machinery with
+	 * the leaf's ACTUAL boundary keys ({@link #assertTailBoundary} against the successor fence,
+	 * {@link #assertHeadBoundary} against the predecessor's last key). This tree keeps no parallel key array, so the
+	 * boundary keys are re-derived on demand via the key extractor over slot 0 and the peek slot. Descents that land on
+	 * an empty leaf are skipped (nothing to assert). Called on the live baseline tree for the pre-commit (pre-WAL) pass,
 	 * where the descent resolves diff layers, and on a freshly merged tree for the post-replay (merge-time) pass with
 	 * plain reads; both use read-path accessors only.
 	 *
-	 * @param registeredLeafKeySources the writable leaf objects registered for this tree; used only as key sources
+	 * @param registeredProbeKeys the boundary keys registered for this tree; used only to relocate the leaf to check
 	 * @throws BPlusTreeCorruptedException when a relocated leaf overlaps an adjacent leaf
 	 */
 	@Override
-	public void validateDirtyScope(@Nonnull Collection<Object> registeredLeafKeySources) {
-		for (final Object keySource : registeredLeafKeySources) {
-			//noinspection unchecked
-			final BPlusLeafTreeNode<E> registered = (BPlusLeafTreeNode<E>) keySource;
-			if (registered.getPeek() < 0) {
-				// empty key source — nothing to relocate by (key-source-only rule)
-				continue;
-			}
-			final int probeKey = registered.getLeftBoundaryKey();
+	public void validateDirtyScope(@Nonnull Collection<Object> registeredProbeKeys) {
+		for (final Object token : registeredProbeKeys) {
+			final int probeKey = (Integer) token;
 			final Cursor cursor = createCursor(probeKey);
 			final BPlusLeafTreeNode<E> leaf = cursor.leafNode();
 			final int peek = leaf.getPeek();
@@ -580,8 +647,14 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 				// the descent landed on an empty leaf — validating it is sound and vacuous
 				continue;
 			}
-			final int firstKey = leaf.getLeftBoundaryKey();
-			final int lastKey = this.keyExtractor.applyAsInt(leaf.getValues()[peek]);
+			// a live leaf reached by a descent must carry its head element; a null head is genuine corruption, so raise
+			// a typed, diagnosable error rather than let the key extractor throw a bare NullPointerException
+			final E[] values = leaf.getValues();
+			if (values.length == 0 || values[0] == null) {
+				throw boundaryKeyUnreadableError(leaf);
+			}
+			final int firstKey = this.keyExtractor.applyAsInt(values[0]);
+			final int lastKey = this.keyExtractor.applyAsInt(values[peek]);
 			assertTailBoundary(cursor, lastKey);
 			assertHeadBoundary(cursor, firstKey);
 		}
@@ -721,8 +794,8 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 			// op-time boundary-mutation asserts run before the (possible) split, while the cursor still reflects
 			// the pre-split spine — a mis-routed insert corrupts cross-leaf order without any structural op firing
 			assertInsertBoundaries(cursor, key);
-			// register the dirtied leaf as a dirty-scope token for this transaction
-			registerDirtyLeafInScope(this, leaf);
+			// register the dirtied leaf's current boundary key as a dirty-scope probe key for this transaction
+			registerDirtyLeafInScope(leaf);
 		}
 
 		// Split the leaf node if it exceeds the block size
@@ -745,10 +818,10 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 		final boolean headRemoved = leaf.size() > 1 && key == leaf.getLeftBoundaryKey();
 		if (leaf.delete(key)) {
 			this.size.set(size() - 1);
-			// register the dirtied leaf as a dirty-scope token for this transaction: a removal
+			// register the dirtied leaf's current boundary key as a dirty-scope probe key for this transaction: a removal
 			// narrows the leaf's key range, but a later reverted layer could restore the wider pre-transaction range
 			// and overlap a neighbour that split during the transaction — so removals are validated too
-			registerDirtyLeafInScope(this, leaf);
+			registerDirtyLeafInScope(leaf);
 		}
 
 		// if the head of the leaf has been removed, we need to update parent keys accordingly
@@ -930,8 +1003,8 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 		// post-replay (merge-time): before this merged version can propagate to the live view, re-derive the
 		// cross-leaf boundary invariants for every leaf this transaction dirtied — against the freshly merged
 		// structure (plain reads; the merged nodes are fresh or unchanged-and-layer-free, so the descent never
-		// consults a diff layer). Registered objects are key sources only; each is relocated by its current key
-		// in the merged tree.
+		// consults a diff layer). The registry holds boundary keys, not nodes; each key routes to whatever leaf
+		// currently owns it in the merged tree, and that landed leaf is validated on its own re-derived boundaries.
 		final Set<Object> dirtyScope = transactionalLayer.getDirtyScopeTokens(this);
 		if (!dirtyScope.isEmpty()) {
 			merged.validateDirtyScope(dirtyScope);
@@ -964,6 +1037,22 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 	) {
 		final int mid = this.valueBlockSize / 2;
 		final E[] originValues = leaf.getValues();
+
+		// invariant assert: inside a transaction the right leaf below adopts `originValues` in place, so that array must
+		// be this leaf's DECOUPLED layer copy, never the still-shared committed base — otherwise a concurrent reader of
+		// the committed version would observe the in-place adoption as corruption. insert()/upsert() run leaf.insert(),
+		// which decouples the layer, before this split fires, so the premise holds; assert it so a future reordering
+		// fails fast here rather than silently corrupting the committed version (the dirty-scope registry no longer
+		// observes orphaned arrays, so this assert is the sole guard of that ordering).
+		if (leaf.transactionalLayer && Transaction.isTransactionAvailable()) {
+			final BPlusLeafTreeNode<E> leafLayer = Transaction.getTransactionalMemoryLayerIfExists(leaf);
+			//noinspection ArrayEquality
+			Assert.isPremiseValid(
+				leafLayer != null && leafLayer.values != leaf.values,
+				() -> "Corrupted in-memory B+ tree: splitting leaf " + leaf.getId() + " would adopt its committed " +
+					"value array in place because the leaf's transactional layer was not decoupled before the split."
+			);
+		}
 
 		// structural assert: the split partitions a sorted leaf into a left half [0, mid) and a right half
 		// [mid, length); the left leaf's last key must sort strictly before the right leaf's first key, and the
@@ -1026,10 +1115,10 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 				cursor.toCursorWithLevel()
 			);
 		}
-		// a split creates a brand-new adjacent leaf pair with a fresh separator between them — register both halves
-		// as dirty-scope tokens for this transaction
-		registerDirtyLeafInScope(this, leftLeaf);
-		registerDirtyLeafInScope(this, rightLeaf);
+		// a split creates a brand-new adjacent leaf pair with a fresh separator between them — register both halves'
+		// current boundary keys as dirty-scope probe keys for this transaction
+		registerDirtyLeafInScope(leftLeaf);
+		registerDirtyLeafInScope(rightLeaf);
 	}
 
 	/**
@@ -1273,6 +1362,11 @@ public class TransactionalElementBPlusTree<E> extends AbstractIntKeyedBPlusTree 
 				final int originPeek = this.peek;
 				this.peek = peek;
 				if (peek < originPeek) {
+					// blank the vacated tail so the leaf holds no stale references past its shrunk range. This array may
+					// still be shared with another holder (`createLayer` hands the diff layer the same array), but the
+					// dirty-scope registry keeps only boundary KEYS, never node objects, so no observer ever reads a
+					// shrunk holder's tail — the in-place blank is safe. Merge donors emptied here are detached from the
+					// tree in the same consolidate step and never read again.
 					Arrays.fill(this.values, peek + 1, originPeek + 1, null);
 				}
 			} else {

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTree.java
@@ -645,39 +645,53 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 	}
 
 	/**
-	 * Registers a rebalanced leaf as a dirty-scope token for this transaction.
-	 * Invoked by the base {@link #consolidate(Cursor)} for each leaf whose boundary keys a steal / merge shifted.
+	 * Registers a rebalanced leaf's current boundary key as a dirty-scope probe key for this transaction. Invoked by the
+	 * base {@link #consolidate(Cursor)} for each leaf whose boundary keys a steal / merge shifted (always a leaf — the
+	 * base guards the call with {@code !isInternal}).
 	 *
 	 * @param leaf the rebalanced leaf node
 	 */
 	@Override
 	protected void registerConsolidatedLeaf(@Nonnull BPlusTreeNode<?> leaf) {
-		registerDirtyLeafInScope(this, leaf);
+		//noinspection unchecked
+		registerDirtyLeafInScope((BPlusLeafTreeNode<V>) leaf);
 	}
 
 	/**
-	 * Dirty-scope validation for this tree. For each registered key source (a writable leaf
-	 * this transaction dirtied) it reads the current first key, descends from this tree's root to the leaf that key
-	 * routes to, and re-derives both cross-leaf half-invariants on the leaf the descent actually landed on — reusing
-	 * the op-time machinery with the leaf's ACTUAL boundary keys ({@link #assertTailBoundary} against the successor
-	 * fence, {@link #assertHeadBoundary} against the predecessor's last key). Empty key sources and descents that land
-	 * on an empty leaf are skipped (nothing to relocate by / assert). Called on the live baseline tree for the
-	 * pre-commit (pre-WAL) pass (the descent resolves diff layers) and on a freshly merged tree for the post-replay
-	 * (merge-time) pass (plain reads); both use read-path accessors only.
+	 * Registers the dirtied leaf's CURRENT first key as a dirty-scope probe key for this transaction. Called from every
+	 * boundary-changing seam (insert, upsert-insert, delete, split, steal / merge). Reads the key through the
+	 * transaction-aware {@link BPlusLeafTreeNode#getKeys()}, so it captures the post-mutation boundary; an emptied leaf
+	 * carries no boundary key and is skipped — nothing needs relocating by a key that no longer exists.
 	 *
-	 * @param registeredLeafKeySources the writable leaf objects registered for this tree; used only as key sources
+	 * @param leaf the dirtied leaf node
+	 */
+	private void registerDirtyLeafInScope(@Nonnull BPlusLeafTreeNode<V> leaf) {
+		final TransactionalLayerMaintainer maintainer = Transaction.getTransactionalLayerMaintainer();
+		// gate on the cheap checks before deriving (and boxing) the probe key: outside a transaction there is no
+		// registry (warm-up bulk load pays nothing), and an emptied leaf has no boundary key to relocate by
+		if (maintainer == null || leaf.getPeek() < 0) {
+			return;
+		}
+		maintainer.registerDirtyScopeToken(this, leaf.getKeys()[0]);
+	}
+
+	/**
+	 * Dirty-scope validation for this tree. For each registered probe key (the first key of a leaf this transaction
+	 * dirtied, captured at op time) it descends from this tree's root to the leaf that key routes to, and re-derives
+	 * both cross-leaf half-invariants on the leaf the descent actually landed on — reusing the op-time machinery with
+	 * the leaf's ACTUAL boundary keys ({@link #assertTailBoundary} against the successor fence,
+	 * {@link #assertHeadBoundary} against the predecessor's last key). Descents that land on an empty leaf are skipped
+	 * (nothing to assert). Called on the live baseline tree for the pre-commit (pre-WAL) pass (the descent resolves diff
+	 * layers) and on a freshly merged tree for the post-replay (merge-time) pass (plain reads); both use read-path
+	 * accessors only.
+	 *
+	 * @param registeredProbeKeys the first keys registered for this tree; used only to relocate the leaf to check
 	 * @throws BPlusTreeCorruptedException when a relocated leaf overlaps an adjacent leaf
 	 */
 	@Override
-	public void validateDirtyScope(@Nonnull Collection<Object> registeredLeafKeySources) {
-		for (final Object keySource : registeredLeafKeySources) {
-			//noinspection unchecked
-			final BPlusLeafTreeNode<V> registered = (BPlusLeafTreeNode<V>) keySource;
-			if (registered.getPeek() < 0) {
-				// empty key source — nothing to relocate by (key-source-only rule)
-				continue;
-			}
-			final long probeKey = registered.getKeys()[0];
+	public void validateDirtyScope(@Nonnull Collection<Object> registeredProbeKeys) {
+		for (final Object token : registeredProbeKeys) {
+			final long probeKey = (Long) token;
 			final Cursor cursor = createCursor(probeKey);
 			final BPlusLeafTreeNode<V> leaf = cursor.leafNode();
 			final int peek = leaf.getPeek();
@@ -802,8 +816,8 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 			// op-time boundary-mutation asserts run before the (possible) split, while the cursor still reflects
 			// the pre-split spine — a mis-routed insert corrupts cross-leaf order without any structural op firing
 			assertInsertBoundaries(cursor, key);
-			// register the dirtied leaf as a dirty-scope token for this transaction
-			registerDirtyLeafInScope(this, leaf);
+			// register the dirtied leaf's current boundary key as a dirty-scope probe key for this transaction
+			registerDirtyLeafInScope(leaf);
 		}
 
 		// Split the leaf node if it exceeds the block size
@@ -872,8 +886,8 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 				this.size.set(size() + 1);
 				// op-time boundary-mutation asserts — see insert(long, V)
 				assertInsertBoundaries(cursor, key);
-				// register the dirtied leaf as a dirty-scope token for this transaction
-				registerDirtyLeafInScope(this, leaf);
+				// register the dirtied leaf's current boundary key as a dirty-scope probe key for this transaction
+				registerDirtyLeafInScope(leaf);
 			}
 
 			// Split the leaf node if it exceeds the block size
@@ -898,11 +912,11 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 		final boolean headRemoved = leaf.size() > 1 && key == leaf.getKeys()[0];
 		if (leaf.delete(key)) {
 			this.size.set(size() - 1);
-			// register the dirtied leaf as a dirty-scope token for this transaction: a
+			// register the dirtied leaf's current boundary key as a dirty-scope probe key for this transaction: a
 			// removal narrows the leaf's key range, but a later reverted layer could restore the wider
 			// pre-transaction range and overlap a neighbour that split during the transaction — so removals are
 			// validated too
-			registerDirtyLeafInScope(this, leaf);
+			registerDirtyLeafInScope(leaf);
 		}
 
 		// if the head of the leaf has been removed, we need to update parent keys accordingly
@@ -1142,7 +1156,8 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 		// cross-leaf boundary invariants for every leaf this transaction dirtied — against the freshly merged
 		// structure (plain reads; the merged nodes are fresh or unchanged-and-layer-free, so the descent never
 		// consults a diff layer).
-		// Registered objects are key sources only; each is relocated by its current key in the merged tree.
+		// The registry holds boundary keys, not nodes; each key routes to whatever leaf currently owns it in the
+		// merged tree, and that landed leaf is validated on its own re-derived boundaries.
 		final Set<Object> dirtyScope = transactionalLayer.getDirtyScopeTokens(this);
 		if (!dirtyScope.isEmpty()) {
 			merged.validateDirtyScope(dirtyScope);
@@ -1277,10 +1292,10 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 				cursor.toCursorWithLevel()
 			);
 		}
-		// a split creates a brand-new adjacent leaf pair with a fresh separator between them — register both halves
-		// as dirty-scope tokens for this transaction
-		registerDirtyLeafInScope(this, leftLeaf);
-		registerDirtyLeafInScope(this, rightLeaf);
+		// a split creates a brand-new adjacent leaf pair with a fresh separator between them — register both halves'
+		// current boundary keys as dirty-scope probe keys for this transaction
+		registerDirtyLeafInScope(leftLeaf);
+		registerDirtyLeafInScope(rightLeaf);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndex.java
@@ -546,6 +546,29 @@ public class ReferenceTypeCardinalityIndex
 		return this.cardinalities.isRootInternal();
 	}
 
+
+	/**
+	 * Emits a removal for every leaf page this index currently has ON DISK, used when the owning entity index is
+	 * dropped and its whole persisted footprint must be reclaimed from the append-only storage. Reads only the
+	 * persisted page baseline (never the live tree) and has no side effects — in particular it does NOT
+	 * {@code forget} the stream, because the index is being discarded rather than reshaped.
+	 *
+	 * @param entityIndexPrimaryKey primary key of the owning entity index
+	 * @param referenceName         the reference this cardinality index belongs to
+	 * @param sink                  the accumulator collecting the removal instructions
+	 */
+	public void emitPersistedLeafPageRemovals(
+		int entityIndexPrimaryKey,
+		@Nonnull String referenceName,
+		@Nonnull TrappedChanges sink
+	) {
+		for (final int persistedPageSequence : this.pageStreamRegistry.pendingLivePageSequences(CARDINALITY_PAGE_STREAM)) {
+			sink.addChangeToStore(
+				new ReferenceTypeCardinalityIndexLeafPageRemoval(entityIndexPrimaryKey, referenceName, persistedPageSequence)
+			);
+		}
+	}
+
 	/**
 	 * Appends this index's modified storage parts to the flush sink. PAGED: one leaf page per CHANGED leaf, a removal per
 	 * freed leaf, plus a PAGED root carrying the high-water, the ordered live leaf-page list and the INLINE companion

--- a/evita_engine/src/main/java/io/evitadb/index/component/AttributeIndexComponent.java
+++ b/evita_engine/src/main/java/io/evitadb/index/component/AttributeIndexComponent.java
@@ -88,4 +88,14 @@ public final class AttributeIndexComponent implements IndexComponent {
 		this.attributeIndex.removeLayer(transactionalLayer);
 	}
 
+	@Override
+	public void emitPersistedFootprintRemovals(
+		int entityIndexPrimaryKey,
+		@Nonnull TrappedChanges trappedChanges
+	) {
+		// whole-index drop: reclaim every persisted leaf page of all five paged families (CHAIN / UNIQUE / SORT /
+		// FILTER inverted + range); the manifest-listed roots are reclaimed by EntityIndex.emitVanishedRootRemovals
+		this.attributeIndex.emitPersistedLeafPageRemovals(entityIndexPrimaryKey, trappedChanges);
+	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/index/component/HistogramIndexMapComponent.java
+++ b/evita_engine/src/main/java/io/evitadb/index/component/HistogramIndexMapComponent.java
@@ -213,4 +213,16 @@ public final class HistogramIndexMapComponent implements IndexComponent {
 		this.histogramIndexes.removeLayer(transactionalLayer);
 	}
 
+	@Override
+	public void emitPersistedFootprintRemovals(
+		int entityIndexPrimaryKey,
+		@Nonnull TrappedChanges trappedChanges
+	) {
+		// whole-index drop: reclaim every persisted bucket / range leaf page + cardinality sibling of every persisted
+		// `(histogram, locale)` sub-index by diffing the persisted baseline against an empty survivor set (nothing
+		// survives). The histogram root is manifest-listed and reclaimed by EntityIndex.emitVanishedRootRemovals.
+		// Reads only the persisted baseline and has no side effects — the baseline field is left untouched.
+		emitDroppedReclaims(entityIndexPrimaryKey, this.persistedLeafPages, Map.of(), trappedChanges);
+	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/index/component/IndexComponent.java
+++ b/evita_engine/src/main/java/io/evitadb/index/component/IndexComponent.java
@@ -93,4 +93,25 @@ public interface IndexComponent {
 	 */
 	void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer);
 
+	/**
+	 * Emits removal instructions reclaiming this component's ENTIRE persisted footprint when the owning
+	 * {@link io.evitadb.index.EntityIndex} is dropped: every persisted leaf page, and any root part addressed
+	 * independently of the {@link EntityIndexManifest} (e.g. the reference-type cardinality root, which the
+	 * manifest-baseline diff in {@code EntityIndex.emitVanishedRootRemovals} does not cover). Manifest-listed
+	 * roots (attribute / price / facet / histogram / hierarchy) are reclaimed by that diff and MUST NOT be
+	 * re-emitted here. Implementations read only their persisted baseline, never live/transactional state.
+	 *
+	 * The default is a no-op — correct for components that persist no leaf pages and whose root (if any) is
+	 * manifest-listed (facet, hierarchy, attribute cardinality).
+	 *
+	 * @param entityIndexPrimaryKey primary key of the owning entity index
+	 * @param trappedChanges        the accumulator collecting the removal instructions
+	 */
+	default void emitPersistedFootprintRemovals(
+		int entityIndexPrimaryKey,
+		@Nonnull TrappedChanges trappedChanges
+	) {
+		// no persisted leaf pages and no non-manifest root — nothing to reclaim
+	}
+
 }

--- a/evita_engine/src/main/java/io/evitadb/index/component/PriceIndexComponent.java
+++ b/evita_engine/src/main/java/io/evitadb/index/component/PriceIndexComponent.java
@@ -117,9 +117,10 @@ public final class PriceIndexComponent implements IndexComponent {
 		// only the SUPER flavour is paged: each of its per-list super indexes holds persisted leaf pages that must be
 		// reclaimed when the whole entity index is dropped (the PAGED roots are manifest-listed and reclaimed elsewhere)
 		if (this.priceIndex instanceof PriceSuperIndex superIndex) {
-			for (final PriceListAndCurrencyPriceIndex pli : superIndex.getPriceListAndCurrencyIndexes()) {
-				// under a PriceSuperIndex every per-list index is a super (paged) index — the generic bound guarantees it
-				((PriceListAndCurrencyPriceSuperIndex) pli).emitPersistedLeafPageRemovals(entityIndexPrimaryKey, trappedChanges);
+			// under a PriceSuperIndex every per-list index is a super (paged) index — its narrowed accessor states that
+			// statically, so no cast (and no ClassCastException risk) is involved here
+			for (final PriceListAndCurrencyPriceSuperIndex pli : superIndex.getPriceListAndCurrencyIndexes()) {
+				pli.emitPersistedLeafPageRemovals(entityIndexPrimaryKey, trappedChanges);
 			}
 		} else if (this.priceIndex instanceof PriceRefIndex) {
 			// intentional no-op: PriceRefIndex per-list indexes are SINGLE-only (inline root, no persisted leaf pages)

--- a/evita_engine/src/main/java/io/evitadb/index/component/PriceIndexComponent.java
+++ b/evita_engine/src/main/java/io/evitadb/index/component/PriceIndexComponent.java
@@ -30,6 +30,7 @@ import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.IndexDataStructure;
 import io.evitadb.index.price.PriceIndexContract;
 import io.evitadb.index.price.PriceListAndCurrencyPriceIndex;
+import io.evitadb.index.price.PriceListAndCurrencyPriceSuperIndex;
 import io.evitadb.index.price.PriceRefIndex;
 import io.evitadb.index.price.PriceSuperIndex;
 import io.evitadb.index.price.VoidPriceIndex;
@@ -105,6 +106,29 @@ public final class PriceIndexComponent implements IndexComponent {
 		// only the non-void flavours implement TransactionalLayerProducer.removeLayer
 		if (this.priceIndex instanceof TransactionalLayerProducer<?, ?> producer) {
 			producer.removeLayer(transactionalLayer);
+		}
+	}
+
+	@Override
+	public void emitPersistedFootprintRemovals(
+		int entityIndexPrimaryKey,
+		@Nonnull TrappedChanges trappedChanges
+	) {
+		// only the SUPER flavour is paged: each of its per-list super indexes holds persisted leaf pages that must be
+		// reclaimed when the whole entity index is dropped (the PAGED roots are manifest-listed and reclaimed elsewhere)
+		if (this.priceIndex instanceof PriceSuperIndex superIndex) {
+			for (final PriceListAndCurrencyPriceIndex pli : superIndex.getPriceListAndCurrencyIndexes()) {
+				// under a PriceSuperIndex every per-list index is a super (paged) index — the generic bound guarantees it
+				((PriceListAndCurrencyPriceSuperIndex) pli).emitPersistedLeafPageRemovals(entityIndexPrimaryKey, trappedChanges);
+			}
+		} else if (this.priceIndex instanceof PriceRefIndex) {
+			// intentional no-op: PriceRefIndex per-list indexes are SINGLE-only (inline root, no persisted leaf pages)
+		} else if (this.priceIndex instanceof VoidPriceIndex) {
+			// intentional no-op: VoidPriceIndex carries no state and persists nothing
+		} else {
+			throw new GenericEvitaInternalError(
+				"Unexpected PriceIndexContract impl: " + this.priceIndex.getClass()
+			);
 		}
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/component/ReferenceTypeCardinalityComponent.java
+++ b/evita_engine/src/main/java/io/evitadb/index/component/ReferenceTypeCardinalityComponent.java
@@ -26,6 +26,7 @@ package io.evitadb.index.component;
 import io.evitadb.core.buffer.TrappedChanges;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.index.cardinality.ReferenceTypeCardinalityIndex;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.ReferenceTypeCardinalityRootRemoval;
 
 import javax.annotation.Nonnull;
 
@@ -78,6 +79,23 @@ public final class ReferenceTypeCardinalityComponent implements IndexComponent {
 		// one inline root.
 		this.indexPrimaryKeyCardinality.appendStorageParts(
 			entityIndexPrimaryKey, this.referenceName, trappedChanges
+		);
+	}
+
+	@Override
+	public void emitPersistedFootprintRemovals(
+		int entityIndexPrimaryKey,
+		@Nonnull TrappedChanges trappedChanges
+	) {
+		// every leaf page the paged cardinality tree currently has on disk
+		this.indexPrimaryKeyCardinality.emitPersistedLeafPageRemovals(
+			entityIndexPrimaryKey, this.referenceName, trappedChanges
+		);
+		// ...and the root. Unlike the attribute / price / facet / histogram / hierarchy roots this part contributes
+		// nothing to the EntityIndexManifest (it is addressed by its own storage key), so the manifest-baseline diff
+		// in EntityIndex cannot see it vanish — it has to be reclaimed here or it would be orphaned forever.
+		trappedChanges.addChangeToStore(
+			new ReferenceTypeCardinalityRootRemoval(entityIndexPrimaryKey, this.referenceName)
 		);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndex.java
@@ -30,6 +30,7 @@ import io.evitadb.core.query.algebra.price.priceIndex.PriceIdContainerFormula;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.dataType.DateTimeRange;
 import io.evitadb.dataType.champ.ChampMap;
+import io.evitadb.index.EntityIndex;
 import io.evitadb.index.bPlusTree.TransactionalElementBPlusTree;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
@@ -334,6 +335,33 @@ public class PriceListAndCurrencyPriceSuperIndex
 			sink.addChangeToStore(
 				new PriceListAndCurrencySuperIndexStoragePart(
 					entityIndexPrimaryKey, this.priceIndexKey, this.validityIndex, this.priceRecords.toArray()
+				)
+			);
+		}
+	}
+
+	/**
+	 * Whole-index-drop reclaim: emits a {@link PriceListAndCurrencySuperIndexLeafPageRemoval} for EVERY persisted leaf
+	 * page of this super index's price-record tree, as if nothing survives. Called when the owning
+	 * {@link EntityIndex} is dropped: this sub-index's own {@link #appendStorageParts} will never run
+	 * again, so the append-only OffsetIndex would copy every orphaned leaf page forward forever unless each is removed
+	 * explicitly. The `PAGED` root itself is manifest-listed and reclaimed by `EntityIndex.emitVanishedRootRemovals`, so
+	 * this method emits only leaf pages.
+	 *
+	 * Unlike {@link #appendStorageParts}, this enumerates the persisted page baseline unconditionally — no `dirty`
+	 * guard, no `isPaged()` branch — and has NO side effects: no `forget`, no bookkeeping mutation. A SINGLE-shaped
+	 * index has no persisted leaf pages, so the registry's live set is empty and nothing is emitted.
+	 *
+	 * @param entityIndexPrimaryKey the owning entity index pk
+	 * @param sink                  the trapped-changes accumulator collecting the removal instructions
+	 */
+	public void emitPersistedLeafPageRemovals(int entityIndexPrimaryKey, @Nonnull TrappedChanges sink) {
+		assertNotTerminated();
+		// reclaim every leaf page the registry still holds ON DISK for this stream — the persisted baseline, read-only
+		for (final int freedPageSequence : this.pageStreamRegistry.pendingLivePageSequences(PRICE_PAGE_STREAM)) {
+			sink.addChangeToStore(
+				new PriceListAndCurrencySuperIndexLeafPageRemoval(
+					entityIndexPrimaryKey, this.priceIndexKey, freedPageSequence
 				)
 			);
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceSuperIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceSuperIndex.java
@@ -43,6 +43,7 @@ import io.evitadb.index.price.model.priceRecord.PriceRecordInnerRecordSpecific;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serial;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -161,6 +162,20 @@ public class PriceSuperIndex
 	@Override
 	protected Map<PriceIndexKey, PriceListAndCurrencyPriceSuperIndex> getPriceIndexes() {
 		return this.priceIndexes;
+	}
+
+	/**
+	 * Narrows the contract's wildcard element type to the concrete super index this implementation maintains. Every
+	 * per-price-list index held by a super index is a {@link PriceListAndCurrencyPriceSuperIndex} - the class generic
+	 * bound already guarantees it, and this override lets callers that need the super-index API (such as reclaiming
+	 * the persisted leaf pages of a dropped index) rely on it statically instead of casting.
+	 *
+	 * @return the per-price-list super indexes maintained by this index
+	 */
+	@Nonnull
+	@Override
+	public Collection<PriceListAndCurrencyPriceSuperIndex> getPriceListAndCurrencyIndexes() {
+		return this.priceIndexes.values();
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/AttributeIndexRootRemoval.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/AttributeIndexRootRemoval.java
@@ -1,0 +1,127 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spi.store.catalog.persistence.storageParts.index;
+
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.spi.store.catalog.persistence.storageParts.DeferredRemovalStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.KeyCompressor;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexStoragePart.AttributeIndexType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serial;
+
+/**
+ * A flush-time instruction to REMOVE the root {@link AttributeIndexStoragePart} of an attribute sub-index that vanished
+ * this commit — either because the individual sub-index (a filter, sort, chain, unique or cardinality structure over a
+ * single attribute) was dropped by churn, or because the whole owning entity index was dropped. Because the append-only
+ * OffsetIndex never overwrites in place, the disappearance of the in-memory structure must be turned into an explicit
+ * removal record so the persisted root part is reclaimed.
+ *
+ * The part carries the sub-index `(entityIndexPrimaryKey, attributeKey, indexType)` identity rather than a pre-resolved
+ * primary key: the writable {@link KeyCompressor} lives store-side, so the target primary key is resolved store-side in
+ * {@link #computeUniquePartIdAndSet}. It carries no payload and is never written, so it needs no Kryo serializer.
+ *
+ * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class AttributeIndexRootRemoval implements DeferredRemovalStoragePart {
+	@Serial private static final long serialVersionUID = 8412093746501283746L;
+
+	/**
+	 * Primary key of the owning {@link io.evitadb.index.EntityIndex} — identity used to resolve the dropped root's
+	 * primary key store-side.
+	 */
+	private final int entityIndexPrimaryKey;
+	/**
+	 * The attribute key of the sub-index — used to resolve the dropped root's primary key store-side.
+	 */
+	@Nonnull private final AttributeIndexKey attributeKey;
+	/**
+	 * The kind of attribute index (filter, sort, chain, unique or cardinality) — needed both to resolve the primary key
+	 * store-side and to select the concrete removed container type.
+	 */
+	@Nonnull private final AttributeIndexType indexType;
+	/**
+	 * The resolved storage-part primary key; `null` until {@link #computeUniquePartIdAndSet} resolves it store-side.
+	 */
+	@Nullable private Long storagePartPK;
+
+	/**
+	 * Creates a removal instruction for the dropped attribute index root identified by its sub-index identity.
+	 *
+	 * @param entityIndexPrimaryKey primary key of the owning entity index
+	 * @param attributeKey          the attribute key of the sub-index
+	 * @param indexType             the kind of attribute index that was dropped
+	 */
+	public AttributeIndexRootRemoval(
+		int entityIndexPrimaryKey,
+		@Nonnull AttributeIndexKey attributeKey,
+		@Nonnull AttributeIndexType indexType
+	) {
+		this.entityIndexPrimaryKey = entityIndexPrimaryKey;
+		this.attributeKey = attributeKey;
+		this.indexType = indexType;
+		this.storagePartPK = null;
+	}
+
+	@Nullable
+	@Override
+	public Long getStoragePartPK() {
+		return this.storagePartPK;
+	}
+
+	/**
+	 * @return the kind of attribute index whose root is being removed — used by the caller for de-duplication and
+	 * logging
+	 */
+	@Nonnull
+	public AttributeIndexType getIndexType() {
+		return this.indexType;
+	}
+
+	@Override
+	public long computeUniquePartIdAndSet(@Nonnull KeyCompressor keyCompressor) {
+		final long computedUniquePartId = AttributeIndexStoragePart.computeUniquePartId(
+			this.entityIndexPrimaryKey, this.indexType, this.attributeKey, keyCompressor
+		);
+		this.storagePartPK = computedUniquePartId;
+		return computedUniquePartId;
+	}
+
+	@Nonnull
+	@Override
+	public Class<? extends StoragePart> removedContainerType() {
+		return switch (this.indexType) {
+			case FILTER -> FilterIndexStoragePart.class;
+			case SORT -> SortIndexStoragePart.class;
+			case CHAIN -> ChainIndexStoragePart.class;
+			case UNIQUE -> UniqueIndexStoragePart.class;
+			case CARDINALITY -> AttributeCardinalityIndexStoragePart.class;
+			default -> throw new GenericEvitaInternalError(
+				"Unexpected attribute index type: " + this.indexType
+			);
+		};
+	}
+}

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/FacetIndexRootRemoval.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/FacetIndexRootRemoval.java
@@ -1,0 +1,98 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spi.store.catalog.persistence.storageParts.index;
+
+import io.evitadb.spi.store.catalog.persistence.storageParts.DeferredRemovalStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.KeyCompressor;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serial;
+
+/**
+ * A flush-time instruction to REMOVE the root {@link FacetIndexStoragePart} of a facet sub-index that vanished this
+ * commit — either because the individual facet index (for a single reference) was dropped by churn, or because the whole
+ * owning entity index was dropped. Because the append-only OffsetIndex never overwrites in place, the disappearance of
+ * the in-memory structure must be turned into an explicit removal record so the persisted root part is reclaimed.
+ *
+ * The part carries the sub-index `(entityIndexPrimaryKey, referenceName)` identity rather than a pre-resolved primary
+ * key: the writable {@link KeyCompressor} lives store-side, so the target primary key is resolved store-side in
+ * {@link #computeUniquePartIdAndSet}. It carries no payload and is never written, so it needs no Kryo serializer.
+ *
+ * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class FacetIndexRootRemoval implements DeferredRemovalStoragePart {
+	@Serial private static final long serialVersionUID = 4610237895012378645L;
+
+	/**
+	 * Primary key of the owning {@link io.evitadb.index.EntityIndex} — identity used to resolve the dropped root's
+	 * primary key store-side.
+	 */
+	private final int entityIndexPrimaryKey;
+	/**
+	 * The reference name of the sub-index — used to resolve the dropped root's primary key store-side.
+	 */
+	@Nonnull private final String referenceName;
+	/**
+	 * The resolved storage-part primary key; `null` until {@link #computeUniquePartIdAndSet} resolves it store-side.
+	 */
+	@Nullable private Long storagePartPK;
+
+	/**
+	 * Creates a removal instruction for the dropped facet index root identified by its sub-index identity.
+	 *
+	 * @param entityIndexPrimaryKey primary key of the owning entity index
+	 * @param referenceName         the reference name of the sub-index
+	 */
+	public FacetIndexRootRemoval(
+		int entityIndexPrimaryKey,
+		@Nonnull String referenceName
+	) {
+		this.entityIndexPrimaryKey = entityIndexPrimaryKey;
+		this.referenceName = referenceName;
+		this.storagePartPK = null;
+	}
+
+	@Nullable
+	@Override
+	public Long getStoragePartPK() {
+		return this.storagePartPK;
+	}
+
+	@Override
+	public long computeUniquePartIdAndSet(@Nonnull KeyCompressor keyCompressor) {
+		final long computedUniquePartId = FacetIndexStoragePart.computeUniquePartId(
+			this.entityIndexPrimaryKey, this.referenceName, keyCompressor
+		);
+		this.storagePartPK = computedUniquePartId;
+		return computedUniquePartId;
+	}
+
+	@Nonnull
+	@Override
+	public Class<? extends StoragePart> removedContainerType() {
+		return FacetIndexStoragePart.class;
+	}
+}

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/HierarchyIndexRootRemoval.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/HierarchyIndexRootRemoval.java
@@ -1,0 +1,81 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spi.store.catalog.persistence.storageParts.index;
+
+import io.evitadb.spi.store.catalog.persistence.storageParts.DeferredRemovalStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.KeyCompressor;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serial;
+
+/**
+ * A flush-time instruction to REMOVE the root {@link HierarchyIndexStoragePart} of a hierarchy sub-index that vanished
+ * this commit — either because the individual hierarchy structure was dropped by churn, or because the whole owning
+ * entity index was dropped. Because the append-only OffsetIndex never overwrites in place, the disappearance of the
+ * in-memory structure must be turned into an explicit removal record so the persisted root part is reclaimed.
+ *
+ * Unlike the other sub-index roots, the hierarchy root's primary key is simply the entity index primary key itself, so
+ * no {@link KeyCompressor} is consulted — {@link #computeUniquePartIdAndSet} ignores its argument, mirroring
+ * {@link HierarchyIndexStoragePart#computeUniquePartIdAndSet}. It carries no payload and is never written, so it needs
+ * no Kryo serializer.
+ *
+ * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class HierarchyIndexRootRemoval implements DeferredRemovalStoragePart {
+	@Serial private static final long serialVersionUID = 6503921847610293845L;
+
+	/**
+	 * Primary key of the owning {@link io.evitadb.index.EntityIndex}, which is also the primary key of the hierarchy
+	 * root storage part being removed.
+	 */
+	private final int entityIndexPrimaryKey;
+
+	/**
+	 * Creates a removal instruction for the dropped hierarchy index root.
+	 *
+	 * @param entityIndexPrimaryKey primary key of the owning entity index (also the removed root's primary key)
+	 */
+	public HierarchyIndexRootRemoval(int entityIndexPrimaryKey) {
+		this.entityIndexPrimaryKey = entityIndexPrimaryKey;
+	}
+
+	@Nullable
+	@Override
+	public Long getStoragePartPK() {
+		return (long) this.entityIndexPrimaryKey;
+	}
+
+	@Override
+	public long computeUniquePartIdAndSet(@Nonnull KeyCompressor keyCompressor) {
+		return this.entityIndexPrimaryKey;
+	}
+
+	@Nonnull
+	@Override
+	public Class<? extends StoragePart> removedContainerType() {
+		return HierarchyIndexStoragePart.class;
+	}
+}

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/HistogramRootRemoval.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/HistogramRootRemoval.java
@@ -1,0 +1,115 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spi.store.catalog.persistence.storageParts.index;
+
+import io.evitadb.spi.store.catalog.persistence.storageParts.DeferredRemovalStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.KeyCompressor;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serial;
+import java.util.Locale;
+
+/**
+ * A flush-time instruction to REMOVE the root {@link HistogramIndexStoragePart} of a histogram sub-index that vanished
+ * this commit — either because the individual histogram (or one locale of a localized histogram) was dropped by churn,
+ * or because the whole owning entity index was dropped. Because the append-only OffsetIndex never overwrites in place,
+ * the disappearance of the in-memory structure must be turned into an explicit removal record so the persisted root part
+ * is reclaimed.
+ *
+ * The part carries the sub-index `(entityIndexPrimaryKey, histogramName, locale)` identity rather than a pre-resolved
+ * primary key: the writable {@link KeyCompressor} lives store-side, so the target primary key is resolved store-side in
+ * {@link #computeUniquePartIdAndSet}. It carries no payload and is never written, so it needs no Kryo serializer.
+ *
+ * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class HistogramRootRemoval implements DeferredRemovalStoragePart {
+	@Serial private static final long serialVersionUID = 5901284736019283746L;
+
+	/**
+	 * Primary key of the owning {@link io.evitadb.index.EntityIndex} — identity used to resolve the dropped root's
+	 * primary key store-side.
+	 */
+	private final int entityIndexPrimaryKey;
+	/**
+	 * The histogram name of the sub-index — used to resolve the dropped root's primary key store-side.
+	 */
+	@Nonnull private final String histogramName;
+	/**
+	 * The locale of the sub-index, or `null` for a non-localized histogram.
+	 */
+	@Nullable private final Locale locale;
+	/**
+	 * The resolved storage-part primary key; `null` until {@link #computeUniquePartIdAndSet} resolves it store-side.
+	 */
+	@Nullable private Long storagePartPK;
+
+	/**
+	 * Creates a removal instruction for the dropped histogram index root identified by its sub-index identity.
+	 *
+	 * @param entityIndexPrimaryKey primary key of the owning entity index
+	 * @param histogramName         the histogram name of the sub-index
+	 * @param locale                the locale of the sub-index, or `null`
+	 */
+	public HistogramRootRemoval(
+		int entityIndexPrimaryKey,
+		@Nonnull String histogramName,
+		@Nullable Locale locale
+	) {
+		this.entityIndexPrimaryKey = entityIndexPrimaryKey;
+		this.histogramName = histogramName;
+		this.locale = locale;
+		this.storagePartPK = null;
+	}
+
+	@Nullable
+	@Override
+	public Long getStoragePartPK() {
+		return this.storagePartPK;
+	}
+
+	/**
+	 * @return the locale of the sub-index whose histogram root is being removed, or `null` for a non-localized histogram
+	 */
+	@Nullable
+	public Locale getLocale() {
+		return this.locale;
+	}
+
+	@Override
+	public long computeUniquePartIdAndSet(@Nonnull KeyCompressor keyCompressor) {
+		final long computedUniquePartId = AbstractHistogramStoragePart.computeUniquePartId(
+			this.entityIndexPrimaryKey, this.histogramName, this.locale, keyCompressor
+		);
+		this.storagePartPK = computedUniquePartId;
+		return computedUniquePartId;
+	}
+
+	@Nonnull
+	@Override
+	public Class<? extends StoragePart> removedContainerType() {
+		return HistogramIndexStoragePart.class;
+	}
+}

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/PriceIndexRootRemoval.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/PriceIndexRootRemoval.java
@@ -1,0 +1,110 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spi.store.catalog.persistence.storageParts.index;
+
+import io.evitadb.index.price.model.PriceIndexKey;
+import io.evitadb.spi.store.catalog.persistence.storageParts.DeferredRemovalStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.KeyCompressor;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serial;
+
+/**
+ * A flush-time instruction to REMOVE the root {@link PriceListAndCurrencyIndexStoragePart} of a price sub-index that
+ * vanished this commit — either because the individual price-list/currency structure was dropped by churn, or because
+ * the whole owning entity index was dropped. Because the append-only OffsetIndex never overwrites in place, the
+ * disappearance of the in-memory structure must be turned into an explicit removal record so the persisted root part is
+ * reclaimed.
+ *
+ * The part carries the sub-index `(entityIndexPrimaryKey, priceIndexKey)` identity rather than a pre-resolved primary
+ * key: the writable {@link KeyCompressor} lives store-side, so the target primary key is resolved store-side in
+ * {@link #computeUniquePartIdAndSet}. Because the super and reference price roots share the same primary-key packing and
+ * are disambiguated only by container type, the caller supplies the concrete `rootType` explicitly. The part carries no
+ * payload and is never written, so it needs no Kryo serializer.
+ *
+ * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class PriceIndexRootRemoval implements DeferredRemovalStoragePart {
+	@Serial private static final long serialVersionUID = 3729048561023784591L;
+
+	/**
+	 * Primary key of the owning {@link io.evitadb.index.EntityIndex} — identity used to resolve the dropped root's
+	 * primary key store-side.
+	 */
+	private final int entityIndexPrimaryKey;
+	/**
+	 * The price index key of the sub-index — used to resolve the dropped root's primary key store-side.
+	 */
+	@Nonnull private final PriceIndexKey priceIndexKey;
+	/**
+	 * The concrete price root container type (super or reference) supplied by the caller — used to disambiguate the two
+	 * roots that share the same primary-key packing.
+	 */
+	@Nonnull private final Class<? extends StoragePart> rootType;
+	/**
+	 * The resolved storage-part primary key; `null` until {@link #computeUniquePartIdAndSet} resolves it store-side.
+	 */
+	@Nullable private Long storagePartPK;
+
+	/**
+	 * Creates a removal instruction for the dropped price index root identified by its sub-index identity.
+	 *
+	 * @param entityIndexPrimaryKey primary key of the owning entity index
+	 * @param priceIndexKey         the price index key of the sub-index
+	 * @param rootType              the concrete price root container type (super or reference) that was dropped
+	 */
+	public PriceIndexRootRemoval(
+		int entityIndexPrimaryKey,
+		@Nonnull PriceIndexKey priceIndexKey,
+		@Nonnull Class<? extends StoragePart> rootType
+	) {
+		this.entityIndexPrimaryKey = entityIndexPrimaryKey;
+		this.priceIndexKey = priceIndexKey;
+		this.rootType = rootType;
+		this.storagePartPK = null;
+	}
+
+	@Nullable
+	@Override
+	public Long getStoragePartPK() {
+		return this.storagePartPK;
+	}
+
+	@Override
+	public long computeUniquePartIdAndSet(@Nonnull KeyCompressor keyCompressor) {
+		final long computedUniquePartId = PriceListAndCurrencyIndexStoragePart.computeUniquePartId(
+			this.entityIndexPrimaryKey, this.priceIndexKey, keyCompressor
+		);
+		this.storagePartPK = computedUniquePartId;
+		return computedUniquePartId;
+	}
+
+	@Nonnull
+	@Override
+	public Class<? extends StoragePart> removedContainerType() {
+		return this.rootType;
+	}
+}

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/ReferenceTypeCardinalityRootRemoval.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/storageParts/index/ReferenceTypeCardinalityRootRemoval.java
@@ -1,0 +1,116 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.spi.store.catalog.persistence.storageParts.index;
+
+import io.evitadb.spi.store.catalog.persistence.storageParts.DeferredRemovalStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.KeyCompressor;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.utils.NumberUtils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serial;
+import java.util.OptionalInt;
+
+/**
+ * A flush-time instruction to REMOVE the root {@link ReferenceTypeCardinalityIndexStoragePart} of a reference-type
+ * cardinality sub-index that vanished this commit — either because the individual sub-index was dropped by churn, or
+ * because the whole owning entity index was dropped. Because the append-only OffsetIndex never overwrites in place, the
+ * disappearance of the in-memory structure must be turned into an explicit removal record so the persisted root part is
+ * reclaimed.
+ *
+ * The part carries the sub-index `(entityIndexPrimaryKey, referenceName)` identity rather than a pre-resolved primary
+ * key: the writable {@link KeyCompressor} lives store-side, so the target primary key is resolved store-side in
+ * {@link #computeUniquePartIdAndSet}. It carries no payload and is never written, so it needs no Kryo serializer.
+ *
+ * @author Jan Novotny (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public class ReferenceTypeCardinalityRootRemoval implements DeferredRemovalStoragePart {
+	@Serial private static final long serialVersionUID = 7218094653012987465L;
+	/**
+	 * Primary key handed back when the reference name has no dictionary entry, which proves the root was never
+	 * written. Negative by construction, so it can never collide with a real `pack(entityIndexPrimaryKey, id)` key and
+	 * the removal it drives resolves to nothing.
+	 */
+	private static final long NEVER_PERSISTED_PART_ID = -1L;
+
+	/**
+	 * Primary key of the owning {@link io.evitadb.index.EntityIndex} — identity used to resolve the dropped root's
+	 * primary key store-side.
+	 */
+	private final int entityIndexPrimaryKey;
+	/**
+	 * The reference name of the sub-index — used to resolve the dropped root's primary key store-side.
+	 */
+	@Nonnull private final String referenceName;
+	/**
+	 * The resolved storage-part primary key; `null` until {@link #computeUniquePartIdAndSet} resolves it store-side.
+	 */
+	@Nullable private Long storagePartPK;
+
+	/**
+	 * Creates a removal instruction for the dropped reference-type cardinality index root identified by its sub-index
+	 * identity.
+	 *
+	 * @param entityIndexPrimaryKey primary key of the owning entity index
+	 * @param referenceName         the reference name of the sub-index
+	 */
+	public ReferenceTypeCardinalityRootRemoval(
+		int entityIndexPrimaryKey,
+		@Nonnull String referenceName
+	) {
+		this.entityIndexPrimaryKey = entityIndexPrimaryKey;
+		this.referenceName = referenceName;
+		this.storagePartPK = null;
+	}
+
+	@Nullable
+	@Override
+	public Long getStoragePartPK() {
+		return this.storagePartPK;
+	}
+
+	@Override
+	public long computeUniquePartIdAndSet(@Nonnull KeyCompressor keyCompressor) {
+		// Unlike the manifest-listed roots — whose removal is only ever emitted for a key present in the index's
+		// persisted baseline, so the dictionary is guaranteed to know it — this root contributes nothing to the
+		// EntityIndexManifest and is therefore emitted unconditionally when its owning index is dropped. A cardinality
+		// index that never reached disk has no dictionary entry, and the drain resolves against the READ-ONLY
+		// compressor, which cannot mint one (it throws). Resolve defensively: an absent key proves the root was never
+		// written, so there is nothing to reclaim and we hand back a primary key that matches no record — the
+		// subsequent removal is then a documented no-op rather than a failed commit.
+		final OptionalInt referenceNameId = keyCompressor.getIdIfExists(new ReferenceNameKey(this.referenceName));
+		final long computedUniquePartId = referenceNameId.isPresent() ?
+			NumberUtils.pack(this.entityIndexPrimaryKey, referenceNameId.getAsInt()) :
+			NEVER_PERSISTED_PART_ID;
+		this.storagePartPK = computedUniquePartId;
+		return computedUniquePartId;
+	}
+
+	@Nonnull
+	@Override
+	public Class<? extends StoragePart> removedContainerType() {
+		return ReferenceTypeCardinalityIndexStoragePart.class;
+	}
+}

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/trace/ObservabilityTracingContext.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/trace/ObservabilityTracingContext.java
@@ -132,7 +132,11 @@ public class ObservabilityTracingContext implements TracingContext {
 		@Nonnull T subject, @Nonnull Function<? super T, String> taskNamer,
 		@Nullable SpanAttribute... attributes
 	) {
-		// spans are really recorded here, so the name has to be composed
+		// this variant opens the parent context itself, so the only thing that can still veto the span is the global
+		// switch - consult it before composing the name, otherwise the whole point of the lazy overload is lost
+		if (!OpenTelemetryTracerSetup.isTracingEnabled()) {
+			return DefaultTracingBlockReference.INSTANCE;
+		}
 		return createAndActivateBlockOpeningParentContext(taskNamer.apply(subject), attributes, null);
 	}
 
@@ -381,7 +385,11 @@ public class ObservabilityTracingContext implements TracingContext {
 		@Nonnull S subject, @Nonnull Function<? super S, String> taskNamer, @Nonnull Supplier<T> lambda,
 		@Nullable Supplier<SpanAttribute[]> attributes
 	) {
-		// spans are really recorded here, so the name has to be composed
+		// no span is recorded unless a parent context is already open and tracing is on - both are cheap reads, so
+		// consult them before composing the name instead of paying for a name the internal method would discard
+		if (!isSpanRecorded()) {
+			return lambda.get();
+		}
 		return executeWithinBlockInternal(taskNamer.apply(subject), lambda, null, attributes);
 	}
 
@@ -512,7 +520,7 @@ public class ObservabilityTracingContext implements TracingContext {
 		@Nullable SpanAttribute[] attributes,
 		@Nullable Supplier<SpanAttribute[]> attributeSupplier
 	) {
-		if (!OpenTelemetryTracerSetup.isTracingEnabled() || !Boolean.TRUE.equals(this.parentContextAvailable.get())) {
+		if (!isSpanRecorded()) {
 			return lambda.get();
 		}
 
@@ -654,7 +662,7 @@ public class ObservabilityTracingContext implements TracingContext {
 	                                                             @Nullable SpanAttribute[] attributes,
 	                                                             @Nullable Supplier<SpanAttribute[]> attributeSupplier,
 	                                                             @Nullable Runnable closeCallback) {
-		if (!OpenTelemetryTracerSetup.isTracingEnabled() || !Boolean.TRUE.equals(this.parentContextAvailable.get())) {
+		if (!isSpanRecorded()) {
 			return DefaultTracingBlockReference.INSTANCE;
 		}
 
@@ -681,5 +689,21 @@ public class ObservabilityTracingContext implements TracingContext {
 		initMdc(clientId, span.getSpanContext().getTraceId());
 
 		return new ObservabilityTracingBlockReference(span, scope, attributeSupplier, closeCallback);
+	}
+
+	/**
+	 * Tells whether a span opened right now on the current thread would really be recorded - i.e. tracing is switched
+	 * on globally and someone up the stack has already opened a parent context. Both are cheap reads (a static field
+	 * and a thread local), which is what allows the lazily-named overloads to consult this before composing a span
+	 * name that a non-recording path would only discard.
+	 *
+	 * Note that the methods opening the parent context themselves ({@link #createAndActivateBlockOpeningParentContext}
+	 * and friends) force the thread local to `true` before reaching the internal methods, so for those the global
+	 * switch alone decides - they must not be gated on this method.
+	 *
+	 * @return true if a span created at this moment would be recorded
+	 */
+	private boolean isSpanRecorded() {
+		return OpenTelemetryTracerSetup.isTracingEnabled() && Boolean.TRUE.equals(this.parentContextAvailable.get());
 	}
 }

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/trace/ObservabilityTracingContext.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/trace/ObservabilityTracingContext.java
@@ -40,6 +40,7 @@ import org.slf4j.MDC;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -123,6 +124,16 @@ public class ObservabilityTracingContext implements TracingContext {
 	@Override
 	public TracingBlockReference createAndActivateBlock(@Nonnull String taskName, @Nullable SpanAttribute... attributes) {
 		return createAndActivateBlockOpeningParentContext(taskName, attributes, null);
+	}
+
+	@Nonnull
+	@Override
+	public <T> TracingBlockReference createAndActivateBlock(
+		@Nonnull T subject, @Nonnull Function<? super T, String> taskNamer,
+		@Nullable SpanAttribute... attributes
+	) {
+		// spans are really recorded here, so the name has to be composed
+		return createAndActivateBlockOpeningParentContext(taskNamer.apply(subject), attributes, null);
 	}
 
 	@Nonnull
@@ -363,6 +374,15 @@ public class ObservabilityTracingContext implements TracingContext {
 	@Override
 	public <T> T executeWithinBlockIfParentContextAvailable(@Nonnull String taskName, @Nonnull Supplier<T> lambda, @Nullable Supplier<SpanAttribute[]> attributes) {
 		return executeWithinBlockInternal(taskName, lambda, null, attributes);
+	}
+
+	@Override
+	public <S, T> T executeWithinBlockIfParentContextAvailable(
+		@Nonnull S subject, @Nonnull Function<? super S, String> taskNamer, @Nonnull Supplier<T> lambda,
+		@Nullable Supplier<SpanAttribute[]> attributes
+	) {
+		// spans are really recorded here, so the name has to be composed
+		return executeWithinBlockInternal(taskNamer.apply(subject), lambda, null, attributes);
 	}
 
 	@Override
@@ -635,7 +655,7 @@ public class ObservabilityTracingContext implements TracingContext {
 	                                                             @Nullable Supplier<SpanAttribute[]> attributeSupplier,
 	                                                             @Nullable Runnable closeCallback) {
 		if (!OpenTelemetryTracerSetup.isTracingEnabled() || !Boolean.TRUE.equals(this.parentContextAvailable.get())) {
-			return new DefaultTracingBlockReference();
+			return DefaultTracingBlockReference.INSTANCE;
 		}
 
 		// the context will contain `traceId` provided by the client, if the propagation has been orchestrated on his side

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/OffsetIndexStoragePartPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/OffsetIndexStoragePartPersistenceService.java
@@ -45,6 +45,8 @@ import io.evitadb.store.shared.model.FileLocation;
 import io.evitadb.store.shared.model.PersistentStorageDescriptor;
 import io.evitadb.store.wal.TransactionalStoragePartPersistenceService;
 
+import lombok.Getter;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.OutputStream;
@@ -84,9 +86,10 @@ public class OffsetIndexStoragePartPersistenceService implements StoragePartPers
 	@Nonnull
 	protected final StorageSettings storageSettings;
 	/**
-	 * Memory key-value store for entities.
+	 * Memory key-value store for entities. Exposed through {@link #getOffsetIndex()} so that diagnostics and
+	 * storage-reclaim tests can enumerate the live record set; read-only use only.
 	 */
-	@Nonnull protected final OffsetIndex offsetIndex;
+	@Getter @Nonnull protected final OffsetIndex offsetIndex;
 	/**
 	 * Memory manager for off-heap memory.
 	 */

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/storage/RemovedReferenceIndexReclaimTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/storage/RemovedReferenceIndexReclaimTest.java
@@ -1,0 +1,542 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.storage;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.SessionTraits;
+import io.evitadb.api.SessionTraits.SessionFlags;
+import io.evitadb.api.TransactionContract.CommitBehavior;
+import io.evitadb.api.configuration.EvitaConfiguration;
+import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
+import io.evitadb.api.requestResponse.data.structure.RepresentativeReferenceKey;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.core.Evita;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.EntityIndexType;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.EntityIdsStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.EntityIndexStoragePart;
+import io.evitadb.spi.store.catalog.persistence.StoragePartPersistenceService;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.FilterIndexLeafPagePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.FilterIndexStoragePart;
+import io.evitadb.store.catalog.OffsetIndexStoragePartPersistenceService;
+import io.evitadb.store.offsetIndex.OffsetIndex;
+import io.evitadb.store.offsetIndex.model.OffsetIndexRecordTypeRegistry;
+import io.evitadb.store.offsetIndex.model.RecordKey;
+import io.evitadb.store.shared.model.FileLocation;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import io.evitadb.utils.NumberUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+
+import static io.evitadb.api.query.QueryConstraints.attributeContentAll;
+import static io.evitadb.api.query.QueryConstraints.referenceContentAll;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static io.evitadb.test.TestTags.STORAGE;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Real-persistence regression guard for the whole-index reclaim path.
+ *
+ * When a reduced (REFERENCED_ENTITY) {@link EntityIndex} that has already been flushed to disk is later emptied and
+ * dropped, `EntityIndexLocalMutationExecutor` removes it from the collection's dirty-index set via
+ * `DataStoreChanges.removeIndex`. The flush pipeline (`DataStoreChanges.popTrappedUpdates`) only iterates the dirty
+ * set and only there does each index's `getModifiedStorageParts` run — the pull-model seam that emits the reclaim
+ * diff (`*LeafPageRemoval`, the `RemovedStoragePart` for the bitmaps, and — implicitly — the index manifest). An
+ * index pulled from the dirty set before that flush therefore emits no removal at all, so its `EntityIndexStoragePart`
+ * manifest (and every sub-index leaf page it ever wrote) stays in the append-only OffsetIndex live set and is copied
+ * forward by every future compaction — the permanent, ever-growing leak this test pins.
+ *
+ * The scenario deliberately spans a transaction boundary: the index is persisted by the warm-up `goLiveAndClose`
+ * flush, then emptied and removed by a *later* transactional commit. An index that is only ever created and emptied
+ * inside a single unflushed transaction has nothing on disk and does not leak — that benign case is not what this
+ * guards.
+ *
+ * Compaction cannot rescue the orphan: `OffsetIndex.compact` copies the current live set verbatim
+ * (`copySnapshotTo(..., roots.currentVersion())`) with no reachability sweep, so a record only ever leaves the live
+ * set through an explicit removal record — exactly the record the drop path fails to emit.
+ */
+@DisplayName("Removed reference index reclaim")
+@Tag(STORAGE)
+@Tag(REFERENCE)
+@Tag(TRANSACTION)
+class RemovedReferenceIndexReclaimTest implements EvitaTestSupport {
+
+	private static final String ATTRIBUTE_CODE = "code";
+	private static final String REFERENCE_CATEGORIES = "categories";
+	private static final int CATEGORY_PK = 1;
+	/** Primary keys of the products that reference {@link #CATEGORY_PK}; deleting all of them empties the index. */
+	private static final int[] PRODUCT_PKS = {100, 101, 102, 103};
+	/** First primary key of the products used by the PAGED-shape variant, kept clear of {@link #PRODUCT_PKS}. */
+	private static final int PAGED_PRODUCT_PK_BASE = 1_000;
+	/**
+	 * Number of distinct `code` values the PAGED-shape variant creates — comfortably above the filter-index block size,
+	 * so the resulting bucket tree spans several leaf pages instead of fitting one record.
+	 */
+	private static final int PAGED_PRODUCT_COUNT = 1_000;
+	/**
+	 * Package holding every index-scoped storage part. Used as the family-blind discriminator of the orphan sweep, so
+	 * that a newly-introduced index storage-part family is covered without touching this test.
+	 */
+	private static final String INDEX_STORAGE_PART_PACKAGE = EntityIndexStoragePart.class.getPackageName();
+
+	private TestPaths paths;
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() {
+		this.paths = createTestPaths("RemovedReferenceIndexReclaim");
+		this.evita = new Evita(configuration());
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (this.evita != null && this.evita.isActive()) {
+			this.evita.close();
+		}
+		cleanupTestPaths(this.paths);
+	}
+
+	@Test
+	@DisplayName("Emptying and dropping a persisted reference index must reclaim its manifest from the on-disk live set")
+	void shouldReclaimStoragePartsOfARemovedReferenceIndex() {
+		// 1) warm-up: schema with a filterable reference-partitioned attribute + products referencing one category,
+		//    flushed to disk on go-live. This persists the reduced REFERENCED_ENTITY index (manifest + sub-index pages).
+		this.evita.defineCatalog(TEST_CATALOG);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.CATEGORY)
+					.withoutGeneratedPrimaryKey()
+					.updateVia(session);
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::filterable)
+					.withReferenceToEntity(
+						REFERENCE_CATEGORIES, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs.indexedForFilteringAndPartitioning()
+					)
+					.updateVia(session);
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, CATEGORY_PK));
+				for (int pk : PRODUCT_PKS) {
+					session.upsertEntity(
+						session.createNewEntity(Entities.PRODUCT, pk)
+							.setAttribute(ATTRIBUTE_CODE, "code-" + pk)
+							.setReference(REFERENCE_CATEGORIES, CATEGORY_PK)
+					);
+				}
+				session.goLiveAndClose();
+			}
+		);
+
+		// capture the reduced index's primary key (== the primary key of its EntityIndexStoragePart) while it is
+		// still live, and prove it was actually persisted to disk before we drop it (guards the test's own premise)
+		final long indexPartPk = reducedReferenceIndexPrimaryKey();
+		assertNotNull(
+			fetchOnDiskManifest(indexPartPk),
+			"pre-condition: the reduced reference index manifest must be on disk after the warm-up flush"
+		);
+
+		// 2) transactional commit that empties the reduced index (deletes its last referencing entities). At the end of
+		//    the mutation executor the now-empty index is dropped via removeIndex — the path under test.
+		try (final EvitaSessionContract session = this.evita.createSession(
+			new SessionTraits(TEST_CATALOG, CommitBehavior.WAIT_FOR_CHANGES_VISIBLE, SessionFlags.READ_WRITE))) {
+			for (int pk : PRODUCT_PKS) {
+				session.deleteEntity(Entities.PRODUCT, pk);
+			}
+		}
+
+		// the index must be gone from memory — confirms removeIndex ran (otherwise the test proves nothing)
+		assertNull(
+			reducedReferenceIndex(),
+			"pre-condition: the emptied reduced reference index must have been removed from the collection"
+		);
+
+		// 3) close + reopen to force a cold read of the on-disk live set only (no in-memory volatile state)
+		this.evita.close();
+		this.evita = new Evita(configuration());
+		this.evita.waitUntilFullyInitialized();
+
+		// the dropped index's whole persisted footprint must have been reclaimed from the append-only live set: the
+		// manifest, the membership bitmaps, and (asserted via the collection-wide manifest count) that only the
+		// surviving GLOBAL index's manifest remains — the reduced index leaves no orphan behind.
+		assertNull(
+			fetchOnDiskManifest(indexPartPk),
+			"a dropped reference index's manifest must be reclaimed from the on-disk live set, not orphaned"
+		);
+		assertNull(
+			fetchOnDiskBitmaps(indexPartPk),
+			"a dropped reference index's membership bitmaps must be reclaimed from the on-disk live set, not orphaned"
+		);
+		assertEquals(
+			1, countOnDiskManifests(),
+			"only the surviving GLOBAL index's manifest may remain on disk after the reduced index is dropped"
+		);
+		// and the family-blind invariant: nothing of the dropped index survives anywhere in the live set
+		assertNoLiveRecordBelongsToIndex(indexPartPk);
+	}
+
+	@Test
+	@DisplayName("Emptying one attribute's sub-index must reclaim its root while the owning index survives")
+	void shouldReclaimRootOfASubIndexThatVanishedWhileTheIndexSurvives() {
+		// 1) warm-up: products referencing one category, each carrying a filterable `code`. Both the GLOBAL index and
+		//    the reduced reference index therefore persist a `code` FilterIndex root.
+		this.evita.defineCatalog(TEST_CATALOG);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.CATEGORY)
+					.withoutGeneratedPrimaryKey()
+					.updateVia(session);
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					// nullable: this test strips the attribute back off every entity to empty its sub-index
+					.withAttribute(ATTRIBUTE_CODE, String.class, whichIs -> whichIs.filterable().nullable())
+					.withReferenceToEntity(
+						REFERENCE_CATEGORIES, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs.indexedForFilteringAndPartitioning()
+					)
+					.updateVia(session);
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, CATEGORY_PK));
+				for (int pk : PRODUCT_PKS) {
+					session.upsertEntity(
+						session.createNewEntity(Entities.PRODUCT, pk)
+							.setAttribute(ATTRIBUTE_CODE, "code-" + pk)
+							.setReference(REFERENCE_CATEGORIES, CATEGORY_PK)
+					);
+				}
+				session.goLiveAndClose();
+			}
+		);
+
+		assertEquals(
+			2, countOnDiskFilterRoots(),
+			"pre-condition: the GLOBAL and the reduced reference index must each persist a `code` filter root"
+		);
+
+		// 2) strip the `code` attribute from every product, keeping the products and their category references. Both
+		//    `code` filter sub-indexes empty out and are dropped from their family maps while the owning entity
+		//    indexes survive — the churn-vanish shape. Their roots are stable-keyed, so nothing supersedes them.
+		try (final EvitaSessionContract session = this.evita.createSession(
+			new SessionTraits(TEST_CATALOG, CommitBehavior.WAIT_FOR_CHANGES_VISIBLE, SessionFlags.READ_WRITE))) {
+			for (int pk : PRODUCT_PKS) {
+				session.getEntity(Entities.PRODUCT, pk, attributeContentAll(), referenceContentAll())
+					.orElseThrow()
+					.openForWrite()
+					.removeAttribute(ATTRIBUTE_CODE)
+					.upsertVia(session);
+			}
+		}
+
+		// 3) cold reload and verify the vanished roots were reclaimed while the indexes themselves live on
+		this.evita.close();
+		this.evita = new Evita(configuration());
+		this.evita.waitUntilFullyInitialized();
+
+		assertNotNull(
+			reducedReferenceIndex(),
+			"the reduced reference index must survive — only its `code` sub-index vanished"
+		);
+		assertEquals(
+			0, countOnDiskFilterRoots(),
+			"a sub-index that emptied out must have its root reclaimed, not left orphaned in the live set"
+		);
+	}
+
+	@Test
+	@DisplayName("Dropping a persisted reference index must reclaim the leaf pages of its PAGED sub-indexes")
+	void shouldReclaimLeafPagesOfAPagedSubIndexOfARemovedReferenceIndex() {
+		// 1) warm-up with enough distinct `code` values that the resulting bucket tree cannot fit a single record, so
+		//    the `code` filter sub-index persists in the PAGED shape (a root plus individual leaf pages) rather than the
+		//    SINGLE shape the sibling tests cover. Every product references the one category, so the reduced index owns
+		//    a paged sub-index of its own.
+		this.evita.defineCatalog(TEST_CATALOG);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.CATEGORY)
+					.withoutGeneratedPrimaryKey()
+					.updateVia(session);
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::filterable)
+					.withReferenceToEntity(
+						REFERENCE_CATEGORIES, Entities.CATEGORY, Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs.indexedForFilteringAndPartitioning()
+					)
+					.updateVia(session);
+				session.upsertEntity(session.createNewEntity(Entities.CATEGORY, CATEGORY_PK));
+				for (int i = 0; i < PAGED_PRODUCT_COUNT; i++) {
+					final int pk = PAGED_PRODUCT_PK_BASE + i;
+					session.upsertEntity(
+						session.createNewEntity(Entities.PRODUCT, pk)
+							.setAttribute(ATTRIBUTE_CODE, "code-" + pk)
+							.setReference(REFERENCE_CATEGORIES, CATEGORY_PK)
+					);
+				}
+				session.goLiveAndClose();
+			}
+		);
+
+		final long indexPartPk = reducedReferenceIndexPrimaryKey();
+		// guards this test's own premise: without leaf pages on disk it would merely be the SINGLE-shape test again
+		assertTrue(
+			countOnDiskFilterLeafPages() > 0,
+			"pre-condition: the `code` filter sub-index must have persisted in the PAGED shape"
+		);
+
+		// 2) delete every referencing product — the reduced index empties out and is dropped whole, taking its paged
+		//    sub-index with it
+		try (final EvitaSessionContract session = this.evita.createSession(
+			new SessionTraits(TEST_CATALOG, CommitBehavior.WAIT_FOR_CHANGES_VISIBLE, SessionFlags.READ_WRITE))) {
+			for (int i = 0; i < PAGED_PRODUCT_COUNT; i++) {
+				session.deleteEntity(Entities.PRODUCT, PAGED_PRODUCT_PK_BASE + i);
+			}
+		}
+
+		// 3) cold reload and verify nothing of the paged footprint survived. The GLOBAL index empties out too (every
+		//    product is gone), so its `code` sub-index vanishes through the churn channel — between them no filter
+		//    root and no leaf page may remain.
+		this.evita.close();
+		this.evita = new Evita(configuration());
+		this.evita.waitUntilFullyInitialized();
+
+		assertNull(
+			fetchOnDiskManifest(indexPartPk),
+			"a dropped reference index's manifest must be reclaimed even when its sub-indexes were paged"
+		);
+		assertEquals(
+			0, countOnDiskFilterRoots(),
+			"the roots of the dropped index's paged sub-indexes must be reclaimed, not left orphaned"
+		);
+		assertEquals(
+			0, countOnDiskFilterLeafPages(),
+			"every leaf page of the dropped index's paged sub-indexes must be reclaimed, not left orphaned"
+		);
+		// and the family-blind invariant, which also covers the paged families this test does not name
+		assertNoLiveRecordBelongsToIndex(indexPartPk);
+	}
+
+	/**
+	 * Builds the per-test Evita configuration wired to the (stable across restarts) test path triplet.
+	 *
+	 * @return the configuration; never null
+	 */
+	@Nonnull
+	private EvitaConfiguration configuration() {
+		return newTestEvitaConfigurationBuilder(this.paths).build();
+	}
+
+	/**
+	 * Returns the key of the reduced REFERENCED_ENTITY index partitioned by {@link #CATEGORY_PK}.
+	 *
+	 * @return the reduced index key; never null
+	 */
+	@Nonnull
+	private static EntityIndexKey reducedReferenceIndexKey() {
+		return new EntityIndexKey(
+			EntityIndexType.REFERENCED_ENTITY,
+			Scope.LIVE,
+			new RepresentativeReferenceKey(new ReferenceKey(REFERENCE_CATEGORIES, CATEGORY_PK))
+		);
+	}
+
+	/**
+	 * Navigates the currently open {@link Evita} to the live reduced reference index.
+	 *
+	 * @return the reduced index, or null when it does not exist (e.g. after it was dropped)
+	 */
+	private EntityIndex reducedReferenceIndex() {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection =
+			(EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		return collection.getIndexByKeyIfExists(reducedReferenceIndexKey());
+	}
+
+	/**
+	 * Resolves the primary key of the live reduced reference index (equal to the primary key of its
+	 * {@link EntityIndexStoragePart}).
+	 *
+	 * @return the index primary key
+	 */
+	private long reducedReferenceIndexPrimaryKey() {
+		final EntityIndex index = reducedReferenceIndex();
+		assertNotNull(index, "the reduced reference index must exist after the warm-up insert");
+		return index.getPrimaryKey();
+	}
+
+	/**
+	 * Reads the reduced index's {@link EntityIndexStoragePart} straight from the on-disk live set of the PRODUCT
+	 * collection (no open transaction, so the read falls through the buffer to the persistence service).
+	 *
+	 * @param indexPartPk the storage-part primary key (== the index primary key)
+	 * @return the on-disk manifest, or null when it is not present in the live set
+	 */
+	private EntityIndexStoragePart fetchOnDiskManifest(long indexPartPk) {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection =
+			(EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		return collection.getDataStoreReader().fetch(
+			catalog.getVersion(), indexPartPk, EntityIndexStoragePart.class
+		);
+	}
+
+	/**
+	 * Reads the reduced index's membership-bitmaps part ({@link EntityIdsStoragePart}) from the PRODUCT collection's
+	 * on-disk live set. Keyed, like the manifest, by the index primary key.
+	 *
+	 * @param indexPartPk the storage-part primary key (== the index primary key)
+	 * @return the on-disk bitmaps part, or null when it is not present in the live set
+	 */
+	private EntityIdsStoragePart fetchOnDiskBitmaps(long indexPartPk) {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection =
+			(EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		return collection.getDataStoreReader().fetch(
+			catalog.getVersion(), indexPartPk, EntityIdsStoragePart.class
+		);
+	}
+
+	/**
+	 * Counts the {@link EntityIndexStoragePart} manifests present in the PRODUCT collection's on-disk live set — one
+	 * per surviving entity index. An orphaned manifest of a dropped index would inflate this count.
+	 *
+	 * @return the number of index manifests on disk for the PRODUCT collection
+	 */
+	private int countOnDiskManifests() {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection =
+			(EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		return collection.getDataStoreReader().countStorageParts(
+			catalog.getVersion(), EntityIndexStoragePart.class
+		);
+	}
+
+	/**
+	 * Counts the {@link FilterIndexStoragePart} roots present in the PRODUCT collection's on-disk live set — one per
+	 * filterable attribute sub-index across all surviving entity indexes. A root left behind by a sub-index that
+	 * emptied out (churn-vanish) would inflate this count.
+	 *
+	 * @return the number of filter-index roots on disk for the PRODUCT collection
+	 */
+	private int countOnDiskFilterRoots() {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection =
+			(EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		return collection.getDataStoreReader().countStorageParts(
+			catalog.getVersion(), FilterIndexStoragePart.class
+		);
+	}
+
+	/**
+	 * Asserts that the PRODUCT collection's live record set contains NO record belonging to the given entity index —
+	 * the general orphan invariant a dropped index must satisfy.
+	 *
+	 * The per-type counting helpers above are whitelists: they only catch a leak in a storage-part family the test
+	 * thought to name, and an index's footprint spans dozens of them. This sweep is family-blind instead: it walks the
+	 * raw {@link OffsetIndex} live set and flags any record whose primary key resolves to the dropped index, so a
+	 * newly-added index storage-part family is covered the day it is introduced rather than the day someone remembers
+	 * to extend a test.
+	 *
+	 * Index-scoped parts are told apart from entity- and schema-scoped ones by their package rather than by an
+	 * enumerated type list (which would reintroduce the very whitelist this replaces). That distinction is load-bearing:
+	 * entity parts are keyed by ENTITY primary key, so a product whose primary key happens to equal the index primary
+	 * key would otherwise be reported as an orphan.
+	 *
+	 * Applicable to the whole-drop case only. When merely a sub-index vanishes, the owning index survives and its
+	 * primary key legitimately remains all over the live set.
+	 *
+	 * @param indexPrimaryKey primary key of the index that was dropped
+	 */
+	private void assertNoLiveRecordBelongsToIndex(long indexPrimaryKey) {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection =
+			(EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		final StoragePartPersistenceService<?> persistenceService = collection.getStoragePartPersistenceService();
+		assertInstanceOf(
+			OffsetIndexStoragePartPersistenceService.class, persistenceService,
+			"the live record set can only be enumerated on an OffsetIndex-backed collection"
+		);
+		final OffsetIndex offsetIndex =
+			((OffsetIndexStoragePartPersistenceService) persistenceService).getOffsetIndex();
+		final OffsetIndexRecordTypeRegistry recordTypeRegistry = offsetIndex.getRecordTypeRegistry();
+
+		final List<String> orphans = new ArrayList<>();
+		for (final Entry<RecordKey, FileLocation> entry : offsetIndex.getEntries(catalog.getVersion())) {
+			final RecordKey recordKey = entry.getKey();
+			final Class<? extends StoragePart> recordType = recordTypeRegistry.typeFor(recordKey.recordType());
+			if (!INDEX_STORAGE_PART_PACKAGE.equals(recordType.getPackageName())) {
+				// entity- and schema-scoped parts live in a different primary-key space
+				continue;
+			}
+			// an index-scoped part is keyed either by the bare index primary key (manifest, membership bitmaps,
+			// hierarchy) or by `pack(indexPrimaryKey, subIndexId)` — both must be free of the dropped index
+			final long partPrimaryKey = recordKey.primaryKey();
+			if (partPrimaryKey == indexPrimaryKey || NumberUtils.unpackHigh(partPrimaryKey) == indexPrimaryKey) {
+				orphans.add(recordType.getSimpleName() + "#" + partPrimaryKey);
+			}
+		}
+
+		assertEquals(
+			List.of(), orphans,
+			"no record of the dropped index may survive in the live set - the append-only store never reclaims " +
+				"an orphan, so every one of these would be copied forward by every future compaction"
+		);
+	}
+
+	/**
+	 * Counts the {@link FilterIndexLeafPagePart} leaf pages present in the PRODUCT collection's on-disk live set. Only a
+	 * PAGED-shaped filter sub-index persists any, so a non-zero count also proves a bucket tree really did page.
+	 *
+	 * @return the number of filter-index leaf pages on disk for the PRODUCT collection
+	 */
+	private int countOnDiskFilterLeafPages() {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection =
+			(EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		return collection.getDataStoreReader().countStorageParts(
+			catalog.getVersion(), FilterIndexLeafPagePart.class
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/observability/trace/DefaultTracingBlockReferenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/observability/trace/DefaultTracingBlockReferenceTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static io.evitadb.test.TestTags.CONTRACT;
 import static io.evitadb.test.TestTags.OBSERVABILITY;
-import static io.evitadb.test.TestTags.REFERENCE;
 
 /**
  * Tests for {@link DefaultTracingBlockReference} verifying that
@@ -44,7 +43,6 @@ import static io.evitadb.test.TestTags.REFERENCE;
 @DisplayName("DefaultTracingBlockReference - no-op tracing")
 @Tag(CONTRACT)
 @Tag(OBSERVABILITY)
-@Tag(REFERENCE)
 class DefaultTracingBlockReferenceTest {
 
 	@Nested

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/observability/trace/LazySpanNameContractTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/observability/trace/LazySpanNameContractTest.java
@@ -25,19 +25,27 @@ package io.evitadb.api.observability.trace;
 
 import io.evitadb.api.observability.trace.TracingContext.SpanAttribute;
 import io.evitadb.externalApi.observability.trace.ObservabilityTracingContext;
+import io.evitadb.externalApi.observability.trace.OpenTelemetryTracerSetup;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static io.evitadb.test.TestTags.CONTRACT;
 import static io.evitadb.test.TestTags.OBSERVABILITY;
-import static io.evitadb.test.TestTags.REFERENCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mockStatic;
 
 /**
  * Pins the laziness contract of
@@ -50,18 +58,37 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  * tests make a violation fail loudly instead, by handing the API a namer that records whether it
  * was called.
  *
+ * Both implementations are pinned: the no-op {@link DefaultTracingContext} and the OpenTelemetry-backed
+ * {@link ObservabilityTracingContext} that a standard server build wires through the `ServiceLoader` — the latter
+ * must skip the namer while tracing is switched off, and apply it exactly once when spans are really recorded.
+ *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
 @DisplayName("TracingContext - lazy span name")
 @Tag(CONTRACT)
 @Tag(OBSERVABILITY)
-@Tag(REFERENCE)
 class LazySpanNameContractTest {
 
 	/**
 	 * Stands in for a value whose `toString()` is too expensive to compute speculatively.
 	 */
 	private static final Object SUBJECT = new Object();
+
+	private SdkTracerProvider tracerProvider;
+	private Tracer tracer;
+
+	@BeforeEach
+	void setUp() {
+		this.tracerProvider = SdkTracerProvider.builder()
+			.addSpanProcessor(SimpleSpanProcessor.create(InMemorySpanExporter.create()))
+			.build();
+		this.tracer = this.tracerProvider.get("test");
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.tracerProvider.shutdown();
+	}
 
 	@Test
 	@DisplayName("no-op context never composes the span name")
@@ -126,6 +153,55 @@ class LazySpanNameContractTest {
 	}
 
 	@Test
+	@DisplayName("observability context never composes the span name of a traced block while tracing is off")
+	void shouldNotComposeBlockSpanNameWhenObservabilityTracingIsDisabled() {
+		final AtomicInteger invocations = new AtomicInteger();
+		final Function<Object, String> namer = subject -> {
+			invocations.incrementAndGet();
+			return "span - " + subject;
+		};
+
+		// this is the implementation a standard server build actually wires through the ServiceLoader, so the
+		// laziness has to hold here as well — otherwise the hot call sites keep paying for names nobody reads
+		final String result = new ObservabilityTracingContext().executeWithinBlockIfParentContextAvailable(
+			SUBJECT, namer, () -> "traced result", () -> SpanAttribute.EMPTY_ARRAY
+		);
+
+		assertEquals(
+			0, invocations.get(),
+			"no span is recorded while tracing is disabled, so the namer must not be invoked"
+		);
+		assertEquals(
+			"traced result", result,
+			"the traced work must still run and its result be returned — laziness applies to the " +
+				"span name, never to the code being traced"
+		);
+	}
+
+	@Test
+	@DisplayName("observability context never composes the span name while tracing is off")
+	void shouldNotComposeSpanNameWhenObservabilityTracingIsDisabled() {
+		final AtomicInteger invocations = new AtomicInteger();
+		final Function<Object, String> namer = subject -> {
+			invocations.incrementAndGet();
+			return "span - " + subject;
+		};
+
+		final TracingBlockReference blockReference = new ObservabilityTracingContext()
+			.createAndActivateBlock(SUBJECT, namer, SpanAttribute.EMPTY_ARRAY);
+		blockReference.close();
+
+		assertSame(
+			DefaultTracingBlockReference.INSTANCE, blockReference,
+			"a disabled tracer records nothing, so it must hand back the shared no-op block reference"
+		);
+		assertEquals(
+			0, invocations.get(),
+			"no span is recorded while tracing is disabled, so the namer must not be invoked"
+		);
+	}
+
+	@Test
 	@DisplayName("recording context composes the span name of a traced block and runs the work")
 	void shouldComposeBlockSpanNameWhenContextRecordsSpans() {
 		final AtomicInteger invocations = new AtomicInteger();
@@ -134,15 +210,26 @@ class LazySpanNameContractTest {
 			return "span - " + subject;
 		};
 
-		final String result = new ObservabilityTracingContext().executeWithinBlockIfParentContextAvailable(
-			SUBJECT, namer, () -> "traced result", () -> SpanAttribute.EMPTY_ARRAY
-		);
+		try (MockedStatic<OpenTelemetryTracerSetup> otel = mockStatic(OpenTelemetryTracerSetup.class)) {
+			otel.when(OpenTelemetryTracerSetup::isTracingEnabled).thenReturn(true);
+			otel.when(OpenTelemetryTracerSetup::getTracer).thenReturn(this.tracer);
 
-		assertEquals(
-			1, invocations.get(),
-			"a span-recording context must apply the namer exactly once per traced block"
-		);
-		assertEquals("traced result", result, "the traced work must run and its result be returned");
+			// this flavour records a span only within an already opened parent context, so the outer block is what
+			// makes the inner call reach the recording path at all
+			final ObservabilityTracingContext tracingContext = new ObservabilityTracingContext();
+			final String result = tracingContext.executeWithinBlock(
+				"outer",
+				() -> tracingContext.executeWithinBlockIfParentContextAvailable(
+					SUBJECT, namer, () -> "traced result", () -> SpanAttribute.EMPTY_ARRAY
+				)
+			);
+
+			assertEquals(
+				1, invocations.get(),
+				"a span-recording context must apply the namer exactly once per traced block"
+			);
+			assertEquals("traced result", result, "the traced work must run and its result be returned");
+		}
 	}
 
 	@Test
@@ -154,16 +241,21 @@ class LazySpanNameContractTest {
 			return "span - " + subject;
 		};
 
-		// this implementation is backed by a real tracer, so it must consume the name it was
-		// promised — laziness must not silently degrade into "the span is never named"
-		final TracingBlockReference blockReference = new ObservabilityTracingContext()
-			.createAndActivateBlock(SUBJECT, namer, SpanAttribute.EMPTY_ARRAY);
-		assertNotNull(blockReference);
-		blockReference.close();
+		try (MockedStatic<OpenTelemetryTracerSetup> otel = mockStatic(OpenTelemetryTracerSetup.class)) {
+			otel.when(OpenTelemetryTracerSetup::isTracingEnabled).thenReturn(true);
+			otel.when(OpenTelemetryTracerSetup::getTracer).thenReturn(this.tracer);
 
-		assertEquals(
-			1, invocations.get(),
-			"a span-recording context must apply the namer exactly once per created block"
-		);
+			// this implementation is backed by a real tracer, so it must consume the name it was
+			// promised — laziness must not silently degrade into "the span is never named"
+			final TracingBlockReference blockReference = new ObservabilityTracingContext()
+				.createAndActivateBlock(SUBJECT, namer, SpanAttribute.EMPTY_ARRAY);
+			assertNotNull(blockReference);
+			blockReference.close();
+
+			assertEquals(
+				1, invocations.get(),
+				"a span-recording context must apply the namer exactly once per created block"
+			);
+		}
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/observability/trace/LazySpanNameContractTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/observability/trace/LazySpanNameContractTest.java
@@ -1,0 +1,169 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.observability.trace;
+
+import io.evitadb.api.observability.trace.TracingContext.SpanAttribute;
+import io.evitadb.externalApi.observability.trace.ObservabilityTracingContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Pins the laziness contract of
+ * {@link TracingContext#createAndActivateBlock(Object, Function, SpanAttribute...)}.
+ *
+ * The whole point of that overload is that a span name which is expensive to compose — such as
+ * `"mutation - " + mutation`, where `Mutation.toString()` walks the entire mutation — is never
+ * composed while no tracing backend is listening. That property is invisible in ordinary
+ * behavioural tests: forgetting it costs no correctness, only throughput on a hot path. These
+ * tests make a violation fail loudly instead, by handing the API a namer that records whether it
+ * was called.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("TracingContext - lazy span name")
+@Tag(CONTRACT)
+@Tag(OBSERVABILITY)
+@Tag(REFERENCE)
+class LazySpanNameContractTest {
+
+	/**
+	 * Stands in for a value whose `toString()` is too expensive to compute speculatively.
+	 */
+	private static final Object SUBJECT = new Object();
+
+	@Test
+	@DisplayName("no-op context never composes the span name")
+	void shouldNotComposeSpanNameWhenTracingIsDisabled() {
+		final AtomicInteger invocations = new AtomicInteger();
+		final Function<Object, String> namer = subject -> {
+			invocations.incrementAndGet();
+			return "span - " + subject;
+		};
+
+		final TracingBlockReference blockReference = DefaultTracingContext.INSTANCE
+			.createAndActivateBlock(SUBJECT, namer, SpanAttribute.EMPTY_ARRAY);
+		blockReference.close();
+
+		assertEquals(
+			0, invocations.get(),
+			"the null-object tracing context discards span names unread, so composing one is " +
+				"pure waste — the namer must not be invoked"
+		);
+	}
+
+	@Test
+	@DisplayName("no-op context reuses the shared block reference")
+	void shouldReuseSharedBlockReferenceWhenTracingIsDisabled() {
+		final Function<Object, String> namer = subject -> "span - " + subject;
+
+		final TracingBlockReference first = DefaultTracingContext.INSTANCE
+			.createAndActivateBlock(SUBJECT, namer, SpanAttribute.EMPTY_ARRAY);
+		final TracingBlockReference second = DefaultTracingContext.INSTANCE
+			.createAndActivateBlock(SUBJECT, namer, SpanAttribute.EMPTY_ARRAY);
+
+		assertSame(
+			DefaultTracingBlockReference.INSTANCE, first,
+			"the no-op block reference is stateless, so it must be shared rather than allocated"
+		);
+		assertSame(first, second, "every disabled-path call must yield the very same instance");
+	}
+
+	@Test
+	@DisplayName("no-op context never composes the span name of a traced block")
+	void shouldNotComposeBlockSpanNameWhenTracingIsDisabled() {
+		final AtomicInteger invocations = new AtomicInteger();
+		final Function<Object, String> namer = subject -> {
+			invocations.incrementAndGet();
+			return "span - " + subject;
+		};
+
+		final String result = DefaultTracingContext.INSTANCE.executeWithinBlockIfParentContextAvailable(
+			SUBJECT, namer, () -> "traced result", () -> SpanAttribute.EMPTY_ARRAY
+		);
+
+		assertEquals(
+			0, invocations.get(),
+			"the null-object tracing context discards span names unread, so composing one is " +
+				"pure waste — the namer must not be invoked"
+		);
+		assertEquals(
+			"traced result", result,
+			"the traced work must still run and its result be returned — laziness applies to the " +
+				"span name, never to the code being traced"
+		);
+	}
+
+	@Test
+	@DisplayName("recording context composes the span name of a traced block and runs the work")
+	void shouldComposeBlockSpanNameWhenContextRecordsSpans() {
+		final AtomicInteger invocations = new AtomicInteger();
+		final Function<Object, String> namer = subject -> {
+			invocations.incrementAndGet();
+			return "span - " + subject;
+		};
+
+		final String result = new ObservabilityTracingContext().executeWithinBlockIfParentContextAvailable(
+			SUBJECT, namer, () -> "traced result", () -> SpanAttribute.EMPTY_ARRAY
+		);
+
+		assertEquals(
+			1, invocations.get(),
+			"a span-recording context must apply the namer exactly once per traced block"
+		);
+		assertEquals("traced result", result, "the traced work must run and its result be returned");
+	}
+
+	@Test
+	@DisplayName("recording context does compose the span name")
+	void shouldComposeSpanNameWhenContextRecordsSpans() {
+		final AtomicInteger invocations = new AtomicInteger();
+		final Function<Object, String> namer = subject -> {
+			invocations.incrementAndGet();
+			return "span - " + subject;
+		};
+
+		// this implementation is backed by a real tracer, so it must consume the name it was
+		// promised — laziness must not silently degrade into "the span is never named"
+		final TracingBlockReference blockReference = new ObservabilityTracingContext()
+			.createAndActivateBlock(SUBJECT, namer, SpanAttribute.EMPTY_ARRAY);
+		assertNotNull(blockReference);
+		blockReference.close();
+
+		assertEquals(
+			1, invocations.get(),
+			"a span-recording context must apply the namer exactly once per created block"
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/buffer/DataStoreChangesSnapshotTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/buffer/DataStoreChangesSnapshotTest.java
@@ -24,20 +24,28 @@
 package io.evitadb.core.buffer;
 
 import io.evitadb.core.buffer.DataStoreChanges.DataStoreChangesMemento;
+import io.evitadb.core.buffer.DataStoreChanges.RemovedStoragePart;
 import io.evitadb.index.EntityIndex;
 import io.evitadb.index.EntityIndexKey;
 import io.evitadb.index.EntityIndexType;
 import io.evitadb.spi.store.catalog.persistence.StorageDescriptor;
 import io.evitadb.spi.store.catalog.persistence.StoragePartPersistenceService;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.EntityIndexStoragePart;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -55,6 +63,11 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 @DisplayName("DataStoreChanges savepoint snapshot/restore of the dirty-index maps")
 class DataStoreChangesSnapshotTest {
 	private static final int INDEX_PRIMARY_KEY = 1;
+	/**
+	 * Stand-in for one of the deferred removal instructions a dropped index stages to reclaim its persisted footprint -
+	 * the concrete part type is irrelevant here, only whether it survives to the flush pipeline.
+	 */
+	private static final StoragePart FOOTPRINT_REMOVAL = new RemovedStoragePart(EntityIndexStoragePart.class, 42L);
 
 	private final DataStoreChanges changes = new DataStoreChanges(mockPersistenceService());
 	private final EntityIndexKey indexKey = new EntityIndexKey(EntityIndexType.GLOBAL);
@@ -112,7 +125,7 @@ class DataStoreChangesSnapshotTest {
 		// pre-snapshot: create the dirty index, then remove it by key — removeIndex deliberately leaves the by-pk
 		// entry in place, so the snapshot-time state is: by-key ABSENT, by-pk PRESENT
 		this.changes.getOrCreateIndexForModification(this.indexKey, key -> index);
-		this.changes.removeIndex(this.indexKey, key -> null);
+		this.changes.removeIndex(0L, this.indexKey, key -> null);
 		assertSame(
 			index, this.changes.getIndexIfExists(INDEX_PRIMARY_KEY, pk -> null),
 			"self-check: removeIndex must leave the by-pk entry in place"
@@ -144,7 +157,7 @@ class DataStoreChangesSnapshotTest {
 		final DataStoreChangesMemento memento = this.changes.snapshot();
 		// in-window: drop the index and re-create it under the same key with a fresh instance (same pk) — the exact
 		// shape of an entity update that removes the last item of an index and then re-populates it
-		this.changes.removeIndex(this.indexKey, key -> null);
+		this.changes.removeIndex(0L, this.indexKey, key -> null);
 		final EntityIndex recreated = entityIndexStub(INDEX_PRIMARY_KEY);
 		this.changes.getOrCreateIndexForModification(this.indexKey, key -> recreated);
 		this.changes.restore(memento);
@@ -157,6 +170,75 @@ class DataStoreChangesSnapshotTest {
 			original, this.changes.getIndexIfExists(INDEX_PRIMARY_KEY, pk -> null),
 			"the by-pk entry must be rewound to the snapshot-time index instance"
 		);
+	}
+
+	@Test
+	@DisplayName("footprint removals staged by a dropped index are drained when the drop is not rolled back")
+	void shouldDrainFootprintRemovalsStagedByDroppedIndex() {
+		final EntityIndex index = entityIndexStubStagingFootprintRemoval();
+
+		this.changes.getOrCreateIndexForModification(this.indexKey, key -> index);
+		this.changes.removeIndex(0L, this.indexKey, key -> null);
+
+		assertEquals(
+			List.of(FOOTPRINT_REMOVAL), drainTrappedChanges(),
+			"the removal staged while dropping the index must reach the flush pipeline"
+		);
+	}
+
+	@Test
+	@DisplayName("footprint removals staged by a dropped index are discarded when the drop is rolled back")
+	void shouldDiscardFootprintRemovalsStagedByDroppedIndexOnRestore() {
+		final EntityIndex index = entityIndexStubStagingFootprintRemoval();
+
+		this.changes.getOrCreateIndexForModification(this.indexKey, key -> index);
+
+		final DataStoreChangesMemento memento = this.changes.snapshot();
+		// in-window: the index is dropped, staging the removals that would reclaim its persisted footprint
+		this.changes.removeIndex(0L, this.indexKey, key -> null);
+		this.changes.restore(memento);
+
+		// the index is alive again, so removing its persisted parts would silently corrupt it - the staged removals
+		// must have been truncated by the undo journal
+		assertSame(
+			index, this.changes.getIndexIfExists(this.indexKey, key -> null),
+			"self-check: the rolled-back drop must have reinstated the index"
+		);
+		assertEquals(
+			List.of(), drainTrappedChanges(),
+			"the removals staged by the rolled-back drop must never reach the flush pipeline"
+		);
+	}
+
+	/**
+	 * Drains the pending changes and materializes them into a list for assertion purposes.
+	 *
+	 * @return all storage parts the flush pipeline would receive
+	 */
+	@Nonnull
+	private List<StoragePart> drainTrappedChanges() {
+		final List<StoragePart> drained = new ArrayList<>(8);
+		final Iterator<StoragePart> it = this.changes.popTrappedUpdates().getTrappedChangesIterator();
+		while (it.hasNext()) {
+			drained.add(it.next());
+		}
+		return drained;
+	}
+
+	/**
+	 * Creates an {@link EntityIndex} stub that behaves as an index with a persisted footprint - dropping it stages
+	 * exactly one removal instruction, which is what the savepoint rollback has to undo.
+	 *
+	 * @return an {@link EntityIndex} stub staging {@link #FOOTPRINT_REMOVAL} when its footprint is reclaimed
+	 */
+	@Nonnull
+	private static EntityIndex entityIndexStubStagingFootprintRemoval() {
+		final EntityIndex index = entityIndexStub(INDEX_PRIMARY_KEY);
+		Mockito.doAnswer(invocation -> {
+			invocation.getArgument(0, TrappedChanges.class).addChangeToStore(FOOTPRINT_REMOVAL);
+			return null;
+		}).when(index).emitFootprintRemovals(ArgumentMatchers.any());
+		return index;
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/ElementLeafSharedArrayShrinkTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/ElementLeafSharedArrayShrinkTest.java
@@ -1,0 +1,176 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.bPlusTree;
+
+import io.evitadb.core.transaction.Transaction;
+import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
+import io.evitadb.dataType.ConsistencySensitiveDataStructure.ConsistencyState;
+import io.evitadb.index.price.model.priceRecord.PriceRecord;
+import io.evitadb.index.price.model.priceRecord.PriceRecordContract;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+import java.util.function.ToIntFunction;
+
+import static io.evitadb.test.TestTags.DATA_TYPE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the transactional invariants that let {@link TransactionalElementBPlusTree.BPlusLeafTreeNode#setPeek(int)} blank
+ * a shrunk leaf's vacated tail in place — safely — rather than pay a copy-on-write allocation for it.
+ *
+ * A leaf hands its transactional diff layer the very same value array (see `createLayer`), and merge / steal shrink one
+ * holder while another still reports its own, larger peek. The historical defect was that the dirty-scope registry
+ * retained the OTHER holder as a node token, so blanking the shrunk holder's tail reached through into a token the
+ * pre-commit validation later dereferenced — a bare `NullPointerException` aborting the commit. The registry now keeps
+ * boundary KEYS, not node objects, so no observer ever reads a shrunk holder's tail and the in-place blank is harmless.
+ *
+ * These tests guard that contract from three angles: the registry never holds a node object (the whole failure class is
+ * forbidden), a root leaf deleted to empty commits without a spurious corruption error (the residual delete-to-empty
+ * hole the copy-on-write shrink left open is closed), and a split-then-merge churn — the exact op mix that originally
+ * NPE'd — commits cleanly with a structurally consistent tree.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Element leaf - shared value-array shrink is registry-safe")
+@Tag(DATA_TYPE)
+@Tag(INDEXING)
+@Tag(TRANSACTION)
+class ElementLeafSharedArrayShrinkTest {
+
+	/**
+	 * The key extractor used by the trees under test: the element's internal price id.
+	 */
+	private static final ToIntFunction<PriceRecordContract> KEY = PriceRecordContract::internalPriceId;
+
+	/**
+	 * Builds a price record whose fields are derived from the given key.
+	 *
+	 * @param key the internal price id
+	 * @return a content-stable price record for the key
+	 */
+	@Nonnull
+	private static PriceRecordContract rec(int key) {
+		return new PriceRecord(key, key + 1, key / 3, key * 100 + 21, key * 100);
+	}
+
+	/**
+	 * Creates an empty element tree with the smallest legal leaf block size (3), so a handful of inserts split the root
+	 * and a handful of deletes drive underflow rebalances / merges — the shrink seams under test.
+	 *
+	 * @return a fresh empty tree with block size 3
+	 */
+	@Nonnull
+	private static TransactionalElementBPlusTree<PriceRecordContract> smallTree() {
+		return new TransactionalElementBPlusTree<>(3, 1, 3, 1, PriceRecordContract.class, KEY);
+	}
+
+	@Test
+	@DisplayName("dirty-scope tokens are boundary probe keys, never leaf nodes")
+	void shouldRegisterProbeKeysNeverNodeObjects() {
+		// churn that dirties several leaves through inserts (with splits) and a delete; the registry that feeds the
+		// pre-commit / post-replay validation must hold only boundary keys — retaining a node object is exactly what
+		// pinned a leaf whose array a sibling later blanked, and it is the failure class this test forbids outright
+		final TransactionalElementBPlusTree<PriceRecordContract> tree = smallTree();
+		assertStateAfterCommit(
+			tree,
+			t -> {
+				for (int i = 1; i <= 8; i++) {
+					t.insert(rec(i));
+				}
+				t.delete(2);
+				final Set<Object> tokens = Transaction.getTransactionalLayerMaintainer().getDirtyScopeTokens(t);
+				assertFalse(tokens.isEmpty(), "the churn must have dirtied at least one leaf");
+				for (final Object token : tokens) {
+					assertFalse(
+						token instanceof BPlusTreeNode,
+						"a dirty-scope token must never be a B+ tree node — a node token pins the node, its array and " +
+							"its elements until commit and reintroduces the stale-observer bug class; got " +
+							token.getClass().getName()
+					);
+					assertTrue(
+						token instanceof Integer,
+						"a dirty-scope token must be an Integer boundary probe key; got " + token.getClass().getName()
+					);
+				}
+			},
+			(t, committed) -> assertNotNull(committed)
+		);
+	}
+
+	@Test
+	@DisplayName("deleting a root leaf down to empty commits without a spurious corruption error")
+	void shouldNotRejectWhenRootLeafDeletedToEmpty() {
+		// a single-leaf (root) tree deleted to empty: delete() blanks slot 0 in place, and the emptied leaf carries no
+		// boundary key so it is never registered — the commit must not raise a false corruption error. This is the
+		// delete-to-empty-root hole the copy-on-write shrink in setPeek could not close (delete never routes through
+		// setPeek), now closed by the key-based registry.
+		final TransactionalElementBPlusTree<PriceRecordContract> tree = smallTree();
+		tree.insert(rec(1));
+		assertStateAfterCommit(
+			tree,
+			t -> {
+				t.delete(1);
+				assertEquals(0, t.size(), "the tree must be empty after deleting its only element");
+			},
+			(t, committed) -> assertNotNull(committed)
+		);
+	}
+
+	@Test
+	@DisplayName("split-then-merge churn commits cleanly with a consistent tree")
+	void shouldCommitSplitThenMergeChain() {
+		// the original defect's op mix: inserts split the root (a right leaf adopts the origin array in place), then
+		// deletes underflow leaves into steal / merge, emptying donors via setPeek(-1) — the in-place blank that used to
+		// reach through a registered node token. With key-based registration it is harmless; the commit's post-replay
+		// validation must pass and the surviving tree must be structurally consistent.
+		final TransactionalElementBPlusTree<PriceRecordContract> tree = smallTree();
+		assertStateAfterCommit(
+			tree,
+			t -> {
+				for (int i = 1; i <= 12; i++) {
+					t.insert(rec(i));
+				}
+				for (int i = 2; i <= 11; i++) {
+					t.delete(i);
+				}
+				assertEquals(2, t.size(), "only the two boundary elements must remain");
+				assertEquals(
+					ConsistencyState.CONSISTENT, t.getConsistencyReport().state(),
+					"the churned tree must be structurally consistent before commit"
+				);
+			},
+			(t, committed) -> assertNotNull(committed)
+		);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTreeTest.java
@@ -2868,8 +2868,9 @@ class TransactionalBucketBPlusTreeTest {
 			final TransactionalBucketBPlusTree<MutableIntKey> tree = assembleSound(List.of(
 				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
 			));
+			// the registry keeps probe KEYS, not node objects; each key relocates to the leaf that owns it
 			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(
-				leafAt(tree, 1), leafAt(tree, 5), leafAt(tree, 10)
+				new MutableIntKey(1), new MutableIntKey(5), new MutableIntKey(10)
 			)));
 		}
 
@@ -2884,9 +2885,10 @@ class TransactionalBucketBPlusTreeTest {
 			// separator is untouched, so relocating by the leaf's own first key (5) still lands on it and the tail
 			// half-invariant fires
 			middle.keyAt(middle.getPeek()).value = 10;
+			// relocate by the leaf's own (unchanged) first key 5 — the descent lands on it and the tail half-invariant fires
 			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
 				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
-				() -> tree.validateDirtyScope(List.<Object>of(middle))
+				() -> tree.validateDirtyScope(List.<Object>of(new MutableIntKey(5)))
 			);
 			assertTrue(
 				ex.getMessage().contains("successor leaf boundary"),
@@ -2905,10 +2907,11 @@ class TransactionalBucketBPlusTreeTest {
 			// against the predecessor's corrupted last key
 			final BPlusLeafTreeNode<MutableIntKey> predecessor = leafAt(tree, 1);
 			predecessor.keyAt(predecessor.getPeek()).value = 5;
-			final BPlusLeafTreeNode<MutableIntKey> middle = leafAt(tree, 5);
+			// relocate the middle leaf by its unchanged first key 5; the head half-invariant compares against the
+			// predecessor's corrupted last key
 			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
 				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
-				() -> tree.validateDirtyScope(List.<Object>of(middle))
+				() -> tree.validateDirtyScope(List.<Object>of(new MutableIntKey(5)))
 			);
 			assertTrue(
 				ex.getMessage().contains("predecessor leaf boundary"),
@@ -2917,19 +2920,13 @@ class TransactionalBucketBPlusTreeTest {
 		}
 
 		@Test
-		@DisplayName("an empty key source is skipped, not dereferenced")
-		void shouldSkipEmptyKeySource() {
-			final TransactionalBucketBPlusTree<MutableIntKey> tree = assembleSound(List.of(
-				singleLeaf(1, 2), singleLeaf(5, 6)
-			));
-			// an empty single-leaf source carries no key (peek < 0) — the scope validation must skip it rather than
-			// dereference the peek slot
-			final TransactionalBucketBPlusTree<MutableIntKey> empty =
+		@DisplayName("a probe key landing on an empty leaf is skipped, not dereferenced")
+		void shouldSkipWhenDescentLandsOnEmptyLeaf() {
+			// an empty tree routes any probe key to its empty root leaf (peek < 0) — the scope validation must skip
+			// it rather than dereference the peek slot
+			final TransactionalBucketBPlusTree<MutableIntKey> tree =
 				new TransactionalBucketBPlusTree<>(10, 1, 3, 1, MutableIntKey.class, null);
-			//noinspection unchecked
-			final BPlusLeafTreeNode<MutableIntKey> emptyLeaf =
-				(BPlusLeafTreeNode<MutableIntKey>) empty.getRoot();
-			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(emptyLeaf)));
+			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(new MutableIntKey(42))));
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalElementBPlusTreeTest.java
@@ -482,6 +482,68 @@ class TransactionalElementBPlusTreeTest {
 				}
 			);
 		}
+
+		@Test
+		@DisplayName("survives large randomized insert/delete churn committed as one transaction")
+		void shouldSurviveRandomizedTransactionalChurn() {
+			// The dirty-scope validation runs only at commit, so a fuzzer that never commits (like the bare-tree
+			// consistency-report churn) is blind to it. This churns hundreds of random insert / delete operations at
+			// small block sizes inside a single committed transaction, so leaves are repeatedly split and merged
+			// within the transaction; the commit-time pre-WAL and post-replay dirty-scope passes must re-derive every
+			// dirtied leaf's boundaries cleanly, and the committed content must match the oracle.
+			for (final int blockSize : new int[]{3, 4, 6}) {
+				for (long seed = 0; seed < 25; seed++) {
+					exerciseTransactionalChurn(blockSize, seed);
+				}
+			}
+		}
+
+		/**
+		 * Runs one big transaction of randomized insert / delete churn against a fresh tree of the given block size,
+		 * mirroring every operation into an oracle map, then commits and asserts the committed tree matches the oracle
+		 * exactly. The commit triggers both dirty-scope validation passes.
+		 *
+		 * @param blockSize the leaf block size (small values force frequent splits and merges)
+		 * @param seed      the RNG seed for reproducibility
+		 */
+		private void exerciseTransactionalChurn(int blockSize, long seed) {
+			final TransactionalElementBPlusTree<PriceRecordContract> tree = treeOf(blockSize);
+			final TreeMap<Integer, PriceRecordContract> oracle = new TreeMap<>();
+			final Random random = new Random(seed);
+			final int range = 120;
+			assertStateAfterCommit(
+				tree,
+				tested -> {
+					for (int op = 0; op < 400; op++) {
+						final int key = random.nextInt(range);
+						// bias towards delete once the tree has grown so merges (donor blanks) run heavily
+						final boolean delete = oracle.size() > 40 ? random.nextInt(3) > 0 : random.nextBoolean();
+						if (delete) {
+							tested.delete(key);
+							oracle.remove(key);
+						} else {
+							final PriceRecordContract record = rec(key);
+							tested.insert(record);
+							oracle.put(key, record);
+						}
+					}
+					// read-your-writes: the in-transaction view must already match the oracle size
+					assertEquals(
+						oracle.size(), tested.size(),
+						"In-transaction size mismatch at blockSize=" + blockSize + " seed=" + seed
+					);
+				},
+				(original, committed) -> {
+					assertEquals(0, original.size(), "The original tree must be untouched before commit-merge");
+					final int[] expectedKeys = new int[oracle.size()];
+					int index = 0;
+					for (final Integer key : oracle.keySet()) {
+						expectedKeys[index++] = key;
+					}
+					verifyTreeConsistency(committed, expectedKeys);
+				}
+			);
+		}
 	}
 
 	@Nested
@@ -550,6 +612,49 @@ class TransactionalElementBPlusTreeTest {
 				result[index++] = key;
 			}
 			return result;
+		}
+	}
+
+	@Nested
+	@DisplayName("Warm-up randomized churn")
+	class WarmUpChurnTest {
+
+		@Test
+		@DisplayName("keeps separators and occupancy consistent through non-transactional insert/delete churn")
+		void shouldKeepConsistentThroughRandomizedChurn() {
+			// The non-transactional (warm-up / bulk-load) path: churn random insert and delete directly on the tree
+			// (no transaction), asserting the consistency report and the exact content after every structural change.
+			// Delete-biased once the tree has grown so borrows and merges are exercised as heavily as splits.
+			for (long seed = 0; seed < 50; seed++) {
+				final Random random = new Random(seed);
+				final TransactionalElementBPlusTree<PriceRecordContract> tree = treeOf(3);
+				final TreeMap<Integer, PriceRecordContract> oracle = new TreeMap<>();
+				for (int op = 0; op < 400; op++) {
+					final int key = random.nextInt(60);
+					final boolean delete = oracle.size() > 20 ? random.nextInt(3) > 0 : random.nextBoolean();
+					if (delete) {
+						tree.delete(key);
+						oracle.remove(key);
+					} else {
+						final PriceRecordContract record = rec(key);
+						tree.insert(record);
+						oracle.put(key, record);
+					}
+					final ConsistencyReport report = tree.getConsistencyReport();
+					assertEquals(
+						ConsistencyState.CONSISTENT, report.state(),
+						"Inconsistent at seed " + seed + " op " + op + ": " + report.report()
+					);
+					assertEquals(oracle.size(), tree.size(), "Size mismatch at seed " + seed + " op " + op);
+				}
+				// final content must match the oracle exactly, in ascending order
+				final int[] expectedKeys = new int[oracle.size()];
+				int index = 0;
+				for (final Integer key : oracle.keySet()) {
+					expectedKeys[index++] = key;
+				}
+				verifyTreeConsistency(tree, expectedKeys);
+			}
 		}
 	}
 
@@ -979,9 +1084,8 @@ class TransactionalElementBPlusTreeTest {
 			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
 				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
 			));
-			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(
-				leafAt(tree, 1), leafAt(tree, 5), leafAt(tree, 10)
-			)));
+			// the registry keeps probe KEYS, not node objects; each key relocates to the leaf that owns it
+			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(1, 5, 10)));
 		}
 
 		@Test
@@ -996,9 +1100,10 @@ class TransactionalElementBPlusTreeTest {
 			// last key reach the successor's first key; the separator is untouched, so relocating by the leaf's own
 			// first key (5) still lands on it and the tail half-invariant fires
 			middle.getValues()[middle.getPeek()] = rec(10);
+			// relocate by the leaf's own (unchanged) first key 5 — the descent lands on it and the tail half-invariant fires
 			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
 				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
-				() -> tree.validateDirtyScope(List.<Object>of(middle))
+				() -> tree.validateDirtyScope(List.<Object>of(5))
 			);
 			assertTrue(
 				ex.getMessage().contains("successor leaf boundary"),
@@ -1017,10 +1122,11 @@ class TransactionalElementBPlusTreeTest {
 			// the predecessor's corrupted last key
 			final TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract> predecessor = leafAt(tree, 1);
 			predecessor.getValues()[predecessor.getPeek()] = rec(5);
-			final TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract> middle = leafAt(tree, 5);
+			// relocate the middle leaf by its unchanged first key 5; the head half-invariant compares against the
+			// predecessor's corrupted last key
 			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
 				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
-				() -> tree.validateDirtyScope(List.<Object>of(middle))
+				() -> tree.validateDirtyScope(List.<Object>of(5))
 			);
 			assertTrue(
 				ex.getMessage().contains("predecessor leaf boundary"),
@@ -1029,18 +1135,13 @@ class TransactionalElementBPlusTreeTest {
 		}
 
 		@Test
-		@DisplayName("an empty key source is skipped, not dereferenced")
-		void shouldSkipEmptyKeySource() {
-			final TransactionalElementBPlusTree<PriceRecordContract> tree = assembleSound(List.of(
-				singleLeaf(1, 2), singleLeaf(5, 6)
-			));
-			// an empty single-leaf source carries no key (peek < 0) — the scope validation must skip it rather than
-			// dereference the peek slot
-			final TransactionalElementBPlusTree<PriceRecordContract> empty =
+		@DisplayName("a probe key landing on an empty leaf is skipped, not dereferenced")
+		void shouldSkipWhenDescentLandsOnEmptyLeaf() {
+			// an empty tree routes any probe key to its empty root leaf (peek < 0) — the scope validation must skip
+			// it rather than dereference the peek slot
+			final TransactionalElementBPlusTree<PriceRecordContract> tree =
 				new TransactionalElementBPlusTree<>(10, 1, 3, 1, PriceRecordContract.class, KEY);
-			final TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract> emptyLeaf =
-				(TransactionalElementBPlusTree.BPlusLeafTreeNode<PriceRecordContract>) empty.getRoot();
-			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(emptyLeaf)));
+			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(42)));
 		}
 
 		/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalIntToLongBPlusTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalIntToLongBPlusTreeTest.java
@@ -652,8 +652,13 @@ class TransactionalIntToLongBPlusTreeTest {
 					if (delete) {
 						tree.delete(key);
 						reference.remove(key);
-					} else {
+					} else if (random.nextBoolean()) {
 						tree.insert(key, valueOf(key));
+						reference.put(key, valueOf(key));
+					} else {
+						// upsert exercises the insert-or-update public path; a value-preserving updater keeps the
+						// oracle exact whether the key was absent (insert + possible split) or already present
+						tree.upsert(key, existing -> valueOf(key));
 						reference.put(key, valueOf(key));
 					}
 
@@ -672,6 +677,74 @@ class TransactionalIntToLongBPlusTreeTest {
 				verifyForwardValueIterator(tree, expectedKeys);
 				verifyReverseValueIterator(tree, expectedKeys);
 			}
+		}
+
+		@Test
+		@DisplayName("survives large randomized insert/delete churn committed as one transaction")
+		void shouldSurviveRandomizedTransactionalChurn() {
+			// Runs the same random insert / upsert / delete churn as the bare-tree consistency fuzzer above, but
+			// inside a single committed transaction, so it exercises the transactional commit-merge path (layer merge
+			// and leaf split/merge within a transaction) that the non-transactional churn never reaches. The committed
+			// content must match the oracle exactly.
+			for (final int blockSize : new int[]{3, 5, 7}) {
+				for (long seed = 0; seed < 25; seed++) {
+					exerciseTransactionalChurn(blockSize, seed);
+				}
+			}
+		}
+
+		/**
+		 * Drives a fixed number of random insert / upsert / delete operations against a fresh tree of the given block
+		 * size inside a single transaction, mirroring the mutations into a `TreeMap` oracle. After the commit the
+		 * original (transactional) view must be empty and the committed tree must match the oracle's ascending key set
+		 * exactly. This exercises the transactional commit-merge and layer-merge path under random churn.
+		 *
+		 * @param blockSize the leaf and internal node block size to build the tree with
+		 * @param seed      the random seed driving the churn for reproducibility
+		 */
+		private void exerciseTransactionalChurn(int blockSize, long seed) {
+			final TransactionalIntToLongBPlusTree tree = new TransactionalIntToLongBPlusTree(
+				blockSize, 1, blockSize, 1);
+			final TreeMap<Integer, Long> oracle = new TreeMap<>();
+			final Random random = new Random(seed);
+
+			assertStateAfterCommit(
+				tree,
+				tested -> {
+					for (int op = 0; op < 400; op++) {
+						final int key = random.nextInt(120);
+						// bias towards delete once the tree has grown so merges and borrows are exercised heavily
+						final boolean delete = oracle.size() > 40
+							? random.nextInt(3) > 0
+							: random.nextBoolean();
+						if (delete) {
+							tested.delete(key);
+							oracle.remove(key);
+						} else if (random.nextBoolean()) {
+							tested.insert(key, valueOf(key));
+							oracle.put(key, valueOf(key));
+						} else {
+							// upsert exercises the insert-or-update public path; value-preserving keeps the oracle exact
+							tested.upsert(key, existing -> valueOf(key));
+							oracle.put(key, valueOf(key));
+						}
+					}
+					assertEquals(
+						oracle.size(), tested.size(),
+						"Size mismatch in transaction at blockSize=" + blockSize + " seed=" + seed
+					);
+				},
+				(original, committed) -> {
+					// the transactional view is empty once the transaction is committed
+					assertEquals(
+						0, original.size(),
+						"Original not empty after commit at blockSize=" + blockSize + " seed=" + seed
+					);
+					// the committed tree must match the oracle's ascending keys exactly and stay structurally consistent
+					final int[] expectedKeys = oracle.keySet().stream().mapToInt(Integer::intValue).toArray();
+					verifyTreeConsistency(committed, expectedKeys);
+				}
+			);
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTreeTest.java
@@ -605,8 +605,13 @@ class TransactionalLongBPlusTreeTest {
 					if (delete) {
 						tree.delete(key);
 						reference.remove(key);
-					} else {
+					} else if (random.nextBoolean()) {
 						tree.insert(key, "Value" + key);
+						reference.put(key, "Value" + key);
+					} else {
+						// upsert exercises the insert-or-update public path; a value-preserving updater keeps the
+						// oracle exact whether the key was absent (insert + possible split) or already present
+						tree.upsert(key, existing -> "Value" + key);
 						reference.put(key, "Value" + key);
 					}
 
@@ -625,6 +630,81 @@ class TransactionalLongBPlusTreeTest {
 				verifyForwardValueIterator(tree, expectedKeys);
 				verifyReverseValueIterator(tree, expectedKeys);
 			}
+		}
+
+		@Test
+		@DisplayName("survives large randomized insert/delete churn committed as one transaction")
+		void shouldSurviveRandomizedTransactionalChurn() {
+			// The dirty-scope validation runs only at commit, so a fuzzer that never commits (like the bare-tree
+			// consistency-report churn above) is blind to it. This churns hundreds of random insert / upsert / delete
+			// operations at small block sizes inside a single committed transaction, so leaves split and merge within
+			// the transaction; the commit-time dirty-scope passes must re-derive every dirtied leaf's boundaries
+			// cleanly and the committed content must match the oracle.
+			for (final int blockSize : new int[]{3, 5, 7}) {
+				for (long seed = 0; seed < 25; seed++) {
+					exerciseTransactionalChurn(blockSize, seed);
+				}
+			}
+		}
+
+		/**
+		 * Churns 400 random insert / upsert / delete operations against a fresh tree of the given block size inside a
+		 * single transaction and asserts the committed tree matches the maintained oracle. Unlike the bare-tree churn
+		 * that validates a consistency report after every operation, this drives the whole batch through one commit so
+		 * the commit-merge and dirty-scope validation paths must reconcile every leaf split and merge accumulated
+		 * within the transaction.
+		 *
+		 * @param blockSize the leaf and internal node block size for the tree
+		 * @param seed      the random seed for reproducibility
+		 */
+		private void exerciseTransactionalChurn(int blockSize, long seed) {
+			final TransactionalLongBPlusTree<String> tree = new TransactionalLongBPlusTree<>(
+				blockSize, 1, blockSize, 1, String.class
+			);
+			final TreeMap<Long, String> oracle = new TreeMap<>();
+			final Random random = new Random(seed);
+
+			assertStateAfterCommit(
+				tree,
+				tested -> {
+					for (int op = 0; op < 400; op++) {
+						final long key = random.nextInt(120);
+						// bias towards delete once the tree has grown so merges and borrows are exercised heavily
+						final boolean delete = oracle.size() > 40
+							? random.nextInt(3) > 0
+							: random.nextBoolean();
+						if (delete) {
+							tested.delete(key);
+							oracle.remove(key);
+						} else if (random.nextBoolean()) {
+							tested.insert(key, "Value" + key);
+							oracle.put(key, "Value" + key);
+						} else {
+							// upsert exercises the insert-or-update public path (and, for this validating tree, its
+							// own dirty-scope registration on the upsert-insert seam); value-preserving keeps the
+							// oracle exact
+							tested.upsert(key, existing -> "Value" + key);
+							oracle.put(key, "Value" + key);
+						}
+					}
+					// the whole batch is verified after commit; only the running size is checked mid-transaction
+					assertEquals(
+						oracle.size(), tested.size(),
+						"Size mismatch inside transaction at blockSize=" + blockSize + " seed=" + seed
+					);
+				},
+				(original, committed) -> {
+					// every mutation happened inside the transaction, so the pre-transaction tree is still empty
+					assertEquals(
+						0, original.size(),
+						"Original tree changed at blockSize=" + blockSize + " seed=" + seed
+					);
+					// the committed tree must match the oracle's ascending keys through the consistency report and
+					// both forward and reverse value iterators
+					final long[] expectedKeys = oracle.keySet().stream().mapToLong(Long::longValue).toArray();
+					verifyTreeConsistency(committed, expectedKeys);
+				}
+			);
 		}
 
 		@Test
@@ -3126,9 +3206,8 @@ class TransactionalLongBPlusTreeTest {
 			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
 				singleLeaf(1, 2), singleLeaf(5, 6), singleLeaf(10, 11)
 			));
-			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(
-				leafAt(tree, 1), leafAt(tree, 5), leafAt(tree, 10)
-			)));
+			// the registry keeps probe KEYS, not node objects; each key relocates to the leaf that owns it
+			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(1L, 5L, 10L)));
 		}
 
 		@Test
@@ -3143,9 +3222,10 @@ class TransactionalLongBPlusTreeTest {
 			// leaf's own first key (5) still lands on it and the tail half-invariant fires
 			final long[] keys = middle.getKeys();
 			keys[1] = 10L;
+			// relocate by the leaf's own (unchanged) first key 5 — the descent lands on it and the tail half-invariant fires
 			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
 				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
-				() -> tree.validateDirtyScope(List.<Object>of(middle))
+				() -> tree.validateDirtyScope(List.<Object>of(5L))
 			);
 			assertTrue(
 				ex.getMessage().contains("successor leaf boundary"),
@@ -3164,10 +3244,11 @@ class TransactionalLongBPlusTreeTest {
 			// the predecessor's corrupted last key
 			final long[] predecessorKeys = leafAt(tree, 1).getKeys();
 			predecessorKeys[1] = 5L;
-			final TransactionalLongBPlusTree.BPlusLeafTreeNode<String> middle = leafAt(tree, 5);
+			// relocate the middle leaf by its unchanged first key 5; the head half-invariant compares against the
+			// predecessor's corrupted last key
 			final AbstractTransactionalBPlusTree.BPlusTreeCorruptedException ex = assertThrows(
 				AbstractTransactionalBPlusTree.BPlusTreeCorruptedException.class,
-				() -> tree.validateDirtyScope(List.<Object>of(middle))
+				() -> tree.validateDirtyScope(List.<Object>of(5L))
 			);
 			assertTrue(
 				ex.getMessage().contains("predecessor leaf boundary"),
@@ -3176,17 +3257,12 @@ class TransactionalLongBPlusTreeTest {
 		}
 
 		@Test
-		@DisplayName("an empty key source is skipped, not dereferenced")
-		void shouldSkipEmptyKeySource() {
-			final TransactionalLongBPlusTree<String> tree = assembleSound(List.of(
-				singleLeaf(1, 2), singleLeaf(5, 6)
-			));
-			// an empty single-leaf source carries no key (peek < 0) — the scope validation must skip it rather than
-			// dereference keys[0]
-			final TransactionalLongBPlusTree<String> empty = new TransactionalLongBPlusTree<>(10, 1, 3, 1, String.class);
-			final TransactionalLongBPlusTree.BPlusLeafTreeNode<String> emptyLeaf =
-				(TransactionalLongBPlusTree.BPlusLeafTreeNode<String>) empty.getRoot();
-			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(emptyLeaf)));
+		@DisplayName("a probe key landing on an empty leaf is skipped, not dereferenced")
+		void shouldSkipWhenDescentLandsOnEmptyLeaf() {
+			// an empty tree routes any probe key to its empty root leaf (peek < 0) — the scope validation must skip
+			// it rather than dereference keys[0]
+			final TransactionalLongBPlusTree<String> tree = new TransactionalLongBPlusTree<>(10, 1, 3, 1, String.class);
+			assertDoesNotThrow(() -> tree.validateDirtyScope(List.<Object>of(42L)));
 		}
 
 		/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalObjectBPlusTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/bPlusTree/TransactionalObjectBPlusTreeTest.java
@@ -796,8 +796,13 @@ class TransactionalObjectBPlusTreeTest {
 					if (delete) {
 						tree.delete(key);
 						reference.remove(key);
-					} else {
+					} else if (random.nextBoolean()) {
 						tree.insert(key, "Value" + key);
+						reference.put(key, "Value" + key);
+					} else {
+						// upsert exercises the insert-or-update public path; a value-preserving updater keeps the
+						// oracle exact whether the key was absent (insert + possible split) or already present
+						tree.upsert(key, existing -> "Value" + key);
 						reference.put(key, "Value" + key);
 					}
 
@@ -816,6 +821,74 @@ class TransactionalObjectBPlusTreeTest {
 				verifyForwardValueIterator(tree, expectedKeys);
 				verifyReverseValueIterator(tree, expectedKeys);
 			}
+		}
+
+		@Test
+		@DisplayName("survives large randomized insert/delete churn committed as one transaction")
+		void shouldSurviveRandomizedTransactionalChurn() {
+			// Runs the same random insert / upsert / delete churn as the bare-tree consistency fuzzer above, but
+			// inside a single committed transaction, so it exercises the transactional commit-merge path (layer merge
+			// and leaf split/merge within a transaction) that the non-transactional churn never reaches. The committed
+			// content must match the oracle exactly.
+			for (final int blockSize : new int[]{3, 5, 7}) {
+				for (long seed = 0; seed < 25; seed++) {
+					exerciseTransactionalChurn(blockSize, seed);
+				}
+			}
+		}
+
+		/**
+		 * Drives a batch of randomized insert / upsert / delete operations against a fresh tree of the given block
+		 * size, all inside a single transaction, then commits and verifies the committed tree against an in-memory
+		 * oracle. This exercises the transactional commit-merge path (layer merge plus leaf split/merge accumulated
+		 * within one transaction) that the non-transactional churn fuzzer never reaches.
+		 *
+		 * @param blockSize the value and internal node block size; the minimum occupancy is derived as `blockSize / 2`
+		 * @param seed      the random seed driving the operation stream
+		 */
+		private static void exerciseTransactionalChurn(int blockSize, long seed) {
+			final TransactionalObjectBPlusTree<Integer, String> tree =
+				new TransactionalObjectBPlusTree<>(blockSize, Integer.class, String.class);
+			final TreeMap<Integer, String> oracle = new TreeMap<>();
+			final Random random = new Random(seed);
+
+			assertStateAfterCommit(
+				tree,
+				tested -> {
+					for (int op = 0; op < 400; op++) {
+						final int key = random.nextInt(120);
+						// bias towards delete once the oracle has grown so merges and borrows are exercised heavily
+						final boolean delete = oracle.size() > 40
+							? random.nextInt(3) > 0
+							: random.nextBoolean();
+						if (delete) {
+							tested.delete(key);
+							oracle.remove(key);
+						} else if (random.nextBoolean()) {
+							tested.insert(key, "Value" + key);
+							oracle.put(key, "Value" + key);
+						} else {
+							// upsert exercises the insert-or-update public path; value-preserving keeps the oracle exact
+							tested.upsert(key, existing -> "Value" + key);
+							oracle.put(key, "Value" + key);
+						}
+					}
+					assertEquals(
+						oracle.size(), tested.size(),
+						"Size mismatch within transaction at blockSize=" + blockSize + " seed=" + seed
+					);
+				},
+				(original, committed) -> {
+					// every mutation landed in the transactional layer, so the original still reflects the empty tree
+					assertEquals(
+						0, original.size(),
+						"Original tree leaked mutations at blockSize=" + blockSize + " seed=" + seed
+					);
+					// the committed tree must match the oracle exactly, in ascending order, and stay consistent
+					final int[] expectedKeys = oracle.keySet().stream().mapToInt(Integer::intValue).toArray();
+					verifyTreeConsistency(committed, expectedKeys);
+				}
+			);
 		}
 
 	}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/api/LongRunningEvitaTransactionalFunctionalTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/api/LongRunningEvitaTransactionalFunctionalTest.java
@@ -915,6 +915,7 @@ public class LongRunningEvitaTransactionalFunctionalTest implements EvitaTestSup
 				.cache(originalConfiguration.cache())
 				.build()
 		);
+		evita.waitUntilFullyInitialized();
 
 		try {
 			final AtomicReference<CompletableFuture<FileForFetch>> lastBackupProcess = new AtomicReference<>();
@@ -1017,6 +1018,7 @@ public class LongRunningEvitaTransactionalFunctionalTest implements EvitaTestSup
 				.cache(originalConfiguration.cache())
 				.build()
 		);
+		evita.waitUntilFullyInitialized();
 
 		try {
 			final AtomicReference<CompletableFuture<FileForFetch>> lastBackupProcess = new AtomicReference<>();

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/bPlusTree/LongRunningTransactionalBucketBPlusTreeTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/bPlusTree/LongRunningTransactionalBucketBPlusTreeTest.java
@@ -259,6 +259,114 @@ class LongRunningTransactionalBucketBPlusTreeTest implements TimeBoundedTestSupp
 		);
 	}
 
+	@ParameterizedTest(
+		name = "TransactionalBucketBPlusTree should survive non-transactional generational churn on it"
+	)
+	@Tag(SLOW)
+	@ArgumentsSource(TimeArgumentProvider.class)
+	@DisplayName("survives randomized non-transactional (warm-up) insert/grow/remove/drain churn")
+	void generationalWarmUpProofTest(@Nonnull GenerationalTestInput input) {
+		final int limitElements = 1000;
+		final long seed = input.randomSeed();
+		// print the seed so a failing run can be reproduced deterministically
+		System.out.println("LongRunningTransactionalBucketBPlusTreeTest (warm-up) seed: " + seed);
+
+		// one long-lived bare tree churned directly (no transaction) at a small block size so splits / merges are dense
+		final TransactionalBucketBPlusTree<Integer> tree = new TransactionalBucketBPlusTree<>(3, Integer.class);
+		final TreeMap<Integer, TreeSet<Integer>> reference = new TreeMap<>();
+		final Random seedRandom = new Random(seed);
+		do {
+			final int key = seedRandom.nextInt(limitElements << 1);
+			if (!reference.containsKey(key)) {
+				final TreeSet<Integer> records = new TreeSet<>();
+				records.add(key);
+				reference.put(key, records);
+				tree.addRecord(key, key);
+			}
+		} while (reference.size() < limitElements);
+		verifyTreeMatchesReference(tree, reference);
+
+		runFor(
+			input, 1000, new WarmUpState(new StringBuilder(512), true),
+			(random, state) -> {
+				final StringBuilder code = state.code();
+				code.setLength(0);
+				try {
+					final boolean drain =
+						(!reference.isEmpty() && random.nextInt(3) == 0)
+							|| (state.limitReached() && reference.size() > limitElements / 2);
+					if (drain) {
+						// promote-then-drain in one shot: grow the bucket so its overflow bitmap layer is opened, then
+						// remove every record so the bucket is deleted - stressing the discardRemovedValueLayer release
+						final Integer key = pickRandomKey(reference, random);
+						final int probe = (limitElements << 1) + key;
+						tree.addRecord(key, probe);
+						final TreeSet<Integer> drainSet = new TreeSet<>(reference.get(key));
+						drainSet.add(probe);
+						tree.removeRecord(key, toArray(drainSet));
+						reference.remove(key);
+						code.append("D:").append(key).append(' ');
+					} else {
+						final int key = random.nextInt(limitElements << 1);
+						final TreeSet<Integer> existing = reference.get(key);
+						if (existing == null) {
+							// insert a new bucket - single or multi from the start
+							if (random.nextBoolean()) {
+								tree.addRecord(key, key);
+								final TreeSet<Integer> records = new TreeSet<>();
+								records.add(key);
+								reference.put(key, records);
+								code.append("I:").append(key).append(' ');
+							} else {
+								final int second = (limitElements << 1) + key;
+								tree.addRecord(key, key, second);
+								final TreeSet<Integer> records = new TreeSet<>();
+								records.add(key);
+								records.add(second);
+								reference.put(key, records);
+								code.append("I2:").append(key).append(' ');
+							}
+						} else {
+							final int choice = random.nextInt(3);
+							if (choice == 0) {
+								// grow: add a distinct record (single->multi promote or multi grow); a duplicate is
+								// deduped on both sides and stays consistent
+								final int extra = (limitElements << 1) + random.nextInt(limitElements << 2);
+								tree.addRecord(key, extra);
+								existing.add(extra);
+								code.append("M:").append(key).append(':').append(extra).append(' ');
+							} else if (existing.size() > 1) {
+								// partial remove: drop one record, the bucket survives
+								final int victim = pickFromSet(existing, random);
+								tree.removeRecord(key, victim);
+								existing.remove(victim);
+								code.append("R:").append(key).append(':').append(victim).append(' ');
+							} else {
+								// remove the sole record - the bucket is deleted
+								final int sole = existing.first();
+								tree.removeRecord(key, sole);
+								reference.remove(key);
+								code.append("R0:").append(key).append(' ');
+							}
+						}
+					}
+
+					verifyTreeMatchesReference(tree, reference);
+
+					return new WarmUpState(
+						state.code(),
+						state.limitReached()
+							? reference.size() > limitElements / 2
+							: reference.size() >= limitElements
+					);
+				} catch (Exception ex) {
+					fail("Generation failed for seed " + seed + " with operation [" + code + "]", ex);
+					throw ex;
+				}
+			}
+		);
+	}
+
 	/**
 	 * Picks a random key present in the reference double.
 	 *
@@ -321,6 +429,20 @@ class LongRunningTransactionalBucketBPlusTreeTest implements TimeBoundedTestSupp
 	private record TestState(
 		@Nonnull StringBuilder code,
 		@Nonnull TreeMap<Integer, TreeSet<Integer>> reference,
+		boolean limitReached
+	) {
+	}
+
+	/**
+	 * Carries the chained warm-up generation state for the non-transactional axis: the running operation log (reset to
+	 * the single current op each generation) and whether the bucket-count growth limit has been reached. The tree and
+	 * its reference double are captured directly and mutated in place across generations.
+	 *
+	 * @param code         the current operation log used for failure reproduction
+	 * @param limitReached whether the growth limit has been reached (switches the churn to drain-biased)
+	 */
+	private record WarmUpState(
+		@Nonnull StringBuilder code,
 		boolean limitReached
 	) {
 	}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/bPlusTree/LongRunningTransactionalElementBPlusTreeTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/bPlusTree/LongRunningTransactionalElementBPlusTreeTest.java
@@ -1,0 +1,368 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.bPlusTree;
+
+import io.evitadb.dataType.ConsistencySensitiveDataStructure.ConsistencyReport;
+import io.evitadb.dataType.ConsistencySensitiveDataStructure.ConsistencyState;
+import io.evitadb.index.price.model.priceRecord.PriceRecord;
+import io.evitadb.index.price.model.priceRecord.PriceRecordContract;
+import io.evitadb.test.duration.TimeArgumentProvider;
+import io.evitadb.test.duration.TimeArgumentProvider.GenerationalTestInput;
+import io.evitadb.test.duration.TimeBoundedTestSupport;
+import io.evitadb.utils.ArrayUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.ToIntFunction;
+
+import static io.evitadb.test.TestTags.DATA_TYPE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.SLOW;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Generational randomized proof test for {@link TransactionalElementBPlusTree} - the element tree backing the price
+ * super-index, keyed on {@link PriceRecordContract#internalPriceId()} and holding immutable
+ * {@link PriceRecordContract} elements (there is no `upsert` public path, so the churn drives insert / delete only).
+ *
+ * The class exposes both coverage axes the family needs:
+ * - the **WARM_UP** (non-transactional / bulk-load) axis churns random insert / delete operations directly on one
+ *   long-lived bare tree, asserting `getConsistencyReport()` == CONSISTENT and the exact ascending content after every
+ *   structural change - this stresses the split / borrow / merge machinery but is deliberately blind to the
+ *   commit-time dirty-scope validation;
+ * - the **ALIVE** (transactional) axis rebuilds a fresh tree from the previous generation's committed contents,
+ *   applies a random batch of insert / delete inside a single transaction and commits via
+ *   {@link io.evitadb.utils.AssertionUtils#assertStateAfterCommit} - which runs the transactional-layer sweep and the
+ *   dirty-scope re-derivation on every commit - then validates the committed tree against a `TreeSet<Integer>`
+ *   reference double. Each generation draws a small block size from `{3, 5, 7}` so leaves split and merge densely,
+ *   which is exactly where the dirty-scope validation fires.
+ *
+ * Chaining the committed output of each generation into the next accumulates any split / merge or dirty-scope error
+ * over thousands of commit cycles. The run is time-bounded; the seed is printed on failure and the per-generation
+ * operation log is included in the failure message so a minimal reproduction can be reconstructed.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Transactional element B+ tree (generational randomized proof)")
+@Tag(INDEXING)
+@Tag(DATA_TYPE)
+@Tag(TRANSACTION)
+class LongRunningTransactionalElementBPlusTreeTest implements TimeBoundedTestSupport {
+	private static final int LIMIT_ELEMENTS = 1000;
+	/**
+	 * Block sizes drawn per generation in the transactional axis; all odd (internal-node constraint) and small enough
+	 * to force frequent splits and merges - the churn density where the dirty-scope validation is exercised.
+	 */
+	private static final int[] BLOCK_SIZES = {3, 5, 7};
+	/**
+	 * The key extractor used by every tree under test: the element's internal price id.
+	 */
+	private static final ToIntFunction<PriceRecordContract> KEY = PriceRecordContract::internalPriceId;
+
+	/**
+	 * Builds a price record whose every field is derived from the given key, so a round-tripped element can be checked
+	 * for identity (`internalPriceId`) and full content equality against a freshly produced reference.
+	 *
+	 * @param key the internal price id (the tree's routing key)
+	 * @return a content-stable price record for the key
+	 */
+	@Nonnull
+	private static PriceRecordContract rec(int key) {
+		return new PriceRecord(key, key + 1, key / 3, key * 100 + 21, key * 100);
+	}
+
+	/**
+	 * Creates an empty element tree with a valid configuration derived from the given leaf block size (any size &gt;= 3,
+	 * odd or even) and the standard key extractor - the same derivation the family's default constructor uses, so merges
+	 * never immediately overflow.
+	 *
+	 * @param blockSize the leaf block size
+	 * @return a fresh empty tree
+	 */
+	@Nonnull
+	private static TransactionalElementBPlusTree<PriceRecordContract> treeOf(int blockSize) {
+		final int minValue = (int) Math.ceil(blockSize / 2.0) - 1;
+		final int internal = blockSize % 2 == 1 ? blockSize : blockSize - 1;
+		final int minInternal = (int) Math.ceil(internal / 2.0) - 1;
+		return new TransactionalElementBPlusTree<>(
+			blockSize, minValue, internal, minInternal, PriceRecordContract.class, KEY
+		);
+	}
+
+	/**
+	 * Builds a fresh element tree of the given block size holding one record per key from the given ascending key set.
+	 *
+	 * @param keys      the ascending distinct keys
+	 * @param blockSize the leaf block size
+	 * @return a tree seeded with a content-stable record per key
+	 */
+	@Nonnull
+	private static TransactionalElementBPlusTree<PriceRecordContract> buildTree(@Nonnull int[] keys, int blockSize) {
+		final TransactionalElementBPlusTree<PriceRecordContract> tree = treeOf(blockSize);
+		for (final int key : keys) {
+			tree.insert(rec(key));
+		}
+		return tree;
+	}
+
+	/**
+	 * Verifies the tree's internal consistency report and that the forward (key + full content) and reverse (key)
+	 * element iterators agree with the expected ascending key array.
+	 *
+	 * @param tree         the tree to verify
+	 * @param expectedKeys the expected ascending key array
+	 */
+	private static void verifyTreeConsistency(
+		@Nonnull TransactionalElementBPlusTree<PriceRecordContract> tree, @Nonnull int... expectedKeys
+	) {
+		final ConsistencyReport report = tree.getConsistencyReport();
+		assertEquals(ConsistencyState.CONSISTENT, report.state(), report.report());
+		assertEquals(expectedKeys.length, tree.size(), "Size mismatch between tree and reference!");
+
+		// forward element iteration: ascending keys + full content
+		int index = 0;
+		final Iterator<PriceRecordContract> forward = tree.valueIterator();
+		while (forward.hasNext()) {
+			final PriceRecordContract record = forward.next();
+			assertEquals(expectedKeys[index], record.internalPriceId(), "Forward iterator key mismatch at " + index);
+			assertEquals(rec(expectedKeys[index]), record, "Forward iterator content mismatch at " + index);
+			index++;
+		}
+		assertEquals(expectedKeys.length, index, "Forward iterator produced a different element count");
+		assertThrows(NoSuchElementException.class, forward::next, "Forward iterator should be exhausted");
+
+		// reverse element iteration: descending keys
+		index = expectedKeys.length;
+		final Iterator<PriceRecordContract> reverse = tree.valueReverseIterator();
+		while (reverse.hasNext()) {
+			final PriceRecordContract record = reverse.next();
+			assertEquals(expectedKeys[--index], record.internalPriceId(), "Reverse iterator key mismatch at " + index);
+		}
+		assertEquals(0, index, "Reverse iterator produced a different element count");
+		assertThrows(NoSuchElementException.class, reverse::next, "Reverse iterator should be exhausted");
+	}
+
+	@ParameterizedTest(
+		name = "TransactionalElementBPlusTree should survive non-transactional generational insert/delete churn"
+	)
+	@Tag(SLOW)
+	@ArgumentsSource(TimeArgumentProvider.class)
+	@DisplayName("survives randomized non-transactional (warm-up) insert/delete churn")
+	void generationalWarmUpProofTest(@Nonnull GenerationalTestInput input) {
+		final long seed = input.randomSeed();
+		// print the seed so a failing run can be reproduced deterministically
+		System.out.println("LongRunningTransactionalElementBPlusTreeTest (warm-up) seed: " + seed);
+
+		// one long-lived bare tree churned directly (no transaction) at a small block size so splits / merges are dense
+		final TransactionalElementBPlusTree<PriceRecordContract> tree = treeOf(3);
+		final Random seedRandom = new Random(seed);
+		int[] initialKeys = new int[0];
+		do {
+			final int key = seedRandom.nextInt(LIMIT_ELEMENTS << 1);
+			tree.insert(rec(key));
+			initialKeys = ArrayUtils.insertIntIntoOrderedArray(key, initialKeys);
+		} while (initialKeys.length < LIMIT_ELEMENTS);
+		verifyTreeConsistency(tree, initialKeys);
+
+		runFor(
+			input, 1000, new GenState(new StringBuilder(512), initialKeys, true),
+			(random, state) -> {
+				final int[] startArray = state.keys();
+				int key = -1;
+				final boolean delete =
+					(startArray.length > 0 && random.nextInt(3) == 0)
+						|| (state.limitReached() && startArray.length > LIMIT_ELEMENTS / 2);
+				try {
+					final int[] endArray;
+					if (delete) {
+						key = startArray[random.nextInt(startArray.length)];
+						endArray = ArrayUtils.removeIntFromOrderedArray(key, startArray);
+						tree.delete(key);
+					} else {
+						key = random.nextInt(LIMIT_ELEMENTS << 1);
+						endArray = ArrayUtils.insertIntIntoOrderedArray(key, startArray);
+						tree.insert(rec(key));
+					}
+
+					verifyTreeConsistency(tree, endArray);
+
+					return new GenState(
+						state.code().append(delete ? "D:" : "I:").append(key).append(' '),
+						endArray,
+						state.limitReached()
+							? endArray.length > LIMIT_ELEMENTS / 2
+							: endArray.length >= LIMIT_ELEMENTS
+					);
+				} catch (Exception ex) {
+					fail("Failed to " + (delete ? "delete" : "insert") + " key " + key + " for seed " + seed, ex);
+					throw ex;
+				}
+			}
+		);
+	}
+
+	@ParameterizedTest(
+		name = "TransactionalElementBPlusTree should survive transactional generational insert/delete churn"
+	)
+	@Tag(SLOW)
+	@ArgumentsSource(TimeArgumentProvider.class)
+	@DisplayName("survives randomized transactional insert/delete churn re-deriving dirty leaf boundaries on commit")
+	void generationalTransactionalProofTest(@Nonnull GenerationalTestInput input) {
+		final long seed = input.randomSeed();
+		// print the seed so a failing run can be reproduced deterministically
+		System.out.println("LongRunningTransactionalElementBPlusTreeTest (transactional) seed: " + seed);
+
+		final Random seedRandom = new Random(seed);
+		final TreeSet<Integer> initialReference = new TreeSet<>();
+		do {
+			initialReference.add(seedRandom.nextInt(LIMIT_ELEMENTS << 1));
+		} while (initialReference.size() < LIMIT_ELEMENTS);
+
+		runFor(
+			input, 1000, new GenState(new StringBuilder(512), toArray(initialReference), true),
+			(random, state) -> {
+				// draw a small block size per generation so every generation is a high-split-density tree
+				final int blockSize = BLOCK_SIZES[random.nextInt(BLOCK_SIZES.length)];
+				final int[] startKeys = state.keys();
+				final TransactionalElementBPlusTree<PriceRecordContract> tree = buildTree(startKeys, blockSize);
+				verifyTreeConsistency(tree, startKeys);
+
+				// oracle mutated in lockstep with the transaction; verified against the committed tree
+				final TreeSet<Integer> oracle = new TreeSet<>();
+				for (final int key : startKeys) {
+					oracle.add(key);
+				}
+				final AtomicReference<int[]> committedKeys = new AtomicReference<>();
+				final StringBuilder code = state.code();
+				code.setLength(0);
+
+				try {
+					assertStateAfterCommit(
+						tree,
+						original -> {
+							final int operations = 1 + random.nextInt(6);
+							for (int op = 0; op < operations; op++) {
+								final boolean delete =
+									(!oracle.isEmpty() && random.nextInt(3) == 0)
+										|| (state.limitReached() && oracle.size() > LIMIT_ELEMENTS / 2);
+								if (delete) {
+									final int key = pickRandomKey(oracle, random);
+									original.delete(key);
+									oracle.remove(key);
+									code.append("D:").append(key).append(' ');
+								} else {
+									final int key = random.nextInt(LIMIT_ELEMENTS << 1);
+									original.insert(rec(key));
+									oracle.add(key);
+									code.append("I:").append(key).append(' ');
+								}
+							}
+						},
+						(original, committed) -> {
+							final int[] expectedKeys = toArray(oracle);
+							verifyTreeConsistency(committed, expectedKeys);
+							committedKeys.set(expectedKeys);
+						}
+					);
+				} catch (Exception ex) {
+					fail(
+						"Generation failed for seed " + seed + " blockSize=" + blockSize
+							+ " with operations [" + code + "]",
+						ex
+					);
+					throw ex;
+				}
+
+				final int[] nextKeys = committedKeys.get();
+				return new GenState(
+					state.code(),
+					nextKeys,
+					state.limitReached()
+						? nextKeys.length > LIMIT_ELEMENTS / 2
+						: nextKeys.length >= LIMIT_ELEMENTS
+				);
+			}
+		);
+	}
+
+	/**
+	 * Picks a random key present in the reference double.
+	 *
+	 * @param reference the reference double
+	 * @param random    the randomizer
+	 * @return a key that currently exists in the reference
+	 */
+	private static int pickRandomKey(@Nonnull TreeSet<Integer> reference, @Nonnull Random random) {
+		final int index = random.nextInt(reference.size());
+		final Iterator<Integer> it = reference.iterator();
+		int key = 0;
+		for (int i = 0; i <= index; i++) {
+			key = it.next();
+		}
+		return key;
+	}
+
+	/**
+	 * Converts an ascending set of keys into a sorted primitive array.
+	 *
+	 * @param set the ascending key set
+	 * @return the ascending keys
+	 */
+	@Nonnull
+	private static int[] toArray(@Nonnull TreeSet<Integer> set) {
+		final int[] array = new int[set.size()];
+		int index = 0;
+		for (final Integer value : set) {
+			array[index++] = value;
+		}
+		return array;
+	}
+
+	/**
+	 * Carries the chained generation state: the running operation log, the committed ascending key snapshot fed to the
+	 * next generation and whether the element-count growth limit has been reached.
+	 *
+	 * @param code         the running operation log used for failure reproduction
+	 * @param keys         the committed ascending key snapshot
+	 * @param limitReached whether the growth limit has been reached (switches the churn to delete-biased)
+	 */
+	private record GenState(
+		@Nonnull StringBuilder code,
+		@Nonnull int[] keys,
+		boolean limitReached
+	) {
+	}
+}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/bPlusTree/LongRunningTransactionalIntToLongBPlusTreeTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/bPlusTree/LongRunningTransactionalIntToLongBPlusTreeTest.java
@@ -1,0 +1,364 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.bPlusTree;
+
+import io.evitadb.dataType.ConsistencySensitiveDataStructure.ConsistencyReport;
+import io.evitadb.dataType.ConsistencySensitiveDataStructure.ConsistencyState;
+import io.evitadb.test.duration.TimeArgumentProvider;
+import io.evitadb.test.duration.TimeArgumentProvider.GenerationalTestInput;
+import io.evitadb.test.duration.TimeBoundedTestSupport;
+import io.evitadb.utils.ArrayUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.PrimitiveIterator;
+import java.util.Random;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.evitadb.test.TestTags.DATA_TYPE;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.SLOW;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Generational randomized proof test for {@link TransactionalIntToLongBPlusTree} - the primitive-`int` key,
+ * primitive-`long` value B+ tree. The value is deterministically derived from the key ({@code key * 10}), so a plain
+ * ascending key set is a sufficient reference double and a value-preserving `upsert` keeps that reference exact whether
+ * the key was absent (insert + possible split) or already present.
+ *
+ * The class exposes both coverage axes the family needs:
+ * - the **WARM_UP** (non-transactional / bulk-load) axis churns random insert / upsert / delete operations directly on
+ *   one long-lived bare tree, asserting `getConsistencyReport()` == CONSISTENT and the exact ascending content after
+ *   every structural change;
+ * - the **ALIVE** (transactional) axis rebuilds a fresh tree from the previous generation's committed contents, applies
+ *   a random batch of insert / upsert / delete inside a single transaction and commits via
+ *   {@link io.evitadb.utils.AssertionUtils#assertStateAfterCommit} - which runs the transactional-layer sweep on every
+ *   commit - then validates the committed tree against a `TreeSet<Integer>` reference double. Each generation draws a
+ *   small block size from `{3, 5, 7}` so leaves split and merge densely.
+ *
+ * All three public mutation paths that drive split / merge (insert, upsert, delete) are exercised. The run is
+ * time-bounded; the seed is printed on failure and the per-generation operation log is included in the failure message.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Transactional int-to-long B+ tree (generational randomized proof)")
+@Tag(INDEXING)
+@Tag(DATA_TYPE)
+@Tag(TRANSACTION)
+class LongRunningTransactionalIntToLongBPlusTreeTest implements TimeBoundedTestSupport {
+	private static final int LIMIT_ELEMENTS = 1000;
+	/**
+	 * Block sizes drawn per generation in the transactional axis; all odd (internal-node constraint) and small enough
+	 * to force frequent splits and merges.
+	 */
+	private static final int[] BLOCK_SIZES = {3, 5, 7};
+
+	/**
+	 * Derives the deterministic value stored for a key.
+	 *
+	 * @param key the key
+	 * @return the value associated with the key (`key * 10`)
+	 */
+	private static long valueOf(int key) {
+		return key * 10L;
+	}
+
+	/**
+	 * Builds a fresh int-to-long tree of the given block size holding one value per key from the given ascending key set.
+	 *
+	 * @param keys      the ascending distinct keys
+	 * @param blockSize the leaf and internal node block size
+	 * @return a tree seeded with a deterministic value per key
+	 */
+	@Nonnull
+	private static TransactionalIntToLongBPlusTree buildTree(@Nonnull int[] keys, int blockSize) {
+		final TransactionalIntToLongBPlusTree tree = new TransactionalIntToLongBPlusTree(blockSize, 1, blockSize, 1);
+		for (final int key : keys) {
+			tree.insert(key, valueOf(key));
+		}
+		return tree;
+	}
+
+	/**
+	 * Verifies the tree's internal consistency report and that both the forward and reverse value iterators agree with
+	 * the deterministic values of the expected ascending key array.
+	 *
+	 * @param tree         the tree to verify
+	 * @param expectedKeys the expected ascending key array
+	 */
+	private static void verifyTreeConsistency(
+		@Nonnull TransactionalIntToLongBPlusTree tree, @Nonnull int... expectedKeys
+	) {
+		final ConsistencyReport report = tree.getConsistencyReport();
+		assertEquals(ConsistencyState.CONSISTENT, report.state(), report.report());
+		assertEquals(expectedKeys.length, tree.size(), "Size mismatch between tree and reference!");
+
+		final long[] expectedValues = new long[expectedKeys.length];
+		for (int i = 0; i < expectedKeys.length; i++) {
+			expectedValues[i] = valueOf(expectedKeys[i]);
+		}
+
+		// forward value iteration
+		final long[] forwardValues = new long[expectedValues.length];
+		int index = 0;
+		final PrimitiveIterator.OfLong forward = tree.valueIterator();
+		while (forward.hasNext()) {
+			forwardValues[index++] = forward.nextLong();
+		}
+		assertEquals(expectedValues.length, index, "Forward iterator produced a different element count");
+		assertArrayEquals(expectedValues, forwardValues, "Forward value iterator mismatch");
+		assertThrows(NoSuchElementException.class, forward::next, "Forward iterator should be exhausted");
+
+		// reverse value iteration
+		final long[] reverseValues = new long[expectedValues.length];
+		index = expectedValues.length;
+		final PrimitiveIterator.OfLong reverse = tree.valueReverseIterator();
+		while (reverse.hasNext()) {
+			reverseValues[--index] = reverse.nextLong();
+		}
+		assertEquals(0, index, "Reverse iterator produced a different element count");
+		assertArrayEquals(expectedValues, reverseValues, "Reverse value iterator mismatch");
+		assertThrows(NoSuchElementException.class, reverse::next, "Reverse iterator should be exhausted");
+	}
+
+	@ParameterizedTest(
+		name = "TransactionalIntToLongBPlusTree should survive non-transactional generational insert/upsert/delete churn"
+	)
+	@Tag(SLOW)
+	@ArgumentsSource(TimeArgumentProvider.class)
+	@DisplayName("survives randomized non-transactional (warm-up) insert/upsert/delete churn")
+	void generationalWarmUpProofTest(@Nonnull GenerationalTestInput input) {
+		final long seed = input.randomSeed();
+		// print the seed so a failing run can be reproduced deterministically
+		System.out.println("LongRunningTransactionalIntToLongBPlusTreeTest (warm-up) seed: " + seed);
+
+		// one long-lived bare tree churned directly (no transaction) at a small block size so splits / merges are dense
+		final TransactionalIntToLongBPlusTree tree = new TransactionalIntToLongBPlusTree(3, 1, 3, 1);
+		final Random seedRandom = new Random(seed);
+		int[] initialKeys = new int[0];
+		do {
+			final int key = seedRandom.nextInt(LIMIT_ELEMENTS << 1);
+			tree.insert(key, valueOf(key));
+			initialKeys = ArrayUtils.insertIntIntoOrderedArray(key, initialKeys);
+		} while (initialKeys.length < LIMIT_ELEMENTS);
+		verifyTreeConsistency(tree, initialKeys);
+
+		runFor(
+			input, 1000, new GenState(new StringBuilder(512), initialKeys, true),
+			(random, state) -> {
+				final int[] startArray = state.keys();
+				int key = -1;
+				final boolean delete =
+					(startArray.length > 0 && random.nextInt(3) == 0)
+						|| (state.limitReached() && startArray.length > LIMIT_ELEMENTS / 2);
+				final boolean useUpsert = !delete && random.nextBoolean();
+				try {
+					final int[] endArray;
+					if (delete) {
+						key = startArray[random.nextInt(startArray.length)];
+						endArray = ArrayUtils.removeIntFromOrderedArray(key, startArray);
+						tree.delete(key);
+					} else {
+						key = random.nextInt(LIMIT_ELEMENTS << 1);
+						endArray = ArrayUtils.insertIntIntoOrderedArray(key, startArray);
+						if (useUpsert) {
+							// value-preserving upsert exercises the insert-or-update public path while keeping the
+							// reference exact whether the key was absent (insert + possible split) or already present
+							final int upsertKey = key;
+							tree.upsert(upsertKey, existing -> valueOf(upsertKey));
+						} else {
+							tree.insert(key, valueOf(key));
+						}
+					}
+
+					verifyTreeConsistency(tree, endArray);
+
+					return new GenState(
+						state.code().append(delete ? "D:" : useUpsert ? "U:" : "I:").append(key).append(' '),
+						endArray,
+						state.limitReached()
+							? endArray.length > LIMIT_ELEMENTS / 2
+							: endArray.length >= LIMIT_ELEMENTS
+					);
+				} catch (Exception ex) {
+					fail(
+						"Failed to " + (delete ? "delete" : useUpsert ? "upsert" : "insert") + " key " + key
+							+ " for seed " + seed,
+						ex
+					);
+					throw ex;
+				}
+			}
+		);
+	}
+
+	@ParameterizedTest(
+		name = "TransactionalIntToLongBPlusTree should survive transactional generational insert/upsert/delete churn"
+	)
+	@Tag(SLOW)
+	@ArgumentsSource(TimeArgumentProvider.class)
+	@DisplayName("survives randomized transactional insert/upsert/delete churn swept cleanly on commit")
+	void generationalTransactionalProofTest(@Nonnull GenerationalTestInput input) {
+		final long seed = input.randomSeed();
+		// print the seed so a failing run can be reproduced deterministically
+		System.out.println("LongRunningTransactionalIntToLongBPlusTreeTest (transactional) seed: " + seed);
+
+		final Random seedRandom = new Random(seed);
+		final TreeSet<Integer> initialReference = new TreeSet<>();
+		do {
+			initialReference.add(seedRandom.nextInt(LIMIT_ELEMENTS << 1));
+		} while (initialReference.size() < LIMIT_ELEMENTS);
+
+		runFor(
+			input, 1000, new GenState(new StringBuilder(512), toArray(initialReference), true),
+			(random, state) -> {
+				// draw a small block size per generation so every generation is a high-split-density tree
+				final int blockSize = BLOCK_SIZES[random.nextInt(BLOCK_SIZES.length)];
+				final int[] startKeys = state.keys();
+				final TransactionalIntToLongBPlusTree tree = buildTree(startKeys, blockSize);
+				verifyTreeConsistency(tree, startKeys);
+
+				// oracle mutated in lockstep with the transaction; verified against the committed tree
+				final TreeSet<Integer> oracle = new TreeSet<>();
+				for (final int key : startKeys) {
+					oracle.add(key);
+				}
+				final AtomicReference<int[]> committedKeys = new AtomicReference<>();
+				final StringBuilder code = state.code();
+				code.setLength(0);
+
+				try {
+					assertStateAfterCommit(
+						tree,
+						original -> {
+							final int operations = 1 + random.nextInt(6);
+							for (int op = 0; op < operations; op++) {
+								final boolean delete =
+									(!oracle.isEmpty() && random.nextInt(3) == 0)
+										|| (state.limitReached() && oracle.size() > LIMIT_ELEMENTS / 2);
+								if (delete) {
+									final int key = pickRandomKey(oracle, random);
+									original.delete(key);
+									oracle.remove(key);
+									code.append("D:").append(key).append(' ');
+								} else {
+									final int key = random.nextInt(LIMIT_ELEMENTS << 1);
+									if (random.nextBoolean()) {
+										original.insert(key, valueOf(key));
+										code.append("I:").append(key).append(' ');
+									} else {
+										// value-preserving upsert keeps the oracle exact on both insert and update
+										original.upsert(key, existing -> valueOf(key));
+										code.append("U:").append(key).append(' ');
+									}
+									oracle.add(key);
+								}
+							}
+						},
+						(original, committed) -> {
+							final int[] expectedKeys = toArray(oracle);
+							verifyTreeConsistency(committed, expectedKeys);
+							committedKeys.set(expectedKeys);
+						}
+					);
+				} catch (Exception ex) {
+					fail(
+						"Generation failed for seed " + seed + " blockSize=" + blockSize
+							+ " with operations [" + code + "]",
+						ex
+					);
+					throw ex;
+				}
+
+				final int[] nextKeys = committedKeys.get();
+				return new GenState(
+					state.code(),
+					nextKeys,
+					state.limitReached()
+						? nextKeys.length > LIMIT_ELEMENTS / 2
+						: nextKeys.length >= LIMIT_ELEMENTS
+				);
+			}
+		);
+	}
+
+	/**
+	 * Picks a random key present in the reference double.
+	 *
+	 * @param reference the reference double
+	 * @param random    the randomizer
+	 * @return a key that currently exists in the reference
+	 */
+	private static int pickRandomKey(@Nonnull TreeSet<Integer> reference, @Nonnull Random random) {
+		final int index = random.nextInt(reference.size());
+		final Iterator<Integer> it = reference.iterator();
+		int key = 0;
+		for (int i = 0; i <= index; i++) {
+			key = it.next();
+		}
+		return key;
+	}
+
+	/**
+	 * Converts an ascending set of keys into a sorted primitive array.
+	 *
+	 * @param set the ascending key set
+	 * @return the ascending keys
+	 */
+	@Nonnull
+	private static int[] toArray(@Nonnull TreeSet<Integer> set) {
+		final int[] array = new int[set.size()];
+		int index = 0;
+		for (final Integer value : set) {
+			array[index++] = value;
+		}
+		return array;
+	}
+
+	/**
+	 * Carries the chained generation state: the running operation log, the committed ascending key snapshot fed to the
+	 * next generation and whether the element-count growth limit has been reached.
+	 *
+	 * @param code         the running operation log used for failure reproduction
+	 * @param keys         the committed ascending key snapshot
+	 * @param limitReached whether the growth limit has been reached (switches the churn to delete-biased)
+	 */
+	private record GenState(
+		@Nonnull StringBuilder code,
+		@Nonnull int[] keys,
+		boolean limitReached
+	) {
+	}
+}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/bPlusTree/LongRunningTransactionalLongBPlusTreeTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/bPlusTree/LongRunningTransactionalLongBPlusTreeTest.java
@@ -31,6 +31,7 @@ import io.evitadb.index.bitmap.TransactionalBitmap;
 import io.evitadb.test.duration.TimeArgumentProvider;
 import io.evitadb.test.duration.TimeArgumentProvider.GenerationalTestInput;
 import io.evitadb.test.duration.TimeBoundedTestSupport;
+import io.evitadb.utils.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,6 +51,8 @@ import static io.evitadb.test.TestTags.TRANSACTION;
 import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -71,18 +74,27 @@ import static org.junit.jupiter.api.Assertions.fail;
 class LongRunningTransactionalLongBPlusTreeTest implements TimeBoundedTestSupport {
 
 	/**
-	 * Builds a fresh transactional tree holding a producer-bitmap value per key from the given reference snapshot.
+	 * Block sizes drawn per generation in the transactional axis; all odd (internal-node constraint) and small enough
+	 * to force frequent splits and merges - the churn density where the dirty-scope validation is exercised.
+	 */
+	private static final int[] BLOCK_SIZES = {3, 5, 7};
+
+	/**
+	 * Builds a fresh transactional tree of the given block size holding a producer-bitmap value per key from the given
+	 * reference snapshot. The small block size forces frequent leaf splits and merges.
 	 *
 	 * @param reference the key to bitmap-contents snapshot
+	 * @param blockSize the leaf and internal node block size
 	 * @return a tree seeded with the snapshot
 	 */
 	@Nonnull
 	private static TransactionalLongBPlusTree<TransactionalBitmap> buildTree(
-		@Nonnull TreeMap<Long, int[]> reference
+		@Nonnull TreeMap<Long, int[]> reference, int blockSize
 	) {
 		// the committed state of a TransactionalBitmap is a plain Bitmap, so the wrapper must reconstruct a
 		// fresh TransactionalBitmap from it on every commit (mirroring how production indexes wrap producer values)
 		final TransactionalLongBPlusTree<TransactionalBitmap> tree = new TransactionalLongBPlusTree<>(
+			blockSize, 1, blockSize, 1,
 			TransactionalBitmap.class,
 			o -> o instanceof TransactionalBitmap transactionalBitmap
 				? transactionalBitmap
@@ -153,7 +165,7 @@ class LongRunningTransactionalLongBPlusTreeTest implements TimeBoundedTestSuppor
 				for (final Map.Entry<Long, int[]> entry : testState.reference().entrySet()) {
 					reference.put(entry.getKey(), entry.getValue().clone());
 				}
-				final TransactionalLongBPlusTree<TransactionalBitmap> tree = buildTree(reference);
+				final TransactionalLongBPlusTree<TransactionalBitmap> tree = buildTree(reference, BLOCK_SIZES[random.nextInt(BLOCK_SIZES.length)]);
 				verifyTreeMatchesReference(tree, reference);
 
 				final AtomicReference<TreeMap<Long, int[]>> committedReference = new AtomicReference<>();
@@ -181,9 +193,21 @@ class LongRunningTransactionalLongBPlusTreeTest implements TimeBoundedTestSuppor
 									final long key = random.nextInt(limitElements << 1);
 									final int[] existing = reference.get(key);
 									if (existing == null) {
-										original.insert(key, new TransactionalBitmap(new int[]{(int) key}));
+										if (random.nextBoolean()) {
+											original.insert(key, new TransactionalBitmap(new int[]{(int) key}));
+											code.append("I:").append(key).append(' ');
+										} else {
+											// value-preserving upsert exercises the insert-or-update public path; the
+											// updater's null branch inserts a fresh producer value (and may split the leaf)
+											original.upsert(
+												key,
+												existingValue -> existingValue == null
+													? new TransactionalBitmap(new int[]{(int) key})
+													: existingValue
+											);
+											code.append("U:").append(key).append(' ');
+										}
 										reference.put(key, new int[]{(int) key});
-										code.append("I:").append(key).append(' ');
 									} else {
 										// mutate the existing producer value in place (mutate-and-keep-instance)
 										final int extra = (int) (limitElements * 2 + key);
@@ -222,6 +246,103 @@ class LongRunningTransactionalLongBPlusTreeTest implements TimeBoundedTestSuppor
 		);
 	}
 
+	@ParameterizedTest(
+		name = "TransactionalLongBPlusTree should survive non-transactional generational insert/upsert/delete churn"
+	)
+	@Tag(SLOW)
+	@ArgumentsSource(TimeArgumentProvider.class)
+	@DisplayName("survives randomized non-transactional (warm-up) insert/upsert/delete churn")
+	void generationalWarmUpProofTest(@Nonnull GenerationalTestInput input) {
+		final int limitElements = 1000;
+		final long seed = input.randomSeed();
+		// print the seed so a failing run can be reproduced deterministically
+		System.out.println("LongRunningTransactionalLongBPlusTreeTest (warm-up) seed: " + seed);
+
+		// one long-lived bare tree of plain String values churned directly (no transaction) at a small block size so
+		// splits / merges are dense; the value is deterministically derived from the key so a bare key set is a
+		// sufficient reference double and a value-preserving upsert keeps it exact
+		final TransactionalLongBPlusTree<String> tree = new TransactionalLongBPlusTree<>(3, 1, 3, 1, String.class);
+		final Random seedRandom = new Random(seed);
+		int[] initialKeys = new int[0];
+		do {
+			final int key = seedRandom.nextInt(limitElements << 1);
+			tree.insert(key, "Value" + key);
+			initialKeys = ArrayUtils.insertIntIntoOrderedArray(key, initialKeys);
+		} while (initialKeys.length < limitElements);
+		verifyStringTreeMatches(tree, initialKeys);
+
+		runFor(
+			input, 1000, new WarmUpState(new StringBuilder(512), initialKeys, true),
+			(random, state) -> {
+				final int[] startArray = state.keys();
+				int key = -1;
+				final boolean delete =
+					(startArray.length > 0 && random.nextInt(3) == 0)
+						|| (state.limitReached() && startArray.length > limitElements / 2);
+				final boolean useUpsert = !delete && random.nextBoolean();
+				try {
+					final int[] endArray;
+					if (delete) {
+						key = startArray[random.nextInt(startArray.length)];
+						endArray = ArrayUtils.removeIntFromOrderedArray(key, startArray);
+						tree.delete(key);
+					} else {
+						key = random.nextInt(limitElements << 1);
+						endArray = ArrayUtils.insertIntIntoOrderedArray(key, startArray);
+						if (useUpsert) {
+							// value-preserving upsert exercises the insert-or-update public path (may split the leaf)
+							final int upsertKey = key;
+							tree.upsert(upsertKey, existing -> "Value" + upsertKey);
+						} else {
+							tree.insert(key, "Value" + key);
+						}
+					}
+
+					verifyStringTreeMatches(tree, endArray);
+
+					return new WarmUpState(
+						state.code().append(delete ? "D:" : useUpsert ? "U:" : "I:").append(key).append(' '),
+						endArray,
+						state.limitReached()
+							? endArray.length > limitElements / 2
+							: endArray.length >= limitElements
+					);
+				} catch (Exception ex) {
+					fail(
+						"Failed to " + (delete ? "delete" : useUpsert ? "upsert" : "insert") + " key " + key
+							+ " for seed " + seed,
+						ex
+					);
+					throw ex;
+				}
+			}
+		);
+	}
+
+	/**
+	 * Verifies the String-valued tree reports a CONSISTENT internal state and that its forward entry iteration matches
+	 * the expected ascending key array exactly, including the deterministically-derived value per key.
+	 *
+	 * @param tree         the tree to verify
+	 * @param expectedKeys the expected ascending key array
+	 */
+	private static void verifyStringTreeMatches(
+		@Nonnull TransactionalLongBPlusTree<String> tree, @Nonnull int[] expectedKeys
+	) {
+		final ConsistencyReport report = tree.getConsistencyReport();
+		assertEquals(ConsistencyState.CONSISTENT, report.state(), report.report());
+		assertEquals(expectedKeys.length, tree.size(), "Size mismatch between tree and reference!");
+
+		final Iterator<Entry<String>> it = tree.entryIterator();
+		for (int i = 0; i < expectedKeys.length; i++) {
+			assertTrue(it.hasNext(), "Tree iterator exhausted before reference at " + i);
+			final Entry<String> entry = it.next();
+			assertEquals(expectedKeys[i], entry.key(), "Key order mismatch at " + i);
+			assertEquals("Value" + expectedKeys[i], entry.value(), "Value mismatch for key " + expectedKeys[i]);
+		}
+		assertFalse(it.hasNext(), "Tree iterator has more entries than reference!");
+	}
+
 	/**
 	 * Picks a random key present in the reference double.
 	 *
@@ -251,6 +372,21 @@ class LongRunningTransactionalLongBPlusTreeTest implements TimeBoundedTestSuppor
 	private record TestState(
 		@Nonnull StringBuilder code,
 		@Nonnull TreeMap<Long, int[]> reference,
+		boolean limitReached
+	) {
+	}
+
+	/**
+	 * Carries the chained warm-up generation state: the running operation log, the committed ascending key snapshot and
+	 * whether the element-count growth limit has been reached.
+	 *
+	 * @param code         the running operation log used for failure reproduction
+	 * @param keys         the committed ascending key snapshot fed to the next generation
+	 * @param limitReached whether the growth limit has been reached (switches the churn to delete-biased)
+	 */
+	private record WarmUpState(
+		@Nonnull StringBuilder code,
+		@Nonnull int[] keys,
 		boolean limitReached
 	) {
 	}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/bPlusTree/LongRunningTransactionalObjectBPlusTreeTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/bPlusTree/LongRunningTransactionalObjectBPlusTreeTest.java
@@ -41,12 +41,15 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.evitadb.test.TestTags.COMPARATOR;
 import static io.evitadb.test.TestTags.DATA_TYPE;
 import static io.evitadb.test.TestTags.INDEXING;
 import static io.evitadb.test.TestTags.SLOW;
 import static io.evitadb.test.TestTags.TRANSACTION;
+import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -62,6 +65,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Tag(DATA_TYPE)
 @Tag(TRANSACTION)
 class LongRunningTransactionalObjectBPlusTreeTest implements TimeBoundedTestSupport {
+	/**
+	 * Block sizes drawn per generation in the transactional axis; all odd (internal-node constraint) and small enough
+	 * to force frequent splits and merges.
+	 */
+	private static final int[] BLOCK_SIZES = {3, 5, 7};
 
 	@ParameterizedTest(
 		name = "TransactionalObjectBPlusTreeTest should survive generational randomized test applying "
@@ -86,6 +94,7 @@ class LongRunningTransactionalObjectBPlusTreeTest implements TimeBoundedTestSupp
 				final boolean delete =
 					(startArray.length > 0 && random.nextInt(3) == 0)
 						|| (testState.limitReached() && startArray.length > limitElements / 2);
+				final boolean useUpsert = !delete && random.nextBoolean();
 
 				try {
 					if (delete) {
@@ -96,13 +105,19 @@ class LongRunningTransactionalObjectBPlusTreeTest implements TimeBoundedTestSupp
 					} else {
 						key = random.nextInt(limitElements * 2);
 						endArray = ArrayUtils.insertIntIntoOrderedArray(key, startArray);
-						theTree.insert(key, "Value" + key);
+						if (useUpsert) {
+							// value-preserving upsert exercises the insert-or-update public path (may split the leaf)
+							final int upsertKey = key;
+							theTree.upsert(upsertKey, existing -> "Value" + upsertKey);
+						} else {
+							theTree.insert(key, "Value" + key);
+						}
 					}
 
 					verifyTreeConsistency(theTree, endArray);
 
 					return new TestState(
-						testState.code().append(delete ? "D:" : "I:").append(key),
+						testState.code().append(delete ? "D:" : useUpsert ? "U:" : "I:").append(key),
 						endArray,
 						testState.limitReached()
 							? endArray.length > limitElements / 2
@@ -110,7 +125,7 @@ class LongRunningTransactionalObjectBPlusTreeTest implements TimeBoundedTestSupp
 					);
 				} catch (Exception ex) {
 					fail(
-						"Failed to " + (delete ? "delete" : "insert") + " key " + key
+						"Failed to " + (delete ? "delete" : useUpsert ? "upsert" : "insert") + " key " + key
 							+ " with initial state: " + theTree,
 						ex
 					);
@@ -183,6 +198,149 @@ class LongRunningTransactionalObjectBPlusTreeTest implements TimeBoundedTestSupp
 				}
 			}
 		);
+	}
+
+	@ParameterizedTest(
+		name = "TransactionalObjectBPlusTreeTest should survive transactional generational insert/upsert/delete churn"
+	)
+	@Tag(SLOW)
+	@ArgumentsSource(TimeArgumentProvider.class)
+	@DisplayName("survives randomized transactional insert/upsert/delete churn swept cleanly on commit")
+	void generationalTransactionalProofTest(@Nonnull GenerationalTestInput input) {
+		final int limitElements = 1000;
+		final long seed = input.randomSeed();
+		// print the seed so a failing run can be reproduced deterministically
+		System.out.println("LongRunningTransactionalObjectBPlusTreeTest (transactional) seed: " + seed);
+
+		final Random seedRandom = new Random(seed);
+		final TreeSet<Integer> initialReference = new TreeSet<>();
+		do {
+			initialReference.add(seedRandom.nextInt(limitElements << 1));
+		} while (initialReference.size() < limitElements);
+
+		runFor(
+			input, 1000, new TestState(new StringBuilder(512), toArray(initialReference), true),
+			(random, testState) -> {
+				// draw a small block size per generation so every generation is a high-split-density tree
+				final int blockSize = BLOCK_SIZES[random.nextInt(BLOCK_SIZES.length)];
+				final int[] startKeys = testState.initialArray();
+				final TransactionalObjectBPlusTree<Integer, String> tree = buildTree(startKeys, blockSize);
+				verifyTreeConsistency(tree, startKeys);
+
+				// oracle mutated in lockstep with the transaction; verified against the committed tree
+				final TreeSet<Integer> oracle = new TreeSet<>();
+				for (final int key : startKeys) {
+					oracle.add(key);
+				}
+				final AtomicReference<int[]> committedKeys = new AtomicReference<>();
+				final StringBuilder code = testState.code();
+				code.setLength(0);
+
+				try {
+					assertStateAfterCommit(
+						tree,
+						original -> {
+							final int operations = 1 + random.nextInt(6);
+							for (int op = 0; op < operations; op++) {
+								final boolean delete =
+									(!oracle.isEmpty() && random.nextInt(3) == 0)
+										|| (testState.limitReached() && oracle.size() > limitElements / 2);
+								if (delete) {
+									final int key = pickRandomKey(oracle, random);
+									original.delete(key);
+									oracle.remove(key);
+									code.append("D:").append(key).append(' ');
+								} else {
+									final int key = random.nextInt(limitElements << 1);
+									if (random.nextBoolean()) {
+										original.insert(key, "Value" + key);
+										code.append("I:").append(key).append(' ');
+									} else {
+										// value-preserving upsert keeps the oracle exact on both insert and update
+										original.upsert(key, existing -> "Value" + key);
+										code.append("U:").append(key).append(' ');
+									}
+									oracle.add(key);
+								}
+							}
+						},
+						(original, committed) -> {
+							final int[] expectedKeys = toArray(oracle);
+							verifyTreeConsistency(committed, expectedKeys);
+							committedKeys.set(expectedKeys);
+						}
+					);
+				} catch (Exception ex) {
+					fail(
+						"Generation failed for seed " + seed + " blockSize=" + blockSize
+							+ " with operations [" + code + "]",
+						ex
+					);
+					throw ex;
+				}
+
+				final int[] nextKeys = committedKeys.get();
+				return new TestState(
+					testState.code(),
+					nextKeys,
+					testState.limitReached()
+						? nextKeys.length > limitElements / 2
+						: nextKeys.length >= limitElements
+				);
+			}
+		);
+	}
+
+	/**
+	 * Builds a fresh object tree of the given block size holding one deterministic value per key from the given
+	 * ascending key set.
+	 *
+	 * @param keys      the ascending distinct keys
+	 * @param blockSize the leaf and internal node block size
+	 * @return a tree seeded with `"Value" + key` per key
+	 */
+	@Nonnull
+	private static TransactionalObjectBPlusTree<Integer, String> buildTree(@Nonnull int[] keys, int blockSize) {
+		final TransactionalObjectBPlusTree<Integer, String> tree = new TransactionalObjectBPlusTree<>(
+			blockSize, 1, blockSize, 1, Integer.class, String.class
+		);
+		for (final int key : keys) {
+			tree.insert(key, "Value" + key);
+		}
+		return tree;
+	}
+
+	/**
+	 * Picks a random key present in the reference double.
+	 *
+	 * @param reference the reference double
+	 * @param random    the randomizer
+	 * @return a key that currently exists in the reference
+	 */
+	private static int pickRandomKey(@Nonnull TreeSet<Integer> reference, @Nonnull Random random) {
+		final int index = random.nextInt(reference.size());
+		final Iterator<Integer> it = reference.iterator();
+		int key = 0;
+		for (int i = 0; i <= index; i++) {
+			key = it.next();
+		}
+		return key;
+	}
+
+	/**
+	 * Converts an ascending set of keys into a sorted primitive array.
+	 *
+	 * @param set the ascending key set
+	 * @return the ascending keys
+	 */
+	@Nonnull
+	private static int[] toArray(@Nonnull TreeSet<Integer> set) {
+		final int[] array = new int[set.size()];
+		int index = 0;
+		for (final Integer value : set) {
+			array[index++] = value;
+		}
+		return array;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Wait for async catalog initialization before hammering a freshly constructed `Evita` instance with 30 parallel generator threads in `shouldBackupAndRestoreCatalogDuringHeavyParallelIndexing`/`...IncludingWal` — fixes a flaky `CatalogTransitioningException` (`BEING_ACTIVATED`) surfaced in CI on the original catalog.
- Rework B+ tree dirty-scope validation so the registry keeps per-participant probe keys instead of node objects, eliminating a `NullPointerException` bug class in commit-time validation.
- Reclaim the on-disk footprint of dropped and emptied indexes (two leak classes: whole-index drop, and sub-index churn-vanish).
- Stop building trace span names while tracing is disabled, avoiding unnecessary allocation on the hot path.

## Test plan
- [x] `evita_long_running_tests` module compiles
- [x] `LongRunningEvitaTransactionalFunctionalTest#shouldBackupAndRestoreCatalogDuringHeavyParallelIndexing` and `...IncludingWal` pass locally
- [x] `LongRunningEvitaReferencesGenerationalTest#shouldNotSurfaceReducedReferenceIndexDriftForSeed1623796816` passes locally (verifies the dirty-scope validation fix)