### PR TITLE
fix: replace dropped NOT branch with EmptyFormula in FormulaOptimizer

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/FormulaOptimizer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/FormulaOptimizer.java
@@ -96,8 +96,12 @@ public class FormulaOptimizer extends FormulaCloner implements FormulaPostProces
 				Formula optimizedSuperset = this.formulasProcessed.get(originalSuperset);
 
 				// Case 1: Superset became Empty or Null -> Result is Empty
+				// the node must be replaced by EmptyFormula, never dropped - `null` instructs the cloner to
+				// remove the child from its parent, which widens an enclosing conjunction (`A AND nothing`
+				// would degrade to `A`) instead of emptying it; EmptyFormula is the absorbing element of
+				// a conjunction and the identity element of a disjunction, so it is correct in both scopes
 				if (optimizedSuperset == null || optimizedSuperset instanceof EmptyFormula) {
-					formulaToStore = null;
+					formulaToStore = EmptyFormula.INSTANCE;
 				}
 				// Case 2: Superset exists, but Subtracted is gone (set size is 1) -> Result is Superset
 				else if (updatedChildren.size() == 1) {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/AbstractEntityByAttributeFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/AbstractEntityByAttributeFilteringFunctionalTest.java
@@ -412,6 +412,44 @@ public abstract class AbstractEntityByAttributeFilteringFunctionalTest {
 		);
 	}
 
+	@DisplayName("Should return no entities when an unsatisfiable nested AND contains a NOT constraint")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnNoEntitiesWhenUnsatisfiableNestedAndContainsNotConstraint(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								// this constraint alone matches a non-empty set of entities
+								attributeIsNotNull(ATTRIBUTE_PRIORITY),
+								and(
+									// no entity carries this priority, so the nested conjunction matches nothing
+									attributeEquals(ATTRIBUTE_PRIORITY, Long.MIN_VALUE),
+									not(
+										attributeEquals(ATTRIBUTE_ALIAS, false)
+									)
+								)
+							)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				// the nested conjunction is unsatisfiable, so the entire query must match nothing - the negated
+				// branch must not disappear from the conjunction and leave its sibling matching on its own
+				assertEquals(0, result.getTotalRecordCount());
+				return null;
+			}
+		);
+	}
+
 	@DisplayName("Should return entities by matching locale")
 	@UseDataSet(HUNDRED_PRODUCTS)
 	@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/filter/FormulaOptimizerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/filter/FormulaOptimizerTest.java
@@ -473,6 +473,29 @@ class FormulaOptimizerTest {
 		}
 
 		@Test
+		@DisplayName("NOT whose superset collapses to empty must not vanish from an enclosing AND")
+		void notWithCollapsingSupersetInsideAnd_shouldCollapseWholeConjunctionToEmpty() {
+			final ConstantFormula sibling = constant(1, 2, 3);
+			final ConstantFormula subtracted = constant(2);
+			// the superset is not empty to begin with - it only collapses to EmptyFormula during optimization,
+			// which is what makes the optimizer drop the NotFormula node instead of replacing it
+			final Formula supersetCollapsingToEmpty = new AndFormula(
+				constant(4, 5),
+				EmptyFormula.INSTANCE
+			);
+
+			final Formula input = new AndFormula(
+				sibling,
+				new NotFormula(subtracted, supersetCollapsingToEmpty)
+			);
+			final Formula result = optimize(input);
+
+			// dropping the negated branch would widen the conjunction to the sibling alone
+			assertArrayEquals(input.compute().getArray(), result.compute().getArray());
+			assertArrayEquals(new int[0], result.compute().getArray());
+		}
+
+		@Test
 		@DisplayName("NOT with both children surviving should preserve semantics")
 		void notWithBothChildrenSurviving_shouldPreserveSemantics() {
 			final ConstantFormula a = constant(1, 2);


### PR DESCRIPTION
Backport of the `FormulaOptimizer` fix to `release_2026-1`. Identical one-line change to the one landed on `dev`.

## Problem

A query combining an unsatisfiable branch with a `not()` returned rows matching none of the requested constraints:

```
filterBy(
  attributeInSet("status", "ACTIVE"),
  and(
    attributeEquals("status", "NO_SUCH_VALUE"),  // empty -> nested and() is unsatisfiable
    not(attributeInSet("status", "INACTIVE"))
  )
)
```

Expected 0, returned the full `status = ACTIVE` set.

`FormulaOptimizer` removed the `NotFormula` node from the tree when its superset collapsed to `EmptyFormula` during optimization. `null` is the `FormulaCloner` signal for "remove this child from the parent" — under a conjunctive parent that widens the result instead of emptying it, so the surviving siblings matched on their own. The drop cascaded: a container left childless was dropped too, propagating up to the first level with a surviving sibling.

## Fix

Store `EmptyFormula.INSTANCE` instead of `null`. `EmptyFormula` is the absorbing element of a conjunction and the identity element of a disjunction, so it is correct under either parent scope and no scope check is needed.

## Verification

Both reproduction tests were confirmed **failing** on unmodified `release_2026-1` before the fix, with the same signatures seen on `dev`:

```
Tests run: 177, Failures: 2, Errors: 0
  shouldReturnNoEntitiesWhenUnsatisfiableNestedAndContainsNotConstraint
    expected: <0> but was: <100>     (the entire collection leaked)
  notWithCollapsingSupersetInsideAnd_shouldCollapseWholeConjunctionToEmpty
    array lengths differ, expected: <0> but was: <3>
```

After the fix: `Tests run: 177, Failures: 0, Errors: 0`.

The existing `notWhereSupersetBecomesEmpty_shouldReturnEmpty` passed throughout, because it places the `NotFormula` at the root of the optimized tree where `getPostProcessedFormula` maps the dropped `null` back to `EmptyFormula`. Both added tests put the node under a conjunctive parent with a surviving sibling, which is the only position where the defect is observable.

Ref: #1309
