### PR TITLE
Pending fixes: query-optimizer NOT leak, index-layer refactors, perf and robustness

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -57,6 +57,18 @@ The test suite is split across four sibling modules under `evita_test/`:
 - **Slow / long-running tests** — `rtk mvn -P longRunning`. Same pattern as `documentation`; selects only the long-running module.
 - **Picking the right tags for a code change** — map the changed source path to layer + capability tags. For example, a change under `evita_engine/src/main/java/io/evitadb/index/facet/` calls for `(facet | indexing) & !slow`; under `evita_external_api/evita_external_api_rest/` use `rest & external_api`. The full path-to-tag mapping is documented in the `TestTags` JavaDoc and in the bulk-tagging script committed during the rollout.
 
+## Reading test results — three traps
+
+These bite when running a **targeted** class from the command line and reading the outcome. All three make a green, correct change *look* broken or unrun:
+
+- **`@Nested`-only classes report `Tests run: 0` in the outer `.txt`.** The convention here is to consolidate methods into `@Nested` inner classes (see above), so most test classes have **no** direct `@Test` methods. Surefire then writes the outer-class report (`target/surefire-reports/io.evitadb.<...>.<Class>.txt`) as `Tests run: 0` and reports each nested class separately under its own `@DisplayName`. **Do not conclude "nothing ran" from the outer `.txt`.** The real number is the run's aggregate stdout line (`[INFO] Tests run: 138, Failures: 0, …`). Capture full stdout to a file and read that aggregate, or sum the per-`@DisplayName` lines — never trust the outer `.txt` alone.
+- **The default reactor skips tests entirely.** The base surefire config sets `skipTests`, flipped on only by a profile — so a bare `mvn -pl evita_test/evita_functional_tests test` (no `-P`) runs **zero** tests and still reports `BUILD SUCCESS`. Always pass `-P unitAndFunctional` (fast loop) for functional/unit tests. Zero-count + success without the profile is the tell.
+- **Stale `~/.m2` engine jar after a signature change.** A dependent test module resolves `evita_engine` from `~/.m2`, not from its freshly-compiled `target/classes`. After any signature / type-parameter / method change in `evita_engine`, reinstall it before running dependent-module tests:
+  ```bash
+  rtk mvn -o -pl evita_engine install -DskipTests
+  ```
+  Skip this and the failure surfaces as a **compile** error in the test module (e.g. `wrong number of type arguments; required 3`, `NoSuchMethodError`) that points at test code which is actually fine — the stale binary is the real cause.
+
 ## Test performance — reuse shared datasets
 
 Booting an embedded evitaDB instance and building a catalog is the dominant cost in a test; amortise it rather than paying it per method (see `@DataSet` / `@UseDataSet` in `io.evitadb.test.annotation`):

--- a/evita_common/src/main/java/io/evitadb/comparator/CollationKeyCache.java
+++ b/evita_common/src/main/java/io/evitadb/comparator/CollationKeyCache.java
@@ -59,11 +59,15 @@ import java.util.concurrent.ConcurrentHashMap;
  * - **per-thread collators** - `RuleBasedCollator.getCollationKey` is `synchronized`, therefore
  *   each thread computes keys on its own {@link Collator} instance, keeping cache misses
  *   monitor-free under concurrent indexing;
- * - **memory bound** - `slots` entries per locale (default 8192, roughly 2 MB warm for typical
- *   attribute value lengths), created lazily only for locales that actually collate; the system
- *   property `evita.collationKeyCache.size` resizes the cache (values round down to a power of
- *   two) and `0` disables it entirely, making comparators delegate straight to
- *   {@link Collator#compare(String, String)}.
+ * - **memory bound** - `slots` entries per locale, created lazily only for locales that actually
+ *   collate. The default slot count is derived from the maximum heap size (see {@link #defaultSize()}),
+ *   because a value large enough to cover a real e-commerce corpus would be disproportionate for a
+ *   small embedded deployment; the system property `evita.collationKeyCache.size` overrides it
+ *   (values round down to a power of two and are capped at {@link #MAX_SIZE}) and `0` disables the
+ *   cache entirely, making comparators delegate straight to {@link Collator#compare(String, String)}.
+ *   Only the slot array is allocated eagerly (`slots × reference size`); entries themselves are
+ *   filled on demand, so the full footprint is reached only by a corpus large enough to fill the
+ *   cache. Both bounds are **per locale**.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
@@ -74,6 +78,25 @@ final class CollationKeyCache implements Serializable {
 	 * Name of the system property controlling the per-locale slot count.
 	 */
 	static final String SIZE_PROPERTY = "evita.collationKeyCache.size";
+	/**
+	 * Hard upper bound on the per-locale slot count; measurement showed the hit rate flattening at
+	 * this size on a real ~1M-product localized catalog, so a larger cache buys nothing.
+	 */
+	private static final int MAX_SIZE = 1 << 20;
+	/**
+	 * Lower bound of the heap-derived default; also the historical fixed default.
+	 */
+	private static final int MIN_DEFAULT_SIZE = 8192;
+	/**
+	 * Fraction of the maximum heap (as a divisor) budgeted for one locale's fully populated cache.
+	 */
+	private static final int DEFAULT_HEAP_SHARE_DIVISOR = 50;
+	/**
+	 * Estimated retained size of a single populated entry in bytes - a {@link CachedKey} record plus
+	 * its collation-key byte array. Collation keys measure roughly 6.5 bytes per character, so this
+	 * corresponds to attribute values of about thirty characters.
+	 */
+	private static final int ESTIMATED_ENTRY_SIZE = 256;
 	/**
 	 * Registry of per-locale caches; populated lazily, never evicted (the locale count is bounded
 	 * by the catalog schemas).
@@ -112,13 +135,51 @@ final class CollationKeyCache implements Serializable {
 
 	/**
 	 * Resolves the configured per-locale slot count, rounding down to a power of two so that slot
-	 * selection can use bit masking, and capping it to keep the worst-case footprint sane.
+	 * selection can use bit masking, and capping it to keep the worst-case footprint sane. When the
+	 * property is not set at all, the default is derived from the heap size (see
+	 * {@link #defaultSize()}).
 	 *
 	 * @return slot count per locale; zero when caching is disabled
 	 */
 	private static int resolveSize() {
-		final int configured = Integer.getInteger(SIZE_PROPERTY, 8192);
-		return configured <= 0 ? 0 : Integer.highestOneBit(Math.min(configured, 1 << 20));
+		final Integer configured = Integer.getInteger(SIZE_PROPERTY);
+		if (configured == null) {
+			return defaultSize();
+		}
+		return configured <= 0 ? 0 : Integer.highestOneBit(Math.min(configured, MAX_SIZE));
+	}
+
+	/**
+	 * Derives the default per-locale slot count from the maximum heap size.
+	 *
+	 * A fixed default cannot serve both ends of the deployment range: measurement on a real
+	 * ~1M-product localized catalog showed the previous fixed default of 8192 slots covering only a
+	 * fraction of the pivot working set (nearly every B+ tree comparison recomputed a full collation
+	 * key), and raising it to {@link #MAX_SIZE} made that workload **2x** faster - while the same
+	 * value on a small embedded deployment would reserve memory out of all proportion to its corpus.
+	 *
+	 * Heap size is used as the proxy for corpus size, because the two correlate in practice and the
+	 * corpus is not known when this class is loaded. The budget is {@link #DEFAULT_HEAP_SHARE_DIVISOR}
+	 * of the maximum heap, divided by the {@link #ESTIMATED_ENTRY_SIZE} average cost of one entry.
+	 *
+	 * Note that entries are populated **lazily**, so this bound is a ceiling that only a corpus large
+	 * enough to fill the cache ever reaches; a small corpus pays just the slot array
+	 * (`slots × reference size`) regardless of how large the default is. The bound is **per locale**,
+	 * so deployments with many localized attribute values should size the cache explicitly through
+	 * the `evita.collationKeyCache.size` system property.
+	 *
+	 * @return slot count per locale, clamped to [{@link #MIN_DEFAULT_SIZE}, {@link #MAX_SIZE}]
+	 */
+	private static int defaultSize() {
+		final long budgetBytes = Runtime.getRuntime().maxMemory() / DEFAULT_HEAP_SHARE_DIVISOR;
+		final long slots = budgetBytes / ESTIMATED_ENTRY_SIZE;
+		if (slots <= MIN_DEFAULT_SIZE) {
+			return MIN_DEFAULT_SIZE;
+		} else if (slots >= MAX_SIZE) {
+			return MAX_SIZE;
+		} else {
+			return Integer.highestOneBit((int) slots);
+		}
 	}
 
 	/**

--- a/evita_common/src/main/java/io/evitadb/utils/FileUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/FileUtils.java
@@ -298,14 +298,26 @@ public class FileUtils {
 	/**
 	 * Returns the size of the specified directory in bytes.
 	 *
+	 * A directory that does not exist occupies no space and therefore reports zero. This is a legitimate
+	 * outcome for every caller of this method - all of them are reporting / metrics consumers that only need
+	 * a byte count. The absence of the folder itself is signalled through other, dedicated channels
+	 * (`CatalogState#MISSING` and the `unusable` flag of `CatalogStatistics`, the transitional catalog states
+	 * for folders that are not created yet or are already deleted), so short-circuiting here hides nothing.
+	 *
 	 * @param directory The path to the directory.
-	 * @return The size of the directory in bytes.
+	 * @return The size of the directory in bytes, zero when the directory does not exist.
 	 */
 	public static long getDirectorySize(@Nonnull Path directory) {
 		// calculate size of all bytes in particular directory
 		Exception ex = null;
 		// we implement a retry logic - the walker fails to calculate folder size when file is removed during the walk
 		for (int i = 0; i < 5; i++) {
+			// a missing directory has a well-defined size of zero - the walker fails hard on an absent root and no
+			// amount of retries can recover from it; the check is repeated on every pass so that a folder removed
+			// between two attempts is resolved the same way instead of exhausting the retries
+			if (!Files.exists(directory)) {
+				return 0L;
+			}
 			try (final Stream<Path> walk = Files.walk(directory);) {
 				return walk
 					.filter(Files::isRegularFile)

--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -121,6 +121,7 @@ import io.evitadb.index.CatalogIndexKey;
 import io.evitadb.index.EntityIndex;
 import io.evitadb.index.EntityIndexKey;
 import io.evitadb.index.EntityIndexType;
+import io.evitadb.index.EntityTypeClassifierResolver;
 import io.evitadb.index.IndexMaintainer;
 import io.evitadb.index.map.MapChanges;
 import io.evitadb.index.map.TransactionalMap;
@@ -182,7 +183,11 @@ import static java.util.Optional.ofNullable;
 @Slf4j
 @ThreadSafe
 public final class Catalog
-	implements CatalogContract, CatalogConsumersListener, TransactionalLayerProducer<DataStoreChanges, Catalog> {
+	implements CatalogContract,
+	CatalogConsumersListener,
+	TransactionalLayerProducer<DataStoreChanges, Catalog>,
+	EntityTypeClassifierResolver
+{
 	/**
 	 * Per-thread stack of batch frames collecting entity types whose expression trigger registry
 	 * must be rebuilt once the current `updateSchema(...)` batch finishes. While a frame is on
@@ -611,7 +616,6 @@ public final class Catalog
 			catalogName, SequenceType.ENTITY_COLLECTION, 0
 		);
 		this.catalogIndex = new CatalogIndex(Scope.LIVE);
-		this.catalogIndex.attachToCatalog(null, this);
 		this.proxyFactory = proxyFactory;
 		this.newCatalogVersionConsumer = newCatalogVersionConsumer;
 		this.lastPersistedSchemaVersion = internalCatalogSchema.version();
@@ -695,12 +699,10 @@ public final class Catalog
 		this.schema = new TransactionalReference<>(new CatalogSchemaDecorator(catalogSchema));
 		this.catalogIndex = this.persistenceService.readCatalogIndex(this, Scope.LIVE)
 			.orElseGet(() -> new CatalogIndex(Scope.LIVE));
-		this.catalogIndex.attachToCatalog(null, this);
 		final CatalogIndex loadedArchiveCatalogIndex = this.persistenceService.readCatalogIndex(this, Scope.ARCHIVED)
 			.filter(it -> !it.isEmpty())
 			.orElse(null);
 		if (loadedArchiveCatalogIndex != null) {
-			loadedArchiveCatalogIndex.attachToCatalog(null, this);
 			this.archiveCatalogIndex.set(loadedArchiveCatalogIndex);
 		}
 		this.cacheSupervisor = cacheSupervisor;
@@ -784,10 +786,6 @@ public final class Catalog
 		this.newCatalogVersionConsumer = previousCatalogVersion.newCatalogVersionConsumer;
 		this.transactionManager = previousCatalogVersion.transactionManager;
 
-		this.catalogIndex.attachToCatalog(null, this);
-		if (archiveCatalogIndex != null) {
-			archiveCatalogIndex.attachToCatalog(null, this);
-		}
 		final StoragePartPersistenceService<StorageDescriptor> storagePartPersistenceService =
 			persistenceService.getStoragePartPersistenceService(catalogVersion);
 		final CatalogSchema catalogSchema = CatalogSchema._internalBuildWithUpdatedEntitySchemaAccessor(
@@ -1070,8 +1068,13 @@ public final class Catalog
 	public EntityCollection getCollectionForEntityOrThrowException(
 		@Nonnull String entityType
 	) throws CollectionNotFoundException {
-		return ofNullable(this.entityCollections.get(entityType))
-			.orElseThrow(() -> new CollectionNotFoundException(entityType));
+		// plain get + null-check + throw (no Optional / capturing-lambda allocation): this runs on the
+		// unique-attribute write path once per value via the EntityTypeClassifierResolver delegators below.
+		final EntityCollection entityCollection = this.entityCollections.get(entityType);
+		if (entityCollection == null) {
+			throw new CollectionNotFoundException(entityType);
+		}
+		return entityCollection;
 	}
 
 	@Override
@@ -1079,8 +1082,24 @@ public final class Catalog
 	public EntityCollection getCollectionForEntityPrimaryKeyOrThrowException(
 		int entityTypePrimaryKey
 	) throws CollectionNotFoundException {
-		return ofNullable(this.entityCollectionsByPrimaryKey.get(entityTypePrimaryKey))
-			.orElseThrow(() -> new CollectionNotFoundException(entityTypePrimaryKey));
+		// plain get + null-check + throw (no Optional / capturing-lambda allocation): this runs on the
+		// unique-attribute write path once per value via the EntityTypeClassifierResolver delegators below.
+		final EntityCollection entityCollection = this.entityCollectionsByPrimaryKey.get(entityTypePrimaryKey);
+		if (entityCollection == null) {
+			throw new CollectionNotFoundException(entityTypePrimaryKey);
+		}
+		return entityCollection;
+	}
+
+	@Override
+	public int toEntityTypePrimaryKey(@Nonnull String entityType) {
+		return getCollectionForEntityOrThrowException(entityType).getEntityTypePrimaryKey();
+	}
+
+	@Nonnull
+	@Override
+	public String toEntityTypeName(int entityTypePrimaryKey) {
+		return getCollectionForEntityPrimaryKeyOrThrowException(entityTypePrimaryKey).getEntityType();
 	}
 
 	@Override
@@ -1150,10 +1169,10 @@ public final class Catalog
 				return new Catalog(
 					catalogVersionAfterRename,
 					catalogState,
-					this.catalogIndex.createCopyForNewCatalogAttachment(catalogState),
+					this.catalogIndex.createShallowCopyWithResetDirtyFlag(),
 					this.archiveCatalogIndex.get() == null ?
 						null :
-						this.archiveCatalogIndex.get().createCopyForNewCatalogAttachment(catalogState),
+						this.archiveCatalogIndex.get().createShallowCopyWithResetDirtyFlag(),
 					newCollections,
 					newIoService,
 					this,
@@ -1202,10 +1221,10 @@ public final class Catalog
 			final Catalog newCatalog = new Catalog(
 				1L,
 				CatalogState.ALIVE,
-				this.catalogIndex.createCopyForNewCatalogAttachment(CatalogState.ALIVE),
+				this.catalogIndex.createShallowCopyWithResetDirtyFlag(),
 				this.archiveCatalogIndex.get() == null ?
 					null :
-					this.archiveCatalogIndex.get().createCopyForNewCatalogAttachment(CatalogState.ALIVE),
+					this.archiveCatalogIndex.get().createShallowCopyWithResetDirtyFlag(),
 				newCollections,
 				this.persistenceService,
 				this,
@@ -1473,15 +1492,12 @@ public final class Catalog
 	@Nonnull
 	public CatalogIndex getCatalogIndex(@Nonnull Scope scope) {
 		if (scope == Scope.ARCHIVED) {
-			// The archived index is lazily initialized on first archived-scope access. Guard the
-			// transition against concurrent read queries: create and attach the candidate before
-			// publishing it, then CAS it in. A candidate that loses the race is discarded (and GC'd)
-			// having been attached exactly once - so attachToCatalog is never invoked twice on the
-			// same instance, which would otherwise trip its "already attached" premise check
+			// The archived index is lazily initialized on first archived-scope access. Create the candidate before
+			// publishing it, then CAS it in; a candidate that loses the race is simply discarded (and GC'd). The
+			// catalog index no longer holds a catalog back-reference, so no attach step is needed here.
 			CatalogIndex existing = this.archiveCatalogIndex.get();
 			if (existing == null) {
 				final CatalogIndex candidate = new CatalogIndex(Scope.ARCHIVED);
-				candidate.attachToCatalog(null, this);
 				existing = this.archiveCatalogIndex.compareAndSet(null, candidate) ?
 					candidate : this.archiveCatalogIndex.get();
 			}

--- a/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
@@ -124,6 +124,7 @@ import io.evitadb.index.*;
 import io.evitadb.index.attribute.FilterIndex;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.map.TransactionalMap;
+import io.evitadb.index.price.SuperIndexResolver;
 import io.evitadb.index.mutation.ConsistencyCheckingLocalMutationExecutor.ImplicitMutationBehavior;
 import io.evitadb.index.mutation.EntityIndexMutation;
 import io.evitadb.index.mutation.IndexMutation;
@@ -489,7 +490,7 @@ public final class EntityCollection implements
 			this::getIndexByPrimaryKeyIfExists,
 			this::getInternalSchema
 		);
-		final IndexTuple indexTuple = previousCollection.createIndexCopiesForNewCatalogAttachment(catalogState);
+		final IndexTuple indexTuple = previousCollection.createIndexCopiesForNewCatalogAttachment();
 		this.indexes = new TransactionalMap<>(
 			indexTuple.indexes(),
 			EntityIndex.class::cast
@@ -1718,15 +1719,27 @@ public final class EntityCollection implements
 
 	@Override
 	public void attachToCatalog(@Nullable String entityType, @Nonnull Catalog catalog) {
+		attachCatalogShell(catalog);
+		// wire the reduced indexes' price ref chains to the super price indexes of this collection's own GLOBAL
+		// entity index (same scope) — the price chain no longer holds a catalog back-reference of its own
+		wireReducedIndexSuperIndexes();
+	}
+
+	/**
+	 * Attaches only the catalog-level shell of this collection: the catalog back-reference and the schema decorator
+	 * that reads through it. Enforces single attachment (this is the one sanctioned catalog back-edge, so a second
+	 * attach is a programming error). Deliberately does NOT wire the reduced indexes' price ref chains — callers that
+	 * build a fresh collection sharing {@link #indexes} by reference (see {@link #createCopyWithNewPersistenceService})
+	 * hold indexes that are already wired, and re-running the wiring would trip the price chain's single-assign guards.
+	 *
+	 * @param catalog the catalog version this collection is being attached to
+	 */
+	private void attachCatalogShell(@Nonnull Catalog catalog) {
+		Assert.isPremiseValid(this.catalog == null, "Catalog was already attached to this collection!");
 		this.catalog = catalog;
 		this.schema = new TransactionalReference<>(
 			new EntitySchemaDecorator(catalog::getSchema, this.initialSchema)
 		);
-		for (EntityIndex entityIndex : this.indexes.values()) {
-			if (entityIndex instanceof CatalogRelatedDataStructure<?> catalogRelatedEntityIndex) {
-				catalogRelatedEntityIndex.attachToCatalog(this.getEntityType(), this.catalog);
-			}
-		}
 	}
 
 	@Override
@@ -1755,7 +1768,11 @@ public final class EntityCollection implements
 			catalogVersion, this.getEntityType(), this.entityTypePrimaryKey
 		);
 		if (transactionalChanges != null) {
-			// when we register all storage parts for persisting, we can now release transactional memory
+			// this is the DIRTY branch, and it must stay the only route for a collection that has pending changes:
+			// indexes are rebuilt here by merging their transactional layer, which yields fresh instances. The clean
+			// branch below instead forwards indexes to the next catalog version BY REFERENCE
+			// (createIndexCopiesForNewCatalogAttachment), which is sound only because a dirty collection never reaches
+			// it — routing one through there would share a live transactional layer across two catalog versions
 			transactionalLayer.removeTransactionalMemoryLayer(this);
 			// this creates copy of the indexes with all changes applied
 			final Map<EntityIndexKey, EntityIndex> modifiedIndexes = transactionalLayer.getStateCopyWithCommittedChanges(this.indexes);
@@ -1797,7 +1814,7 @@ public final class EntityCollection implements
 			if (this.persistenceService != newPersistenceService) {
 				// if the compaction occurred, the persistence service may have changed
 				// we just create a new collection with the new persistence service, but leave the rest of the state intact
-				final IndexTuple indexTuple = createIndexCopiesForNewCatalogAttachment(CatalogState.ALIVE);
+				final IndexTuple indexTuple = createIndexCopiesForNewCatalogAttachment();
 				return new EntityCollection(
 					catalogVersion,
 					CatalogState.ALIVE,
@@ -1848,11 +1865,11 @@ public final class EntityCollection implements
 			this.cacheSupervisor,
 			this.trafficRecorder
 		);
-		// the catalog remains the same here
-		entityCollection.catalog = this.catalog;
-		entityCollection.schema = new TransactionalReference<>(
-			new EntitySchemaDecorator(this.catalog::getSchema, internalSchema)
-		);
+		// the catalog remains the same here; attach only the collection shell. The fresh copy shares this.indexes by
+		// reference and they are already wired to their super price indexes, so index wiring must NOT re-run here —
+		// re-wiring would trip the price chain's single-assign guards. The copy's initialSchema equals internalSchema
+		// (set by the constructor above), so the shell's schema decorator is identical to the previous hand-wiring.
+		entityCollection.attachCatalogShell(this.catalog);
 		return entityCollection;
 	}
 
@@ -1864,7 +1881,7 @@ public final class EntityCollection implements
 	@Override
 	@Nonnull
 	public EntityCollection createCopyForNewCatalogAttachment(@Nonnull CatalogState catalogState) {
-		final IndexTuple indexTuple = createIndexCopiesForNewCatalogAttachment(catalogState);
+		final IndexTuple indexTuple = createIndexCopiesForNewCatalogAttachment();
 		return new EntityCollection(
 			this.catalog.getVersion(),
 			catalogState,
@@ -1889,8 +1906,10 @@ public final class EntityCollection implements
 	 * @param entityIndex the index to be added, must not be null
 	 */
 	public void addIndex(@Nonnull EntityIndex entityIndex) {
-		if (entityIndex instanceof CatalogRelatedDataStructure<?> crds) {
-			crds.attachToCatalog(this.getEntityType(), this.catalog);
+		// disk load / WAL replay register GLOBAL indexes before reduced ones, so the reduced index's super price
+		// indexes are already present in this collection's GLOBAL entity index when it is wired here
+		if (entityIndex instanceof AbstractReducedEntityIndex reducedIndex) {
+			wireReducedIndexSuperIndex(reducedIndex);
 		}
 		this.indexes.put(entityIndex.getIndexKey(), entityIndex);
 		this.indexesByPrimaryKey.put(entityIndex.getPrimaryKey(), entityIndex);
@@ -2569,7 +2588,8 @@ public final class EntityCollection implements
 				.orElseThrow(() -> new IllegalStateException(
 					"No entity collection found for entity type `" + otherEntityType + "` " +
 						"while resolving schema for cross-entity expression evaluation."
-				))
+				)),
+			this.catalog
 		);
 
 		return localMutationExecutorCollector.execute(
@@ -2607,30 +2627,88 @@ public final class EntityCollection implements
 	}
 
 	/**
-	 * Creates a map of index copies for a new catalog attachment, based on the current indexes.
-	 * If an index is a catalog-related data structure, a copy for the new catalog attachment is created;
-	 * otherwise, the original index is reused.
+	 * Creates the index maps for a new catalog attachment from a **clean** collection, carrying every index — GLOBAL,
+	 * referenced-type and reduced alike — across the version boundary **by reference** inside a fresh map wrapper.
 	 *
-	 * @param catalogState the state of the new catalog to which the indices will be attached
-	 * @return a map containing keys and their corresponding index copies or original indexes
+	 * Reduced indexes no longer hold any catalog back-reference: their price ref chain captures the GLOBAL entity index
+	 * directly through a {@link SuperIndexResolver}, and that GLOBAL is carried by reference here in the very same step,
+	 * so a carried reduced index's captured GLOBAL and every combo-super pointer remain identity-stable across the bump.
+	 * {@link #wireReducedIndexSuperIndex(AbstractReducedEntityIndex)} therefore verifies the carried wiring during
+	 * re-attachment instead of re-shelling and re-wiring it on every commit.
+	 *
+	 * Carrying transactional sub-structures by reference is only sound when this collection is clean. What actually
+	 * guarantees that is the routing: a dirty collection is rebuilt through the merge path and never reaches this
+	 * method. The premise assertion below is a partial backstop on top of that routing, not a replacement for it — a
+	 * layer on the index maps records an uncommitted change to the index *set* (an index added or removed), because a
+	 * transactional map tracks its key-to-value mapping rather than mutation happening inside a mapped value. An index
+	 * mutated internally therefore leaves these maps untouched and is caught by the routing, not by this check.
+	 *
+	 * @return the index maps whose values are the current indexes shared by reference
 	 */
 	@Nonnull
-	private IndexTuple createIndexCopiesForNewCatalogAttachment(@Nonnull CatalogState catalogState) {
+	private IndexTuple createIndexCopiesForNewCatalogAttachment() {
+		Assert.isPremiseValid(
+			Transaction.getTransactionalMemoryLayerIfExists(this.indexes) == null &&
+				Transaction.getTransactionalMemoryLayerIfExists(this.indexesByPrimaryKey) == null,
+			"Indexes may only be carried to a new catalog version from a clean collection, but an uncommitted change to the index set was found!"
+		);
 		final Map<EntityIndexKey, EntityIndex> indexes = CollectionUtils.createHashMap(this.indexes.size());
 		final Map<Integer, EntityIndex> indexesByPk = CollectionUtils.createHashMap(this.indexes.size());
 		for (Entry<EntityIndexKey, EntityIndex> entry : this.indexes.entrySet()) {
-			if (entry.getValue() instanceof CatalogRelatedDataStructure) {
-				//noinspection unchecked
-				final EntityIndex copyForNewCatalogAttachment = ((CatalogRelatedDataStructure<? extends EntityIndex>) entry.getValue())
-					.createCopyForNewCatalogAttachment(catalogState);
-				indexes.put(entry.getKey(), copyForNewCatalogAttachment);
-				indexesByPk.put(copyForNewCatalogAttachment.getPrimaryKey(), copyForNewCatalogAttachment);
-			} else {
-				indexes.put(entry.getKey(), entry.getValue());
-				indexesByPk.put(entry.getValue().getPrimaryKey(), entry.getValue());
-			}
+			final EntityIndex index = entry.getValue();
+			indexes.put(entry.getKey(), index);
+			indexesByPk.put(index.getPrimaryKey(), index);
 		}
 		return new IndexTuple(indexes, indexesByPk);
+	}
+
+	/**
+	 * Wires every reduced entity index held by this collection to the super price indexes of its scope's
+	 * {@link GlobalEntityIndex}. Called after re-attaching the collection to a catalog version, when the reduced
+	 * indexes have been freshly merged or shelled and their price ref chains carry no super index yet. Reduced indexes
+	 * added incrementally (disk load, lazy creation during mutation) are wired individually through
+	 * {@link #wireReducedIndexSuperIndex(AbstractReducedEntityIndex)}.
+	 */
+	private void wireReducedIndexSuperIndexes() {
+		for (final EntityIndex entityIndex : this.indexes.values()) {
+			if (entityIndex instanceof AbstractReducedEntityIndex reducedIndex) {
+				wireReducedIndexSuperIndex(reducedIndex);
+			}
+		}
+	}
+
+	/**
+	 * Wires a single reduced entity index's price ref chain to the super price indexes of this collection's
+	 * {@link GlobalEntityIndex} of the same scope, or — for a reduced index carried across a catalog version by
+	 * reference (see {@link #createIndexCopiesForNewCatalogAttachment()}) — verifies that its existing wiring still
+	 * points at this version's GLOBAL. The GLOBAL index is captured directly by the {@link SuperIndexResolver} — no
+	 * {@link Catalog} nor owning-collection back-reference is retained — so the reduced index carries no catalog
+	 * dependency of its own and is forwarded across catalog versions by reference together with its GLOBAL.
+	 *
+	 * @param reducedIndex the reduced entity index whose price ref chain should be wired or verified
+	 */
+	private void wireReducedIndexSuperIndex(@Nonnull AbstractReducedEntityIndex reducedIndex) {
+		final Scope scope = reducedIndex.getIndexKey().scope();
+		reducedIndex.getPriceIndex().wireOrVerifySuperIndexes(resolveGlobalIndex(scope));
+	}
+
+	/**
+	 * Resolves this collection's {@link GlobalEntityIndex} of the given scope, which owns the super price indexes that
+	 * back the scope's reduced indexes. The GLOBAL index is always present by the time a reduced index references it
+	 * (GLOBAL indexes are registered first on load, and a reduced index cannot exist before its collection's GLOBAL) —
+	 * the assertion makes that ordering assumption loud rather than silently resolving `null`.
+	 *
+	 * @param scope the scope whose GLOBAL entity index should be resolved
+	 * @return the GLOBAL entity index of the given scope
+	 */
+	@Nonnull
+	private GlobalEntityIndex resolveGlobalIndex(@Nonnull Scope scope) {
+		final EntityIndex globalIndex = this.indexes.get(new EntityIndexKey(EntityIndexType.GLOBAL, scope));
+		Assert.isPremiseValid(
+			globalIndex instanceof GlobalEntityIndex,
+			() -> "Global entity index of scope `" + scope + "` must exist to wire super price indexes!"
+		);
+		return (GlobalEntityIndex) globalIndex;
 	}
 
 	/**
@@ -2871,8 +2949,8 @@ public final class EntityCollection implements
 								throw new GenericEvitaInternalError("Unsupported entity index type: " + eikAgain.type());
 							}
 
-							if (entityIndex instanceof CatalogRelatedDataStructure<?> lateInitializationIndex) {
-								lateInitializationIndex.attachToCatalog(EntityCollection.this.getEntityType(), EntityCollection.this.catalog);
+							if (entityIndex instanceof AbstractReducedEntityIndex reducedIndex) {
+								EntityCollection.this.wireReducedIndexSuperIndex(reducedIndex);
 							}
 
 							// register index also in the map by primary key for fast access

--- a/evita_engine/src/main/java/io/evitadb/core/management/EvitaManagement.java
+++ b/evita_engine/src/main/java/io/evitadb/core/management/EvitaManagement.java
@@ -54,6 +54,7 @@ import io.evitadb.utils.IOUtils;
 import io.evitadb.utils.UUIDUtil;
 import io.evitadb.utils.VersionUtils;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -82,6 +83,7 @@ import java.util.function.Supplier;
  * @see EvitaManagementContract
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
+@Slf4j
 public class EvitaManagement implements EvitaManagementContract, Closeable {
 	/**
 	 * Contains reference to the main evita service.
@@ -196,7 +198,7 @@ public class EvitaManagement implements EvitaManagementContract, Closeable {
 	public CatalogStatistics[] getCatalogStatistics() {
 		return this.evita.getCatalogs()
 			.stream()
-			.map(CatalogContract::getStatistics)
+			.map(EvitaManagement::getCatalogStatisticsSafely)
 			.sorted(Comparator.comparing(CatalogStatistics::catalogName))
 			.toArray(CatalogStatistics[]::new);
 	}
@@ -428,6 +430,42 @@ public class EvitaManagement implements EvitaManagementContract, Closeable {
 			this.exportService::close,
 			this.fileManagementService::close
 		);
+	}
+
+	/**
+	 * Collects statistics of a single catalog, degrading to a minimal placeholder record when the catalog fails to
+	 * provide them.
+	 *
+	 * Statistics of all catalogs are aggregated into a single response, so an exception raised by one catalog would
+	 * otherwise abort the entire listing and hide every healthy catalog from the client as well. A catalog that cannot
+	 * report its statistics is still a catalog the client needs to see - it is reported as `unusable` with unknown
+	 * (`-1`) figures instead of taking the whole response down with it.
+	 *
+	 * @param catalog the catalog to collect the statistics for
+	 * @return statistics of the catalog, or an `unusable` placeholder when they cannot be collected
+	 */
+	@Nonnull
+	private static CatalogStatistics getCatalogStatisticsSafely(@Nonnull CatalogContract catalog) {
+		try {
+			return catalog.getStatistics();
+		} catch (RuntimeException ex) {
+			log.error(
+				"Failed to collect statistics of catalog `{}` - reporting it as unusable.",
+				catalog.getName(), ex
+			);
+			return new CatalogStatistics(
+				null,
+				catalog.getName(),
+				true,
+				false,
+				catalog.getCatalogState(),
+				-1L,
+				-1L,
+				-1L,
+				-1L,
+				new CatalogStatistics.EntityCollectionStatistics[0]
+			);
+		}
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanningContext.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanningContext.java
@@ -136,7 +136,7 @@ public class QueryPlanningContext implements LocaleProvider, PrefetchStrategyRes
 	 * Contains reference to the enveloping {@link EvitaSessionContract} within which the {@link #evitaRequest} is executed.
 	 */
 	@Getter
-	@Nonnull private final EvitaSession evitaSession;
+	@Nullable private final EvitaSession evitaSession;
 	/**
 	 * Contains input in {@link EvitaRequest}.
 	 */
@@ -678,6 +678,16 @@ public class QueryPlanningContext implements LocaleProvider, PrefetchStrategyRes
 	}
 
 	/**
+	 * Returns the entity-type name ↔ compact primary key resolver backed by the catalog targeted by this query.
+	 * Used by the globally-unique attribute filter translators to decode the entity type stored inside the
+	 * global unique index's packed tuples.
+	 */
+	@Nonnull
+	public EntityTypeClassifierResolver getEntityTypeClassifierResolver() {
+		return this.catalog;
+	}
+
+	/**
 	 * Returns entity schema.
 	 */
 	@Nonnull
@@ -735,9 +745,12 @@ public class QueryPlanningContext implements LocaleProvider, PrefetchStrategyRes
 	 */
 	@Nonnull
 	public Formula analyse(@Nonnull Formula formula) {
-		return ofNullable(this.evitaRequest.getEntityType())
-			.map(it -> this.cacheSupervisor.analyse(this.evitaSession, it, formula))
-			.orElse(formula);
+		final String theEntityType = this.evitaRequest.getEntityType();
+		if (this.evitaSession != null && theEntityType != null) {
+			return this.cacheSupervisor.analyse(this.evitaSession, theEntityType, formula);
+		} else {
+			return formula;
+		}
 	}
 
 	/**
@@ -746,9 +759,12 @@ public class QueryPlanningContext implements LocaleProvider, PrefetchStrategyRes
 	 */
 	@Nonnull
 	public <U, T extends CacheableEvitaResponseExtraResultComputer<U>> EvitaResponseExtraResultComputer<U> analyse(@Nonnull T computer) {
-		return ofNullable(this.evitaRequest.getEntityType())
-			.map(it -> this.planningPolicy.analyse(this.cacheSupervisor, this.evitaSession, it, computer))
-			.orElse(computer);
+		final String theEntityType = this.evitaRequest.getEntityType();
+		if (this.evitaSession != null && theEntityType != null) {
+			return this.planningPolicy.analyse(this.cacheSupervisor, this.evitaSession, theEntityType, computer);
+		} else {
+			return computer;
+		}
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/filteredPriceRecords/FilteredPriceRecords.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/filteredPriceRecords/FilteredPriceRecords.java
@@ -255,11 +255,11 @@ public interface FilteredPriceRecords extends Serializable {
 				totalIndexCount += lazy.getPriceIndexes().length;
 			}
 		}
-		final PriceListAndCurrencyPriceIndex<?, ?>[] priceIndexes = new PriceListAndCurrencyPriceIndex[totalIndexCount];
+		final PriceListAndCurrencyPriceIndex<?>[] priceIndexes = new PriceListAndCurrencyPriceIndex[totalIndexCount];
 		int offset = 0;
 		for (final FilteredPriceRecords cachedRecord : cachedRecords) {
 			if (cachedRecord instanceof LazyEvaluatedEntityPriceRecords lazy) {
-				final PriceListAndCurrencyPriceIndex<?, ?>[] indexes = lazy.getPriceIndexes();
+				final PriceListAndCurrencyPriceIndex<?>[] indexes = lazy.getPriceIndexes();
 				System.arraycopy(indexes, 0, priceIndexes, offset, indexes.length);
 				offset += indexes.length;
 			}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/filteredPriceRecords/NonResolvedFilteredPriceRecords.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/filteredPriceRecords/NonResolvedFilteredPriceRecords.java
@@ -55,7 +55,7 @@ public class NonResolvedFilteredPriceRecords implements FilteredPriceRecords {
 	 * {@link PriceRecordContract#internalPriceId()}. The order of price indexes is crucial the first price index
 	 * that returns non-null price will finish the lookup for particular price.
 	 */
-	private final PriceListAndCurrencyPriceIndex<?,?>[] priceIndexes;
+	private final PriceListAndCurrencyPriceIndex<?>[] priceIndexes;
 	/**
 	 * Contains the array of {@link CumulatedVirtualPriceRecord} that cannot be looked up anywhere and must be kept
 	 * the same as were previously computed.
@@ -74,7 +74,7 @@ public class NonResolvedFilteredPriceRecords implements FilteredPriceRecords {
 	public NonResolvedFilteredPriceRecords(
 		@Nonnull PriceRecordContract[] cumulatedPriceRecords,
 		@Nonnull Bitmap priceRecordsIds,
-		@Nonnull PriceListAndCurrencyPriceIndex<?,?>[] priceIndexes
+		@Nonnull PriceListAndCurrencyPriceIndex<?>[] priceIndexes
 	) {
 		this.cumulatedPriceRecords = cumulatedPriceRecords;
 		this.priceRecordsIds = priceRecordsIds;
@@ -105,7 +105,7 @@ public class NonResolvedFilteredPriceRecords implements FilteredPriceRecords {
 		final AtomicInteger resultPeek = new AtomicInteger(this.cumulatedPriceRecords.length);
 
 		final RoaringBitmapWriter<PersistentRoaringBitmap> notFound = RoaringBitmapBackedBitmap.buildWriter();
-		for (PriceListAndCurrencyPriceIndex<?,?> priceIndex : this.priceIndexes) {
+		for (PriceListAndCurrencyPriceIndex<?> priceIndex : this.priceIndexes) {
 			priceIndex.forEachPriceRecord(
 				this.priceRecordsIds,
 				priceRecordContract -> result[resultPeek.getAndIncrement()] = priceRecordContract,

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIdContainerFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIdContainerFormula.java
@@ -58,9 +58,9 @@ public class PriceIdContainerFormula extends AbstractFormula implements PriceInd
 	 * Contains reference to the {@link PriceListAndCurrencyPriceIndex} the prices (ids or full records) produced by
 	 * this formula comes from.
 	 */
-	@Getter private final PriceListAndCurrencyPriceIndex<?,?> priceIndex;
+	@Getter private final PriceListAndCurrencyPriceIndex<?> priceIndex;
 
-	public PriceIdContainerFormula(@Nonnull PriceListAndCurrencyPriceIndex<?,?> priceIndex, @Nonnull Formula delegate) {
+	public PriceIdContainerFormula(@Nonnull PriceListAndCurrencyPriceIndex<?> priceIndex, @Nonnull Formula delegate) {
 		this.priceIndex = priceIndex;
 		this.initFields(delegate);
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIndexContainerFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIndexContainerFormula.java
@@ -58,15 +58,15 @@ public class PriceIndexContainerFormula extends AbstractCacheableFormula impleme
 	 * Contains reference to the {@link PriceListAndCurrencyPriceIndex index} that was used for computation
 	 * of the {@link #getDelegate()} result
 	 */
-	@Getter private final PriceListAndCurrencyPriceIndex<?,?> priceIndex;
+	@Getter private final PriceListAndCurrencyPriceIndex<?> priceIndex;
 
-	public PriceIndexContainerFormula(@Nonnull PriceListAndCurrencyPriceIndex<?,?> priceIndex, @Nonnull Formula delegate) {
+	public PriceIndexContainerFormula(@Nonnull PriceListAndCurrencyPriceIndex<?> priceIndex, @Nonnull Formula delegate) {
 		super(null);
 		this.priceIndex = priceIndex;
 		this.initFields(delegate);
 	}
 
-	private PriceIndexContainerFormula(@Nullable Consumer<CacheableFormula> computationCallback, @Nonnull PriceListAndCurrencyPriceIndex<?,?> priceIndex, @Nonnull Formula delegate) {
+	private PriceIndexContainerFormula(@Nullable Consumer<CacheableFormula> computationCallback, @Nonnull PriceListAndCurrencyPriceIndex<?> priceIndex, @Nonnull Formula delegate) {
 		super(computationCallback);
 		this.priceIndex = priceIndex;
 		this.initFields(delegate);

--- a/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/translate/PriceIdToEntityIdTranslateFormula.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/algebra/price/translate/PriceIdToEntityIdTranslateFormula.java
@@ -202,7 +202,7 @@ public class PriceIdToEntityIdTranslateFormula extends AbstractCacheableFormula 
 			// iterate through prices
 			for (PriceIdContainerFormula priceIdFormula : priceIdFormulas) {
 				// collect array of price records that were used in the input formula (only some of them will be in current input)
-				final PriceListAndCurrencyPriceIndex<?, ?> priceIndex = priceIdFormula.getPriceIndex();
+				final PriceListAndCurrencyPriceIndex<?> priceIndex = priceIdFormula.getPriceIndex();
 				final RoaringBitmapWriter<PersistentRoaringBitmap> notFound = RoaringBitmapBackedBitmap.buildWriter();
 				priceIndex.forEachPriceRecord(
 					priceIdBitmap,

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/FormulaOptimizer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/FormulaOptimizer.java
@@ -96,8 +96,12 @@ public class FormulaOptimizer extends FormulaCloner implements FormulaPostProces
 				Formula optimizedSuperset = this.formulasProcessed.get(originalSuperset);
 
 				// Case 1: Superset became Empty or Null -> Result is Empty
+				// the node must be replaced by EmptyFormula, never dropped - `null` instructs the cloner to
+				// remove the child from its parent, which widens an enclosing conjunction (`A AND nothing`
+				// would degrade to `A`) instead of emptying it; EmptyFormula is the absorbing element of
+				// a conjunction and the identity element of a disjunction, so it is correct in both scopes
 				if (optimizedSuperset == null || optimizedSuperset instanceof EmptyFormula) {
-					formulaToStore = null;
+					formulaToStore = EmptyFormula.INSTANCE;
 				}
 				// Case 2: Superset exists, but Subtracted is gone (set size is 1) -> Result is Superset
 				else if (updatedChildren.size() == 1) {

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeEqualsTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeEqualsTranslator.java
@@ -88,7 +88,7 @@ public class AttributeEqualsTranslator extends AbstractAttributeTranslator
 			attributeKey,
 			filterByVisitor.applyOnFirstGlobalUniqueIndex(
 				globalAttributeSchema,
-				index -> index.getEntityReferenceByUniqueValue(comparedValue, attributeKey.locale())
+				index -> index.getEntityReferenceByUniqueValue(comparedValue, attributeKey.locale(), filterByVisitor.getEntityTypeClassifierResolver())
 					.map(
 						it -> (Formula) new MultipleEntityFormula(
 							new long[]{index.getId()},

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeInSetTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeInSetTranslator.java
@@ -95,7 +95,7 @@ public class AttributeInSetTranslator extends AbstractAttributeTranslator
 					.map(
 						comparedValue -> filterByVisitor.applyOnFirstGlobalUniqueIndex(
 							globalAttributeSchema,
-							index -> index.getEntityReferenceByUniqueValue(comparedValue, attributeKey.locale())
+							index -> index.getEntityReferenceByUniqueValue(comparedValue, attributeKey.locale(), filterByVisitor.getEntityTypeClassifierResolver())
 								.map(it -> (Formula) new MultipleEntityFormula(
 									new long[]{index.getId()},
 									new BaseBitmap(filterByVisitor.translateEntityReference(it))

--- a/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeIsTranslator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/filter/translator/attribute/AttributeIsTranslator.java
@@ -175,7 +175,7 @@ public class AttributeIsTranslator extends AbstractAttributeTranslator
 			filterByVisitor.applyOnGlobalUniqueIndexes(
 				attributeDefinition,
 				uniqueIndex -> new NotFormula(
-					uniqueIndex.getRecordIdsFormula(filterByVisitor.getEntityType()),
+					uniqueIndex.getRecordIdsFormula(filterByVisitor.getEntityType(), filterByVisitor.getEntityTypeClassifierResolver()),
 					FormulaFactory.or(
 						filterByVisitor.getEntityIndexStream()
 							.map(EntityIndex::getAllPrimaryKeysFormula)
@@ -271,7 +271,7 @@ public class AttributeIsTranslator extends AbstractAttributeTranslator
 					filterByVisitor.applyOnGlobalUniqueIndexes(
 						globalAttributeSchema,
 						index -> {
-							final Bitmap recordIds = index.getRecordIds(filterByVisitor.getEntityType());
+							final Bitmap recordIds = index.getRecordIds(filterByVisitor.getEntityType(), filterByVisitor.getEntityTypeClassifierResolver());
 							return recordIds.isEmpty() ? EmptyFormula.INSTANCE : new ConstantFormula(recordIds);
 						}
 					)

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/Transaction.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/Transaction.java
@@ -31,6 +31,7 @@ import io.evitadb.core.transaction.memory.TransactionalLayerCreator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainerFinalizer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.TransactionalMemory;
 import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.exception.GenericEvitaInternalError;
@@ -377,7 +378,7 @@ public final class Transaction implements TransactionContract {
 	 *
 	 * @param txRoot root of the transactional object tree whose changes are committed or rolled back
 	 */
-	public <S, X, T extends TransactionalLayerProducer<X, S>> Transaction(@Nonnull T txRoot) {
+	public <S, T extends TransactionalStateProducer<S>> Transaction(@Nonnull T txRoot) {
 		this.transactionId = UUID.randomUUID();
 		this.transactionHandler = null;
 		this.transactionalMemory = new TransactionalMemory(
@@ -518,7 +519,7 @@ public final class Transaction implements TransactionContract {
 	 */
 	@Nullable
 	public <S> S getCommitedState() {
-		if (this.transactionalMemory.getFinalizer() instanceof IsolatedTransactionalLayerMaintainerFinalizer<?,?,?> finalizer) {
+		if (this.transactionalMemory.getFinalizer() instanceof IsolatedTransactionalLayerMaintainerFinalizer<?,?> finalizer) {
 			//noinspection unchecked
 			return (S) finalizer.getCommitted();
 		} else {
@@ -548,11 +549,10 @@ public final class Transaction implements TransactionContract {
 	 * commit and rollback operations in a transactional context.
 	 *
 	 * @param <S> the type of the state object being managed
-	 * @param <X> the type of the transactional layer's intermediate representation
 	 * @param <T> the type of the transactional layer producer
 	 */
 	@Slf4j
-	private static class IsolatedTransactionalLayerMaintainerFinalizer<S, X, T extends TransactionalLayerProducer<X, S>>
+	private static class IsolatedTransactionalLayerMaintainerFinalizer<S, T extends TransactionalStateProducer<S>>
 		implements TransactionalLayerMaintainerFinalizer {
 		/**
 		 * Root of the transactional object tree. Changes of this object will be subject to commit / rollback.

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalContainerChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalContainerChanges.java
@@ -40,7 +40,7 @@ import static java.util.Optional.ofNullable;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
-public final class TransactionalContainerChanges<DIFF_PIECE, COPY, PRODUCER extends TransactionalLayerProducer<DIFF_PIECE, COPY>>
+public final class TransactionalContainerChanges<COPY, PRODUCER extends TransactionalStateProducer<COPY>>
 	implements Snapshotable<TransactionalContainerChanges.ContainerChangesMemento<PRODUCER>> {
 	/**
 	 * Lazily allocated list of objects created in this transaction; `null` until the first {@link #addCreatedItem}.

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerCreator.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerCreator.java
@@ -23,11 +23,6 @@
 
 package io.evitadb.core.transaction.memory;
 
-import javax.annotation.Nonnull;
-
-import static io.evitadb.core.transaction.Transaction.getTransactionalLayerMaintainer;
-import static java.util.Optional.ofNullable;
-
 /**
  * Interface allowing classes to participate in a transaction memory handling process. Implementations should implement
  * all get / set state methods in following pattern (these accessors are normally reached through the static
@@ -56,11 +51,17 @@ import static java.util.Optional.ofNullable;
 public interface TransactionalLayerCreator<T> {
 
 	/**
-	 * Uniquely identifies instance of {@link TransactionalLayerCreator} among other instances of the same class.
-	 * Each instance of the class must return unique id that doesn't change in time. Id connect origin object with
-	 * its transactional states in memory.
+	 * Uniquely identifies this instance among **all** live {@link TransactionalLayerCreator} instances, not merely among
+	 * instances of the same class. The id must not change in time - it connects the origin object with its transactional
+	 * state in memory, and is the sole key of the diff-layer registry.
 	 *
-	 * Using {@link TransactionalObjectVersion} is highly recommended.
+	 * Ids must be drawn from {@link TransactionalObjectVersion#SEQUENCE}, which is what guarantees the global
+	 * uniqueness this contract requires. Returning a constant, or an id from any other source, lets one object be handed
+	 * a diff layer belonging to another - {@link TransactionalLayerMaintainer} therefore verifies the invariant and
+	 * fails loudly on a collision.
+	 *
+	 * The value {@link TransactionalObjectVersion#NO_LAYER_ID} is reserved to denote "no layer" and is never emitted by
+	 * the sequence, so it must never be returned here.
 	 */
 	long getId();
 
@@ -70,22 +71,5 @@ public interface TransactionalLayerCreator<T> {
 	 * {@link #getId()} value.
 	 */
 	T createLayer();
-
-	/**
-	 * Method implementation must remove entire diff memory from the current transaction. If object maintains inner
-	 * objects, their memory must be removed as well.
-	 */
-	default void removeLayer() {
-		ofNullable(getTransactionalLayerMaintainer())
-			.ifPresent(this::removeLayer);
-	}
-
-	/**
-	 * Method implementation must remove entire diff memory from the current transaction. If object maintains inner
-	 * objects, their memory must be removed as well.
-	 *
-	 * @param transactionalLayer object that provides access to entire transactional memory so that it can be manipulated
-	 */
-	void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer);
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerEntry.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerEntry.java
@@ -6,7 +6,7 @@
  *             |  __/\ V /| | || (_| | |_| | |_) |
  *              \___| \_/ |_|\__\__,_|____/|____/
  *
- *   Copyright (c) 2023-2024
+ *   Copyright (c) 2023-2025
  *
  *   Licensed under the Business Source License, Version 1.1 (the "License");
  *   you may not use this file except in compliance with the License.
@@ -27,23 +27,38 @@ import io.evitadb.utils.Assert;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * This wrapper envelopes the object that {@link io.evitadb.index.array.TransactionalObject} uses to track the changes
- * made upon the immutable state. It also maintains information about it's state so that we can count all created
- * instances during {@link TransactionalLayerMaintainer#commit()} and verify all of them were processed and applied.
+ * Single registered diff layer of the software transactional memory - who owns it, the diff itself and its lifecycle
+ * state. One entry is allocated per layer *creation* (never per lookup), and its lifetime matches the layer's, which
+ * is what makes it the right place to retain the owning {@link TransactionalLayerCreator}: the registry is keyed by
+ * the creator's {@link TransactionalLayerCreator#getId() id} alone, so nothing else keeps the creator reachable.
+ *
+ * The creator reference is needed on two paths:
+ *
+ * - {@link TransactionalLayerMaintainer#verifyLayerWasFullySwept()} reports the live creator objects behind any layer
+ *   left {@link TransactionalLayerState#ALIVE} at commit;
+ * - the registry asserts that one id never maps to two distinct live creators.
+ *
+ * The reference is held rather than eagerly stringified on purpose - rendering diagnostics for every created layer
+ * would put `toString()` on a hot path; it belongs on the error path only.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 @NotThreadSafe
 @RequiredArgsConstructor
-class TransactionalLayerWrapper<T> {
+class TransactionalLayerEntry<T> {
+	/**
+	 * Contains the object that created the diff layer and that the layer belongs to.
+	 */
+	@Nonnull @Getter private final TransactionalLayerCreator<T> creator;
 	/**
 	 * Contains the object that {@link io.evitadb.index.array.TransactionalObject} uses to track the changes made upon
 	 * the immutable state.
 	 */
-	@Getter private final T item;
+	@Nonnull @Getter private final T item;
 	/**
 	 * Contains state of the transactional layer - used to track whether all states were applied during
 	 * {@link TransactionalLayerMaintainer#commit()}.

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerMaintainer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerMaintainer.java
@@ -23,6 +23,9 @@
 
 package io.evitadb.core.transaction.memory;
 
+import com.carrotsearch.hppc.LongObjectHashMap;
+import com.carrotsearch.hppc.cursors.LongObjectCursor;
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import io.evitadb.core.exception.DataStructureCorruptedException;
 import io.evitadb.core.exception.StaleTransactionMemoryException;
 import io.evitadb.exception.GenericEvitaInternalError;
@@ -34,7 +37,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Closeable;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedList;
@@ -43,8 +45,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static java.util.Optional.ofNullable;
 
 /**
  * Transactional layer is a temporary storage for storing {@link TransactionalLayerCreator#createLayer()} objects.
@@ -62,9 +62,15 @@ public class TransactionalLayerMaintainer {
 	@Nonnull private final TransactionalLayerMaintainerFinalizer finalizer;
 	/**
 	 * Index of all transactional layer memories of all {@link io.evitadb.index.array.TransactionalObject} that work
-	 * with isolated transactional memory.
+	 * with isolated transactional memory, keyed by {@link TransactionalLayerCreator#getId()}.
+	 *
+	 * The map is primitive-keyed on purpose. Ids come from a JVM-wide sequence and therefore always sit outside the
+	 * {@link Long#valueOf(long)} cache, so a `Map<Long, …>` would allocate a boxed key on **every** visit - and the
+	 * registry is visited by every read and write of every transactional data structure. The open-addressed HPPC map
+	 * also drops the per-entry node allocation. It is thread-confined to a single transaction, so the absence of
+	 * concurrency support costs nothing here.
 	 */
-	private final Map<TransactionalLayerCreatorKey, TransactionalLayerWrapper<?>> transactionalLayer;
+	private final LongObjectHashMap<TransactionalLayerEntry<?>> transactionalLayer;
 	/**
 	 * Internal flag that allows to avoid marking the used transactional layer as {@link TransactionalLayerState#DISCARDED}.
 	 * It's used when we need merged transactional state within the current transaction leaving the modification state
@@ -105,7 +111,7 @@ public class TransactionalLayerMaintainer {
 		@Nonnull TransactionalLayerMaintainerFinalizer finalizer
 	) {
 		this.finalizer = finalizer;
-		this.transactionalLayer = new HashMap<>(4096);
+		this.transactionalLayer = new LongObjectHashMap<>(4096);
 	}
 
 	/**
@@ -175,14 +181,14 @@ public class TransactionalLayerMaintainer {
 	 */
 	@Nonnull
 	public <T> T removeTransactionalMemoryLayer(@Nonnull TransactionalLayerCreator<T> layerCreator) {
-		final TransactionalLayerCreatorKey key = new TransactionalLayerCreatorKey(layerCreator);
-		@SuppressWarnings("unchecked") final TransactionalLayerWrapper<T> removedValue = (TransactionalLayerWrapper<T>) this.transactionalLayer.get(key);
+		final long id = layerCreator.getId();
+		final TransactionalLayerEntry<T> removedValue = getEntryIfExists(id, layerCreator);
 		Assert.notNull(removedValue, "Value should have been removed but was not!");
 		// when a savepoint is open the removal must be reversible (see recordSavepointRemovalIfNeeded)
 		if (this.currentSavepoint != null) {
-			recordSavepointRemovalIfNeeded(key, removedValue);
+			recordSavepointRemovalIfNeeded(id, removedValue);
 		}
-		this.transactionalLayer.remove(key);
+		this.transactionalLayer.remove(id);
 		return removedValue.getItem();
 	}
 
@@ -191,18 +197,17 @@ public class TransactionalLayerMaintainer {
 	 */
 	@Nullable
 	public <T> T removeTransactionalMemoryLayerIfExists(@Nonnull TransactionalLayerCreator<T> layerCreator) {
-		final TransactionalLayerCreatorKey key = new TransactionalLayerCreatorKey(layerCreator);
-		final TransactionalLayerWrapper<?> wrapper = this.transactionalLayer.get(key);
-		if (wrapper == null) {
+		final long id = layerCreator.getId();
+		final TransactionalLayerEntry<T> entry = getEntryIfExists(id, layerCreator);
+		if (entry == null) {
 			return null;
 		}
 		// when a savepoint is open the removal must be reversible (see recordSavepointRemovalIfNeeded)
 		if (this.currentSavepoint != null) {
-			recordSavepointRemovalIfNeeded(key, wrapper);
+			recordSavepointRemovalIfNeeded(id, entry);
 		}
-		this.transactionalLayer.remove(key);
-		//noinspection unchecked
-		return (T) wrapper.getItem();
+		this.transactionalLayer.remove(id);
+		return entry.getItem();
 	}
 
 	/**
@@ -214,13 +219,13 @@ public class TransactionalLayerMaintainer {
 	 */
 	@Nullable
 	public <T> T getOrCreateTransactionalMemoryLayer(@Nonnull TransactionalLayerCreator<T> layerCreator) {
-		final TransactionalLayerCreatorKey key = new TransactionalLayerCreatorKey(layerCreator);
-		@SuppressWarnings("unchecked") final TransactionalLayerWrapper<T> transactionalMemoryWrapper = (TransactionalLayerWrapper<T>) this.transactionalLayer.get(key);
-		if (transactionalMemoryWrapper != null) {
+		final long id = layerCreator.getId();
+		final TransactionalLayerEntry<T> transactionalMemoryEntry = getEntryIfExists(id, layerCreator);
+		if (transactionalMemoryEntry != null) {
 			// the caller is about to mutate this existing layer — if a savepoint is open, capture its
 			// pre-mutation state on first touch so it can be restored on rollbackSavepoint
-			recordSavepointSnapshotIfNeeded(key, transactionalMemoryWrapper.getItem());
-			return transactionalMemoryWrapper.getItem();
+			recordSavepointSnapshotIfNeeded(id, transactionalMemoryEntry.getItem());
+			return transactionalMemoryEntry.getItem();
 		}
 
 		final T transactionalMemory;
@@ -231,9 +236,9 @@ public class TransactionalLayerMaintainer {
 
 		transactionalMemory = layerCreator.createLayer();
 		if (transactionalMemory != null) {
-			this.transactionalLayer.put(key, new TransactionalLayerWrapper<>(transactionalMemory));
+			this.transactionalLayer.put(id, new TransactionalLayerEntry<>(layerCreator, transactionalMemory));
 			// the layer was created within an open savepoint — mark it so rollbackSavepoint drops it entirely
-			recordSavepointCreationIfNeeded(key);
+			recordSavepointCreationIfNeeded(id);
 		}
 
 		return transactionalMemory;
@@ -247,8 +252,7 @@ public class TransactionalLayerMaintainer {
 	 */
 	@Nullable
 	public <T> T getTransactionalMemoryLayerIfExists(@Nonnull TransactionalLayerCreator<T> layerProvider) {
-		final TransactionalLayerCreatorKey key = new TransactionalLayerCreatorKey(layerProvider);
-		@SuppressWarnings("unchecked") final TransactionalLayerWrapper<T> transactionalMemory = (TransactionalLayerWrapper<T>) this.transactionalLayer.get(key);
+		final TransactionalLayerEntry<T> transactionalMemory = getEntryIfExists(layerProvider.getId(), layerProvider);
 		if (transactionalMemory == null) {
 			return null;
 		}
@@ -272,14 +276,14 @@ public class TransactionalLayerMaintainer {
 	 */
 	@Nullable
 	public <T> T getTransactionalMemoryLayerForWriteIfExists(@Nonnull TransactionalLayerCreator<T> layerProvider) {
-		final TransactionalLayerCreatorKey key = new TransactionalLayerCreatorKey(layerProvider);
-		@SuppressWarnings("unchecked") final TransactionalLayerWrapper<T> transactionalMemory = (TransactionalLayerWrapper<T>) this.transactionalLayer.get(key);
+		final long id = layerProvider.getId();
+		final TransactionalLayerEntry<T> transactionalMemory = getEntryIfExists(id, layerProvider);
 		if (transactionalMemory == null) {
 			return null;
 		}
 		// the caller is about to mutate this existing layer through the fast path — capture its pre-mutation state on
 		// first touch so it can be restored on rollbackSavepoint
-		recordSavepointSnapshotIfNeeded(key, transactionalMemory.getItem());
+		recordSavepointSnapshotIfNeeded(id, transactionalMemory.getItem());
 		return transactionalMemory.getItem();
 	}
 
@@ -291,8 +295,8 @@ public class TransactionalLayerMaintainer {
 	 * Method returns NULL if no transactional changes were made to the object, and it may remain same.
 	 */
 	@Nonnull
-	public <S, T> S getStateCopyWithCommittedChangesWithoutDiscardingState(
-		@Nonnull TransactionalLayerProducer<T, S> transactionalLayerProducer
+	public <S> S getStateCopyWithCommittedChangesWithoutDiscardingState(
+		@Nonnull TransactionalStateProducer<S> transactionalLayerProducer
 	) {
 		try {
 			Assert.isTrue(
@@ -311,12 +315,30 @@ public class TransactionalLayerMaintainer {
 	 * the transaction.
 	 */
 	@Nonnull
-	public <S, T> S getStateCopyWithCommittedChanges(@Nonnull TransactionalLayerProducer<T, S> transactionalLayerProducer) {
-		final TransactionalLayerWrapper<T> transactionalLayerForItem = getTransactionalMemoryLayerItemWrapperIfExists(transactionalLayerProducer);
+	public <S> S getStateCopyWithCommittedChanges(@Nonnull TransactionalStateProducer<S> transactionalStateProducer) {
+		// pure dispatch - the producer's own type decides whether a diff layer has to be resolved at all, so objects
+		// that own no layer skip the registry lookup that would be guaranteed to miss for them
+		return transactionalStateProducer.createCopyWithMergedTransactionalMemory(this);
+	}
+
+	/**
+	 * Resolves the diff layer owned by the passed producer, lets it merge that layer into a new committed instance and
+	 * disposes of the layer afterwards.
+	 *
+	 * This is the **single** place where a diff layer is resolved and discarded. Implementations therefore cannot forget
+	 * to discard - they never touch the layer's lifecycle - and a layer left `ALIVE` is reported by
+	 * {@link #verifyLayerWasFullySwept()} rather than silently dropping committed changes.
+	 *
+	 * @param transactionalLayerProducer producer that owns a diff layer
+	 * @return committed form of the passed producer
+	 */
+	@Nonnull
+	<T, S> S copyWithOwnLayer(@Nonnull TransactionalLayerProducer<T, S> transactionalLayerProducer) {
+		final TransactionalLayerEntry<T> transactionalLayerForItem = getEntryIfExists(
+			transactionalLayerProducer.getId(), transactionalLayerProducer
+		);
 		final S copyWithCommittedChanges = transactionalLayerProducer.createCopyWithMergedTransactionalMemory(
-			ofNullable(transactionalLayerForItem)
-				.map(TransactionalLayerWrapper::getItem)
-				.orElse(null),
+			transactionalLayerForItem == null ? null : transactionalLayerForItem.getItem(),
 			this
 		);
 		if (!this.avoidDiscardingState.get() && transactionalLayerForItem != null) {
@@ -335,11 +357,10 @@ public class TransactionalLayerMaintainer {
 	public void verifyLayerWasFullySwept() throws StaleTransactionMemoryException {
 		// collect all data that has not been processed and discarded by the consumers and connect them with their creators
 		final List<TransactionalLayerCreator<?>> uncommittedData = new LinkedList<>();
-		for (Entry<TransactionalLayerCreatorKey, TransactionalLayerWrapper<?>> entry : this.transactionalLayer.entrySet()) {
-			if (entry.getValue().getState() == TransactionalLayerState.ALIVE) {
-				final TransactionalLayerCreatorKey key = entry.getKey();
-				final TransactionalLayerCreator<?> transactionalLayerCreator = key.transactionalLayerCreator();
-				uncommittedData.add(transactionalLayerCreator);
+		for (final ObjectCursor<TransactionalLayerEntry<?>> cursor : this.transactionalLayer.values()) {
+			final TransactionalLayerEntry<?> layerEntry = cursor.value;
+			if (layerEntry.getState() == TransactionalLayerState.ALIVE) {
+				uncommittedData.add(layerEntry.getCreator());
 			}
 		}
 		// if any stale uncommitted data found, report exception
@@ -428,8 +449,8 @@ public class TransactionalLayerMaintainer {
 		);
 		// deactivate the savepoint first so the releaseMemento() operations below do not re-record into it
 		this.currentSavepoint = null;
-		for (final Entry<TransactionalLayerCreatorKey, Object> entry : savepoint.mementos.entrySet()) {
-			final Object memento = entry.getValue();
+		for (final LongObjectCursor<Object> cursor : savepoint.mementos) {
+			final Object memento = cursor.value;
 			if (memento == CREATED_IN_SAVEPOINT || memento instanceof RemovedLayer) {
 				// a layer created inside the savepoint was never snapshotted (nothing to release); a layer removed
 				// inside the savepoint is already detached from the transactional memory - neither keeps drainable
@@ -437,13 +458,13 @@ public class TransactionalLayerMaintainer {
 				continue;
 			}
 			// a plain memento is only ever recorded for a layer that still exists (a removal upgrades it to a
-			// RemovedLayer), so the wrapper must be present - a missing one would be a programming error
-			final TransactionalLayerWrapper<?> wrapper = this.transactionalLayer.get(entry.getKey());
+			// RemovedLayer), so the entry must be present - a missing one would be a programming error
+			final TransactionalLayerEntry<?> layerEntry = this.transactionalLayer.get(cursor.key);
 			Assert.isPremiseValid(
-				wrapper != null,
+				layerEntry != null,
 				"A snapshotted layer disappeared from the transactional memory without being recorded as removed!"
 			);
-			releaseLayerMemento(wrapper.getItem(), memento);
+			releaseLayerMemento(layerEntry.getItem(), memento);
 		}
 	}
 
@@ -461,32 +482,32 @@ public class TransactionalLayerMaintainer {
 		);
 		// deactivate the savepoint first so the restore() operations below do not re-record into it
 		this.currentSavepoint = null;
-		for (final Entry<TransactionalLayerCreatorKey, Object> entry : savepoint.mementos.entrySet()) {
-			final Object memento = entry.getValue();
+		for (final LongObjectCursor<Object> cursor : savepoint.mementos) {
+			final Object memento = cursor.value;
 			if (memento == CREATED_IN_SAVEPOINT) {
 				// the layer did not exist when the savepoint opened - drop it together with all its changes
-				this.transactionalLayer.remove(entry.getKey());
+				this.transactionalLayer.remove(cursor.key);
 			} else if (memento instanceof final RemovedLayer removed) {
 				// the layer existed when the savepoint opened but was removed inside it (e.g. a B+ tree node
-				// dropped during a split/merge) - re-attach the original wrapper and restore its pre-savepoint state
-				this.transactionalLayer.put(entry.getKey(), removed.wrapper());
-				restoreLayer(removed.wrapper().getItem(), removed.memento());
+				// dropped during a split/merge) - re-attach the original entry and restore its pre-savepoint state
+				this.transactionalLayer.put(cursor.key, removed.entry());
+				restoreLayer(removed.entry().getItem(), removed.memento());
 				// the savepoint is closed - let the layer drop its per-savepoint scratch state (the restore above has
 				// already rewound it), so post-rollback mutations stop paying the savepoint bookkeeping cost
-				releaseLayerMemento(removed.wrapper().getItem(), removed.memento());
+				releaseLayerMemento(removed.entry().getItem(), removed.memento());
 			} else {
-				final TransactionalLayerWrapper<?> wrapper = this.transactionalLayer.get(entry.getKey());
+				final TransactionalLayerEntry<?> layerEntry = this.transactionalLayer.get(cursor.key);
 				// a plain memento is only ever recorded for a layer that still exists - a removal upgrades the
-				// memento to a RemovedLayer (see recordSavepointRemovalIfNeeded), so the wrapper must be present;
+				// memento to a RemovedLayer (see recordSavepointRemovalIfNeeded), so the entry must be present;
 				// a missing one would be a silent partial-rollback gap and is therefore a programming error
 				Assert.isPremiseValid(
-					wrapper != null,
+					layerEntry != null,
 					"A snapshotted layer disappeared from the transactional memory without being recorded as removed!"
 				);
-				restoreLayer(wrapper.getItem(), memento);
+				restoreLayer(layerEntry.getItem(), memento);
 				// the savepoint is closed - let the layer drop its per-savepoint scratch state (the restore above has
 				// already rewound it), so post-rollback mutations stop paying the savepoint bookkeeping cost
-				releaseLayerMemento(wrapper.getItem(), memento);
+				releaseLayerMemento(layerEntry.getItem(), memento);
 			}
 		}
 	}
@@ -521,14 +542,14 @@ public class TransactionalLayerMaintainer {
 	 * {@link Snapshotable} cannot be rolled back, so this is treated as a programming error rather than silently
 	 * skipped (which would leave a partial-rollback gap).
 	 *
-	 * @param key   the key of the layer being modified
+	 * @param id    the id of the layer being modified
 	 * @param layer the existing (non-null) diff layer about to be mutated
 	 */
-	private void recordSavepointSnapshotIfNeeded(@Nonnull TransactionalLayerCreatorKey key, @Nonnull Object layer) {
+	private void recordSavepointSnapshotIfNeeded(long id, @Nonnull Object layer) {
 		final Savepoint savepoint = this.currentSavepoint;
-		if (savepoint != null && !savepoint.mementos.containsKey(key)) {
+		if (savepoint != null && !savepoint.mementos.containsKey(id)) {
 			if (layer instanceof final Snapshotable<?> snapshotable) {
-				savepoint.mementos.put(key, snapshotable.snapshot());
+				savepoint.mementos.put(id, snapshotable.snapshot());
 			} else {
 				throw new GenericEvitaInternalError(
 					"Transactional layer " + layer.getClass().getName() + " is modified inside a savepoint but does " +
@@ -542,34 +563,34 @@ public class TransactionalLayerMaintainer {
 
 	/**
 	 * Records that a layer was created inside the open savepoint, so {@link #rollbackSavepoint(Savepoint)} drops it
-	 * entirely. No-op when no savepoint is open or the key was already recorded.
+	 * entirely. No-op when no savepoint is open or the id was already recorded.
 	 *
-	 * @param key the key of the newly created layer
+	 * @param id the id of the newly created layer
 	 */
-	private void recordSavepointCreationIfNeeded(@Nonnull TransactionalLayerCreatorKey key) {
+	private void recordSavepointCreationIfNeeded(long id) {
 		final Savepoint savepoint = this.currentSavepoint;
-		if (savepoint != null && !savepoint.mementos.containsKey(key)) {
-			savepoint.mementos.put(key, CREATED_IN_SAVEPOINT);
+		if (savepoint != null && !savepoint.mementos.containsKey(id)) {
+			savepoint.mementos.put(id, CREATED_IN_SAVEPOINT);
 		}
 	}
 
 	/**
 	 * Records that an existing layer is about to be removed while a savepoint is open, so the removal can be undone on
-	 * {@link #rollbackSavepoint(Savepoint)} by re-attaching the captured wrapper and restoring its pre-savepoint state.
+	 * {@link #rollbackSavepoint(Savepoint)} by re-attaching the captured entry and restoring its pre-savepoint state.
 	 * A layer that was created inside this savepoint is left marked {@link #CREATED_IN_SAVEPOINT} (removing it now plus
 	 * dropping it on rollback are both correct, so no extra bookkeeping is needed). A layer modified inside a savepoint
 	 * that does not implement {@link Snapshotable} cannot be reverted — treated as a programming error rather than a
 	 * silent partial-rollback gap.
 	 *
-	 * @param key     the key of the layer being removed
-	 * @param wrapper the wrapper of the layer being removed
+	 * @param id    the id of the layer being removed
+	 * @param entry the entry of the layer being removed
 	 */
-	private void recordSavepointRemovalIfNeeded(@Nonnull TransactionalLayerCreatorKey key, @Nonnull TransactionalLayerWrapper<?> wrapper) {
+	private void recordSavepointRemovalIfNeeded(long id, @Nonnull TransactionalLayerEntry<?> entry) {
 		final Savepoint savepoint = this.currentSavepoint;
 		if (savepoint == null) {
 			return;
 		}
-		final Object existing = savepoint.mementos.get(key);
+		final Object existing = savepoint.mementos.get(id);
 		if (existing == CREATED_IN_SAVEPOINT || existing instanceof RemovedLayer) {
 			// created-then-removed inside this savepoint (stays dropped on rollback), or already recorded as removed
 			return;
@@ -578,7 +599,7 @@ public class TransactionalLayerMaintainer {
 		if (existing == null) {
 			// the removal is the first touch of this layer inside the savepoint — its current state is the
 			// pre-savepoint state we must be able to restore
-			final Object item = wrapper.getItem();
+			final Object item = entry.getItem();
 			if (item instanceof final Snapshotable<?> snapshotable) {
 				memento = snapshotable.snapshot();
 			} else {
@@ -593,53 +614,40 @@ public class TransactionalLayerMaintainer {
 			// the layer was already snapshotted earlier in this savepoint — reuse that pre-mutation memento
 			memento = existing;
 		}
-		savepoint.mementos.put(key, new RemovedLayer(wrapper, memento));
+		savepoint.mementos.put(id, new RemovedLayer(entry, memento));
 	}
 
 	/**
-	 * Returns existing transactional memory for passed {@link TransactionalLayerCreator}. If no transactional memory
-	 * diff piece exists NULL is returned.
+	 * Returns the registry entry registered under the passed id, or NULL when the creator owns no diff layer yet. Never
+	 * creates one.
 	 *
-	 * @return NULL value when no diff piece is found, new diff piece is never created by this method
+	 * On a hit it also enforces the invariant the registry rests on: **one id maps to one and only one live creator**.
+	 * Reference identity is the right test - two distinct live objects are distinct owners no matter how they compare -
+	 * and a violation means one object would be handed a diff layer belonging to another, silently mixing two objects'
+	 * changes. The check runs on hits only (a miss returns NULL first), so it costs one reference comparison per layer
+	 * that actually exists.
+	 *
+	 * @param id            id of the requested layer, always {@link TransactionalLayerCreator#getId()} of `creator`
+	 * @param creator       the creator claiming the layer
+	 * @return NULL value when no diff piece is found
 	 */
 	@Nullable
-	private <T> TransactionalLayerWrapper<T> getTransactionalMemoryLayerItemWrapperIfExists(@Nonnull TransactionalLayerCreator<T> layerProvider) {
-		final TransactionalLayerCreatorKey key = new TransactionalLayerCreatorKey(layerProvider);
-		@SuppressWarnings("unchecked") final TransactionalLayerWrapper<T> transactionalMemory = (TransactionalLayerWrapper<T>) this.transactionalLayer.get(key);
-		return transactionalMemory;
-	}
-
-	/**
-	 * Class represents caching key for the diff piece created by {@link TransactionalLayerCreator#createLayer()}.
-	 * Equals and hash logic uses {@link TransactionalLayerCreator#getId()} and {@link TransactionalLayerCreator} class.
-	 */
-	private record TransactionalLayerCreatorKey(
-		@Nonnull TransactionalLayerCreator<?> transactionalLayerCreator,
-		long transactionalLayerProviderId
-	) {
-
-		TransactionalLayerCreatorKey(@Nonnull TransactionalLayerCreator<?> transactionalLayerCreator) {
-			this(transactionalLayerCreator, transactionalLayerCreator.getId());
+	private <T> TransactionalLayerEntry<T> getEntryIfExists(long id, @Nonnull TransactionalLayerCreator<T> creator) {
+		final TransactionalLayerEntry<?> entry = this.transactionalLayer.get(id);
+		if (entry == null) {
+			return null;
 		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
-
-			TransactionalLayerCreatorKey that = (TransactionalLayerCreatorKey) o;
-
-			return this.transactionalLayerProviderId == that.transactionalLayerProviderId &&
-				this.transactionalLayerCreator.getClass().equals(that.transactionalLayerCreator.getClass());
+		if (entry.getCreator() != creator) {
+			throw new GenericEvitaInternalError(
+				"Transactional layer id " + id + " is claimed by two distinct creators: " +
+					entry.getCreator().getClass().getName() + " and " + creator.getClass().getName() + "! Ids must be " +
+					"drawn from TransactionalObjectVersion.SEQUENCE - a constant or reused id lets one object be handed " +
+					"the diff layer of another.",
+				"Transactional layer id " + id + " is claimed by two distinct creators!"
+			);
 		}
-
-		@Override
-		public int hashCode() {
-			int result = this.transactionalLayerCreator.getClass().hashCode();
-			result = 31 * result + Long.hashCode(this.transactionalLayerProviderId);
-			return result;
-		}
-
+		//noinspection unchecked
+		return (TransactionalLayerEntry<T>) entry;
 	}
 
 	/**
@@ -656,7 +664,7 @@ public class TransactionalLayerMaintainer {
 		 * {@link RemovedLayer} (layer present at savepoint open but removed inside it → re-attached + restored on
 		 * rollback).
 		 */
-		private final Map<TransactionalLayerCreatorKey, Object> mementos = new HashMap<>(64);
+		private final LongObjectHashMap<Object> mementos = new LongObjectHashMap<>(64);
 
 		private Savepoint() {
 		}
@@ -664,13 +672,13 @@ public class TransactionalLayerMaintainer {
 
 	/**
 	 * Savepoint bookkeeping for a layer that existed when the savepoint was opened but was removed while it was open.
-	 * On {@link #rollbackSavepoint(Savepoint)} the {@link #wrapper} is re-attached to the maintainer and its item is
+	 * On {@link #rollbackSavepoint(Savepoint)} the {@link #entry} is re-attached to the maintainer and its item is
 	 * restored to {@link #memento} (the pre-savepoint state).
 	 *
-	 * @param wrapper the wrapper that was removed
-	 * @param memento the pre-savepoint state of the wrapper's item
+	 * @param entry the entry that was removed
+	 * @param memento the pre-savepoint state of the entry's item
 	 */
-	private record RemovedLayer(@Nonnull TransactionalLayerWrapper<?> wrapper, @Nonnull Object memento) {
+	private record RemovedLayer(@Nonnull TransactionalLayerEntry<?> entry, @Nonnull Object memento) {
 	}
 
 }

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerProducer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerProducer.java
@@ -30,15 +30,36 @@ import javax.annotation.Nullable;
  * Interface allowing classes to participate in a transaction memory handling process. This specific form of the transactional
  * layer provider merges the changes to the separate copy of the original object.
  *
+ * It is the common case: the object both **owns a diff layer** ({@link TransactionalLayerCreator}) and **produces its
+ * committed form** ({@link TransactionalStateProducer}). Objects that only produce a copy, without owning a layer,
+ * implement {@link VoidTransactionMemoryProducer} instead.
+ *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2017
  */
-public interface TransactionalLayerProducer<DIFF_PIECE, COPY> extends TransactionalLayerCreator<DIFF_PIECE> {
+public interface TransactionalLayerProducer<DIFF_PIECE, COPY>
+	extends TransactionalLayerCreator<DIFF_PIECE>, TransactionalStateProducer<COPY> {
+
+	/**
+	 * Resolves this object's own diff layer and merges it, disposing of the layer afterwards.
+	 *
+	 * Implementations must not override this method - implement
+	 * {@link #createCopyWithMergedTransactionalMemory(Object, TransactionalLayerMaintainer)} instead. Overriding it
+	 * would bypass layer resolution and disposal; the layer would then stay `ALIVE` and
+	 * {@link TransactionalLayerMaintainer#verifyLayerWasFullySwept()} would fail the commit rather than silently losing
+	 * the changes.
+	 */
+	@Nonnull
+	@Override
+	default COPY createCopyWithMergedTransactionalMemory(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
+		return transactionalLayer.copyWithOwnLayer(this);
+	}
 
 	/**
 	 * Merges changes / differences captured in a transactional layer to separate (new) cloned object instance.
-	 * Merge is ought to be performed deep-wise. Ie. if current object contains references to other {@link TransactionalLayerProducer}
-	 * instances it's required to call `createCopyWithMergedTransactionalMemory` on them when collecting changes
-	 * to the return instance.
+	 * Merge is ought to be performed deep-wise. Ie. if current object contains references to other
+	 * {@link TransactionalStateProducer} instances it's required to obtain their committed form through
+	 * {@link TransactionalLayerMaintainer#getStateCopyWithCommittedChanges(TransactionalStateProducer)} when collecting
+	 * changes to the return instance.
 	 *
 	 * @param layer              the transactional memory of this object that holds the difference protocol to apply to get updated version of the object
 	 * @param transactionalLayer object that provides access to entire transactional memory so that it can be manipulated

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerState.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalLayerState.java
@@ -24,7 +24,7 @@
 package io.evitadb.core.transaction.memory;
 
 /**
- * Describes the state of the {@link TransactionalLayerWrapper}.
+ * Describes the state of the {@link TransactionalLayerEntry}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalMemory.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalMemory.java
@@ -185,11 +185,24 @@ public class TransactionalMemory {
 	 * function.
 	 */
 	public <T, U> U suppressTransactionalMemoryLayerForWithResult(@Nonnull T object, @Nonnull Function<T, U> objectConsumer) {
-		Assert.isPremiseValid(object instanceof TransactionalLayerCreator, "Object " + object.getClass() + " doesn't implement TransactionalLayerCreator interface!");
-		Assert.isPremiseValid(getTransactionalMemoryLayerIfExists((TransactionalLayerCreator<?>) object) == null, "There already exists transactional memory for passed creator!");
+		Assert.isPremiseValid(
+			object instanceof TransactionalLayerCreator || object instanceof TransactionalStateProducer,
+			"Object " + object.getClass() + " doesn't implement TransactionalLayerCreator nor TransactionalStateProducer interface!"
+		);
+		// an object that owns no diff layer has nothing to suppress for itself - only the creators it maintains have,
+		// and those are collected below. Both checks must run before the stack is pushed, so that the finally block
+		// below never pops a frame that was never pushed.
+		final TransactionalLayerCreator<?> layerCreator = object instanceof TransactionalLayerCreator<?> creator ?
+			creator : null;
+		Assert.isPremiseValid(
+			layerCreator == null || getTransactionalMemoryLayerIfExists(layerCreator) == null,
+			"There already exists transactional memory for passed creator!"
+		);
 		try {
 			final ObjectIdentityHashSet<TransactionalLayerCreator<?>> suppressedSet = new ObjectIdentityHashSet<>(16, 0.8d);
-			suppressedSet.add((TransactionalLayerCreator<?>) object);
+			if (layerCreator != null) {
+				suppressedSet.add(layerCreator);
+			}
 			if (object instanceof TransactionalCreatorMaintainer) {
 				final Collection<TransactionalLayerCreator<?>> creators = ((TransactionalCreatorMaintainer) object).getMaintainedTransactionalCreators();
 				for (TransactionalLayerCreator<?> creator : creators) {

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalObjectVersion.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalObjectVersion.java
@@ -24,8 +24,6 @@
 package io.evitadb.core.transaction.memory;
 
 import io.evitadb.api.exception.IdentifierOverflowException;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -34,52 +32,76 @@ import java.util.concurrent.atomic.AtomicLong;
  * This class allows generating sequence of unique transactional object versions in a thread safe manner. Versions
  * are unique only in single JVM instance and might be reused between JVM instance restarts.
  *
- * There is very little chance of potential issue when the sequence will overflow and start from the beginning. In such
- * a case we might have two different objects with the same version if one is very old (non-changed for a long time) and
- * another is very new. Transactional ids are used for calculation cache hash and the returned results might be wrong.
+ * The sequence hands out `1L` first, counts up through {@link Long#MAX_VALUE}, wraps in two's complement to
+ * {@link Long#MIN_VALUE} and continues up to `-1L`, so the whole `2^64 - 1` non-zero space is usable. **`0L` is
+ * reserved and is never emitted**: it denotes "no transactional layer", which lets an identifier-keyed registry
+ * represent absence without any risk of confusing it with a live creator.
  *
- * If we detect overflow situation we stop providing new ids and throw exception - this will effectively stop
- * the database from accepting new updates.
+ * Returning to `0L` therefore means the entire identifier space has been consumed. At that point the sequence is
+ * poisoned and stops providing new ids - this will effectively stop the database from accepting new updates, because
+ * handing out a recycled id would silently corrupt the query cache (transactional ids are used to compute cache hashes,
+ * so a duplicate id makes a stale cached result look current).
+ *
+ * **The exhaustion boundary is not guarded against a concurrent race.** Threads that increment the counter past `0L`
+ * before the detecting thread poisons it would receive already-used ids. Closing that window would require either a
+ * compare-and-set loop or a `volatile` flag read on a path executed for every transactional object in the JVM, and the
+ * boundary is unreachable in practice - exhausting `2^64 - 1` ids takes roughly 58 000 years at ten million ids per
+ * second. The cost is therefore not paid for a corner that cannot be reached.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
 public class TransactionalObjectVersion {
+	/**
+	 * Reserved identifier denoting "no transactional layer". It is never handed out by {@link #nextId()}, which is what
+	 * allows an identifier-keyed layer registry to use it as an unambiguous absence marker.
+	 */
+	public static final long NO_LAYER_ID = 0L;
 	/**
 	 * JVM-wide singleton sequence shared by all transactional objects when assigning their version ids.
 	 */
 	public static final TransactionalObjectVersion SEQUENCE = new TransactionalObjectVersion();
 	/**
-	 * Backing counter; starts at {@link Long#MIN_VALUE} and is incremented on every {@link #nextId()} call, so ids
-	 * begin in the negative domain and cross into the positive domain over the lifetime of the JVM.
+	 * Backing counter; starts at {@link #NO_LAYER_ID} so that the first id handed out is `1L`, and is incremented on
+	 * every {@link #nextId()} call. It wraps naturally from {@link Long#MAX_VALUE} to {@link Long#MIN_VALUE} and is
+	 * exhausted only when it returns to {@link #NO_LAYER_ID}.
 	 */
-	private final AtomicLong version = new AtomicLong(Long.MIN_VALUE);
-	/**
-	 * If TRUE, the domain of the version is positive numbers, otherwise negative numbers. Declared
-	 * `volatile` because {@link #SEQUENCE} is a JVM-wide singleton read and written by many
-	 * transaction threads concurrently; without it the secondary overflow guard could observe a
-	 * stale value across threads.
-	 */
-	private volatile boolean positiveDomain = false;
+	private final AtomicLong version;
 
 	/**
-	 * Returns the next unique id from the sequence.
+	 * Creates a sequence seeded to an arbitrary position. Visible for tests, which have to observe the wrap-around and
+	 * exhaustion behaviour without performing `2^64` increments to reach it.
 	 *
-	 * @throws IdentifierOverflowException once the sequence wraps back into the negative domain, halting further
-	 *                                     updates to avoid handing out a duplicate version (see class JavaDoc)
+	 * @param seed value the counter starts at; the first id handed out is `seed + 1`
+	 */
+	TransactionalObjectVersion(long seed) {
+		this.version = new AtomicLong(seed);
+	}
+
+	/**
+	 * Creates a sequence positioned so that the first id handed out is `1L`.
+	 */
+	TransactionalObjectVersion() {
+		this(NO_LAYER_ID);
+	}
+
+	/**
+	 * Returns the next unique id from the sequence. The returned value is never {@link #NO_LAYER_ID}.
+	 *
+	 * @throws IdentifierOverflowException once the entire identifier space has been handed out, halting further updates
+	 *                                     to avoid handing out a duplicate version (see class JavaDoc)
 	 */
 	public long nextId() {
 		final long id = this.version.incrementAndGet();
-		if (!this.positiveDomain && id >= 0) {
-			this.positiveDomain = true;
-		}
-		if (id == Long.MAX_VALUE || (id < 0 && this.positiveDomain)) {
+		if (id == NO_LAYER_ID) {
+			// rewind onto the last identifier of the space so that every subsequent call increments back onto
+			// NO_LAYER_ID and fails identically, instead of silently resuming at 1 with ids that are already in use
+			this.version.set(-1L);
 			log.error(
-				"Transactional object version sequence overflowed, which can cause unpredictable results! " +
+				"Transactional object version sequence exhausted, which can cause unpredictable results! " +
 					"Database cannot accept any new modifications. Please restart database to start counting from the beginning."
 			);
-			throw new IdentifierOverflowException("Transactional object version sequence overflowed!");
+			throw new IdentifierOverflowException("Transactional object version sequence exhausted!");
 		}
 		return id;
 	}

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalStateProducer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/TransactionalStateProducer.java
@@ -1,0 +1,87 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.transaction.memory;
+
+import javax.annotation.Nonnull;
+
+import static io.evitadb.core.transaction.Transaction.getTransactionalLayerMaintainer;
+import static java.util.Optional.ofNullable;
+
+/**
+ * Participant of the commit-time merge cascade: an object that can produce its committed form and that can propagate
+ * diff-layer removal through the objects it holds.
+ *
+ * Both capabilities are needed by **every** participant, whereas owning a diff layer
+ * ({@link TransactionalLayerCreator}) is needed only by some. Objects that maintain transactionally modifiable internal
+ * fields but cannot be modified themselves - see {@link VoidTransactionMemoryProducer} - implement this interface alone:
+ * they rebuild from their (possibly changed) children without ever holding a diff of their own.
+ *
+ * Keeping the two roles apart is what allows an identifier-keyed layer registry to be safe by construction: a type with
+ * no {@link TransactionalLayerCreator#getId()} cannot be looked up in it at all, so it can never be handed a diff layer
+ * belonging to a different object.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public interface TransactionalStateProducer<COPY> {
+
+	/**
+	 * Merges changes / differences captured in the transactional layer to a separate (new) cloned object instance.
+	 * Merge is ought to be performed deep-wise. Ie. if the current object contains references to other
+	 * {@link TransactionalStateProducer} instances it's required to obtain their committed form through
+	 * {@link TransactionalLayerMaintainer#getStateCopyWithCommittedChanges(TransactionalStateProducer)} when collecting
+	 * changes to the returned instance.
+	 *
+	 * Implementations that own a diff layer must not implement this method - {@link TransactionalLayerProducer} provides
+	 * it, resolving the layer through the maintainer and implementing
+	 * {@link TransactionalLayerProducer#createCopyWithMergedTransactionalMemory(Object, TransactionalLayerMaintainer)}
+	 * instead. That arrangement keeps layer resolution and disposal in a single place.
+	 *
+	 * @param transactionalLayer object that provides access to entire transactional memory so that it can be manipulated
+	 */
+	@Nonnull
+	COPY createCopyWithMergedTransactionalMemory(@Nonnull TransactionalLayerMaintainer transactionalLayer);
+
+	/**
+	 * Method implementation must remove entire diff memory from the current transaction. If object maintains inner
+	 * objects, their memory must be removed as well.
+	 */
+	default void removeLayer() {
+		ofNullable(getTransactionalLayerMaintainer())
+			.ifPresent(this::removeLayer);
+	}
+
+	/**
+	 * Method implementation must remove entire diff memory from the current transaction. If object maintains inner
+	 * objects, their memory must be removed as well.
+	 *
+	 * Removal has to propagate through the whole object graph, which is why it lives here rather than on
+	 * {@link TransactionalLayerCreator} - an object that owns no layer of its own may still hold children that do.
+	 * Layer owners additionally drop their own layer through
+	 * {@link TransactionalLayerMaintainer#removeTransactionalMemoryLayerIfExists(TransactionalLayerCreator)}.
+	 *
+	 * @param transactionalLayer object that provides access to entire transactional memory so that it can be manipulated
+	 */
+	void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer);
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/memory/VoidTransactionMemoryProducer.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/memory/VoidTransactionMemoryProducer.java
@@ -24,24 +24,17 @@
 package io.evitadb.core.transaction.memory;
 
 /**
- * This extension of {@link TransactionalLayerProducer} produces {@link Void} transactional memory diff piece. It should
- * be used in all all objects that maintain transactionally modifiable internal data fields but cannot be modified by
- * themselves. I.e. their transactional diff piece is Void (NULL), but they need to provide
- * {@link TransactionalLayerProducer#createCopyWithMergedTransactionalMemory(Object, TransactionalLayerMaintainer)} implementation
- * so that the could create new instance consisting of new internal objects.
+ * This extension of {@link TransactionalStateProducer} owns **no** transactional memory diff piece. It should be used in
+ * all objects that maintain transactionally modifiable internal data fields but cannot be modified by themselves. I.e.
+ * they hold no diff of their own, but they need to provide a `createCopyWithMergedTransactionalMemory` implementation so
+ * that they can create a new instance consisting of new internal objects.
+ *
+ * Such objects deliberately are **not** {@link TransactionalLayerCreator}s: having no id, they cannot be looked up in
+ * the diff-layer registry at all, which is what makes it impossible for one of them to be handed a layer belonging to a
+ * different object. They also skip the registry lookup entirely during the merge cascade, where it would be guaranteed
+ * to miss.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
-public interface VoidTransactionMemoryProducer<S> extends TransactionalLayerProducer<Void, S> {
-
-	@Override
-	default long getId() {
-		return 1L;
-	}
-
-	@Override
-	default Void createLayer() {
-		throw new UnsupportedOperationException("This object doesn't handle changes directly!");
-	}
-
+public interface VoidTransactionMemoryProducer<S> extends TransactionalStateProducer<S> {
 }

--- a/evita_engine/src/main/java/io/evitadb/index/AbstractReducedEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/AbstractReducedEntityIndex.java
@@ -249,7 +249,6 @@ public abstract class AbstractReducedEntityIndex extends EntityIndex
 
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		// the price index is removed by the component-loop inside the super call — no extra hop
 		super.removeTransactionalMemoryOfReferencedProducers(transactionalLayer);
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/AbstractReducedEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/AbstractReducedEntityIndex.java
@@ -34,8 +34,6 @@ import io.evitadb.api.requestResponse.schema.EntitySortableAttributeCompoundSche
 import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.api.requestResponse.schema.SortableAttributeCompoundSchemaContract;
-import io.evitadb.core.catalog.Catalog;
-import io.evitadb.core.catalog.CatalogRelatedDataStructure;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer;
@@ -96,8 +94,7 @@ import java.util.function.Function;
  * @see ReducedGroupEntityIndex
  */
 public abstract class AbstractReducedEntityIndex extends EntityIndex
-	implements VoidTransactionMemoryProducer<AbstractReducedEntityIndex>,
-	CatalogRelatedDataStructure<AbstractReducedEntityIndex> {
+	implements VoidTransactionMemoryProducer<AbstractReducedEntityIndex> {
 
 	/**
 	 * This part of index collects information about prices of the entities. It provides data that are necessary for
@@ -167,49 +164,6 @@ public abstract class AbstractReducedEntityIndex extends EntityIndex
 	}
 
 	/**
-	 * Creates a reduced entity index as a transactional copy that preserves original storage part state.
-	 * Used internally by {@link ReducedEntityIndex#createCopyForNewCatalogAttachment(io.evitadb.api.CatalogState)}.
-	 *
-	 * @param primaryKey                  the primary key of this index
-	 * @param indexKey                    the key identifying this index
-	 * @param version                     the version of this index
-	 * @param entityIds                   transactional bitmap of entity primary keys
-	 * @param entityIdsByLanguage         transactional map of entity primary keys by locale
-	 * @param attributeIndex              the attribute index
-	 * @param hierarchyIndex              the hierarchy index
-	 * @param facetIndex                  the facet index
-	 * @param originalHierarchyIndexEmpty whether the hierarchy index was originally empty
-	 * @param originalAttributeIndexes    original attribute index storage keys
-	 * @param originalPriceIndexes        original price index keys
-	 * @param originalFacetIndexes        original facet index referenced entities
-	 * @param priceIndex                  the price reference index
-	 */
-	protected AbstractReducedEntityIndex(
-		int primaryKey,
-		@Nonnull EntityIndexKey indexKey,
-		int version,
-		@Nonnull TransactionalBitmap entityIds,
-		@Nonnull TransactionalMap<Locale, TransactionalBitmap> entityIdsByLanguage,
-		@Nonnull ReferenceAttributeIndex attributeIndex,
-		@Nonnull HierarchyIndex hierarchyIndex,
-		@Nonnull FacetIndex facetIndex,
-		boolean originalHierarchyIndexEmpty,
-		@Nonnull Set<AttributeIndexStorageKey> originalAttributeIndexes,
-		@Nonnull Set<PriceIndexKey> originalPriceIndexes,
-		@Nonnull Set<String> originalFacetIndexes,
-		@Nonnull PriceRefIndex priceIndex
-	) {
-		super(
-			primaryKey, indexKey, version, entityIds,
-			entityIdsByLanguage, attributeIndex, hierarchyIndex, facetIndex,
-			originalHierarchyIndexEmpty,
-			originalAttributeIndexes, originalPriceIndexes, originalFacetIndexes
-		);
-		this.priceIndex = priceIndex;
-		addComponent(new PriceIndexComponent(this.priceIndex));
-	}
-
-	/**
 	 * Retrieves the reference key associated with the current entity index.
 	 * The reference key is derived from the discriminator of the index key.
 	 *
@@ -229,11 +183,6 @@ public abstract class AbstractReducedEntityIndex extends EntityIndex
 	@Nonnull
 	public RepresentativeReferenceKey getRepresentativeReferenceKey() {
 		return Objects.requireNonNull((RepresentativeReferenceKey) this.indexKey.discriminator());
-	}
-
-	@Override
-	public void attachToCatalog(@Nullable String entityType, @Nonnull Catalog catalog) {
-		this.priceIndex.attachToCatalog(entityType, catalog);
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/index/CatalogIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/CatalogIndex.java
@@ -283,7 +283,7 @@ public class CatalogIndex implements
 	 * This class collects changes in {@link #uniqueIndex} transactional maps.
 	 */
 	public static class CatalogIndexChanges implements Snapshotable<CatalogIndexChanges.CatalogIndexChangesMemento> {
-		private final TransactionalContainerChanges<Void, GlobalUniqueIndex, GlobalUniqueIndex> uniqueIndexChanges = new TransactionalContainerChanges<>();
+		private final TransactionalContainerChanges<GlobalUniqueIndex, GlobalUniqueIndex> uniqueIndexChanges = new TransactionalContainerChanges<>();
 
 		public void addCreatedItem(@Nonnull GlobalUniqueIndex uniqueIndex) {
 			this.uniqueIndexChanges.addCreatedItem(uniqueIndex);

--- a/evita_engine/src/main/java/io/evitadb/index/CatalogIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/CatalogIndex.java
@@ -23,15 +23,12 @@
 
 package io.evitadb.index;
 
-import io.evitadb.api.CatalogState;
 import io.evitadb.api.exception.EntityLocaleMissingException;
 import io.evitadb.api.exception.UniqueValueViolationException;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
 import io.evitadb.core.buffer.TrappedChanges;
-import io.evitadb.core.catalog.Catalog;
-import io.evitadb.core.catalog.CatalogRelatedDataStructure;
 import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.memory.Snapshotable;
 import io.evitadb.core.transaction.memory.TransactionalContainerChanges;
@@ -74,8 +71,7 @@ import static java.util.Optional.ofNullable;
  */
 public class CatalogIndex implements
 	Index<CatalogIndexKey>, TransactionalLayerProducer<CatalogIndexChanges, CatalogIndex>,
-	IndexDataStructure,
-	CatalogRelatedDataStructure<CatalogIndex>
+	IndexDataStructure
 {
 	@Getter private final long id = TransactionalObjectVersion.SEQUENCE.nextId();
 	/**
@@ -96,11 +92,6 @@ public class CatalogIndex implements
 	 * transaction is committed and anything in this index was changed).
 	 */
 	@Getter private final int version;
-	/**
-	 * Contains reference to the current catalog instance.
-	 * Beware this reference changes with each entity collection exchange during transactional commit.
-	 */
-	private Catalog catalog;
 
 	public CatalogIndex(@Nonnull Scope scope) {
 		this.version = 1;
@@ -120,18 +111,26 @@ public class CatalogIndex implements
 		this.uniqueIndex = new TransactionalMap<>(uniqueIndex, GlobalUniqueIndex.class, Function.identity());
 	}
 
-	@Override
-	public void attachToCatalog(@Nullable String entityType, @Nonnull Catalog catalog) {
-		Assert.isPremiseValid(this.catalog == null, "Catalog was already attached to this index!");
-		this.catalog = catalog;
-		for (GlobalUniqueIndex globalUniqueIndex : this.uniqueIndex.values()) {
-			globalUniqueIndex.attachToCatalog(null, catalog);
-		}
-	}
-
+	/**
+	 * Produces a fresh {@link CatalogIndex} wrapper (fresh {@link #dirty} flag, fresh {@link #uniqueIndex} map) that
+	 * shares the very same {@link GlobalUniqueIndex} child instances. Global unique indexes hold no back-reference to
+	 * anything version-scoped (their entity-type resolution is supplied per call by an
+	 * {@link EntityTypeClassifierResolver}), so there is nothing per-version to detach in a child — reusing the same
+	 * instances is safe.
+	 *
+	 * The **fresh `dirty` flag is the reason this method cannot be replaced by forwarding the original index.** Outside
+	 * a transaction — i.e. while the catalog is still warming up — {@link #dirty} is written straight into the base
+	 * value, and no production code path ever calls {@link #resetDirty()}: the flag is a latch for the lifetime of the
+	 * instance. Both callers (going live and catalog rename) run right after the catalog has been flushed, so the latch
+	 * is stale by then, yet forwarding the same instance would carry it into the new catalog version and spuriously bump
+	 * {@link #version} on the first commit that follows. Every other producer of a `CatalogIndex` — this method,
+	 * {@link #createCopyWithMergedTransactionalMemory(CatalogIndexChanges, TransactionalLayerMaintainer)} on the
+	 * transactional path, and loading from disk — starts from a fresh flag.
+	 *
+	 * @return the fresh wrapper sharing the same child global unique indexes
+	 */
 	@Nonnull
-	@Override
-	public CatalogIndex createCopyForNewCatalogAttachment(@Nonnull CatalogState catalogState) {
+	public CatalogIndex createShallowCopyWithResetDirtyFlag() {
 		return new CatalogIndex(
 			this.version,
 			this.indexKey,
@@ -141,7 +140,7 @@ public class CatalogIndex implements
 				.collect(
 					Collectors.toMap(
 						Entry::getKey,
-						entry -> entry.getValue().createCopyForNewCatalogAttachment(catalogState)
+						Entry::getValue
 					)
 				)
 		);
@@ -171,7 +170,8 @@ public class CatalogIndex implements
 		@Nonnull Set<Locale> allowedLocales,
 		@Nullable Locale locale,
 		@Nonnull Object value,
-		int recordId
+		int recordId,
+		@Nonnull EntityTypeClassifierResolver resolver
 	) {
 		final GlobalUniqueIndex theUniqueIndex = this.uniqueIndex.computeIfAbsent(
 			createAttributeKey(attributeSchema, allowedLocales, getIndexKey().scope(), locale, value),
@@ -179,14 +179,13 @@ public class CatalogIndex implements
 				final GlobalUniqueIndex newUniqueIndex = new GlobalUniqueIndex(
 					this.getIndexKey().scope(), lookupKey, attributeSchema.getType()
 				);
-				newUniqueIndex.attachToCatalog(null, this.catalog);
 				ofNullable(Transaction.getOrCreateTransactionalMemoryLayer(this))
 					.ifPresent(it -> it.addCreatedItem(newUniqueIndex));
 				this.dirty.setToTrue();
 				return newUniqueIndex;
 			}
 		);
-		theUniqueIndex.registerUniqueKey(value, entitySchema.getName(), locale, recordId);
+		theUniqueIndex.registerUniqueKey(value, entitySchema.getName(), locale, recordId, resolver);
 	}
 
 	/**
@@ -200,12 +199,13 @@ public class CatalogIndex implements
 		@Nonnull Set<Locale> allowedLocales,
 		@Nullable Locale locale,
 		@Nonnull Object value,
-		int recordId
+		int recordId,
+		@Nonnull EntityTypeClassifierResolver resolver
 	) {
 		final AttributeKey lookupKey = createAttributeKey(attributeSchema, allowedLocales, getIndexKey().scope(), locale, value);
 		final GlobalUniqueIndex theUniqueIndex = this.uniqueIndex.get(lookupKey);
 		notNull(theUniqueIndex, "Unique index for attribute `" + attributeSchema.getName() + "` not found!");
-		theUniqueIndex.unregisterUniqueKey(value, entitySchema.getName(), locale, recordId);
+		theUniqueIndex.unregisterUniqueKey(value, entitySchema.getName(), locale, recordId, resolver);
 
 		if (theUniqueIndex.isEmpty()) {
 			Assert.isPremiseValid(theUniqueIndex == this.uniqueIndex.remove(lookupKey), "Expected unique index was not removed!");

--- a/evita_engine/src/main/java/io/evitadb/index/EntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/EntityIndex.java
@@ -329,66 +329,6 @@ public abstract class EntityIndex implements
 	}
 
 	/**
-	 * "Preserve originals" constructor used by the catalog-reattachment / transactional-copy path
-	 * (see {@link ReducedEntityIndex#createCopyForNewCatalogAttachment}). The pre-built transactional
-	 * `entityIds` and `entityIdsByLanguage` are taken verbatim — no defensive copy — and the
-	 * change-detection baseline (`originalHierarchyIndexEmpty`, `originalAttributeIndexes`,
-	 * `originalPriceIndexes`, `originalFacetIndexes`) is set directly from the caller-supplied
-	 * snapshot rather than being recomputed.
-	 *
-	 * Subclasses going through this path **must not** call {@link #captureOriginalsFromComponents()} —
-	 * doing so would overwrite the caller-supplied baselines with current state and silently lose
-	 * the dirty-tracking information that drove this copy to begin with. The `originalHistogramKeys`
-	 * field is initialized to empty here because callers that need histogram-aware change detection
-	 * pre-populate it after construction.
-	 *
-	 * @param primaryKey                  the unique identifier of this index instance within the catalog
-	 * @param indexKey                    the key describing what slice of data this index covers
-	 * @param version                     the index version carried over from the source copy
-	 * @param entityIds                   transactional bitmap of all entity primary keys (used as-is)
-	 * @param entityIdsByLanguage         transactional map of entity primary keys by locale (used as-is)
-	 * @param attributeIndex              the attribute sub-index carried over from the source copy
-	 * @param hierarchyIndex              the hierarchy sub-index carried over from the source copy
-	 * @param facetIndex                  the facet sub-index carried over from the source copy
-	 * @param originalHierarchyIndexEmpty pre-computed baseline: whether the hierarchy index was originally empty
-	 * @param originalAttributeIndexes    pre-computed baseline: attribute-index storage keys at the snapshot point
-	 * @param originalPriceIndexes        pre-computed baseline: price-index storage keys at the snapshot point
-	 * @param originalFacetIndexes        pre-computed baseline: facet referenced entity types at the snapshot point
-	 */
-	protected EntityIndex(
-		int primaryKey,
-		@Nonnull EntityIndexKey indexKey,
-		int version,
-		@Nonnull TransactionalBitmap entityIds,
-		@Nonnull TransactionalMap<Locale, TransactionalBitmap> entityIdsByLanguage,
-		@Nonnull AttributeIndex attributeIndex,
-		@Nonnull HierarchyIndex hierarchyIndex,
-		@Nonnull FacetIndex facetIndex,
-		boolean originalHierarchyIndexEmpty,
-		@Nonnull Set<AttributeIndexStorageKey> originalAttributeIndexes,
-		@Nonnull Set<PriceIndexKey> originalPriceIndexes,
-		@Nonnull Set<String> originalFacetIndexes
-	) {
-		this.primaryKey = primaryKey;
-		this.indexKey = indexKey;
-		this.version = version;
-		this.dirty = new TransactionalBoolean();
-		this.entityIds = entityIds;
-		// the "preserve originals" copy carries the source index's persisted-bitmap state verbatim
-		this.previouslyPersisted = !entityIds.isEmpty();
-		this.entityIdsByLanguage = entityIdsByLanguage;
-		this.attributeIndex = attributeIndex;
-		this.hierarchyIndex = hierarchyIndex;
-		this.facetIndex = facetIndex;
-		this.originalHierarchyIndexEmpty = originalHierarchyIndexEmpty;
-		this.originalAttributeIndexes = originalAttributeIndexes;
-		this.originalPriceIndexes = originalPriceIndexes;
-		this.originalFacetIndexes = originalFacetIndexes;
-		this.originalHistogramKeys = Collections.emptySet();
-		registerBaseComponents();
-	}
-
-	/**
 	 * Registers new entity primary key to the superset of entity ids of this entity index.
 	 */
 	public boolean insertPrimaryKeyIfMissing(int entityPrimaryKey) {
@@ -1064,11 +1004,10 @@ public abstract class EntityIndex implements
 	 * The base {@link EntityIndex} constructors initialize all `original*` fields to empty placeholders
 	 * and do not capture any baseline themselves — the component list is only partially populated at
 	 * that point. Every terminal subclass constructor must invoke this method as its final step, after
-	 * the super constructor has run and after every subclass-owned `addComponent(...)` call. The single
-	 * exception is the "preserve originals" constructor path (e.g.
-	 * {@link ReducedEntityIndex#createCopyForNewCatalogAttachment}) which receives pre-computed
-	 * baselines from the caller; calling this method along that path would overwrite the caller-supplied
-	 * snapshot with current state and silently lose dirty-tracking information.
+	 * the super constructor has run and after every subclass-owned `addComponent(...)` call. Any future
+	 * constructor that instead receives pre-computed baselines from its caller must **not** call this
+	 * method, since doing so would overwrite those baselines with current state and silently lose the
+	 * dirty-tracking information they carry.
 	 */
 	protected final void captureOriginalsFromComponents() {
 		final EntityIndexManifest baseline = new EntityIndexManifest();

--- a/evita_engine/src/main/java/io/evitadb/index/EntityTypeClassifierResolver.java
+++ b/evita_engine/src/main/java/io/evitadb/index/EntityTypeClassifierResolver.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index;
+
+import io.evitadb.core.catalog.Catalog;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Narrow view that translates between an entity type name and the compact integer primary key that the
+ * catalog assigns to it. Catalog-wide index structures (namely the global unique index) store the compact
+ * type primary key inside their packed tuples to save memory, but must occasionally translate it back to the
+ * human-readable name (and vice versa). This resolver is the ONLY dependency such an index needs on the
+ * surrounding catalog — the resolution is version-sensitive (a collection rename or delete changes the
+ * name ↔ pk mapping), so it must always be supplied by the caller's current snapshot rather than captured as
+ * a long-lived back-reference inside the index.
+ *
+ * Implemented by {@link Catalog}; the two methods delegate to its collection lookups.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+public interface EntityTypeClassifierResolver {
+
+	/**
+	 * Translates an entity type name to the compact integer primary key stored in packed index tuples.
+	 *
+	 * @param entityType the entity type name
+	 * @return the compact entity type primary key
+	 */
+	int toEntityTypePrimaryKey(@Nonnull String entityType);
+
+	/**
+	 * Translates the compact integer primary key stored in packed index tuples back to the entity type name.
+	 *
+	 * @param entityTypePrimaryKey the compact entity type primary key
+	 * @return the entity type name
+	 */
+	@Nonnull
+	String toEntityTypeName(int entityTypePrimaryKey);
+
+}

--- a/evita_engine/src/main/java/io/evitadb/index/GlobalEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/GlobalEntityIndex.java
@@ -303,7 +303,7 @@ public class GlobalEntityIndex extends EntityIndex
 	@Nonnull
 	@Override
 	public GlobalEntityIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer
+		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		// we can safely throw away dirty flag now
 		final Boolean wasDirty = transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
@@ -321,7 +321,6 @@ public class GlobalEntityIndex extends EntityIndex
 
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		// the price index is removed by the component-loop inside the super call — no extra hop
 		super.removeTransactionalMemoryOfReferencedProducers(transactionalLayer);
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/HistogramIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/HistogramIndex.java
@@ -420,7 +420,6 @@ public abstract class HistogramIndex
 	@Nonnull
 	@Override
 	public abstract HistogramIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	);
 

--- a/evita_engine/src/main/java/io/evitadb/index/LocalizedHistogramIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/LocalizedHistogramIndex.java
@@ -334,7 +334,6 @@ public class LocalizedHistogramIndex extends HistogramIndex {
 	@Nonnull
 	@Override
 	public HistogramIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		return new LocalizedHistogramIndex(
@@ -349,7 +348,6 @@ public class LocalizedHistogramIndex extends HistogramIndex {
 
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		this.filterIndexes.removeLayer(transactionalLayer);
 		this.cardinalities.removeLayer(transactionalLayer);
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/ReducedEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/ReducedEntityIndex.java
@@ -244,7 +244,6 @@ public class ReducedEntityIndex extends AbstractReducedEntityIndex {
 	@Nonnull
 	@Override
 	public ReducedEntityIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		// we can safely throw away dirty flag now

--- a/evita_engine/src/main/java/io/evitadb/index/ReducedEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/ReducedEntityIndex.java
@@ -23,7 +23,6 @@
 
 package io.evitadb.index;
 
-import io.evitadb.api.CatalogState;
 import io.evitadb.api.requestResponse.data.ReferenceContract;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
@@ -39,10 +38,7 @@ import io.evitadb.index.component.loader.IndexReloadPlan;
 import io.evitadb.index.component.loader.LoadedComponentBundle;
 import io.evitadb.index.facet.FacetIndex;
 import io.evitadb.index.hierarchy.HierarchyIndex;
-import io.evitadb.index.map.TransactionalMap;
 import io.evitadb.index.price.PriceRefIndex;
-import io.evitadb.index.price.model.PriceIndexKey;
-import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexStorageKey;
 import io.evitadb.utils.Assert;
 import io.evitadb.utils.StringUtils;
 
@@ -177,69 +173,6 @@ public class ReducedEntityIndex extends AbstractReducedEntityIndex {
 				facet.facetIndex()
 			);
 		});
-
-	/**
-	 * Creates a reduced entity index as a transactional copy. This constructor is used internally by
-	 * {@link #createCopyForNewCatalogAttachment(CatalogState)} and preserves original storage part state.
-	 *
-	 * @param primaryKey                  the primary key of this index
-	 * @param indexKey                    the key identifying this index
-	 * @param version                     the version of this index
-	 * @param entityIds                   transactional bitmap of entity primary keys
-	 * @param entityIdsByLanguage         transactional map of entity primary keys by locale
-	 * @param attributeIndex              the attribute index
-	 * @param hierarchyIndex              the hierarchy index
-	 * @param facetIndex                  the facet index
-	 * @param originalHierarchyIndexEmpty whether the hierarchy index was originally empty
-	 * @param originalAttributeIndexes    original attribute index storage keys
-	 * @param originalPriceIndexes        original price index keys
-	 * @param originalFacetIndexes        original facet index referenced entities
-	 * @param priceIndex                  the price reference index
-	 */
-	private ReducedEntityIndex(
-		int primaryKey,
-		@Nonnull EntityIndexKey indexKey,
-		int version,
-		@Nonnull TransactionalBitmap entityIds,
-		@Nonnull TransactionalMap<Locale, TransactionalBitmap> entityIdsByLanguage,
-		@Nonnull ReferenceAttributeIndex attributeIndex,
-		@Nonnull HierarchyIndex hierarchyIndex,
-		@Nonnull FacetIndex facetIndex,
-		boolean originalHierarchyIndexEmpty,
-		@Nonnull Set<AttributeIndexStorageKey> originalAttributeIndexes,
-		@Nonnull Set<PriceIndexKey> originalPriceIndexes,
-		@Nonnull Set<String> originalFacetIndexes,
-		@Nonnull PriceRefIndex priceIndex
-	) {
-		super(
-			primaryKey, indexKey, version, entityIds,
-			entityIdsByLanguage, attributeIndex, hierarchyIndex, facetIndex,
-			originalHierarchyIndexEmpty,
-			originalAttributeIndexes, originalPriceIndexes, originalFacetIndexes,
-			priceIndex
-		);
-		// do NOT call captureOriginalsFromComponents here — this constructor is the "preserve
-		// originals" path used by catalog re-attachment, and recapturing would overwrite the
-		// caller-provided baselines with the current live state, losing dirty/change tracking
-	}
-
-	@Nonnull
-	@Override
-	public ReducedEntityIndex createCopyForNewCatalogAttachment(@Nonnull CatalogState catalogState) {
-		return new ReducedEntityIndex(
-			this.primaryKey, this.indexKey, this.version,
-			this.entityIds, this.entityIdsByLanguage,
-			// safe: AttributeIndex#createCopy preserves the subclass identity established by EntityIndex#isReferenceScoped
-			(ReferenceAttributeIndex) this.attributeIndex,
-			this.hierarchyIndex,
-			this.facetIndex,
-			this.originalHierarchyIndexEmpty,
-			this.originalAttributeIndexes,
-			this.originalPriceIndexes,
-			this.originalFacetIndexes,
-			getPriceIndex().createCopyForNewCatalogAttachment(catalogState)
-		);
-	}
 
 	@Nonnull
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/index/ReducedGroupEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/ReducedGroupEntityIndex.java
@@ -851,7 +851,6 @@ public class ReducedGroupEntityIndex extends AbstractReducedEntityIndex implemen
 	@Nonnull
 	@Override
 	public ReducedGroupEntityIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		// we can safely throw away dirty flag now

--- a/evita_engine/src/main/java/io/evitadb/index/ReducedGroupEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/ReducedGroupEntityIndex.java
@@ -23,7 +23,6 @@
 
 package io.evitadb.index;
 
-import io.evitadb.api.CatalogState;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
@@ -56,11 +55,8 @@ import io.evitadb.index.hierarchy.HierarchyIndex;
 import io.evitadb.index.map.PersistentTransactionalMap;
 import io.evitadb.index.map.TransactionalMap;
 import io.evitadb.index.price.PriceRefIndex;
-import io.evitadb.index.price.model.PriceIndexKey;
 import io.evitadb.index.result.CardinalityChange;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexKey;
-import io.evitadb.spi.store.catalog.persistence.storageParts.index.AttributeIndexStorageKey;
-import io.evitadb.spi.store.catalog.persistence.storageParts.index.HistogramIndexStorageKey;
 import io.evitadb.utils.Assert;
 import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.StringUtils;
@@ -279,98 +275,10 @@ public class ReducedGroupEntityIndex extends AbstractReducedEntityIndex implemen
 			);
 		});
 
-	/**
-	 * Creates a reduced group entity index as a transactional copy. This constructor is used internally by
-	 * {@link #createCopyForNewCatalogAttachment(CatalogState)} and preserves original storage part state.
-	 *
-	 * @param primaryKey                  the primary key of this index
-	 * @param indexKey                    the key identifying this index
-	 * @param version                     the version of this index
-	 * @param entityIds                   transactional bitmap of entity primary keys
-	 * @param entityIdsByLanguage         transactional map of entity primary keys by locale
-	 * @param attributeIndex              the attribute index
-	 * @param hierarchyIndex              the hierarchy index
-	 * @param facetIndex                  the facet index
-	 * @param originalHierarchyIndexEmpty whether the hierarchy index was originally empty
-	 * @param originalAttributeIndexes    original attribute index storage keys (incl. CARDINALITY)
-	 * @param originalPriceIndexes        original price index keys
-	 * @param originalFacetIndexes        original facet index referenced entities
-	 * @param originalHistogramKeys       original histogram index storage keys
-	 * @param priceIndex                  the price reference index
-	 * @param pkCardinalities             cardinality tracking for entity primary keys
-	 * @param referencedPrimaryKeysIndex  maps referenced entity PKs to bitmaps of entity PKs
-	 * @param cardinalityIndexes          cardinality tracking for filter attributes
-	 * @param histogramIndexes            histogram indexes by histogram name
-	 */
-	private ReducedGroupEntityIndex(
-		int primaryKey,
-		@Nonnull EntityIndexKey indexKey,
-		int version,
-		@Nonnull TransactionalBitmap entityIds,
-		@Nonnull TransactionalMap<Locale, TransactionalBitmap> entityIdsByLanguage,
-		@Nonnull ReferenceAttributeIndex attributeIndex,
-		@Nonnull HierarchyIndex hierarchyIndex,
-		@Nonnull FacetIndex facetIndex,
-		boolean originalHierarchyIndexEmpty,
-		@Nonnull Set<AttributeIndexStorageKey> originalAttributeIndexes,
-		@Nonnull Set<PriceIndexKey> originalPriceIndexes,
-		@Nonnull Set<String> originalFacetIndexes,
-		@Nonnull Set<HistogramIndexStorageKey> originalHistogramKeys,
-		@Nonnull PriceRefIndex priceIndex,
-		@Nonnull PersistentTransactionalMap<Integer, Integer> pkCardinalities,
-		@Nonnull TransactionalMap<Integer, TransactionalBitmap> referencedPrimaryKeysIndex,
-		@Nonnull TransactionalMap<AttributeIndexKey, AttributeCardinalityIndex> cardinalityIndexes,
-		@Nonnull TransactionalMap<String, HistogramIndex> histogramIndexes
-	) {
-		super(
-			primaryKey, indexKey, version, entityIds,
-			entityIdsByLanguage, attributeIndex, hierarchyIndex, facetIndex,
-			originalHierarchyIndexEmpty,
-			originalAttributeIndexes, originalPriceIndexes, originalFacetIndexes,
-			priceIndex
-		);
-		this.cardinalityDirty = new TransactionalBoolean();
-		this.pkCardinalities = pkCardinalities;
-		this.referencedPrimaryKeysIndex = referencedPrimaryKeysIndex;
-		this.cardinalityIndexes = cardinalityIndexes;
-		this.histogramIndexes = histogramIndexes;
-		// preserve the histogram baseline from the source instance — the base constructor only
-		// handles UNIQUE/FILTER/SORT/CHAIN + facet + price + hierarchy baselines, so subclass-only
-		// histogram keys must be propagated explicitly
-		this.originalHistogramKeys = originalHistogramKeys;
-		registerSubclassComponents();
-		// do NOT call captureOriginalsFromComponents here — this constructor is the "preserve
-		// originals" path used by catalog re-attachment, and recapturing would overwrite the
-		// caller-provided baselines with the current live state, losing dirty/change tracking
-	}
-
 	@Override
 	public boolean isEmpty() {
 		// null check required: parent constructor calls isEmpty() before subclass fields are initialized
 		return super.isEmpty() && this.pkCardinalities.isEmpty() && this.histogramIndexes.isEmpty();
-	}
-
-	@Nonnull
-	@Override
-	public ReducedGroupEntityIndex createCopyForNewCatalogAttachment(@Nonnull CatalogState catalogState) {
-		return new ReducedGroupEntityIndex(
-			this.primaryKey, this.indexKey, this.version,
-			this.entityIds, this.entityIdsByLanguage,
-			// safe: AttributeIndex#createCopy preserves the subclass identity established by EntityIndex#isReferenceScoped
-			(ReferenceAttributeIndex) this.attributeIndex,
-			this.hierarchyIndex,
-			this.facetIndex,
-			this.originalHierarchyIndexEmpty,
-			this.originalAttributeIndexes,
-			this.originalPriceIndexes,
-			this.originalFacetIndexes,
-			this.originalHistogramKeys,
-			getPriceIndex().createCopyForNewCatalogAttachment(catalogState),
-			this.pkCardinalities,
-			this.referencedPrimaryKeysIndex,
-			this.cardinalityIndexes,
-			this.histogramIndexes
-		);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/ReferencedTypeEntityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/ReferencedTypeEntityIndex.java
@@ -720,7 +720,6 @@ public class ReferencedTypeEntityIndex extends EntityIndex implements
 	@Nonnull
 	@Override
 	public ReferencedTypeEntityIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		// we can safely throw away dirty flag now
@@ -744,7 +743,6 @@ public class ReferencedTypeEntityIndex extends EntityIndex implements
 		// drop our own diff layer (no-op for VoidTransactionMemoryProducer) and propagate the
 		// recursive remove into every registered component via the base method — the base loop
 		// covers the AttributeCardinality, Histogram and ReferenceTypeCardinality components too
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		super.removeTransactionalMemoryOfReferencedProducers(transactionalLayer);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/SimpleHistogramIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/SimpleHistogramIndex.java
@@ -182,7 +182,6 @@ public class SimpleHistogramIndex extends HistogramIndex {
 	@Nonnull
 	@Override
 	public HistogramIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		return new SimpleHistogramIndex(
@@ -197,7 +196,6 @@ public class SimpleHistogramIndex extends HistogramIndex {
 
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		this.filterIndex.removeLayer(transactionalLayer);
 		this.cardinality.removeLayer(transactionalLayer);
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/array/ChangePlan.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/ChangePlan.java
@@ -41,6 +41,31 @@ class ChangePlan {
 	@Getter private boolean both;
 	@Getter private boolean none;
 
+	/**
+	 * Selects and records the next merge operation for the two cursor positions. INSERTION wins ties
+	 * against a later removal; an equal insertion/removal position plans both; a lone removal or the
+	 * exhausted state (`-1`/`-1`) fall through accordingly. This is the single decision shared by every
+	 * diff layer's merge loop ({@link IntArrayChanges}, {@link ObjArrayChanges}, {@link ComplexObjArrayChanges}).
+	 *
+	 * @param nextInsertionPosition index of the next non-processed insertion command, or -1 if none
+	 * @param nextRemovalPosition   index of the next non-processed removal command, or -1 if none
+	 */
+	void planNextOperation(int nextInsertionPosition, int nextRemovalPosition) {
+		if (nextInsertionPosition >= 0) {
+			if (nextRemovalPosition == -1 || nextRemovalPosition > nextInsertionPosition) {
+				planInsertOperation(nextInsertionPosition);
+			} else if (nextInsertionPosition == nextRemovalPosition) {
+				planBothOperations(nextInsertionPosition);
+			} else {
+				planRemovalOperation(nextRemovalPosition);
+			}
+		} else if (nextRemovalPosition >= 0) {
+			planRemovalOperation(nextRemovalPosition);
+		} else {
+			noOperations();
+		}
+	}
+
 	void planInsertOperation(int position) {
 		this.position = position;
 		this.insertion = true;

--- a/evita_engine/src/main/java/io/evitadb/index/array/ComplexObjArrayChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/ComplexObjArrayChanges.java
@@ -26,6 +26,7 @@ package io.evitadb.index.array;
 import io.evitadb.core.transaction.memory.Snapshotable;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.ArrayUtils.InsertionPosition;
 import io.evitadb.utils.Assert;
@@ -44,7 +45,6 @@ import java.util.function.Predicate;
 import static io.evitadb.core.transaction.Transaction.getTransactionalLayerMaintainer;
 import static io.evitadb.core.transaction.Transaction.suppressTransactionalMemoryLayerFor;
 import static io.evitadb.core.transaction.Transaction.suppressTransactionalMemoryLayerForWithResult;
-import static java.util.Optional.ofNullable;
 
 /**
  * Collects insertions, removals, and combine/reduce operations recorded against
@@ -55,7 +55,7 @@ import static java.util.Optional.ofNullable;
  */
 @NotThreadSafe
 @SuppressWarnings("unchecked")
-class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>>
+class ComplexObjArrayChanges<T extends TransactionalObject<T> & Comparable<T>>
 	implements Snapshotable<ComplexObjArrayChanges.ComplexObjArrayChangesMemento<T>> {
 	/**
 	 * Keeps type of the object that is monitored in changes.
@@ -133,7 +133,7 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 			final T[] delegateCopy = (T[]) Array.newInstance(objectType, values.length);
 			for (int i = 0; i < values.length; i++) {
 				final T item = values[i];
-				if (item instanceof TransactionalLayerProducer<?, ?> producer) {
+				if (item instanceof TransactionalStateProducer<?> producer) {
 					delegateCopy[i] = getTransactionalCopy(transactionalLayer, producer);
 				} else {
 					delegateCopy[i] = item;
@@ -152,7 +152,7 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 	@Nonnull
 	private static <T> T getTransactionalCopy(
 		@Nullable TransactionalLayerMaintainer transactionalLayer,
-		@Nonnull TransactionalLayerProducer<?, ?> value
+		@Nonnull TransactionalStateProducer<?> value
 	) {
 		return transactionalLayer == null
 			? (T) value
@@ -166,38 +166,11 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 	@Nonnull
 	private static <T> T getTransactionalCopyWithoutDiscardingState(
 		@Nullable TransactionalLayerMaintainer transactionalLayer,
-		@Nonnull TransactionalLayerProducer<?, ?> value
+		@Nonnull TransactionalStateProducer<?> value
 	) {
 		return transactionalLayer == null
 			? (T) value
 			: (T) transactionalLayer.getStateCopyWithCommittedChangesWithoutDiscardingState(value);
-	}
-
-	/**
-	 * Computes closest modification operation that should occur upon the original array.
-	 *
-	 * @param nextInsertionPosition index of next non-processed insertion
-	 * @param nextRemovalPosition   index of next non-processed removal
-	 * @param plan                  plan to populate
-	 */
-	private static void getNextOperations(
-		int nextInsertionPosition,
-		int nextRemovalPosition,
-		@Nonnull ChangePlan plan
-	) {
-		if (nextInsertionPosition >= 0) {
-			if (nextRemovalPosition == -1 || nextRemovalPosition > nextInsertionPosition) {
-				plan.planInsertOperation(nextInsertionPosition);
-			} else if (nextInsertionPosition == nextRemovalPosition) {
-				plan.planBothOperations(nextInsertionPosition);
-			} else {
-				plan.planRemovalOperation(nextRemovalPosition);
-			}
-		} else if (nextRemovalPosition >= 0 && nextInsertionPosition == -1) {
-			plan.planRemovalOperation(nextRemovalPosition);
-		} else {
-			plan.noOperations();
-		}
 	}
 
 	/**
@@ -324,18 +297,49 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 	}
 
 	/**
+	 * Propagates diff-layer removal to the passed element, if the element participates in the transactional memory.
+	 *
+	 * Elements of this array are only required to be {@link TransactionalObject}s - producing transactional state is
+	 * **not** part of that contract, so the capability has to be tested rather than assumed. Assuming it would break
+	 * arrays of non-producing elements, which are a supported case.
+	 *
+	 * @param value              element to propagate the removal to; may be NULL
+	 * @param transactionalLayer object that provides access to entire transactional memory
+	 */
+	private static void removeLayerIfProducer(
+		@Nullable Object value,
+		@Nonnull TransactionalLayerMaintainer transactionalLayer
+	) {
+		if (value instanceof TransactionalStateProducer<?> transactionalStateProducer) {
+			transactionalStateProducer.removeLayer(transactionalLayer);
+		}
+	}
+
+	/**
+	 * Propagates diff-layer removal to the passed element within the current transaction, if the element participates
+	 * in the transactional memory. See {@link #removeLayerIfProducer(Object, TransactionalLayerMaintainer)}.
+	 *
+	 * @param value element to propagate the removal to; may be NULL
+	 */
+	private static void removeLayerIfProducer(@Nullable Object value) {
+		if (value instanceof TransactionalStateProducer<?> transactionalStateProducer) {
+			transactionalStateProducer.removeLayer();
+		}
+	}
+
+	/**
 	 * Cleans information of all internal original and inserted data.
 	 */
 	public void cleanAll(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		for (T originalValue : this.original) {
-			originalValue.removeLayer(transactionalLayer);
+			removeLayerIfProducer(originalValue, transactionalLayer);
 		}
 		for (T removedValue : this.removedValues) {
-			removedValue.removeLayer(transactionalLayer);
+			removeLayerIfProducer(removedValue, transactionalLayer);
 		}
 		for (T[] insertedValues : this.insertedValues) {
 			for (T insertedValue : insertedValues) {
-				insertedValue.removeLayer(transactionalLayer);
+				removeLayerIfProducer(insertedValue, transactionalLayer);
 			}
 		}
 	}
@@ -501,7 +505,7 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 
 				// get first position with change operations
 				final ChangePlan plan = new ChangePlan();
-				getNextOperations(nextInsertionPosition, nextRemovalPosition, plan);
+				plan.planNextOperation(nextInsertionPosition, nextRemovalPosition);
 
 				// create new array instance
 				T[] delegateArray = getTransactionalCopy(
@@ -658,7 +662,7 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 						: -1;
 
 					// plan next operations
-					getNextOperations(nextInsertionPosition, nextRemovalPosition, plan);
+					plan.planNextOperation(nextInsertionPosition, nextRemovalPosition);
 				}
 
 				// copy rest of the original array
@@ -738,10 +742,10 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 		final int removalIndex = Arrays.binarySearch(this.removals, position);
 		if (removalIndex >= 0) {
 			final T removedValue = this.removedValues[removalIndex];
-			if (transactionalLayer == null || !(removedValue instanceof TransactionalLayerProducer<?, ?>)) {
+			if (transactionalLayer == null || !(removedValue instanceof TransactionalStateProducer<?>)) {
 				return removedValue;
 			}
-			return getTransactionalCopy(transactionalLayer, (TransactionalLayerProducer<?, ?>) removedValue);
+			return getTransactionalCopy(transactionalLayer, (TransactionalStateProducer<?>) removedValue);
 		} else {
 			return null;
 		}
@@ -759,11 +763,11 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 		final int removalIndex = Arrays.binarySearch(this.removals, position);
 		if (removalIndex >= 0) {
 			final T removedValue = this.removedValues[removalIndex];
-			if (transactionalLayer == null || !(removedValue instanceof TransactionalLayerProducer<?, ?>)) {
+			if (transactionalLayer == null || !(removedValue instanceof TransactionalStateProducer<?>)) {
 				return removedValue;
 			}
 			return getTransactionalCopyWithoutDiscardingState(
-				transactionalLayer, (TransactionalLayerProducer<?, ?>) removedValue
+				transactionalLayer, (TransactionalStateProducer<?>) removedValue
 			);
 		} else {
 			return null;
@@ -820,7 +824,7 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 				final T delegateClone = insertedValuesBefore[innerPosition.position()];
 				this.combiner.accept(delegateClone, recordId);
 				// remove orphan transactional memory
-				recordId.removeLayer();
+				removeLayerIfProducer(recordId);
 			}
 		} else {
 			// no existing record, add at target place
@@ -859,9 +863,9 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 			if (reducedValue == null
 				|| (this.obsoleteChecker != null && this.obsoleteChecker.test(reducedValue))) {
 				// remove removed value
-				ofNullable(reducedValue).ifPresent(TransactionalObject::removeLayer);
+				removeLayerIfProducer(reducedValue);
 				// remove added value (negates removal)
-				recordId.removeLayer();
+				removeLayerIfProducer(recordId);
 
 				final int[] newRemovals = new int[this.removals.length - 1];
 				System.arraycopy(this.removals, 0, newRemovals, 0, removalIndex);
@@ -959,7 +963,7 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 			// no reducer or reduced record is obsolete
 			if (reducedValue == null
 				|| (this.obsoleteChecker != null && this.obsoleteChecker.test(reducedValue))) {
-				ofNullable(reducedValue).ifPresent(TransactionalObject::removeLayer);
+				removeLayerIfProducer(reducedValue);
 
 				// remove from the insertion set
 				final T[] insertedValuesAfter = ArrayUtils.removeRecordFromOrderedArray(
@@ -1125,7 +1129,7 @@ class ComplexObjArrayChanges<T extends TransactionalObject<T, ?> & Comparable<T>
 	 *                           reduce family)
 	 * @param <T>                element runtime type, a transactional, comparable object
 	 */
-	public record ComplexObjArrayChangesMemento<T extends TransactionalObject<T, ?> & Comparable<T>>(
+	public record ComplexObjArrayChangesMemento<T extends TransactionalObject<T> & Comparable<T>>(
 		@Nonnull int[] insertions,
 		@Nonnull T[][] insertedValues,
 		@Nonnull int[] removals,

--- a/evita_engine/src/main/java/io/evitadb/index/array/IntArrayChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/IntArrayChanges.java
@@ -75,28 +75,6 @@ public class IntArrayChanges
 	@Nullable private int[] memoizedMergedArray;
 
 	/**
-	 * Computes closest modification operation that should occur upon the original array.
-	 *
-	 * @param nextInsertionPosition index of the next non-processed insertion command
-	 * @param nextRemovalPosition   index of the next non-processed removal command
-	 */
-	private static void getNextOperations(int nextInsertionPosition, int nextRemovalPosition, ChangePlan plan) {
-		if (nextInsertionPosition >= 0) {
-			if (nextRemovalPosition == -1 || nextRemovalPosition > nextInsertionPosition) {
-				plan.planInsertOperation(nextInsertionPosition);
-			} else if (nextInsertionPosition == nextRemovalPosition) {
-				plan.planBothOperations(nextInsertionPosition);
-			} else {
-				plan.planRemovalOperation(nextRemovalPosition);
-			}
-		} else if (nextRemovalPosition >= 0 && nextInsertionPosition == -1) {
-			plan.planRemovalOperation(nextRemovalPosition);
-		} else {
-			plan.noOperations();
-		}
-	}
-
-	/**
 	 * Creates a new change layer over the given delegate array.
 	 *
 	 * @param delegate the immutable baseline array
@@ -278,7 +256,7 @@ public class IntArrayChanges
 
 				// from left to right get first position with change operations
 				final ChangePlan plan = new ChangePlan();
-				getNextOperations(nextInsertionPosition, nextRemovalPosition, plan);
+				plan.planNextOperation(nextInsertionPosition, nextRemovalPosition);
 
 				while (plan.hasAnythingToDo()) {
 					if (plan.bothOperationsRequested()) {
@@ -355,7 +333,7 @@ public class IntArrayChanges
 					}
 
 					// plan next operations
-					getNextOperations(nextInsertionPosition, nextRemovalPosition, plan);
+					plan.planNextOperation(nextInsertionPosition, nextRemovalPosition);
 				}
 
 				// copy rest of the original array into the result (no operations were planned for this part)

--- a/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/ObjArrayChanges.java
@@ -78,32 +78,6 @@ public class ObjArrayChanges<T> implements Snapshotable<ObjArrayChanges.ObjArray
 	@Nullable private T[] memoizedMergedArray;
 
 	/**
-	 * Computes closest modification operation that should occur upon the original array.
-	 *
-	 * @param nextInsertionPosition index of the next non-processed insertion command
-	 * @param nextRemovalPosition   index of the next non-processed removal command
-	 */
-	private static void getNextOperations(
-		int nextInsertionPosition,
-		int nextRemovalPosition,
-		@Nonnull ChangePlan plan
-	) {
-		if (nextInsertionPosition >= 0) {
-			if (nextRemovalPosition == -1 || nextRemovalPosition > nextInsertionPosition) {
-				plan.planInsertOperation(nextInsertionPosition);
-			} else if (nextInsertionPosition == nextRemovalPosition) {
-				plan.planBothOperations(nextInsertionPosition);
-			} else {
-				plan.planRemovalOperation(nextRemovalPosition);
-			}
-		} else if (nextRemovalPosition >= 0 && nextInsertionPosition == -1) {
-			plan.planRemovalOperation(nextRemovalPosition);
-		} else {
-			plan.noOperations();
-		}
-	}
-
-	/**
 	 * Creates a new change layer over the given delegate array.
 	 *
 	 * @param delegate the immutable baseline array
@@ -381,7 +355,7 @@ public class ObjArrayChanges<T> implements Snapshotable<ObjArrayChanges.ObjArray
 
 				// from left to right get first position with change operations
 				final ChangePlan plan = new ChangePlan();
-				getNextOperations(nextInsertionPosition, nextRemovalPosition, plan);
+				plan.planNextOperation(nextInsertionPosition, nextRemovalPosition);
 
 				while (plan.hasAnythingToDo()) {
 					if (plan.bothOperationsRequested()) {
@@ -475,7 +449,7 @@ public class ObjArrayChanges<T> implements Snapshotable<ObjArrayChanges.ObjArray
 					}
 
 					// plan next operations
-					getNextOperations(nextInsertionPosition, nextRemovalPosition, plan);
+					plan.planNextOperation(nextInsertionPosition, nextRemovalPosition);
 				}
 
 				// copy rest of the original array into the result (no operations were planned for this part)

--- a/evita_engine/src/main/java/io/evitadb/index/array/TransactionalComplexObjArray.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/TransactionalComplexObjArray.java
@@ -26,6 +26,7 @@ package io.evitadb.index.array;
 import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.dataType.iterator.ConstantObjIterator;
 import io.evitadb.utils.ArrayUtils;
@@ -67,7 +68,7 @@ import static java.util.Optional.ofNullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
 public class TransactionalComplexObjArray<
-	T extends TransactionalObject<T, ?> & Comparable<T>>
+	T extends TransactionalObject<T> & Comparable<T>>
 	implements TransactionalLayerProducer<
 	ComplexObjArrayChanges<T>, T[]>, Serializable {
 	@Serial private static final long serialVersionUID = 1929748392138616409L;
@@ -107,7 +108,7 @@ public class TransactionalComplexObjArray<
 		//noinspection unchecked
 		this.objectType = (Class<T>) delegate.getClass().getComponentType();
 		this.transactionalLayerProducer =
-			TransactionalLayerProducer.class
+			TransactionalStateProducer.class
 				.isAssignableFrom(this.objectType);
 		this.delegate = delegate;
 		this.producer = null;
@@ -163,7 +164,7 @@ public class TransactionalComplexObjArray<
 		//noinspection unchecked
 		this.objectType = (Class<T>) delegate.getClass().getComponentType();
 		this.transactionalLayerProducer =
-			TransactionalLayerProducer.class
+			TransactionalStateProducer.class
 				.isAssignableFrom(this.objectType);
 		this.delegate = delegate;
 		this.producer = producer;
@@ -441,12 +442,11 @@ public class TransactionalComplexObjArray<
 			for (int i = 0; i < this.delegate.length; i++) {
 				T item = this.delegate[i];
 				if (this.transactionalLayerProducer) {
-					@SuppressWarnings("unchecked") final TransactionalLayerProducer<ComplexObjArrayChanges<T>, ?> theProducer =
-						(TransactionalLayerProducer<ComplexObjArrayChanges<T>, ?>) item;
+					// the element may own a diff layer or not - either way it resolves its own committed form, so the
+					// layer must not be passed in from here (it belongs to this array, never to the element)
+					final TransactionalStateProducer<?> theProducer = (TransactionalStateProducer<?>) item;
 					//noinspection unchecked
-					item = (T) theProducer.createCopyWithMergedTransactionalMemory(
-						null, transactionalLayer
-					);
+					item = (T) theProducer.createCopyWithMergedTransactionalMemory(transactionalLayer);
 				}
 				copy[i] = item;
 			}

--- a/evita_engine/src/main/java/io/evitadb/index/array/TransactionalComplexObjArrayIterator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/TransactionalComplexObjArrayIterator.java
@@ -38,7 +38,7 @@ import static io.evitadb.core.transaction.Transaction.suppressTransactionalMemor
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
-class TransactionalComplexObjArrayIterator<T extends TransactionalObject<T, ?> & Comparable<T>>
+class TransactionalComplexObjArrayIterator<T extends TransactionalObject<T> & Comparable<T>>
 	implements Iterator<T> {
 	/**
 	 * Contains reference to original immutable array of objects.

--- a/evita_engine/src/main/java/io/evitadb/index/array/TransactionalObject.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/TransactionalObject.java
@@ -23,20 +23,20 @@
 
 package io.evitadb.index.array;
 
-import io.evitadb.core.transaction.memory.TransactionalLayerCreator;
-
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * This interface must be implemented by all objects in order to be placed inside {@link TransactionalComplexObjArray}.
  *
+ * It carries no transactional-memory role of its own - implementations declare that separately, typically as
+ * {@link io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer}.
+ *
  * @param <T>          the concrete type of the transactional object (self-referencing bound)
- * @param <DIFF_LAYER> the type of the transactional diff layer created by this object
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
 @ThreadSafe
-public interface TransactionalObject<T, DIFF_LAYER> extends TransactionalLayerCreator<DIFF_LAYER> {
+public interface TransactionalObject<T> {
 
 	/**
 	 * Method implementation must create deep clone of the object itself and all transactionally active inner objects.

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/AttributeIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/AttributeIndex.java
@@ -1898,11 +1898,11 @@ public abstract sealed class AttributeIndex implements AttributeIndexContract,
 	public static class AttributeIndexChanges implements Snapshotable<AttributeIndexChanges.AttributeIndexChangesMemento> {
 		// five producer containers: UNIQUE is standalone, FILTER data lives in the shared value-index container, the
 		// range structure is its own producer container, plus sort and chain.
-		private final TransactionalContainerChanges<Void, UniqueIndex, UniqueIndex> uniqueIndexChanges = new TransactionalContainerChanges<>();
-		private final TransactionalContainerChanges<Void, InvertedIndex, InvertedIndex> sharedValueIndexChanges = new TransactionalContainerChanges<>();
-		private final TransactionalContainerChanges<Void, RangeIndex, RangeIndex> sharedRangeIndexChanges = new TransactionalContainerChanges<>();
-		private final TransactionalContainerChanges<SortIndexChanges, SortIndex, SortIndex> sortIndexChanges = new TransactionalContainerChanges<>();
-		private final TransactionalContainerChanges<ChainIndexChanges, ChainIndex, ChainIndex> chainIndexChanges = new TransactionalContainerChanges<>();
+		private final TransactionalContainerChanges<UniqueIndex, UniqueIndex> uniqueIndexChanges = new TransactionalContainerChanges<>();
+		private final TransactionalContainerChanges<InvertedIndex, InvertedIndex> sharedValueIndexChanges = new TransactionalContainerChanges<>();
+		private final TransactionalContainerChanges<RangeIndex, RangeIndex> sharedRangeIndexChanges = new TransactionalContainerChanges<>();
+		private final TransactionalContainerChanges<SortIndex, SortIndex> sortIndexChanges = new TransactionalContainerChanges<>();
+		private final TransactionalContainerChanges<ChainIndex, ChainIndex> chainIndexChanges = new TransactionalContainerChanges<>();
 
 		public void addCreatedItem(@Nonnull UniqueIndex uniqueIndex) {
 			this.uniqueIndexChanges.addCreatedItem(uniqueIndex);

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
@@ -78,6 +78,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -371,9 +372,9 @@ public class GlobalUniqueIndex implements
 		this.pageStreamRegistry = new PageStreamRegistry();
 		seedTree(values, payloads);
 		this.idToLocaleIndex = new TransactionalMap<>(localeIndex);
+		primeLocaleSequence(localeIndex.keySet());
 		this.localeToIdIndex = new TransactionalMap<>(
 			localeIndex.entrySet().stream()
-				.peek(it -> this.localePkSequence.getAndUpdate(currentValue -> currentValue < it.getKey() ? it.getKey() : currentValue))
 				.collect(
 					Collectors.toMap(
 						Entry::getValue,
@@ -424,9 +425,9 @@ public class GlobalUniqueIndex implements
 		this.pageStreamRegistry = pageStreamRegistry;
 		this.entitiesPerType = new TransactionalMap<>(entitiesPerType, TransactionalBitmap.class, TransactionalBitmap::new);
 		this.idToLocaleIndex = new TransactionalMap<>(localeIndex);
+		primeLocaleSequence(localeIndex.keySet());
 		this.localeToIdIndex = new TransactionalMap<>(
 			localeIndex.entrySet().stream()
-				.peek(it -> this.localePkSequence.getAndUpdate(currentValue -> currentValue < it.getKey() ? it.getKey() : currentValue))
 				.collect(
 					Collectors.toMap(
 						Entry::getValue,
@@ -449,6 +450,7 @@ public class GlobalUniqueIndex implements
 	 * @param entitiesPerType per-entity-type record id bitmaps to adopt
 	 * @param localeToIdIndex {@link Locale} to internal locale id mapping to adopt
 	 * @param idToLocaleIndex reverse internal locale id to {@link Locale} mapping to adopt
+	 * @param localePkSequenceSeed the source index's current locale-id high-water used to seed this copy's sequence
 	 */
 	private GlobalUniqueIndex(
 		@Nonnull Scope scope,
@@ -458,7 +460,8 @@ public class GlobalUniqueIndex implements
 		@Nonnull PageStreamRegistry pageStreamRegistry,
 		@Nonnull TransactionalMap<Integer, TransactionalBitmap> entitiesPerType,
 		@Nonnull TransactionalMap<Locale, Integer> localeToIdIndex,
-		@Nonnull TransactionalMap<Integer, Locale> idToLocaleIndex
+		@Nonnull TransactionalMap<Integer, Locale> idToLocaleIndex,
+		int localePkSequenceSeed
 	) {
 		this.attributeKey = attributeKey;
 		this.scope = scope;
@@ -471,6 +474,31 @@ public class GlobalUniqueIndex implements
 		this.entitiesPerType = entitiesPerType;
 		this.localeToIdIndex = localeToIdIndex;
 		this.idToLocaleIndex = idToLocaleIndex;
+		// the locale maps are adopted BY REFERENCE and already carry assigned ids; the sequence must start past the
+		// highest id ever assigned by the source (which the source's high-water reflects even for ids added but not yet
+		// committed to the shared map), otherwise a first-time locale registered through this copy would be handed an
+		// id that already belongs to another locale and overwrite it in the shared reverse map. The source high-water is
+		// read from a plain (non-transactional) sequence, so seeding never touches the transactional layer of the shared
+		// maps — a layer that may be mid-commit when this shell is created.
+		this.localePkSequence.set(localePkSequenceSeed);
+	}
+
+	/**
+	 * Primes {@link #localePkSequence} so the next locale registered through {@link #fromLocale} receives an id past
+	 * every id already present in the adopted locale map. The sequence must start past the highest adopted locale id;
+	 * otherwise a newly seen locale would be handed an id that already belongs to another locale, overwriting it in the
+	 * shared reverse map and corrupting locale decoding of every tuple that carries the clobbered id.
+	 *
+	 * @param assignedLocaleIds the internal locale ids already in use (keys of the id to {@link Locale} map)
+	 */
+	private void primeLocaleSequence(@Nonnull Set<Integer> assignedLocaleIds) {
+		int highestId = this.localePkSequence.get();
+		for (final Integer localeId : assignedLocaleIds) {
+			if (localeId > highestId) {
+				highestId = localeId;
+			}
+		}
+		this.localePkSequence.set(highestId);
 	}
 
 	/**
@@ -500,7 +528,8 @@ public class GlobalUniqueIndex implements
 			this.pageStreamRegistry,
 			this.entitiesPerType,
 			this.localeToIdIndex,
-			this.idToLocaleIndex
+			this.idToLocaleIndex,
+			this.localePkSequence.get()
 		);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
@@ -670,7 +670,7 @@ public class GlobalUniqueIndex implements
 	 */
 	@Nonnull
 	@Override
-	public GlobalUniqueIndex createCopyWithMergedTransactionalMemory(@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
+	public GlobalUniqueIndex createCopyWithMergedTransactionalMemory(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		final TransactionalBucketBPlusTree committedTree =
 			(TransactionalBucketBPlusTree) transactionalLayer.getStateCopyWithCommittedChanges(this.tree);
 		// publish the page baseline staged by this commit's flush: the merge runs only AFTER the flush has durably
@@ -695,7 +695,6 @@ public class GlobalUniqueIndex implements
 	 */
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		this.dirty.removeLayer(transactionalLayer);
 		this.tree.removeLayer(transactionalLayer);
 		this.entitiesPerType.removeLayer(transactionalLayer);

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/GlobalUniqueIndex.java
@@ -23,14 +23,10 @@
 
 package io.evitadb.index.attribute;
 
-import io.evitadb.api.CatalogState;
 import io.evitadb.api.exception.UniqueValueViolationException;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.api.requestResponse.data.structure.EntityReference;
 import io.evitadb.core.buffer.TrappedChanges;
-import io.evitadb.core.catalog.Catalog;
-import io.evitadb.core.catalog.CatalogRelatedDataStructure;
-import io.evitadb.core.collection.EntityCollection;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.ConstantFormula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
@@ -41,6 +37,7 @@ import io.evitadb.dataType.Scope;
 import io.evitadb.dataType.array.CompositeLongArray;
 import io.evitadb.dataType.array.CompositeObjectArray;
 import io.evitadb.index.CatalogIndex;
+import io.evitadb.index.EntityTypeClassifierResolver;
 import io.evitadb.index.IndexDataStructure;
 import io.evitadb.index.bPlusTree.LongPayloadBucketTree;
 import io.evitadb.index.bPlusTree.TransactionalBucketBPlusTree;
@@ -79,7 +76,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -113,8 +109,7 @@ import static java.util.Optional.ofNullable;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class GlobalUniqueIndex implements
 	VoidTransactionMemoryProducer<GlobalUniqueIndex>,
-	IndexDataStructure,
-	CatalogRelatedDataStructure<GlobalUniqueIndex>
+	IndexDataStructure
 {
 	@Getter private final long id = TransactionalObjectVersion.SEQUENCE.nextId();
 	/**
@@ -184,22 +179,6 @@ public class GlobalUniqueIndex implements
 	 * The sequence starts with the highest assigned id found in {@link #localeToIdIndex} in constructor.
 	 */
 	private final AtomicInteger localePkSequence = new AtomicInteger();
-	/**
-	 * Contains reference to the current catalog instance.
-	 * Beware this reference changes with each entity collection exchange during transactional commit.
-	 * The reference is used to translate {@link EntityCollection#getEntityType()} to {@link EntityCollection#getEntityTypePrimaryKey()}
-	 * and vice versa. We want to use short int ids in {@link EntityWithTypeTuple} so that we save a few bytes for object
-	 * pointer.
-	 */
-	private Catalog catalog;
-	/**
-	 * Maps entity type primary key to entity type name.
-	 */
-	private final Map<Integer, String> primaryKeyToEntityType = new ConcurrentHashMap<>();
-	/**
-	 * Maps entity type name to entity type primary key.
-	 */
-	private final Map<String, Integer> entityTypeToPk = new ConcurrentHashMap<>();
 
 	/**
 	 * Creates a fresh, empty value tree (long payload column holding the packed entity tuple) ordered by the given
@@ -438,52 +417,6 @@ public class GlobalUniqueIndex implements
 	}
 
 	/**
-	 * Adopts already-wrapped transactional structures directly instead of re-wrapping plain maps. Used by
-	 * {@link #createCopyForNewCatalogAttachment(CatalogState)} to produce a detached copy that shares the same
-	 * transactional backing structures while resetting the catalog reference.
-	 *
-	 * @param scope           scope of the owning {@link CatalogIndex}
-	 * @param attributeKey    identifies the indexed attribute (name and optional locale)
-	 * @param attributeType   runtime type of the indexed attribute value
-	 * @param tree            value to entity tuple tree to adopt
-	 * @param pageStreamRegistry the catalog-resident page bookkeeping, carried BY REFERENCE (shares the same `tree`)
-	 * @param entitiesPerType per-entity-type record id bitmaps to adopt
-	 * @param localeToIdIndex {@link Locale} to internal locale id mapping to adopt
-	 * @param idToLocaleIndex reverse internal locale id to {@link Locale} mapping to adopt
-	 * @param localePkSequenceSeed the source index's current locale-id high-water used to seed this copy's sequence
-	 */
-	private GlobalUniqueIndex(
-		@Nonnull Scope scope,
-		@Nonnull AttributeKey attributeKey,
-		@Nonnull Class<? extends Serializable> attributeType,
-		@Nonnull LongPayloadBucketTree tree,
-		@Nonnull PageStreamRegistry pageStreamRegistry,
-		@Nonnull TransactionalMap<Integer, TransactionalBitmap> entitiesPerType,
-		@Nonnull TransactionalMap<Locale, Integer> localeToIdIndex,
-		@Nonnull TransactionalMap<Integer, Locale> idToLocaleIndex,
-		int localePkSequenceSeed
-	) {
-		this.attributeKey = attributeKey;
-		this.scope = scope;
-		this.type = attributeType;
-		this.dirty = new TransactionalBoolean();
-		this.plainType = plainTypeOf(attributeType);
-		this.comparator = comparatorFor(this.plainType);
-		this.tree = tree;
-		this.pageStreamRegistry = pageStreamRegistry;
-		this.entitiesPerType = entitiesPerType;
-		this.localeToIdIndex = localeToIdIndex;
-		this.idToLocaleIndex = idToLocaleIndex;
-		// the locale maps are adopted BY REFERENCE and already carry assigned ids; the sequence must start past the
-		// highest id ever assigned by the source (which the source's high-water reflects even for ids added but not yet
-		// committed to the shared map), otherwise a first-time locale registered through this copy would be handed an
-		// id that already belongs to another locale and overwrite it in the shared reverse map. The source high-water is
-		// read from a plain (non-transactional) sequence, so seeding never touches the transactional layer of the shared
-		// maps — a layer that may be mid-commit when this shell is created.
-		this.localePkSequence.set(localePkSequenceSeed);
-	}
-
-	/**
 	 * Primes {@link #localePkSequence} so the next locale registered through {@link #fromLocale} receives an id past
 	 * every id already present in the adopted locale map. The sequence must start past the highest adopted locale id;
 	 * otherwise a newly seen locale would be handed an id that already belongs to another locale, overwriting it in the
@@ -502,56 +435,26 @@ public class GlobalUniqueIndex implements
 	}
 
 	/**
-	 * Captures the catalog reference needed to translate between entity type names and their short int primary keys
-	 * (see {@link #catalog}). Enforces single attachment: the index must not already be bound to a catalog.
-	 */
-	@Override
-	public void attachToCatalog(@Nullable String entityType, @Nonnull Catalog catalog) {
-		Assert.isPremiseValid(this.catalog == null, "Catalog was already attached to this index!");
-		this.catalog = catalog;
-	}
-
-	/**
-	 * Produces a detached copy that shares the same transactional backing structures but carries no catalog reference,
-	 * so it can be reattached to a new catalog version while the original stays bound to the previous one. The cached
-	 * entity-type-to-pk lookups ({@link #primaryKeyToEntityType}, {@link #entityTypeToPk}) are intentionally not
-	 * carried over — they are rebuilt lazily against the freshly attached catalog.
-	 */
-	@Nonnull
-	@Override
-	public GlobalUniqueIndex createCopyForNewCatalogAttachment(@Nonnull CatalogState catalogState) {
-		return new GlobalUniqueIndex(
-			this.scope,
-			this.attributeKey,
-			this.type,
-			this.tree,
-			this.pageStreamRegistry,
-			this.entitiesPerType,
-			this.localeToIdIndex,
-			this.idToLocaleIndex,
-			this.localePkSequence.get()
-		);
-	}
-
-	/**
 	 * Registers new record id to a single unique value.
 	 *
+	 * @param resolver translates the entity type name to its compact primary key (and back for violation messages)
 	 * @throws UniqueValueViolationException when value is not unique
 	 */
-	public void registerUniqueKey(@Nonnull Object value, @Nonnull String entityType, @Nullable Locale locale, int recordId) {
-		final int classifierId = fromClassifier(entityType);
+	public void registerUniqueKey(@Nonnull Object value, @Nonnull String entityType, @Nullable Locale locale, int recordId, @Nonnull EntityTypeClassifierResolver resolver) {
+		final int classifierId = resolver.toEntityTypePrimaryKey(entityType);
 		final int localeId = fromLocale(locale);
-		registerUniqueKeyValue(value, new EntityWithTypeTuple(classifierId, recordId, localeId));
+		registerUniqueKeyValue(value, new EntityWithTypeTuple(classifierId, recordId, localeId), resolver);
 	}
 
 	/**
 	 * Unregisters new record id from a single unique value.
 	 *
+	 * @param resolver translates the entity type name to its compact primary key
 	 * @return removed record id relation
 	 */
 	@Nullable
-	public EntityReferenceWithLocale unregisterUniqueKey(@Nonnull Object value, @Nonnull String entityType, @Nullable Locale locale, int recordId) {
-		final int classifierId = fromClassifier(entityType);
+	public EntityReferenceWithLocale unregisterUniqueKey(@Nonnull Object value, @Nonnull String entityType, @Nullable Locale locale, int recordId, @Nonnull EntityTypeClassifierResolver resolver) {
+		final int classifierId = resolver.toEntityTypePrimaryKey(entityType);
 		final int localeId = fromLocale(locale);
 		return unregisterUniqueKeyValue(value, new EntityWithTypeTuple(classifierId, recordId, localeId)) == null ?
 			null : new EntityReferenceWithLocale(entityType, recordId, locale);
@@ -559,23 +462,26 @@ public class GlobalUniqueIndex implements
 
 	/**
 	 * Returns record id by its unique value.
+	 *
+	 * @param resolver translates the compact entity type primary key stored in the tuple back to its name
 	 */
 	@Nonnull
-	public Optional<EntityReferenceWithLocale> getEntityReferenceByUniqueValue(@Nonnull Serializable value, @Nullable Locale locale) {
+	public Optional<EntityReferenceWithLocale> getEntityReferenceByUniqueValue(@Nonnull Serializable value, @Nullable Locale locale, @Nonnull EntityTypeClassifierResolver resolver) {
 		return ofNullable(lookupTuple(value))
 			.filter(it -> locale == null || it.locale() == NO_LOCALE || fromLocale(locale) == it.locale())
-			.map(it -> new EntityReferenceWithLocale(toClassifier(it.entityType()), it.entityPrimaryKey(), toLocale(it.locale())));
+			.map(it -> new EntityReferenceWithLocale(resolver.toEntityTypeName(it.entityType()), it.entityPrimaryKey(), toLocale(it.locale())));
 	}
 
 	/**
 	 * Generates a {@link Formula} instance that provides the record IDs associated with the specified entity type.
 	 *
 	 * @param entityType the type of the entity for which to generate the record IDs formula
+	 * @param resolver   translates the entity type name to its compact primary key
 	 * @return a {@link Formula} instance that computes the record IDs for the given entity type
 	 */
 	@Nonnull
-	public Formula getRecordIdsFormula(@Nonnull String entityType) {
-		final Bitmap recordIds = getRecordIds(entityType);
+	public Formula getRecordIdsFormula(@Nonnull String entityType, @Nonnull EntityTypeClassifierResolver resolver) {
+		final Bitmap recordIds = getRecordIds(entityType, resolver);
 		return recordIds instanceof EmptyBitmap ? EmptyFormula.INSTANCE : new ConstantFormula(recordIds);
 	}
 
@@ -583,11 +489,12 @@ public class GlobalUniqueIndex implements
 	 * Retrieves the record IDs associated with a specific entity type.
 	 *
 	 * @param entityType the type of the entity for which record IDs are being retrieved
+	 * @param resolver   translates the entity type name to its compact primary key
 	 * @return a Bitmap containing the record IDs for the specified entity type
 	 */
 	@Nonnull
-	public Bitmap getRecordIds(@Nonnull String entityType) {
-		final int entityTypePk = fromClassifier(entityType);
+	public Bitmap getRecordIds(@Nonnull String entityType, @Nonnull EntityTypeClassifierResolver resolver) {
+		final int entityTypePk = resolver.toEntityTypePrimaryKey(entityType);
 		return ofNullable(this.entitiesPerType.get(entityTypePk))
 			.map(Bitmap.class::cast)
 			.orElse(EmptyBitmap.INSTANCE);
@@ -766,14 +673,16 @@ public class GlobalUniqueIndex implements
 	/**
 	 * Returns array of sorted references maintained by this index. Walks the value tree directly via a cursor (no map
 	 * materialization). Still O(n) over the whole index, so it stays a test-only inspection helper.
+	 *
+	 * @param resolver translates the compact entity type primary key stored in each tuple back to its name
 	 */
 	@Nonnull
-	EntityReference[] getEntityReferences() {
+	EntityReference[] getEntityReferences(@Nonnull EntityTypeClassifierResolver resolver) {
 		final CompositeObjectArray<EntityReference> references = new CompositeObjectArray<>(EntityReference.class);
 		final BucketCursor cursor = this.tree.cursor();
 		while (cursor.next()) {
 			final EntityWithTypeTuple tuple = unpackTuple(cursor.longRecordId());
-			references.add(new EntityReference(toClassifier(tuple.entityType()), tuple.entityPrimaryKey()));
+			references.add(new EntityReference(resolver.toEntityTypeName(tuple.entityType()), tuple.entityPrimaryKey()));
 		}
 		final EntityReference[] result = references.toArray();
 		Arrays.sort(result);
@@ -894,25 +803,26 @@ public class GlobalUniqueIndex implements
 	 *
 	 * @param key    the unique value, or array of unique values, to claim
 	 * @param record the entity tuple claiming the value(s)
+	 * @param resolver translates entity type primary keys to names for the violation message
 	 * @throws UniqueValueViolationException when any value is already owned by a different record
 	 */
 	@SuppressWarnings("unchecked")
-	private <T extends Serializable & Comparable<T>> void registerUniqueKeyValue(@Nonnull Object key, @Nonnull EntityWithTypeTuple record) {
+	private <T extends Serializable & Comparable<T>> void registerUniqueKeyValue(@Nonnull Object key, @Nonnull EntityWithTypeTuple record, @Nonnull EntityTypeClassifierResolver resolver) {
 		if (key instanceof @Nonnull final Object[] valueArray) {
 			verifyValueArray(key);
 			// first verify removed data without modifications
 			for (Object valueItem : valueArray) {
 				final T theValueItem = (T) valueItem;
 				final EntityWithTypeTuple existingRecordId = lookupTuple(theValueItem);
-				assertUniqueKeyIsFree(theValueItem, record, existingRecordId);
+				assertUniqueKeyIsFree(theValueItem, record, existingRecordId, resolver);
 			}
 			// now perform alteration
 			for (Object valueItem : valueArray) {
-				registerUniqueKeyValue(valueItem, record);
+				registerUniqueKeyValue(valueItem, record, resolver);
 			}
 		} else {
 			verifyValue(key);
-			registerUniqueKeyValue((T) key, record);
+			registerUniqueKeyValue((T) key, record, resolver);
 		}
 		this.dirty.setToTrue();
 	}
@@ -928,11 +838,16 @@ public class GlobalUniqueIndex implements
 	 *
 	 * @param key    the scalar unique value to claim
 	 * @param record the entity tuple claiming the value
+	 * @param resolver translates entity type primary keys to names for the violation message
 	 * @throws UniqueValueViolationException when the value is already owned by a different record in the same locale
 	 */
-	private <T extends Serializable & Comparable<T>> void registerUniqueKeyValue(@Nonnull T key, @Nonnull EntityWithTypeTuple record) {
+	private <T extends Serializable & Comparable<T>> void registerUniqueKeyValue(
+		@Nonnull T key,
+		@Nonnull EntityWithTypeTuple record,
+		@Nonnull EntityTypeClassifierResolver resolver
+	) {
 		final EntityWithTypeTuple existingRecordId = lookupTuple(key);
-		assertUniqueKeyIsFree(key, record, existingRecordId);
+		assertUniqueKeyIsFree(key, record, existingRecordId, resolver);
 		if (existingRecordId == null) {
 			this.tree.addLongRecord(key, packTuple(record));
 		} else if (!existingRecordId.equals(record)) {
@@ -948,8 +863,8 @@ public class GlobalUniqueIndex implements
 
 	/**
 	 * Releases a unique key that may be either a single value or an array of values, the inverse of
-	 * {@link #registerUniqueKeyValue(Object, EntityWithTypeTuple)}. Ownership of every element is verified up front
-	 * so a mismatch leaves the index unchanged (all-or-nothing).
+	 * {@link #registerUniqueKeyValue(Object, EntityWithTypeTuple, EntityTypeClassifierResolver)}.
+	 * Ownership of every element is verified up front so a mismatch leaves the index unchanged (all-or-nothing).
 	 *
 	 * @param key            the unique value, or array of unique values, to release
 	 * @param expectedRecord the record expected to currently own the value(s)
@@ -1014,45 +929,22 @@ public class GlobalUniqueIndex implements
 	 * @param key            the unique value being claimed (for error reporting)
 	 * @param record         the record attempting to claim the value
 	 * @param existingRecord the record currently owning the value, or `null` if unowned
+	 * @param resolver       translates entity type primary keys to names for the violation message
 	 * @throws UniqueValueViolationException when the value is already owned by a different record in the same locale
 	 */
-	private <T extends Serializable & Comparable<T>> void assertUniqueKeyIsFree(@Nonnull T key, EntityWithTypeTuple record, @Nullable EntityWithTypeTuple existingRecord) {
+	private <T extends Serializable & Comparable<T>> void assertUniqueKeyIsFree(@Nonnull T key, EntityWithTypeTuple record, @Nullable EntityWithTypeTuple existingRecord, @Nonnull EntityTypeClassifierResolver resolver) {
 		if (!(existingRecord == null || existingRecord.equals(record))) {
 			if (!this.attributeKey.localized() || existingRecord.locale() == record.locale()) {
 				throw new UniqueValueViolationException(
 					this.attributeKey.attributeName(), this.attributeKey.locale(), key,
-					toClassifier(existingRecord.entityType()), existingRecord.entityPrimaryKey(),
-					toClassifier(record.entityType()), record.entityPrimaryKey()
+					resolver.toEntityTypeName(existingRecord.entityType()), existingRecord.entityPrimaryKey(),
+					resolver.toEntityTypeName(record.entityType()), record.entityPrimaryKey()
 				);
 			}
 		}
 	}
 
-	/**
-	 * Resolves the compact entity-type primary key stored in tuples back to the entity type name, caching the
-	 * result. Requires the index to be attached to a catalog.
-	 */
-	@Nonnull
-	private String toClassifier(int entityType) {
-		return this.primaryKeyToEntityType.computeIfAbsent(
-			entityType,
-			epk -> {
-				final EntityCollection entityCollection = this.catalog.getCollectionForEntityPrimaryKeyOrThrowException(epk);
-				return entityCollection.getEntityType();
-			}
-		);
-	}
 
-	/**
-	 * Resolves an entity type name to the compact primary key stored in tuples, caching the result. The compact id
-	 * keeps {@link EntityWithTypeTuple} small. Requires the index to be attached to a catalog.
-	 */
-	private int fromClassifier(@Nonnull String entityType) {
-		return this.entityTypeToPk.computeIfAbsent(
-			entityType,
-			et -> this.catalog.getCollectionForEntityOrThrowException(et).getEntityTypePrimaryKey()
-		);
-	}
 
 	/**
 	 * Resolves an internal locale id stored in tuples back to its {@link Locale}, returning `null` for the

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerFilterIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerFilterIndex.java
@@ -258,7 +258,6 @@ public final class OwnerFilterIndex extends FilterIndex implements VoidTransacti
 	@Nonnull
 	@Override
 	public OwnerFilterIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
@@ -276,7 +275,6 @@ public final class OwnerFilterIndex extends FilterIndex implements VoidTransacti
 
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		getInvertedIndex().removeLayer(transactionalLayer);
 		final RangeIndex theRangeIndex = getRangeIndex();
 		if (theRangeIndex != null) {

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/OwnerUniqueIndex.java
@@ -408,7 +408,6 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 	@Nonnull
 	@Override
 	public UniqueIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		final boolean isDirty = transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
@@ -432,7 +431,6 @@ public final class OwnerUniqueIndex extends UniqueIndex {
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		transactionalLayer.removeTransactionalMemoryLayerIfExists(this.dirty);
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		this.tree.removeLayer(transactionalLayer);
 		this.recordIds.removeLayer(transactionalLayer);
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/UniqueIndexView.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/UniqueIndexView.java
@@ -165,19 +165,9 @@ public final class UniqueIndexView extends UniqueIndex {
 		// a view owns no dirty flag - the shared tree's dirtiness is reset through the FilterIndex view
 	}
 
-	@Nullable
-	@Override
-	public Void createLayer() {
-		// a view never participates in a commit: it owns no transactional state, so it yields no layer (its enclosing
-		// transactional cache map deep-commits it as an identity and rebuilds it fresh over the committed shared tree).
-		// Overrides the VoidTransactionMemoryProducer default (which throws) to stay defensive if ever reached.
-		return null;
-	}
-
 	@Nonnull
 	@Override
 	public UniqueIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		// view instances are non-transactional and rebuilt fresh over the committed shared tree by AttributeIndex;
@@ -188,7 +178,6 @@ public final class UniqueIndexView extends UniqueIndex {
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		// a view never registered its placeholder structures with the layer - nothing else to discard
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/AbstractTransactionalBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/AbstractTransactionalBPlusTree.java
@@ -28,6 +28,7 @@ import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.memory.DirtyScopeValidator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.index.reference.TransactionalReference;
 import io.evitadb.utils.ArrayUtils.InsertionPosition;
@@ -439,7 +440,7 @@ public abstract class AbstractTransactionalBPlusTree implements Serializable {
 				final int peek = node.getPeek();
 				for (int i = 0; i <= peek; i++) {
 					// value producers guard their own (and their children's) layer removal internally
-					if (values[i] instanceof final TransactionalLayerProducer<?, ?> producer) {
+					if (values[i] instanceof final TransactionalStateProducer<?> producer) {
 						producer.removeLayer(transactionalLayer);
 					}
 				}

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTree.java
@@ -29,6 +29,7 @@ import io.evitadb.core.transaction.memory.DirtyScopeValidator;
 import io.evitadb.core.transaction.memory.Snapshotable;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.bitmap.Bitmap;
@@ -724,7 +725,7 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 			"Internal node block size must not exceed the value block size, otherwise internal node merges overflow the node arrays."
 		);
 		Assert.isPremiseValid(
-			!TransactionalLayerProducer.class.isAssignableFrom(keyType),
+			!TransactionalStateProducer.class.isAssignableFrom(keyType),
 			"Key type cannot implement TransactionalLayerProducer."
 		);
 		Assert.isPremiseValid(

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalBucketBPlusTree.java
@@ -726,7 +726,7 @@ public class TransactionalBucketBPlusTree<K extends Comparable<K>> implements
 		);
 		Assert.isPremiseValid(
 			!TransactionalStateProducer.class.isAssignableFrom(keyType),
-			"Key type cannot implement TransactionalLayerProducer."
+			"Key type cannot implement TransactionalStateProducer."
 		);
 		Assert.isPremiseValid(
 			comparator != null || Comparable.class.isAssignableFrom(keyType),

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTree.java
@@ -343,7 +343,7 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 		super(valueBlockSize, minValueBlockSize, internalNodeBlockSize, minInternalNodeBlockSize, root, size);
 		Assert.isPremiseValid(
 			transactionalLayerWrapper != null || !TransactionalStateProducer.class.isAssignableFrom(valueType),
-			"Value type cannot implement TransactionalLayerProducer if no transactional layer wrapper is provided."
+			"Value type cannot implement TransactionalStateProducer if no transactional layer wrapper is provided."
 		);
 		this.valueType = valueType;
 		this.transactionalLayerWrapper = transactionalLayerWrapper;

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalLongBPlusTree.java
@@ -29,6 +29,7 @@ import io.evitadb.core.transaction.memory.DirtyScopeValidator;
 import io.evitadb.core.transaction.memory.Snapshotable;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.dataType.ConsistencySensitiveDataStructure;
 import io.evitadb.exception.GenericEvitaInternalError;
@@ -341,7 +342,7 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 	) {
 		super(valueBlockSize, minValueBlockSize, internalNodeBlockSize, minInternalNodeBlockSize, root, size);
 		Assert.isPremiseValid(
-			transactionalLayerWrapper != null || !TransactionalLayerProducer.class.isAssignableFrom(valueType),
+			transactionalLayerWrapper != null || !TransactionalStateProducer.class.isAssignableFrom(valueType),
 			"Value type cannot implement TransactionalLayerProducer if no transactional layer wrapper is provided."
 		);
 		this.valueType = valueType;
@@ -2927,13 +2928,13 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 			}
 
 			V[] newValues = null;
-			if (TransactionalLayerProducer.class.isAssignableFrom(this.values.getClass().getComponentType())) {
+			if (TransactionalStateProducer.class.isAssignableFrom(this.values.getClass().getComponentType())) {
 				for (int i = 0; i < thePeek + 1; i++) {
 					// this.transactionalLayerWrapper is not null, because the values are transactional layers
 					//noinspection unchecked,DataFlowIssue
 					final V value = this.transactionalLayerWrapper.apply(
 						transactionalLayer.getStateCopyWithCommittedChanges(
-							(TransactionalLayerProducer<?, ? extends V>) theValues[i]
+							(TransactionalStateProducer<? extends V>) theValues[i]
 						)
 					);
 					if (newValues == null && value != theValues[i]) {
@@ -3062,7 +3063,7 @@ public class TransactionalLongBPlusTree<V> extends AbstractTransactionalBPlusTre
 		 * @param removed the value removed from the leaf, may be null
 		 */
 		private static void discardRemovedValueLayer(@Nullable Object removed) {
-			if (removed instanceof final TransactionalLayerProducer<?, ?> producer) {
+			if (removed instanceof final TransactionalStateProducer<?> producer) {
 				producer.removeLayer();
 			}
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalObjectBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalObjectBPlusTree.java
@@ -28,6 +28,7 @@ import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.memory.Snapshotable;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.dataType.ConsistencySensitiveDataStructure;
 import io.evitadb.exception.GenericEvitaInternalError;
@@ -476,11 +477,11 @@ public class TransactionalObjectBPlusTree<K extends Comparable<K>, V> extends Ab
 	) {
 		super(valueBlockSize, minValueBlockSize, internalNodeBlockSize, minInternalNodeBlockSize, root, size);
 		Assert.isPremiseValid(
-			!TransactionalLayerProducer.class.isAssignableFrom(keyType),
+			!TransactionalStateProducer.class.isAssignableFrom(keyType),
 			"Key type cannot implement TransactionalLayerProducer."
 		);
 		Assert.isPremiseValid(
-			transactionalLayerWrapper != null || !TransactionalLayerProducer.class.isAssignableFrom(valueType),
+			transactionalLayerWrapper != null || !TransactionalStateProducer.class.isAssignableFrom(valueType),
 			"Value type cannot implement TransactionalLayerProducer if no transactional layer wrapper is provided."
 		);
 		Assert.isPremiseValid(
@@ -2549,13 +2550,13 @@ public class TransactionalObjectBPlusTree<K extends Comparable<K>, V> extends Ab
 			}
 
 			N[] newValues = null;
-			if (TransactionalLayerProducer.class.isAssignableFrom(this.values.getClass().getComponentType())) {
+			if (TransactionalStateProducer.class.isAssignableFrom(this.values.getClass().getComponentType())) {
 				for (int i = 0; i < thePeek + 1; i++) {
 					// this.transactionalLayerWrapper is not null, because the values are transactional layers
 					//noinspection unchecked,DataFlowIssue
 					final N value = this.transactionalLayerWrapper.apply(
 						transactionalLayer.getStateCopyWithCommittedChanges(
-							(TransactionalLayerProducer<?, ? extends N>) theValues[i]
+							(TransactionalStateProducer<? extends N>) theValues[i]
 						)
 					);
 					if (newValues == null && value != theValues[i]) {
@@ -2677,7 +2678,7 @@ public class TransactionalObjectBPlusTree<K extends Comparable<K>, V> extends Ab
 		 * @param removed the value removed from the leaf, may be null
 		 */
 		private static void discardRemovedValueLayer(@Nullable Object removed) {
-			if (removed instanceof final TransactionalLayerProducer<?, ?> producer) {
+			if (removed instanceof final TransactionalStateProducer<?> producer) {
 				producer.removeLayer();
 			}
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalObjectBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalObjectBPlusTree.java
@@ -478,11 +478,11 @@ public class TransactionalObjectBPlusTree<K extends Comparable<K>, V> extends Ab
 		super(valueBlockSize, minValueBlockSize, internalNodeBlockSize, minInternalNodeBlockSize, root, size);
 		Assert.isPremiseValid(
 			!TransactionalStateProducer.class.isAssignableFrom(keyType),
-			"Key type cannot implement TransactionalLayerProducer."
+			"Key type cannot implement TransactionalStateProducer."
 		);
 		Assert.isPremiseValid(
 			transactionalLayerWrapper != null || !TransactionalStateProducer.class.isAssignableFrom(valueType),
-			"Value type cannot implement TransactionalLayerProducer if no transactional layer wrapper is provided."
+			"Value type cannot implement TransactionalStateProducer if no transactional layer wrapper is provided."
 		);
 		Assert.isPremiseValid(
 			comparator != null || Comparable.class.isAssignableFrom(keyType),

--- a/evita_engine/src/main/java/io/evitadb/index/cardinality/AttributeCardinalityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/cardinality/AttributeCardinalityIndex.java
@@ -212,7 +212,6 @@ public class AttributeCardinalityIndex
 
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		this.cardinalities.removeLayer(transactionalLayer);
 		this.dirty.removeLayer(transactionalLayer);
 	}
@@ -220,7 +219,6 @@ public class AttributeCardinalityIndex
 	@Nonnull
 	@Override
 	public AttributeCardinalityIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		// we can safely throw away dirty flag now

--- a/evita_engine/src/main/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/cardinality/ReferenceTypeCardinalityIndex.java
@@ -645,7 +645,6 @@ public class ReferenceTypeCardinalityIndex
 
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		this.cardinalities.removeLayer(transactionalLayer);
 		this.referencedPrimaryKeysIndex.removeLayer(transactionalLayer);
 		this.dirty.removeLayer(transactionalLayer);
@@ -658,7 +657,7 @@ public class ReferenceTypeCardinalityIndex
 	@Nonnull
 	@Override
 	public ReferenceTypeCardinalityIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
+		@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		// we can safely throw away dirty flag now
 		final boolean isDirty = transactionalLayer.getStateCopyWithCommittedChanges(this.dirty);
 		if (isDirty) {

--- a/evita_engine/src/main/java/io/evitadb/index/component/PriceIndexComponent.java
+++ b/evita_engine/src/main/java/io/evitadb/index/component/PriceIndexComponent.java
@@ -26,6 +26,7 @@ package io.evitadb.index.component;
 import io.evitadb.core.buffer.TrappedChanges;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.IndexDataStructure;
 import io.evitadb.index.price.PriceIndexContract;
@@ -104,7 +105,7 @@ public final class PriceIndexComponent implements IndexComponent {
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		// only the non-void flavours implement TransactionalLayerProducer.removeLayer
-		if (this.priceIndex instanceof TransactionalLayerProducer<?, ?> producer) {
+		if (this.priceIndex instanceof TransactionalStateProducer<?> producer) {
 			producer.removeLayer(transactionalLayer);
 		}
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/facet/FacetGroupIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/facet/FacetGroupIndex.java
@@ -249,7 +249,7 @@ public class FacetGroupIndex implements TransactionalLayerProducer<FacetGroupInd
 	 * This class collects changes in {@link #facetIdIndexes} transactional map and its sub structure.
 	 */
 	public static class FacetGroupIndexChanges implements Snapshotable<FacetGroupIndexChanges.FacetGroupIndexChangesMemento> {
-		private final TransactionalContainerChanges<Void, FacetIdIndex, FacetIdIndex> items = new TransactionalContainerChanges<>();
+		private final TransactionalContainerChanges<FacetIdIndex, FacetIdIndex> items = new TransactionalContainerChanges<>();
 
 		public void addCreatedItem(@Nonnull FacetIdIndex baseIndex) {
 			this.items.addCreatedItem(baseIndex);

--- a/evita_engine/src/main/java/io/evitadb/index/facet/FacetIdIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/facet/FacetIdIndex.java
@@ -114,7 +114,6 @@ public class FacetIdIndex implements VoidTransactionMemoryProducer<FacetIdIndex>
 	@Nonnull
 	@Override
 	public FacetIdIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		return new FacetIdIndex(
@@ -125,6 +124,5 @@ public class FacetIdIndex implements VoidTransactionMemoryProducer<FacetIdIndex>
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		this.records.removeLayer(transactionalLayer);
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 	}
 }

--- a/evita_engine/src/main/java/io/evitadb/index/facet/FacetIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/facet/FacetIndex.java
@@ -43,7 +43,6 @@ import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.component.EntityIndexManifest;
 import io.evitadb.index.component.IndexComponent;
 import io.evitadb.index.facet.FacetIndex.FacetIndexChanges;
-import io.evitadb.index.facet.FacetReferenceIndex.FacetEntityTypeIndexChanges;
 import io.evitadb.index.map.TransactionalMap;
 import io.evitadb.index.set.TransactionalSet;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.FacetIndexStoragePart;
@@ -357,7 +356,7 @@ public class FacetIndex implements FacetIndexContract, TransactionalLayerProduce
 	 * This class collects changes in {@link #facetingEntities} transactional map and its sub structure.
 	 */
 	public static class FacetIndexChanges implements Snapshotable<FacetIndexChanges.FacetIndexChangesMemento> {
-		private final TransactionalContainerChanges<FacetEntityTypeIndexChanges, FacetReferenceIndex, FacetReferenceIndex> facetGroupIndexChanges = new TransactionalContainerChanges<>();
+		private final TransactionalContainerChanges<FacetReferenceIndex, FacetReferenceIndex> facetGroupIndexChanges = new TransactionalContainerChanges<>();
 
 		public void addCreatedItem(@Nonnull FacetReferenceIndex index) {
 			this.facetGroupIndexChanges.addCreatedItem(index);

--- a/evita_engine/src/main/java/io/evitadb/index/facet/FacetReferenceIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/facet/FacetReferenceIndex.java
@@ -37,7 +37,6 @@ import io.evitadb.function.TriFunction;
 import io.evitadb.index.IndexDataStructure;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
-import io.evitadb.index.facet.FacetGroupIndex.FacetGroupIndexChanges;
 import io.evitadb.index.facet.FacetReferenceIndex.FacetEntityTypeIndexChanges;
 import io.evitadb.index.map.TransactionalMap;
 import io.evitadb.core.expression.trigger.DependencyType;
@@ -438,7 +437,7 @@ public class FacetReferenceIndex implements TransactionalLayerProducer<FacetEnti
 	 * This class collects changes in {@link #groupedFacets} transactional map and its sub structure.
 	 */
 	public static class FacetEntityTypeIndexChanges implements Snapshotable<FacetEntityTypeIndexChanges.FacetEntityTypeIndexChangesMemento> {
-		private final TransactionalContainerChanges<FacetGroupIndexChanges, FacetGroupIndex, FacetGroupIndex> items = new TransactionalContainerChanges<>();
+		private final TransactionalContainerChanges<FacetGroupIndex, FacetGroupIndex> items = new TransactionalContainerChanges<>();
 
 		public void addCreatedItem(@Nonnull FacetGroupIndex baseIndex) {
 			this.items.addCreatedItem(baseIndex);

--- a/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/hierarchy/HierarchyIndex.java
@@ -940,7 +940,6 @@ public class HierarchyIndex
 	@Nonnull
 	@Override
 	public HierarchyIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		// we can safely throw away dirty flag now
@@ -964,7 +963,6 @@ public class HierarchyIndex
 	 */
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		this.dirty.removeLayer(transactionalLayer);
 		this.roots.removeLayer(transactionalLayer);
 		this.levelIndex.removeLayer(transactionalLayer);

--- a/evita_engine/src/main/java/io/evitadb/index/invertedIndex/InvertedIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/invertedIndex/InvertedIndex.java
@@ -921,7 +921,6 @@ public class InvertedIndex implements
 	@Nonnull
 	@Override
 	public InvertedIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		final boolean isDirty = transactionalLayer
@@ -958,7 +957,6 @@ public class InvertedIndex implements
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		transactionalLayer.removeTransactionalMemoryLayerIfExists(this.dirty);
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		this.buckets.removeLayer(transactionalLayer);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/invertedIndex/ValueToRecordBitmap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/invertedIndex/ValueToRecordBitmap.java
@@ -52,7 +52,7 @@ import java.util.PrimitiveIterator.OfInt;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2019
  */
 public class ValueToRecordBitmap implements ValueToRecord,
-	TransactionalObject<ValueToRecordBitmap, Void>,
+	TransactionalObject<ValueToRecordBitmap>,
 	TransactionalCreatorMaintainer {
 	@Serial private static final long serialVersionUID = 8584161806399686698L;
 	/**
@@ -247,7 +247,6 @@ public class ValueToRecordBitmap implements ValueToRecord,
 	@Nonnull
 	@Override
 	public ValueToRecordBitmap createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		return new ValueToRecordBitmap(
@@ -258,7 +257,6 @@ public class ValueToRecordBitmap implements ValueToRecord,
 
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		this.recordIds.removeLayer(transactionalLayer);
 	}
 

--- a/evita_engine/src/main/java/io/evitadb/index/invertedIndex/ValueToRecordPrimitive.java
+++ b/evita_engine/src/main/java/io/evitadb/index/invertedIndex/ValueToRecordPrimitive.java
@@ -132,7 +132,6 @@ public class ValueToRecordPrimitive implements ValueToRecord {
 	@Nonnull
 	@Override
 	public ValueToRecord createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		// immutable and layer-less: the committed copy is the very same instance (free on commit)

--- a/evita_engine/src/main/java/io/evitadb/index/list/ListChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/list/ListChanges.java
@@ -24,8 +24,8 @@
 package io.evitadb.index.list;
 
 import io.evitadb.core.transaction.memory.Snapshotable;
-import io.evitadb.core.transaction.memory.TransactionalLayerCreator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.UndoJournal;
 import io.evitadb.utils.Assert;
 import lombok.Getter;
@@ -304,8 +304,8 @@ class ListChanges<V> implements Serializable, Snapshotable<ListChanges.ListChang
 		final Iterator<Entry<Integer, V>> it = this.addedItems.entrySet().iterator();
 		while (it.hasNext()) {
 			final Entry<Integer, V> entry = it.next();
-			if (entry.getValue() instanceof TransactionalLayerCreator<?> transactionalLayerCreator) {
-				transactionalLayerCreator.removeLayer(transactionalLayer);
+			if (entry.getValue() instanceof TransactionalStateProducer<?> transactionalStateProducer) {
+				transactionalStateProducer.removeLayer(transactionalLayer);
 			}
 			it.remove();
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/list/TransactionalList.java
+++ b/evita_engine/src/main/java/io/evitadb/index/list/TransactionalList.java
@@ -27,6 +27,7 @@ import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.memory.TransactionalLayerCreator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.exception.GenericEvitaInternalError;
 import lombok.Getter;
@@ -64,7 +65,6 @@ import static java.util.Optional.ofNullable;
 public class TransactionalList<V> implements
 	List<V>,
 	Serializable,
-	Cloneable,
 	TransactionalLayerCreator<ListChanges<V>>,
 	TransactionalLayerProducer<ListChanges<V>, List<V>>
 {
@@ -126,7 +126,7 @@ public class TransactionalList<V> implements
 		return createCopyWithMergedTransactionalMemory(
 			layer,
 			value -> (V) transactionalLayer.getStateCopyWithCommittedChanges(
-				(TransactionalLayerProducer) value
+				(TransactionalStateProducer) value
 			)
 		);
 	}
@@ -440,22 +440,6 @@ public class TransactionalList<V> implements
 
 	@Nonnull
 	@Override
-	public Object clone() throws CloneNotSupportedException {
-		// clone transactional list contents with all recorded changes and create separate transactional memory piece for it
-		@SuppressWarnings("unchecked") final TransactionalList<V> clone = (TransactionalList<V>) super.clone();
-		final ListChanges<V> layer = getTransactionalMemoryLayerIfExists(this);
-		if (layer != null) {
-			final ListChanges<V> clonedLayer = Transaction.getOrCreateTransactionalMemoryLayer(clone);
-			if (clonedLayer != null) {
-				clonedLayer.getRemovedItems().addAll(layer.getRemovedItems());
-				clonedLayer.getAddedItems().putAll(layer.getAddedItems());
-			}
-		}
-		return clone;
-	}
-
-	@Nonnull
-	@Override
 	public String toString() {
 		final Iterator<V> it = iterator();
 		if (!it.hasNext())
@@ -479,7 +463,7 @@ public class TransactionalList<V> implements
 	@SuppressWarnings({"rawtypes"})
 	private List<V> createCopyWithMergedTransactionalMemory(
 		@Nullable ListChanges<V> layer,
-		@Nonnull Function<TransactionalLayerProducer<?, ?>, V> transactionLayerExtractor
+		@Nonnull Function<TransactionalStateProducer<?>, V> transactionLayerExtractor
 	) {
 		// create new array list of requested size
 		final ArrayList<V> copy = new ArrayList<>(size());
@@ -488,8 +472,8 @@ public class TransactionalList<V> implements
 			V value = this.listDelegate.get(i);
 			// we need to always create copy - something in the referenced object might have changed
 			// even the removed values need to be evaluated (in order to discard them from transactional memory set)
-			if (value instanceof TransactionalLayerProducer) {
-				value = transactionLayerExtractor.apply((TransactionalLayerProducer) value);
+			if (value instanceof TransactionalStateProducer) {
+				value = transactionLayerExtractor.apply((TransactionalStateProducer) value);
 			}
 			// except those that were removed
 			if (layer == null || !layer.getRemovedItems().contains(i)) {
@@ -501,8 +485,8 @@ public class TransactionalList<V> implements
 			for (Integer updatedItem : layer.getAddedItems().keySet()) {
 				V value = layer.getAddedItems().get(updatedItem);
 				// we need to always create copy - something in the referenced object might have changed
-				if (value instanceof TransactionalLayerProducer) {
-					value = transactionLayerExtractor.apply((TransactionalLayerProducer) value);
+				if (value instanceof TransactionalStateProducer) {
+					value = transactionLayerExtractor.apply((TransactionalStateProducer) value);
 				}
 				// add the element in the result list
 				copy.add(updatedItem, value);

--- a/evita_engine/src/main/java/io/evitadb/index/map/MapChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/MapChanges.java
@@ -24,9 +24,9 @@
 package io.evitadb.index.map;
 
 import io.evitadb.core.transaction.memory.Snapshotable;
-import io.evitadb.core.transaction.memory.TransactionalLayerCreator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.UndoJournal;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.utils.Assert;
@@ -122,13 +122,13 @@ public class MapChanges<K, V>
 	 * @param mapDelegate original map
 	 * @param transactionalLayerWrapper the function that wraps result of {@link TransactionalLayerProducer#createCopyWithMergedTransactionalMemory(Object, TransactionalLayerMaintainer)} into a V type
 	 */
-	public <S, T extends TransactionalLayerProducer<?, S>> MapChanges(
+	public <S, T extends TransactionalStateProducer<S>> MapChanges(
 		@Nonnull Map<K, V> mapDelegate,
 		@Nonnull Class<T> valueType,
 		@Nonnull Function<S, V> transactionalLayerWrapper
 	) {
 		Assert.isTrue(
-			TransactionalLayerProducer.class.isAssignableFrom(valueType),
+			TransactionalStateProducer.class.isAssignableFrom(valueType),
 			"Value type is expected to implement TransactionalLayerProducer!"
 		);
 		this.mapDelegate = mapDelegate;
@@ -205,7 +205,7 @@ public class MapChanges<K, V>
 				// while still guaranteeing it is swept (releaseLayer is idempotent, so a caller's explicit release is
 				// harmless).
 				originalValue = removeCreatedKey((K) key);
-				if (originalValue instanceof TransactionalLayerProducer) {
+				if (originalValue instanceof TransactionalStateProducer) {
 					stashCreatedThenRemovedProducer(originalValue);
 				}
 			}
@@ -241,7 +241,7 @@ public class MapChanges<K, V>
 			// the key was removed earlier in this transaction and is now being re-inserted with a (potentially)
 			// different value — the original instance is discarded, so release its layer. The release is
 			// identity-based: keep the layer if some surviving key still references the very same instance.
-			if (originalValue instanceof TransactionalLayerProducer<?, ?> transactionalLayerProducer
+			if (originalValue instanceof TransactionalStateProducer<?> transactionalLayerProducer
 				&& originalValue != value
 				&& isInstanceNotReferencedBySurvivingKey(key, originalValue)
 			) {
@@ -367,7 +367,7 @@ public class MapChanges<K, V>
 			return;
 		}
 		for (final Object instance : this.createdThenRemovedProducers) {
-			if (instance instanceof TransactionalLayerProducer<?, ?> transactionalLayerProducer
+			if (instance instanceof TransactionalStateProducer<?> transactionalLayerProducer
 				&& isInstanceNotReferencedBySurvivingKey(null, instance)) {
 				transactionalLayerProducer.removeLayer(transactionalLayer);
 			}
@@ -413,11 +413,11 @@ public class MapChanges<K, V>
 				final boolean wasRemoved = containsRemoved(key);
 				// we need to always create copy - something in the referenced object might have changed
 				// even the removed values need to be evaluated (in order to discard them from transactional memory set)
-				if (key instanceof TransactionalLayerProducer) {
+				if (key instanceof TransactionalStateProducer) {
 					throw new IllegalStateException("Transactional layer producer is not expected to be used as a key!");
 				}
 				V value = entry.getValue();
-				if (value instanceof TransactionalLayerProducer<?, ?> transactionalLayerProducer) {
+				if (value instanceof TransactionalStateProducer<?> transactionalLayerProducer) {
 					if (wasRemoved) {
 						// release the removed value's transactional layer, but only when no surviving key still
 						// references the very same instance. The decision must be identity-based (`==`): a
@@ -444,11 +444,11 @@ public class MapChanges<K, V>
 		for (Entry<K, V> entry : this.modifiedKeys.entrySet()) {
 			final K key = entry.getKey();
 			// we need to always create copy - something in the referenced object might have changed
-			if (key instanceof TransactionalLayerProducer) {
+			if (key instanceof TransactionalStateProducer) {
 				throw new IllegalStateException("Transactional layer producer is not expected to be used as a key!");
 			}
 			V value = entry.getValue();
-			if (value instanceof TransactionalLayerProducer<?, ?> transactionalLayerProducer) {
+			if (value instanceof TransactionalStateProducer<?> transactionalLayerProducer) {
 				value = this.transactionalLayerWrapper.apply(
 					transactionalLayer.getStateCopyWithCommittedChanges(transactionalLayerProducer)
 				);
@@ -543,21 +543,6 @@ public class MapChanges<K, V>
 	V removeModifiedKey(@Nonnull K key) {
 		journalModifiedEntry(key);
 		return this.modifiedKeys.remove(key);
-	}
-
-	/**
-	 * Copies the changes from this layer to another one.
-	 */
-	void copyState(@Nonnull MapChanges<K, V> layer) {
-		layer.createdKeyCount = this.createdKeyCount;
-		layer.removedKeys.addAll(this.removedKeys);
-		layer.modifiedKeys.putAll(this.modifiedKeys);
-		if (this.createdThenRemovedProducers != null) {
-			layer.createdThenRemovedProducers = Collections.newSetFromMap(
-				new IdentityHashMap<>(this.createdThenRemovedProducers.size())
-			);
-			layer.createdThenRemovedProducers.addAll(this.createdThenRemovedProducers);
-		}
 	}
 
 	/**
@@ -781,16 +766,16 @@ public class MapChanges<K, V>
 		final Iterator<Entry<K, V>> it = this.modifiedKeys.entrySet().iterator();
 		while (it.hasNext()) {
 			final Entry<K, V> entry = it.next();
-			if (entry.getValue() instanceof TransactionalLayerCreator<?> transactionalLayerCreator) {
-				transactionalLayerCreator.removeLayer(transactionalLayer);
+			if (entry.getValue() instanceof TransactionalStateProducer<?> transactionalStateProducer) {
+				transactionalStateProducer.removeLayer(transactionalLayer);
 			}
 			it.remove();
 		}
 		// drop the layers of any created-then-removed producers stashed for the deferred commit-time release
 		if (this.createdThenRemovedProducers != null) {
 			for (final Object instance : this.createdThenRemovedProducers) {
-				if (instance instanceof TransactionalLayerCreator<?> transactionalLayerCreator) {
-					transactionalLayerCreator.removeLayer(transactionalLayer);
+				if (instance instanceof TransactionalStateProducer<?> transactionalStateProducer) {
+					transactionalStateProducer.removeLayer(transactionalLayer);
 				}
 			}
 			this.createdThenRemovedProducers = null;

--- a/evita_engine/src/main/java/io/evitadb/index/map/MapChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/MapChanges.java
@@ -129,7 +129,7 @@ public class MapChanges<K, V>
 	) {
 		Assert.isTrue(
 			TransactionalStateProducer.class.isAssignableFrom(valueType),
-			"Value type is expected to implement TransactionalLayerProducer!"
+			"Value type is expected to implement TransactionalStateProducer!"
 		);
 		this.mapDelegate = mapDelegate;
 		//noinspection unchecked

--- a/evita_engine/src/main/java/io/evitadb/index/map/PersistentTransactionalMap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/PersistentTransactionalMap.java
@@ -27,6 +27,7 @@ import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.memory.TransactionalLayerCreator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.dataType.champ.ChampMap;
 import io.evitadb.index.map.TransactionalMap.TransactionalMemoryEntrySet;
@@ -105,7 +106,6 @@ import static java.util.Optional.ofNullable;
 @ThreadSafe
 public class PersistentTransactionalMap<K, V> implements Map<K, V>,
 	Serializable,
-	Cloneable,
 	TransactionalLayerCreator<MapChanges<K, V>>,
 	TransactionalLayerProducer<MapChanges<K, V>, Map<K, V>>
 {
@@ -217,7 +217,7 @@ public class PersistentTransactionalMap<K, V> implements Map<K, V>,
 		ChampMap<K, V> result = ChampMap.from(layer.getMapDelegate());
 		// apply inserts and updates (modifiedKeys and removedKeys are disjoint by MapChanges construction)
 		for (final Entry<K, V> entry : layer.getModifiedKeys().entrySet()) {
-			if (entry.getKey() instanceof TransactionalLayerProducer) {
+			if (entry.getKey() instanceof TransactionalStateProducer) {
 				throw new IllegalStateException("Transactional layer producer is not expected to be used as a key!");
 			}
 			result = result.updated(entry.getKey(), entry.getValue());
@@ -452,26 +452,6 @@ public class PersistentTransactionalMap<K, V> implements Map<K, V>,
 			}
 			sb.append(',').append(' ');
 		}
-	}
-
-	/**
-	 * Creates a shallow clone. The state is sealed first so the clone and this map share the same immutable
-	 * {@link ChampMap} safely (never a shared mutable buffer). If a transaction is active, the current diff
-	 * layer state is copied into the clone's own layer so both instances can diverge afterward.
-	 */
-	@Override
-	public Object clone() throws CloneNotSupportedException {
-		sealed();
-		@SuppressWarnings("unchecked")
-		final PersistentTransactionalMap<K, V> clone = (PersistentTransactionalMap<K, V>) super.clone();
-		final MapChanges<K, V> layer = getTransactionalMemoryLayerIfExists(this);
-		if (layer != null) {
-			final MapChanges<K, V> clonedLayer = Transaction.getOrCreateTransactionalMemoryLayer(clone);
-			if (clonedLayer != null) {
-				layer.copyState(clonedLayer);
-			}
-		}
-		return clone;
 	}
 
 	/* ===========================================================================================

--- a/evita_engine/src/main/java/io/evitadb/index/map/PersistentTransactionalProducerMap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/PersistentTransactionalProducerMap.java
@@ -113,7 +113,7 @@ public class PersistentTransactionalProducerMap<K, V> extends PersistentTransact
 		super(source);
 		Assert.isTrue(
 			TransactionalStateProducer.class.isAssignableFrom(valueType),
-			"Value type is expected to implement TransactionalLayerProducer!"
+			"Value type is expected to implement TransactionalStateProducer!"
 		);
 		this.valueType = valueType;
 		//noinspection unchecked

--- a/evita_engine/src/main/java/io/evitadb/index/map/PersistentTransactionalProducerMap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/PersistentTransactionalProducerMap.java
@@ -26,6 +26,7 @@ package io.evitadb.index.map;
 import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.dataType.champ.ChampMap;
 import io.evitadb.index.invertedIndex.InvertedIndex;
 import io.evitadb.index.range.RangeIndex;
@@ -104,14 +105,14 @@ public class PersistentTransactionalProducerMap<K, V> extends PersistentTransact
 	 * @param <S> the state type produced by the value's transactional layer
 	 * @param <T> the concrete producer type of the value
 	 */
-	public <S, T extends TransactionalLayerProducer<?, S>> PersistentTransactionalProducerMap(
+	public <S, T extends TransactionalStateProducer<S>> PersistentTransactionalProducerMap(
 		@Nonnull Map<K, V> source,
 		@Nonnull Class<T> valueType,
 		@Nonnull Function<S, V> transactionalLayerWrapper
 	) {
 		super(source);
 		Assert.isTrue(
-			TransactionalLayerProducer.class.isAssignableFrom(valueType),
+			TransactionalStateProducer.class.isAssignableFrom(valueType),
 			"Value type is expected to implement TransactionalLayerProducer!"
 		);
 		this.valueType = valueType;
@@ -188,7 +189,7 @@ public class PersistentTransactionalProducerMap<K, V> extends PersistentTransact
 		ofNullable(changes).ifPresent(it -> it.cleanAll(transactionalLayer));
 		for (final Entry<K, V> entry : sealed().entrySet()) {
 			final V value = entry.getValue();
-			if (value instanceof TransactionalLayerProducer<?, ?> transactionalLayerProducer) {
+			if (value instanceof TransactionalStateProducer<?> transactionalLayerProducer) {
 				transactionalLayerProducer.removeLayer(transactionalLayer);
 			}
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/map/ProducerMapChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/ProducerMapChanges.java
@@ -25,6 +25,7 @@ package io.evitadb.index.map;
 
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.dataType.champ.ChampMap;
 
 import javax.annotation.Nonnull;
@@ -84,7 +85,7 @@ public class ProducerMapChanges<K, V> extends MapChanges<K, V> {
 	 * @param <S> the state type produced by the value's transactional layer
 	 * @param <T> the concrete producer type of the value
 	 */
-	public <S, T extends TransactionalLayerProducer<?, S>> ProducerMapChanges(
+	public <S, T extends TransactionalStateProducer<S>> ProducerMapChanges(
 		@Nonnull Map<K, V> mapDelegate,
 		@Nonnull Class<T> valueType,
 		@Nonnull Function<S, V> transactionalLayerWrapper
@@ -103,20 +104,6 @@ public class ProducerMapChanges<K, V> extends MapChanges<K, V> {
 		// share the inherited undo journal so a savepoint rollback also reverts this dirty-key addition
 		journalSetMembership(this.valueMutatedKeys, key);
 		this.valueMutatedKeys.add(key);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * Also carries the {@link #valueMutatedKeys} dirty-key set into the target layer when it is itself a
-	 * {@link ProducerMapChanges} (the clone path always creates a matching producer layer).
-	 */
-	@Override
-	void copyState(@Nonnull MapChanges<K, V> layer) {
-		super.copyState(layer);
-		if (layer instanceof ProducerMapChanges<K, V> producerLayer) {
-			producerLayer.valueMutatedKeys.addAll(this.valueMutatedKeys);
-		}
 	}
 
 	/**
@@ -143,11 +130,11 @@ public class ProducerMapChanges<K, V> extends MapChanges<K, V> {
 
 		// 1) removals (highest precedence): release the removed producer's layer (survivor-guarded) and drop the key
 		for (final K key : getRemovedKeys()) {
-			if (key instanceof TransactionalLayerProducer) {
+			if (key instanceof TransactionalStateProducer) {
 				throw new IllegalStateException("Transactional layer producer is not expected to be used as a key!");
 			}
 			final V value = getMapDelegate().get(key);
-			if (value instanceof TransactionalLayerProducer<?, ?> transactionalLayerProducer
+			if (value instanceof TransactionalStateProducer<?> transactionalLayerProducer
 				&& isInstanceNotReferencedBySurvivingKey(key, value)) {
 				// release the removed value's layer, but only when no surviving key still references the very same
 				// instance (identity-based, exactly as in createMergedMap)
@@ -161,11 +148,11 @@ public class ProducerMapChanges<K, V> extends MapChanges<K, V> {
 		while (modifiedIt.hasNext()) {
 			final Entry<K, V> entry = modifiedIt.next();
 			final K key = entry.getKey();
-			if (key instanceof TransactionalLayerProducer) {
+			if (key instanceof TransactionalStateProducer) {
 				throw new IllegalStateException("Transactional layer producer is not expected to be used as a key!");
 			}
 			V value = entry.getValue();
-			if (value instanceof TransactionalLayerProducer<?, ?> transactionalLayerProducer) {
+			if (value instanceof TransactionalStateProducer<?> transactionalLayerProducer) {
 				value = wrapper.apply(
 					transactionalLayer.getStateCopyWithCommittedChanges(transactionalLayerProducer)
 				);
@@ -179,7 +166,7 @@ public class ProducerMapChanges<K, V> extends MapChanges<K, V> {
 				continue;
 			}
 			final V value = getMapDelegate().get(key);
-			if (value instanceof TransactionalLayerProducer<?, ?> transactionalLayerProducer) {
+			if (value instanceof TransactionalStateProducer<?> transactionalLayerProducer) {
 				final V committed = wrapper.apply(
 					transactionalLayer.getStateCopyWithCommittedChanges(transactionalLayerProducer)
 				);

--- a/evita_engine/src/main/java/io/evitadb/index/map/TransactionalMap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/TransactionalMap.java
@@ -27,6 +27,7 @@ import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.memory.TransactionalLayerCreator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.utils.Assert;
@@ -64,7 +65,6 @@ import static java.util.Optional.ofNullable;
 @ThreadSafe
 public class TransactionalMap<K, V> implements Map<K, V>,
 	Serializable,
-	Cloneable,
 	TransactionalLayerCreator<MapChanges<K, V>>,
 	TransactionalLayerProducer<MapChanges<K, V>, Map<K, V>>
 {
@@ -100,13 +100,13 @@ public class TransactionalMap<K, V> implements Map<K, V>,
 	 * @param <S> the state type produced by the transactional layer producer
 	 * @param <T> the concrete type of the transactional layer producer
 	 */
-	public <S, T extends TransactionalLayerProducer<?, S>> TransactionalMap(
+	public <S, T extends TransactionalStateProducer<S>> TransactionalMap(
 		@Nonnull Map<K, V> mapDelegate,
 		@Nonnull Class<T> valueType,
 		@Nonnull Function<S, V> transactionalLayerWrapper
 	) {
 		Assert.isTrue(
-			TransactionalLayerProducer.class.isAssignableFrom(valueType),
+			TransactionalStateProducer.class.isAssignableFrom(valueType),
 			"Value type is expected to implement TransactionalLayerProducer!"
 		);
 		this.valueType = valueType;
@@ -164,18 +164,18 @@ public class TransactionalMap<K, V> implements Map<K, V>,
 		// iterate over inserted or updated keys
 		if (layer != null) {
 			return layer.createMergedMap(transactionalLayer);
-		} else if (this.valueType == null || TransactionalLayerProducer.class.isAssignableFrom(this.valueType)) {
+		} else if (this.valueType == null || TransactionalStateProducer.class.isAssignableFrom(this.valueType)) {
 			// iterate original map and copy all values from it
 			List<Tuple<K, V>> modifiedEntries = null;
 			for (Entry<K, V> entry : this.mapDelegate.entrySet()) {
 				K key = entry.getKey();
 				// we need to always create copy - something in the referenced object might have changed
 				// even the removed values need to be evaluated (in order to discard them from transactional memory set)
-				if (key instanceof TransactionalLayerProducer) {
+				if (key instanceof TransactionalStateProducer) {
 					throw new IllegalStateException("Transactional layer producer is not expected to be used as a key!");
 				}
 				V value = entry.getValue();
-				if (value instanceof TransactionalLayerProducer<?,?> transactionalLayerProducer) {
+				if (value instanceof TransactionalStateProducer<?> transactionalLayerProducer) {
 					value = this.transactionalLayerWrapper.apply(
 						transactionalLayer.getStateCopyWithCommittedChanges(transactionalLayerProducer)
 					);
@@ -212,7 +212,7 @@ public class TransactionalMap<K, V> implements Map<K, V>,
 		ofNullable(changes).ifPresent(it -> it.cleanAll(transactionalLayer));
 		for (Entry<K, V> entry : this.mapDelegate.entrySet()) {
 			V value = entry.getValue();
-			if (value instanceof TransactionalLayerProducer<?,?> transactionalLayerProducer) {
+			if (value instanceof TransactionalStateProducer<?> transactionalLayerProducer) {
 				transactionalLayerProducer.removeLayer(transactionalLayer);
 			}
 		}
@@ -403,24 +403,6 @@ public class TransactionalMap<K, V> implements Map<K, V>,
 		}
 
 		return true;
-	}
-
-	/**
-	 * Creates a shallow clone of this transactional map. If an active transaction exists, the current diff
-	 * layer state is copied into the clone's own layer so that both instances share the same logical snapshot
-	 * but can diverge independently afterward.
-	 */
-	@Override
-	public Object clone() throws CloneNotSupportedException {
-		@SuppressWarnings("unchecked") final TransactionalMap<K, V> clone = (TransactionalMap<K, V>) super.clone();
-		final MapChanges<K, V> layer = getTransactionalMemoryLayerIfExists(this);
-		if (layer != null) {
-			final MapChanges<K, V> clonedLayer = Transaction.getOrCreateTransactionalMemoryLayer(clone);
-			if (clonedLayer != null) {
-				layer.copyState(clonedLayer);
-			}
-		}
-		return clone;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/map/TransactionalMap.java
+++ b/evita_engine/src/main/java/io/evitadb/index/map/TransactionalMap.java
@@ -107,7 +107,7 @@ public class TransactionalMap<K, V> implements Map<K, V>,
 	) {
 		Assert.isTrue(
 			TransactionalStateProducer.class.isAssignableFrom(valueType),
-			"Value type is expected to implement TransactionalLayerProducer!"
+			"Value type is expected to implement TransactionalStateProducer!"
 		);
 		this.valueType = valueType;
 		this.mapDelegate = mapDelegate;

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/AttributeIndexMutator.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/AttributeIndexMutator.java
@@ -216,7 +216,7 @@ public interface AttributeIndexMutator {
 					);
 					catalogIndex.removeUniqueAttribute(
 						entitySchema, globalAttributeSchema, allowedLocales, locale,
-						theValueToRemove, epkForRemoval
+						theValueToRemove, epkForRemoval, executor.getEntityTypeClassifierResolver()
 					);
 				}
 
@@ -224,7 +224,8 @@ public interface AttributeIndexMutator {
 					IndexType.ATTRIBUTE_UNIQUE_INDEX, Target.NEW
 				);
 				catalogIndex.insertUniqueAttribute(
-					entitySchema, globalAttributeSchema, allowedLocales, locale, valueToInsert, epkForUpsert
+					entitySchema, globalAttributeSchema, allowedLocales, locale, valueToInsert, epkForUpsert,
+					executor.getEntityTypeClassifierResolver()
 				);
 			}
 		}
@@ -331,7 +332,7 @@ public interface AttributeIndexMutator {
 				final CatalogIndex catalogIndex = executor.getCatalogIndex(scope);
 				catalogIndex.removeUniqueAttribute(
 					entitySchema, globalAttributeSchema, allowedLocales, locale, valueToRemoveSupplier.get(),
-					existingPk
+					existingPk, executor.getEntityTypeClassifierResolver()
 				);
 			}
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/mutation/local/EntityIndexLocalMutationExecutor.java
+++ b/evita_engine/src/main/java/io/evitadb/index/mutation/local/EntityIndexLocalMutationExecutor.java
@@ -176,6 +176,13 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 	 */
 	private final Supplier<EntitySchema> schemaAccessor;
 	/**
+	 * Resolves an entity type name to its compact primary key and back. Supplied by the current catalog snapshot at
+	 * construction and threaded into the global unique index (via {@link CatalogIndex#insertUniqueAttribute} /
+	 * {@link CatalogIndex#removeUniqueAttribute}), which stores the compact type primary key inside its packed tuples
+	 * and no longer holds a catalog back-reference of its own.
+	 */
+	@Nonnull private final EntityTypeClassifierResolver entityTypeClassifierResolver;
+	/**
 	 * The sequence service that assigns new price internal ids.
 	 */
 	@Nonnull private final IntSupplier priceInternalIdSupplier;
@@ -319,7 +326,8 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 		@Nonnull Supplier<Entity> fullEntitySupplier,
 		@Nullable Supplier<CatalogExpressionTriggerRegistry> triggerRegistrySupplier,
 		@Nullable BiFunction<String, Scope, FacetExpressionTrigger> localFacetTriggerSupplier,
-		@Nullable Function<String, EntitySchemaContract> crossEntitySchemaResolver
+		@Nullable Function<String, EntitySchemaContract> crossEntitySchemaResolver,
+		@Nonnull EntityTypeClassifierResolver entityTypeClassifierResolver
 	) {
 		this.containerAccessor = containerAccessor;
 		this.entityPrimaryKey.add((anyType, anyPurpose) -> entityPrimaryKey);
@@ -332,6 +340,7 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 		this.triggerRegistrySupplier = triggerRegistrySupplier;
 		this.localFacetTriggerSupplier = localFacetTriggerSupplier;
 		this.crossEntitySchemaResolver = crossEntitySchemaResolver;
+		this.entityTypeClassifierResolver = entityTypeClassifierResolver;
 	}
 
 	/**
@@ -735,6 +744,18 @@ public class EntityIndexLocalMutationExecutor implements LocalMutationExecutor {
 	@Nonnull
 	public CatalogIndex getCatalogIndex(@Nonnull Scope scope) {
 		return this.catalogIndexCreatingAccessor.getOrCreateIndex(new CatalogIndexKey(scope));
+	}
+
+	/**
+	 * Returns the entity type name ↔ compact primary key resolver backed by the current catalog snapshot. Threaded into
+	 * the global unique index by {@link AttributeIndexMutator} so the index can decode the entity type stored inside its
+	 * packed tuples without holding a catalog back-reference.
+	 *
+	 * @return the entity type classifier resolver
+	 */
+	@Nonnull
+	public EntityTypeClassifierResolver getEntityTypeClassifierResolver() {
+		return this.entityTypeClassifierResolver;
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/price/AbstractPriceIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/AbstractPriceIndex.java
@@ -176,7 +176,7 @@ abstract class AbstractPriceIndex<T extends PriceListAndCurrencyPriceIndex> impl
 
 	@Override
 	public void resetDirty() {
-		for (PriceListAndCurrencyPriceIndex<?,?> priceIndex : getPriceIndexes().values()) {
+		for (PriceListAndCurrencyPriceIndex<?> priceIndex : getPriceIndexes().values()) {
 			priceIndex.resetDirty();
 		}
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/price/AbstractPriceListAndCurrencyPriceIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/AbstractPriceListAndCurrencyPriceIndex.java
@@ -65,7 +65,7 @@ import static io.evitadb.core.transaction.Transaction.isTransactionAvailable;
  */
 public abstract class AbstractPriceListAndCurrencyPriceIndex<SELF extends AbstractPriceListAndCurrencyPriceIndex<SELF>>
 	implements VoidTransactionMemoryProducer<SELF>,
-	PriceListAndCurrencyPriceIndex<Void, SELF>,
+	PriceListAndCurrencyPriceIndex<SELF>,
 	IndexDataStructure, Serializable {
 
 	/**
@@ -412,7 +412,6 @@ public abstract class AbstractPriceListAndCurrencyPriceIndex<SELF extends Abstra
 
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		this.dirty.removeLayer(transactionalLayer);
 		this.terminated.removeLayer(transactionalLayer);
 		this.indexedPriceEntityIds.removeLayer(transactionalLayer);

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceIndex.java
@@ -26,7 +26,7 @@ package io.evitadb.index.price;
 import io.evitadb.core.buffer.TrappedChanges;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.price.priceIndex.PriceIdContainerFormula;
-import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.dataType.array.CompositeObjectArray;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.IndexDataStructure;
@@ -50,7 +50,7 @@ import java.util.function.IntConsumer;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
-public interface PriceListAndCurrencyPriceIndex<DIFF_PIECE, COPY> extends IndexDataStructure, TransactionalLayerProducer<DIFF_PIECE, COPY>, Serializable {
+public interface PriceListAndCurrencyPriceIndex<COPY> extends IndexDataStructure, TransactionalStateProducer<COPY>, Serializable {
 
 	/**
 	 * Returns unique identification of this index - contains price list name and currency combination.

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndex.java
@@ -160,7 +160,7 @@ public class PriceListAndCurrencyPriceRefIndex
 		assertNotTerminated();
 		Assert.isPremiseValid(entityType != null, "Entity type must be provided!");
 		Assert.isPremiseValid(this.superIndex == null, "Catalog was already attached to this index!");
-		final PriceListAndCurrencyPriceIndex<?, ?> superIndex = catalog.getEntityIndexIfExists(
+		final PriceListAndCurrencyPriceIndex<?> superIndex = catalog.getEntityIndexIfExists(
 			entityType,
 			new EntityIndexKey(EntityIndexType.GLOBAL, this.scope),
 			GlobalEntityIndex.class
@@ -340,7 +340,6 @@ public class PriceListAndCurrencyPriceRefIndex
 	@Nonnull
 	@Override
 	public PriceListAndCurrencyPriceRefIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		// we can safely throw away dirty flag now

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndex.java
@@ -23,16 +23,12 @@
 
 package io.evitadb.index.price;
 
-import io.evitadb.api.CatalogState;
 import io.evitadb.core.catalog.Catalog;
-import io.evitadb.core.catalog.CatalogRelatedDataStructure;
 import io.evitadb.core.query.algebra.price.priceIndex.PriceIdContainerFormula;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.dataType.DateTimeRange;
 import io.evitadb.dataType.Scope;
-import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.EntityIndexKey;
-import io.evitadb.index.EntityIndexType;
 import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.index.bPlusTree.TransactionalElementBPlusTree;
 import io.evitadb.index.bitmap.Bitmap;
@@ -64,8 +60,7 @@ import java.util.Objects;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
 public class PriceListAndCurrencyPriceRefIndex
-	extends AbstractPriceListAndCurrencyPriceIndex<PriceListAndCurrencyPriceRefIndex>
-	implements CatalogRelatedDataStructure<PriceListAndCurrencyPriceRefIndex> {
+	extends AbstractPriceListAndCurrencyPriceIndex<PriceListAndCurrencyPriceRefIndex> {
 
 	@Serial private static final long serialVersionUID = 182980639981206272L;
 	/**
@@ -75,7 +70,7 @@ public class PriceListAndCurrencyPriceRefIndex
 	private final Scope scope;
 	/**
 	 * Reference to the main {@link PriceListAndCurrencyPriceSuperIndex} that keeps memory expensive objects, which
-	 * is initialized in {@link #attachToCatalog(String, Catalog)} callback.
+	 * is wired in by the owning entity collection through {@link #wireSuperIndex(PriceListAndCurrencyPriceSuperIndex)}.
 	 */
 	private PriceListAndCurrencyPriceSuperIndex superIndex;
 
@@ -97,51 +92,12 @@ public class PriceListAndCurrencyPriceRefIndex
 		this.scope = scope;
 	}
 
-	private PriceListAndCurrencyPriceRefIndex(
-		@Nonnull Scope scope,
-		@Nonnull PriceIndexKey priceIndexKey,
-		@Nonnull Bitmap indexedPriceEntityIds,
-		@Nonnull Bitmap priceIds,
-		@Nonnull RangeIndex validityIndex
-	) {
-		super(priceIndexKey, indexedPriceEntityIds, priceIds, validityIndex);
-		this.scope = scope;
-	}
-
-	private PriceListAndCurrencyPriceRefIndex(
-		@Nonnull Scope scope,
-		@Nonnull PriceIndexKey priceIndexKey,
-		@Nonnull TransactionalBitmap indexedPriceEntityIds,
-		@Nonnull TransactionalBitmap priceIds,
-		@Nonnull RangeIndex validityIndex
-	) {
-		super(priceIndexKey, indexedPriceEntityIds, priceIds, validityIndex);
-		this.scope = scope;
-	}
-
-	/**
-	 * Copy constructor used by {@link #createCopyForNewCatalogAttachment} that shares the existing
-	 * {@link io.evitadb.index.bitmap.TransactionalBitmap} instances AND the derived {@link #priceRecords} tree BY
-	 * REFERENCE. The in-memory re-attachment keeps the super index's {@link PriceRecord} instances, so the carried tree
-	 * stays valid and attach need not rebuild it.
-	 */
-	private PriceListAndCurrencyPriceRefIndex(
-		@Nonnull Scope scope,
-		@Nonnull PriceIndexKey priceIndexKey,
-		@Nonnull TransactionalBitmap indexedPriceEntityIds,
-		@Nonnull TransactionalBitmap priceIds,
-		@Nonnull RangeIndex validityIndex,
-		@Nonnull TransactionalElementBPlusTree<PriceRecordContract> priceRecords
-	) {
-		super(priceIndexKey, indexedPriceEntityIds, priceIds, validityIndex, priceRecords);
-		this.scope = scope;
-	}
-
 	/**
 	 * Copy constructor used by {@link #createCopyWithMergedTransactionalMemory} that adopts the already-merged committed
 	 * {@link #priceRecords} tree BY REFERENCE. The ref tree holds the very same shared {@link PriceRecord} instances as
 	 * the super index (created once in the add-price path), so a commit carries it forward instead of rebuilding it from
-	 * the super index — only a disk-load attach reconstructs it (see {@link #attachToCatalog(String, Catalog)}).
+	 * the super index — only a disk-load attach reconstructs it (see
+	 * {@link #wireSuperIndex(PriceListAndCurrencyPriceSuperIndex)}).
 	 */
 	private PriceListAndCurrencyPriceRefIndex(
 		@Nonnull Scope scope,
@@ -155,27 +111,19 @@ public class PriceListAndCurrencyPriceRefIndex
 		this.scope = scope;
 	}
 
-	@Override
-	public void attachToCatalog(@Nullable String entityType, @Nonnull Catalog catalog) {
+	/**
+	 * Wires the memory-expensive {@link PriceListAndCurrencyPriceSuperIndex} that backs this reduced ref index. The
+	 * owning entity collection resolves the super index from its own {@link GlobalEntityIndex} (same scope, same
+	 * collection) and passes it here — no {@link Catalog} back-reference is retained, so this ref index can be carried
+	 * across catalog versions by reference once its super instance is likewise carried.
+	 *
+	 * @param superIndex the super price index of the owning collection's GLOBAL entity index for this price-list /
+	 *                   currency combination
+	 */
+	public void wireSuperIndex(@Nonnull PriceListAndCurrencyPriceSuperIndex superIndex) {
 		assertNotTerminated();
-		Assert.isPremiseValid(entityType != null, "Entity type must be provided!");
-		Assert.isPremiseValid(this.superIndex == null, "Catalog was already attached to this index!");
-		final PriceListAndCurrencyPriceIndex<?> superIndex = catalog.getEntityIndexIfExists(
-			entityType,
-			new EntityIndexKey(EntityIndexType.GLOBAL, this.scope),
-			GlobalEntityIndex.class
-		)
-			.map(it -> it.getPriceIndex(this.priceIndexKey))
-			.orElse(null);
-		Assert.isPremiseValid(
-			superIndex instanceof PriceListAndCurrencyPriceSuperIndex,
-			() -> new GenericEvitaInternalError(
-				"PriceListAndCurrencyPriceRefIndex can only be initialized with PriceListAndCurrencyPriceSuperIndex, " +
-					"actual instance is `" + (this.superIndex == null ? "NULL" : this.superIndex.getClass().getName()) + "`",
-				"PriceListAndCurrencyPriceRefIndex can only be initialized with PriceListAndCurrencyPriceSuperIndex"
-			)
-		);
-		this.superIndex = (PriceListAndCurrencyPriceSuperIndex) superIndex;
+		Assert.isPremiseValid(this.superIndex == null, "Super index was already wired to this index!");
+		this.superIndex = superIndex;
 		// the price-record tree is rebuilt from the super index ONLY on a disk-load attach, where deserialization left it
 		// null (the ref index persists just its price ids + validity, never the memory-expensive PriceRecord objects, so
 		// the tree must be reconstructed by pointing at the super index's existing heap instances — the dedup that collapses
@@ -194,27 +142,6 @@ public class PriceListAndCurrencyPriceRefIndex
 			}
 			this.indexedPriceEntityIds = new TransactionalBitmap(entityIds);
 		}
-	}
-
-	@Nonnull
-	@Override
-	public PriceListAndCurrencyPriceRefIndex createCopyForNewCatalogAttachment(@Nonnull CatalogState catalogState) {
-		assertNotTerminated();
-		// carry the derived price-record tree forward by reference rather than dropping it: this is a purely in-memory
-		// re-attachment (goLive / persistence-service swap / collection replace), where the GLOBAL entity index — and with
-		// it the super price index's PriceRecord instances — is carried by reference, NOT reloaded from disk (see
-		// EntityCollection#createIndexCopiesForNewCatalogAttachment). The carried tree therefore still points at exactly the
-		// instances the re-resolved super index holds, so attachToCatalog can skip the rebuild (only the disk-load path,
-		// which deserializes a null tree, must reconstruct it). Dropping the tree here would force that rebuild's insert
-		// loop to run during the finalized commit-merge, where #569's guard forbids creating a new transactional layer.
-		return new PriceListAndCurrencyPriceRefIndex(
-			this.scope,
-			this.priceIndexKey,
-			this.indexedPriceEntityIds,
-			this.indexedPriceIds,
-			this.validityIndex,
-			this.priceRecords
-		);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndex.java
@@ -261,7 +261,7 @@ public class PriceListAndCurrencyPriceRefIndex
 		// remove the presence of the record
 		this.indexedPriceIds.remove(priceRecord.internalPriceId());
 
-		if (!entityPrices.containsAnyOf(this.priceRecords.toArray())) {
+		if (!containsAnyPriceOf(entityPrices)) {
 			// remove the presence of the record
 			this.indexedPriceEntityIds.remove(priceRecord.entityPrimaryKey());
 		}
@@ -271,6 +271,27 @@ public class PriceListAndCurrencyPriceRefIndex
 		markDirtyAndInvalidateCache();
 
 		return priceRecord;
+	}
+
+	/**
+	 * Tells whether any price of `entityPrices` is still present in this index's price-record tree.
+	 *
+	 * The entity holds a handful of prices while the tree holds every price record of the whole
+	 * price-list/currency combination, so the containment is resolved by probing the tree for each of
+	 * the entity's internal price ids rather than by materializing the tree and scanning it - the
+	 * latter is O(tree size) in both time and allocation on a path that runs once per removed price.
+	 *
+	 * @param entityPrices prices of the entity whose price is being removed
+	 * @return true when at least one price of the entity remains indexed here
+	 */
+	private boolean containsAnyPriceOf(@Nonnull EntityPrices entityPrices) {
+		final int[] internalPriceIds = entityPrices.getInternalPriceIds();
+		for (final int internalPriceId : internalPriceIds) {
+			if (this.priceRecords.search(internalPriceId) != null) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Nonnull

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndex.java
@@ -508,7 +508,6 @@ public class PriceListAndCurrencyPriceSuperIndex
 	@Nonnull
 	@Override
 	public PriceListAndCurrencyPriceSuperIndex createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		assertNotTerminated();

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceRefIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceRefIndex.java
@@ -23,12 +23,9 @@
 
 package io.evitadb.index.price;
 
-import io.evitadb.api.CatalogState;
 import io.evitadb.api.query.order.PriceNatural;
 import io.evitadb.api.requestResponse.data.PriceContract;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
-import io.evitadb.core.catalog.Catalog;
-import io.evitadb.core.catalog.CatalogRelatedDataStructure;
 import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.memory.Snapshotable;
 import io.evitadb.core.transaction.memory.TransactionalContainerChanges;
@@ -38,6 +35,7 @@ import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
 import io.evitadb.dataType.DateTimeRange;
 import io.evitadb.dataType.Scope;
 import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.index.map.TransactionalMap;
 import io.evitadb.index.price.PriceListAndCurrencyPriceIndex.PriceListAndCurrencyPriceIndexTerminated;
 import io.evitadb.index.price.PriceRefIndex.PriceIndexChanges;
@@ -53,9 +51,7 @@ import javax.annotation.Nullable;
 import java.io.Serial;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static java.util.Optional.ofNullable;
 
@@ -76,8 +72,7 @@ import static java.util.Optional.ofNullable;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class PriceRefIndex extends AbstractPriceIndex<PriceListAndCurrencyPriceRefIndex> implements
-	TransactionalLayerProducer<PriceIndexChanges, PriceRefIndex>,
-	CatalogRelatedDataStructure<PriceRefIndex>
+	TransactionalLayerProducer<PriceIndexChanges, PriceRefIndex>
 {
 	@Serial private static final long serialVersionUID = 7596276815836027747L;
 	/**
@@ -91,11 +86,16 @@ public class PriceRefIndex extends AbstractPriceIndex<PriceListAndCurrencyPriceR
 	 */
 	@Getter protected final TransactionalMap<PriceIndexKey, PriceListAndCurrencyPriceRefIndex> priceIndexes;
 	/**
-	 * Lambda that manages initialization of new price list indexes. These indexes needs to locate their
-	 * {@link PriceListAndCurrencyPriceSuperIndex} from the catalog data and use it for locating shared price records
-	 * instances.
+	 * Resolver that maps a {@link PriceIndexKey} to the memory-expensive
+	 * {@link PriceListAndCurrencyPriceSuperIndex} that backs each reduced ref index. The owning entity collection wires
+	 * it in through {@link #wireSuperIndexes(Function)}, and in production always supplies a {@link SuperIndexResolver}
+	 * that closes over the collection's own {@link GlobalEntityIndex} — no {@link io.evitadb.core.catalog.Catalog} nor
+	 * owning-collection back-reference is retained. It is used to wire newly created per-price-list ref indexes to the
+	 * shared price record instances. The field is typed as a bare {@link Function} only so unit tests can wire a stub
+	 * resolver directly; the concrete {@link SuperIndexResolver} keeps its captured GLOBAL inspectable for the
+	 * carry-by-reference identity check.
 	 */
-	private Consumer<PriceListAndCurrencyPriceRefIndex> initCallback;
+	private Function<PriceIndexKey, PriceListAndCurrencyPriceSuperIndex> superIndexResolver;
 
 	public PriceRefIndex(@Nonnull Scope scope) {
 		this.scope = scope;
@@ -110,29 +110,48 @@ public class PriceRefIndex extends AbstractPriceIndex<PriceListAndCurrencyPriceR
 		this.priceIndexes = new TransactionalMap<>(priceIndexes, PriceListAndCurrencyPriceRefIndex.class, Function.identity());
 	}
 
-	@Override
-	public void attachToCatalog(@Nullable String entityType, @Nonnull Catalog catalog) {
-		Assert.isPremiseValid(this.initCallback == null, "Catalog was already attached to this index!");
-		this.initCallback = priceListAndCurrencyPriceRefIndex -> priceListAndCurrencyPriceRefIndex.attachToCatalog(entityType, catalog);
-		// delegate call to price list indexes
-		this.priceIndexes.values().forEach(it -> it.attachToCatalog(entityType, catalog));
+	/**
+	 * Wires the resolver that this index uses to obtain the {@link PriceListAndCurrencyPriceSuperIndex} for each
+	 * price-list / currency combination, and immediately wires every already-present combination index to its super
+	 * index. Called by the owning entity collection, which resolves super indexes from its own
+	 * {@link GlobalEntityIndex} (same scope, same collection) instead of routing through the catalog.
+	 *
+	 * @param superIndexResolver maps a {@link PriceIndexKey} to the super price index backing that combination
+	 */
+	public void wireSuperIndexes(@Nonnull Function<PriceIndexKey, PriceListAndCurrencyPriceSuperIndex> superIndexResolver) {
+		Assert.isPremiseValid(this.superIndexResolver == null, "Super index resolver was already wired to this index!");
+		this.superIndexResolver = superIndexResolver;
+		// wire every existing combination index to its super index
+		this.priceIndexes.values().forEach(it -> it.wireSuperIndex(superIndexResolver.apply(it.getPriceIndexKey())));
 	}
 
-	@Nonnull
-	@Override
-	public PriceRefIndex createCopyForNewCatalogAttachment(@Nonnull CatalogState catalogState) {
-		return new PriceRefIndex(
-			this.scope,
-			this.priceIndexes
-				.entrySet()
-				.stream()
-				.collect(
-					Collectors.toMap(
-						Map.Entry::getKey,
-						it -> it.getValue().createCopyForNewCatalogAttachment(catalogState)
-					)
-				)
-		);
+	/**
+	 * Wires this index's price ref chain to the super price indexes held by the given {@link GlobalEntityIndex}, or —
+	 * when the chain was already wired and this index was carried across a catalog version **by reference** — verifies
+	 * that the captured GLOBAL is still this version's GLOBAL instead of re-wiring (the single-assign guard in
+	 * {@link #wireSuperIndexes(Function)} forbids a second wire).
+	 *
+	 * A carried reduced index keeps the {@link SuperIndexResolver} it was originally wired with; because the
+	 * clean-collection copy carries the GLOBAL entity index by reference in the very same step, that captured GLOBAL
+	 * must be identity-equal to the one resolved for the new version. A mismatch means a stale super-index pointer
+	 * survived a version bump — surface it here, at attach time, rather than letting a query read a retired version's
+	 * super price index.
+	 *
+	 * @param globalIndex the GLOBAL entity index of this reduced index's scope, owning the backing super price indexes
+	 */
+	public void wireOrVerifySuperIndexes(@Nonnull GlobalEntityIndex globalIndex) {
+		if (this.superIndexResolver == null) {
+			// fresh (re-shelled on disk load, lazily created, or merged) index: wire its price ref chain for the first time
+			wireSuperIndexes(new SuperIndexResolver(globalIndex));
+		} else {
+			// carried-by-reference index: prove its existing wiring still points at the current version's GLOBAL entity
+			// index rather than silently skipping — GLOBAL identity is a strict superset of per-combo super identity
+			// (any dirty combo yields a new combo instance, hence a changed combo map, hence a new GLOBAL)
+			Assert.isPremiseValid(
+				this.superIndexResolver instanceof SuperIndexResolver sir && sir.globalIndex() == globalIndex,
+				"Carried price ref index is wired to a stale GLOBAL entity index (expected the current version's GLOBAL)!"
+			);
+		}
 	}
 
 	/*
@@ -169,7 +188,7 @@ public class PriceRefIndex extends AbstractPriceIndex<PriceListAndCurrencyPriceR
 	@Nonnull
 	protected PriceListAndCurrencyPriceRefIndex createNewPriceListAndCurrencyIndex(@Nonnull PriceIndexKey lookupKey) {
 		final PriceListAndCurrencyPriceRefIndex newPriceListIndex = new PriceListAndCurrencyPriceRefIndex(this.scope, lookupKey);
-		this.initCallback.accept(newPriceListIndex);
+		newPriceListIndex.wireSuperIndex(this.superIndexResolver.apply(lookupKey));
 		ofNullable(Transaction.getOrCreateTransactionalMemoryLayer(this))
 			.ifPresent(it -> it.addCreatedItem(newPriceListIndex));
 		return newPriceListIndex;

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceRefIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceRefIndex.java
@@ -221,7 +221,7 @@ public class PriceRefIndex extends AbstractPriceIndex<PriceListAndCurrencyPriceR
 	 * This class collects changes in {@link #priceIndexes} transactional map.
 	 */
 	public static class PriceIndexChanges implements Snapshotable<PriceIndexChanges.PriceIndexChangesMemento> {
-		private final TransactionalContainerChanges<Void, PriceListAndCurrencyPriceRefIndex, PriceListAndCurrencyPriceRefIndex> collectedPriceIndexChanges = new TransactionalContainerChanges<>();
+		private final TransactionalContainerChanges<PriceListAndCurrencyPriceRefIndex, PriceListAndCurrencyPriceRefIndex> collectedPriceIndexChanges = new TransactionalContainerChanges<>();
 
 		public void addCreatedItem(@Nonnull PriceListAndCurrencyPriceRefIndex priceIndex) {
 			this.collectedPriceIndexChanges.addCreatedItem(priceIndex);

--- a/evita_engine/src/main/java/io/evitadb/index/price/PriceSuperIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/PriceSuperIndex.java
@@ -182,7 +182,7 @@ public class PriceSuperIndex
 	 * This class collects changes in {@link #priceIndexes} transactional map.
 	 */
 	public static class PriceIndexChanges implements Snapshotable<PriceIndexChanges.PriceIndexChangesMemento> {
-		private final TransactionalContainerChanges<Void, PriceListAndCurrencyPriceSuperIndex, PriceListAndCurrencyPriceSuperIndex> collectedPriceIndexChanges = new TransactionalContainerChanges<>();
+		private final TransactionalContainerChanges<PriceListAndCurrencyPriceSuperIndex, PriceListAndCurrencyPriceSuperIndex> collectedPriceIndexChanges = new TransactionalContainerChanges<>();
 
 		public void addCreatedItem(PriceListAndCurrencyPriceSuperIndex priceIndex) {
 			this.collectedPriceIndexChanges.addCreatedItem(priceIndex);

--- a/evita_engine/src/main/java/io/evitadb/index/price/SuperIndexResolver.java
+++ b/evita_engine/src/main/java/io/evitadb/index/price/SuperIndexResolver.java
@@ -1,0 +1,75 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.index.price;
+
+import io.evitadb.index.GlobalEntityIndex;
+import io.evitadb.index.price.model.PriceIndexKey;
+import io.evitadb.utils.Assert;
+
+import javax.annotation.Nonnull;
+import java.util.function.Function;
+
+/**
+ * Resolves the memory-expensive {@link PriceListAndCurrencyPriceSuperIndex} backing each reduced
+ * {@link PriceListAndCurrencyPriceRefIndex} from a single {@link GlobalEntityIndex} — the GLOBAL entity index of the
+ * owning collection and matching scope, whose {@link PriceSuperIndex} holds the shared super price indexes.
+ *
+ * Closing over the GLOBAL entity index — rather than over the owning entity collection — is what keeps this resolver
+ * free of any collection or {@link io.evitadb.core.catalog.Catalog} back-reference: it pins nothing from the catalog
+ * version that wired it. The lazy {@link PriceSuperIndex#getPriceIndex(PriceIndexKey)} read inside
+ * {@link #apply(PriceIndexKey)} still consults the transactional combo map, so a price-list / currency combination added
+ * later in the same transaction remains visible exactly as it did through the former owning-collection detour.
+ *
+ * The captured GLOBAL is deliberately kept inspectable through {@link #globalIndex()} — a record accessor, unlike an
+ * opaque lambda. That accessor exists so a wiring pass can compare, by a single identity check, whether a given resolver
+ * still points at a particular GLOBAL entity index, which is the enabling property for forwarding a reduced index across
+ * catalog versions by reference (its GLOBAL is carried by reference on the clean-collection copy path) without silently
+ * leaving a stale super-index pointer behind.
+ *
+ * @param globalIndex the GLOBAL entity index whose price super indexes back the reduced index being wired
+ */
+public record SuperIndexResolver(@Nonnull GlobalEntityIndex globalIndex)
+	implements Function<PriceIndexKey, PriceListAndCurrencyPriceSuperIndex> {
+
+	/**
+	 * Resolves the super price index for a single price-list / currency combination from the captured GLOBAL entity
+	 * index. Mirrors the non-null contract of the former owning-collection resolver: the combination is always present
+	 * by the time a reduced index references it (a price is added to the super index before the reduced ref index that
+	 * points at it), so a missing super index is a programming error rather than an expected absence.
+	 *
+	 * @param priceIndexKey the price-list / currency combination to resolve
+	 * @return the super price index backing the combination (never `null`)
+	 */
+	@Nonnull
+	@Override
+	public PriceListAndCurrencyPriceSuperIndex apply(@Nonnull PriceIndexKey priceIndexKey) {
+		final PriceListAndCurrencyPriceSuperIndex superIndex = this.globalIndex.getPriceIndex().getPriceIndex(priceIndexKey);
+		Assert.isPremiseValid(
+			superIndex != null,
+			() -> "Super price index for `" + priceIndexKey + "` must exist in the GLOBAL entity index!"
+		);
+		return superIndex;
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/index/range/RangeIndex.java
+++ b/evita_engine/src/main/java/io/evitadb/index/range/RangeIndex.java
@@ -862,7 +862,7 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 
 	@Nonnull
 	@Override
-	public RangeIndex createCopyWithMergedTransactionalMemory(Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
+	public RangeIndex createCopyWithMergedTransactionalMemory(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		// consume the dirty layer first (mirrors InvertedIndex): when this index was not touched in the transaction,
 		// return THIS instance unchanged - preserving identity so the enclosing map can structurally share it, and
 		// sparing the full B+ tree rebuild that getStateCopyWithCommittedChanges(this.ranges) would otherwise perform.
@@ -893,7 +893,6 @@ public class RangeIndex implements VoidTransactionMemoryProducer<RangeIndex>, Se
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		this.dirty.removeLayer(transactionalLayer);
 		this.ranges.removeLayer(transactionalLayer);
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/range/TransactionalRangePoint.java
+++ b/evita_engine/src/main/java/io/evitadb/index/range/TransactionalRangePoint.java
@@ -58,7 +58,7 @@ import java.util.Objects;
 @ThreadSafe
 @EqualsAndHashCode(of = "threshold")
 public class TransactionalRangePoint
-	implements TransactionalObject<TransactionalRangePoint, Void>,
+	implements TransactionalObject<TransactionalRangePoint>,
 	VoidTransactionMemoryProducer<TransactionalRangePoint>,
 	RangePoint<TransactionalRangePoint>,
 	TransactionalCreatorMaintainer,
@@ -171,7 +171,6 @@ public class TransactionalRangePoint
 	@Nonnull
 	@Override
 	public TransactionalRangePoint createCopyWithMergedTransactionalMemory(
-		@Nullable Void layer,
 		@Nonnull TransactionalLayerMaintainer transactionalLayer
 	) {
 		final boolean isDirty = transactionalLayer
@@ -189,7 +188,6 @@ public class TransactionalRangePoint
 
 	@Override
 	public void removeLayer(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
-		transactionalLayer.removeTransactionalMemoryLayerIfExists(this);
 		this.dirty.removeLayer(transactionalLayer);
 		this.starts.removeLayer(transactionalLayer);
 		this.ends.removeLayer(transactionalLayer);

--- a/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/set/SetChanges.java
@@ -27,6 +27,7 @@ import io.evitadb.api.requestResponse.data.ContentComparator;
 import io.evitadb.core.transaction.memory.Snapshotable;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.UndoJournal;
 import lombok.Getter;
 
@@ -272,9 +273,9 @@ public class SetChanges<K> implements Serializable, Snapshotable<SetChanges.SetC
 			// referenced object might have changed; even the removed
 			// values need to be evaluated (to discard them from
 			// transactional memory set)
-			if (key instanceof TransactionalLayerProducer) {
+			if (key instanceof TransactionalStateProducer) {
 				key = (K) transactionalLayer.getStateCopyWithCommittedChanges(
-					(TransactionalLayerProducer<?, ?>) key
+					(TransactionalStateProducer<?>) key
 				);
 			}
 			// except those that were removed
@@ -285,8 +286,8 @@ public class SetChanges<K> implements Serializable, Snapshotable<SetChanges.SetC
 
 		// iterate over inserted keys
 		for (K key : getCreatedKeys()) {
-			if (key instanceof TransactionalLayerProducer) {
-				key = (K) transactionalLayer.getStateCopyWithCommittedChanges((TransactionalLayerProducer<?, ?>) key);
+			if (key instanceof TransactionalStateProducer) {
+				key = (K) transactionalLayer.getStateCopyWithCommittedChanges((TransactionalStateProducer<?>) key);
 			}
 			copy.add(key);
 		}
@@ -357,18 +358,6 @@ public class SetChanges<K> implements Serializable, Snapshotable<SetChanges.SetC
 	 */
 	boolean containsRemoved(@Nonnull K key) {
 		return this.removedKeys != null && this.removedKeys.contains(key);
-	}
-
-	/**
-	 * Copies the changes from this layer to another one.
-	 */
-	void copyState(@Nonnull SetChanges<K> layer) {
-		if (this.createdKeys != null && !this.createdKeys.isEmpty()) {
-			layer.getOrCreateCreatedKeys().addAll(this.createdKeys);
-		}
-		if (this.removedKeys != null && !this.removedKeys.isEmpty()) {
-			layer.getOrCreateRemovedKeys().addAll(this.removedKeys);
-		}
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/set/TransactionalSet.java
+++ b/evita_engine/src/main/java/io/evitadb/index/set/TransactionalSet.java
@@ -27,6 +27,7 @@ import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.memory.TransactionalLayerCreator;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 import io.evitadb.core.transaction.memory.TransactionalObjectVersion;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.utils.Assert;
@@ -62,7 +63,7 @@ import static io.evitadb.core.transaction.Transaction.getTransactionalMemoryLaye
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2017
  */
 @ThreadSafe
-public class TransactionalSet<K> implements Set<K>, Serializable, Cloneable,
+public class TransactionalSet<K> implements Set<K>, Serializable,
 	TransactionalLayerCreator<SetChanges<K>>, TransactionalLayerProducer<SetChanges<K>, Set<K>> {
 	@Serial private static final long serialVersionUID = 6678551073928034251L;
 	private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
@@ -104,10 +105,10 @@ public class TransactionalSet<K> implements Set<K>, Serializable, Cloneable,
 				// values need to be evaluated (in order to discard them
 				// from transactional memory set)
 				final K transformedEntry;
-				if (entry instanceof TransactionalLayerProducer) {
+				if (entry instanceof TransactionalStateProducer) {
 					//noinspection unchecked
 					transformedEntry = (K) transactionalLayer.getStateCopyWithCommittedChanges(
-						(TransactionalLayerProducer<?, ?>) entry
+						(TransactionalStateProducer<?>) entry
 					);
 				} else {
 					transformedEntry = entry;
@@ -337,20 +338,6 @@ public class TransactionalSet<K> implements Set<K>, Serializable, Cloneable,
 		}
 
 		return true;
-	}
-
-	@Nonnull
-	@Override
-	public Object clone() throws CloneNotSupportedException {
-		@SuppressWarnings("unchecked") final TransactionalSet<K> clone = (TransactionalSet<K>) super.clone();
-		final SetChanges<K> layer = getTransactionalMemoryLayerIfExists(this);
-		if (layer != null) {
-			final SetChanges<K> clonedLayer = Transaction.getOrCreateTransactionalMemoryLayer(clone);
-			if (clonedLayer != null) {
-				layer.copyState(clonedLayer);
-			}
-		}
-		return clone;
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/AbstractEntityByAttributeFilteringFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/attribute/AbstractEntityByAttributeFilteringFunctionalTest.java
@@ -5734,6 +5734,44 @@ public abstract class AbstractEntityByAttributeFilteringFunctionalTest {
 		);
 	}
 
+	@DisplayName("Should return no entities when an unsatisfiable nested AND contains a NOT constraint")
+	@UseDataSet(HUNDRED_PRODUCTS)
+	@Test
+	void shouldReturnNoEntitiesWhenUnsatisfiableNestedAndContainsNotConstraint(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final EvitaResponse<EntityReference> result = session.query(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								// this constraint alone matches a non-empty set of entities
+								attributeIsNotNull(ATTRIBUTE_PRIORITY),
+								and(
+									// no entity carries this priority, so the nested conjunction matches nothing
+									attributeEquals(ATTRIBUTE_PRIORITY, Long.MIN_VALUE),
+									not(
+										attributeEquals(ATTRIBUTE_ALIAS, false)
+									)
+								)
+							)
+						),
+						require(
+							page(1, Integer.MAX_VALUE),
+							debug(DebugMode.VERIFY_ALTERNATIVE_INDEX_RESULTS, DebugMode.VERIFY_POSSIBLE_CACHING_TREES)
+						)
+					),
+					EntityReference.class
+				);
+				// the nested conjunction is unsatisfiable, so the entire query must match nothing - the negated
+				// branch must not disappear from the conjunction and leave its sibling matching on its own
+				assertEquals(0, result.getTotalRecordCount());
+				return null;
+			}
+		);
+	}
+
 	@DisplayName("Should return entities combining NOT constraint with attributeIsNull in OR context")
 	@UseDataSet(HUNDRED_PRODUCTS)
 	@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReducedIndexCatalogVersionCarryTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/indexing/ReducedIndexCatalogVersionCarryTest.java
@@ -1,0 +1,187 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.indexing;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaEditor;
+import io.evitadb.core.Evita;
+import io.evitadb.core.catalog.Catalog;
+import io.evitadb.core.collection.EntityCollection;
+import io.evitadb.index.EntityIndex;
+import io.evitadb.index.EntityIndexKey;
+import io.evitadb.index.EntityIndexType;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.math.BigDecimal;
+import java.util.Currency;
+
+import static io.evitadb.api.functional.indexing.IndexingTestSupport.getReferencedEntityIndex;
+import static io.evitadb.test.TestTags.INDEXING;
+import static io.evitadb.test.TestTags.PRICE;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Locks in the clean-collection carry-by-reference contract: when a clean collection is copied for a new catalog
+ * version, its reduced entity indexes are forwarded **by reference** rather than re-shelled (a fresh copy) on every
+ * version bump.
+ *
+ * A reduced index holds no catalog back-reference of its own — its price ref chain captures the GLOBAL entity index
+ * directly through a `SuperIndexResolver`, and that GLOBAL is carried by reference in the same copy step — so the
+ * reduced index can safely survive a version boundary as the very same instance. `goLive` is the deterministic clean
+ * version bump used here: it routes every collection through the clean-copy path.
+ *
+ * Before carry-by-reference this test would fail (the reduced index came back as a fresh re-shelled instance); the
+ * assertions therefore pin the alloc-saving mechanism against a silent revert to per-commit re-shelling (the actual
+ * allocation win is measured separately by the senesi JMH gate).
+ */
+@DisplayName("Reduced index carried by reference across a clean catalog version bump")
+@Tag(INDEXING)
+@Tag(REFERENCE)
+@Tag(PRICE)
+@Tag(TRANSACTION)
+class ReducedIndexCatalogVersionCarryTest implements EvitaTestSupport {
+
+	private static final String PRICE_LIST_BASIC = "basic";
+	private static final Currency CURRENCY_EUR = Currency.getInstance("EUR");
+	private static final int BRAND_PK = 1;
+	private static final int PRODUCT_PK = 1;
+
+	private TestPaths paths;
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() {
+		this.paths = createTestPaths("ReducedIndexCatalogVersionCarry");
+		this.evita = new Evita(newTestEvitaConfigurationBuilder(this.paths).build());
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (this.evita != null && this.evita.isActive()) {
+			this.evita.close();
+		}
+		cleanupTestPaths(this.paths);
+	}
+
+	@Test
+	@DisplayName("goLive must forward a reduced index (and its GLOBAL) by reference, not re-shell it")
+	void shouldCarryReducedIndexByReferenceAcrossGoLive() {
+		// 1) warm-up: a product with a price and an indexed reference to a brand builds a REFERENCED_ENTITY reduced
+		//    index (owning a price ref chain wired to the collection's GLOBAL super price index). Do NOT go live yet.
+		this.evita.defineCatalog(TEST_CATALOG);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.BRAND)
+					.withoutGeneratedPrimaryKey()
+					.updateVia(session);
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withPrice()
+					.withReferenceToEntity(
+						Entities.BRAND,
+						Entities.BRAND,
+						Cardinality.ZERO_OR_ONE,
+						ReferenceSchemaEditor::indexedForFilteringAndPartitioning
+					)
+					.updateVia(session);
+
+				session.upsertEntity(session.createNewEntity(Entities.BRAND, BRAND_PK));
+				session.upsertEntity(
+					session.createNewEntity(Entities.PRODUCT, PRODUCT_PK)
+						.setPriceInnerRecordHandling(PriceInnerRecordHandling.NONE)
+						.setPrice(1, PRICE_LIST_BASIC, CURRENCY_EUR, BigDecimal.TEN, BigDecimal.ZERO, BigDecimal.TEN, true)
+						.setReference(Entities.BRAND, BRAND_PK)
+				);
+			}
+		);
+
+		// capture the reduced index and its backing GLOBAL while the catalog is still WARMING_UP
+		final EntityIndex reducedBefore = referencedEntityIndex();
+		final EntityIndex globalBefore = globalEntityIndex();
+		assertNotNull(reducedBefore, "The REFERENCED_ENTITY reduced index must exist after the warm-up upsert!");
+
+		// 2) clean version bump: go live routes every (clean) collection through the clean-copy path. Block-bodied
+		//    lambda deliberately — a void expression lambda is ambiguous between Consumer and Function here.
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			EvitaSessionContract::goLiveAndClose
+		);
+
+		// 3) the GLOBAL entity index and the reduced index must both be the SAME instances as before the bump —
+		//    carried by reference together, so the reduced index's captured GLOBAL stays identity-stable
+		final EntityIndex globalAfter = globalEntityIndex();
+		final EntityIndex reducedAfter = referencedEntityIndex();
+		assertNotNull(reducedAfter, "The REFERENCED_ENTITY reduced index must survive the version bump!");
+		assertSame(
+			globalBefore, globalAfter,
+			"The GLOBAL entity index must be carried across the version bump by reference!"
+		);
+		assertSame(
+			reducedBefore, reducedAfter,
+			"The reduced index must be carried across the clean version bump by reference (not re-shelled)!"
+		);
+	}
+
+	/**
+	 * Reaches into the live {@link Entities#PRODUCT} collection and returns the REFERENCED_ENTITY reduced index for the
+	 * single indexed brand reference.
+	 *
+	 * @return the reduced entity index, or {@code null} if it has not been created yet
+	 */
+	@Nonnull
+	private EntityIndex referencedEntityIndex() {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection = (EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		return getReferencedEntityIndex(collection, Entities.BRAND, BRAND_PK);
+	}
+
+	/**
+	 * Reaches into the live {@link Entities#PRODUCT} collection and returns its GLOBAL entity index (the owner of the
+	 * super price indexes that back the reduced index's price ref chain).
+	 *
+	 * @return the GLOBAL entity index; never {@code null} for an existing collection
+	 */
+	@Nonnull
+	private EntityIndex globalEntityIndex() {
+		final Catalog catalog = (Catalog) this.evita.getCatalogInstance(TEST_CATALOG).orElseThrow();
+		final EntityCollection collection = (EntityCollection) catalog.getCollectionForEntity(Entities.PRODUCT).orElseThrow();
+		final EntityIndex globalIndex = collection.getIndexByKeyIfExists(new EntityIndexKey(EntityIndexType.GLOBAL));
+		assertNotNull(globalIndex, "The GLOBAL entity index must exist!");
+		return globalIndex;
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIndexContainerFormulaTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/algebra/price/priceIndex/PriceIndexContainerFormulaTest.java
@@ -93,7 +93,7 @@ class PriceIndexContainerFormulaTest {
 		@Test
 		@DisplayName("should expose price index via getter")
 		void shouldExposePriceIndexViaGetter() {
-			final PriceListAndCurrencyPriceIndex<?, ?> index = createPriceIndex("basic", CZK);
+			final PriceListAndCurrencyPriceIndex<?> index = createPriceIndex("basic", CZK);
 			final PriceIndexContainerFormula formula = new PriceIndexContainerFormula(
 				index, createConstantFormula(1)
 			);
@@ -126,7 +126,7 @@ class PriceIndexContainerFormulaTest {
 		@Test
 		@DisplayName("should preserve price index in clone")
 		void shouldPreservePriceIndexInClone() {
-			final PriceListAndCurrencyPriceIndex<?, ?> index = createPriceIndex("vip", EUR);
+			final PriceListAndCurrencyPriceIndex<?> index = createPriceIndex("vip", EUR);
 			final PriceIndexContainerFormula original = new PriceIndexContainerFormula(
 				index, createConstantFormula(1, 2)
 			);
@@ -207,7 +207,7 @@ class PriceIndexContainerFormulaTest {
 	 * @return new price index instance
 	 */
 	@Nonnull
-	private static PriceListAndCurrencyPriceIndex<?, ?> createPriceIndex(
+	private static PriceListAndCurrencyPriceIndex<?> createPriceIndex(
 		@Nonnull String priceList,
 		@Nonnull Currency currency
 	) {

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/filter/FormulaOptimizerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/filter/FormulaOptimizerTest.java
@@ -478,6 +478,29 @@ class FormulaOptimizerTest {
 		}
 
 		@Test
+		@DisplayName("NOT whose superset collapses to empty must not vanish from an enclosing AND")
+		void notWithCollapsingSupersetInsideAnd_shouldCollapseWholeConjunctionToEmpty() {
+			final ConstantFormula sibling = constant(1, 2, 3);
+			final ConstantFormula subtracted = constant(2);
+			// the superset is not empty to begin with - it only collapses to EmptyFormula during optimization,
+			// which is what makes the optimizer drop the NotFormula node instead of replacing it
+			final Formula supersetCollapsingToEmpty = new AndFormula(
+				constant(4, 5),
+				EmptyFormula.INSTANCE
+			);
+
+			final Formula input = new AndFormula(
+				sibling,
+				new NotFormula(subtracted, supersetCollapsingToEmpty)
+			);
+			final Formula result = optimize(input);
+
+			// dropping the negated branch would widen the conjunction to the sibling alone
+			assertArrayEquals(input.compute().getArray(), result.compute().getArray());
+			assertArrayEquals(new int[0], result.compute().getArray());
+		}
+
+		@Test
 		@DisplayName("NOT with both children surviving should preserve semantics")
 		void notWithBothChildrenSurviving_shouldPreserveSemantics() {
 			final ConstantFormula a = constant(1, 2);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/filter/FormulaOptimizerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/query/filter/FormulaOptimizerTest.java
@@ -482,8 +482,9 @@ class FormulaOptimizerTest {
 		void notWithCollapsingSupersetInsideAnd_shouldCollapseWholeConjunctionToEmpty() {
 			final ConstantFormula sibling = constant(1, 2, 3);
 			final ConstantFormula subtracted = constant(2);
-			// the superset is not empty to begin with - it only collapses to EmptyFormula during optimization,
-			// which is what makes the optimizer drop the NotFormula node instead of replacing it
+			// the superset must be a container that the optimizer *reduces* to EmptyFormula rather than
+			// EmptyFormula itself - only then do the NotFormula children change during optimization, which is
+			// the path on which the optimizer used to drop the whole NotFormula node instead of replacing it
 			final Formula supersetCollapsingToEmpty = new AndFormula(
 				constant(4, 5),
 				EmptyFormula.INSTANCE

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/memory/TransactionalLeafTypesTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/memory/TransactionalLeafTypesTest.java
@@ -36,12 +36,13 @@ import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.TRANSACTION;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Verifies the small leaf types of the software transactional memory: {@link TransactionalLayerWrapper} state
+ * Verifies the small leaf types of the software transactional memory: {@link TransactionalLayerEntry} state
  * transitions, the {@link VoidTransactionMemoryProducer} contract and {@link TransactionalContainerChanges} clean-up
  * semantics.
  *
@@ -53,40 +54,77 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class TransactionalLeafTypesTest {
 
 	@Nested
-	@DisplayName("TransactionalLayerWrapper")
-	class TransactionalLayerWrapperTest {
+	@DisplayName("TransactionalLayerEntry")
+	class TransactionalLayerEntryTest {
 
 		@Test
-		@DisplayName("exposes the wrapped item and starts in the ALIVE state")
-		void shouldExposeItemAndStartAlive() {
+		@DisplayName("exposes the owning creator, the diff item and starts in the ALIVE state")
+		void shouldExposeCreatorAndItemAndStartAlive() {
 			final Object item = new Object();
-			final TransactionalLayerWrapper<Object> wrapper = new TransactionalLayerWrapper<>(item);
+			final TransactionalLayerCreator<Object> creator = createLayerCreator(item);
+			final TransactionalLayerEntry<Object> entry = new TransactionalLayerEntry<>(creator, item);
 
-			assertSame(item, wrapper.getItem());
-			assertEquals(TransactionalLayerState.ALIVE, wrapper.getState());
+			// the registry is keyed by the creator's id alone, so the entry is the only thing keeping the creator
+			// reachable for StaleTransactionMemoryException reporting and the one-id-one-creator assertion
+			assertSame(creator, entry.getCreator());
+			assertSame(item, entry.getItem());
+			assertEquals(TransactionalLayerState.ALIVE, entry.getState());
 		}
 
 		@Test
 		@DisplayName("transitions to DISCARDED on the first discard")
 		void shouldTransitionToDiscardedOnce() {
-			final TransactionalLayerWrapper<Object> wrapper = new TransactionalLayerWrapper<>(new Object());
+			final TransactionalLayerEntry<Object> entry = createEntry();
 
-			wrapper.discard();
+			entry.discard();
 
-			assertEquals(TransactionalLayerState.DISCARDED, wrapper.getState());
+			assertEquals(TransactionalLayerState.DISCARDED, entry.getState());
 		}
 
 		@Test
 		@DisplayName("throws on a repeated discard")
 		void shouldThrowOnDoubleDiscard() {
-			final TransactionalLayerWrapper<Object> wrapper = new TransactionalLayerWrapper<>(new Object());
-			wrapper.discard();
+			final TransactionalLayerEntry<Object> entry = createEntry();
+			entry.discard();
 
 			final GenericEvitaInternalError ex = assertThrows(
 				GenericEvitaInternalError.class,
-				wrapper::discard
+				entry::discard
 			);
 			assertTrue(ex.getPrivateMessage().contains("already discarded"));
+		}
+
+		/**
+		 * Creates an entry over a throw-away diff item and its creator.
+		 *
+		 * @return newly created entry in the ALIVE state
+		 */
+		@Nonnull
+		private static TransactionalLayerEntry<Object> createEntry() {
+			final Object item = new Object();
+			return new TransactionalLayerEntry<>(createLayerCreator(item), item);
+		}
+
+		/**
+		 * Creates a minimal layer creator handing out a real sequence id and the passed diff layer.
+		 *
+		 * @param layer the diff layer the creator reports
+		 * @return newly created layer creator
+		 */
+		@Nonnull
+		private static TransactionalLayerCreator<Object> createLayerCreator(@Nonnull Object layer) {
+			final long id = TransactionalObjectVersion.SEQUENCE.nextId();
+			return new TransactionalLayerCreator<>() {
+				@Override
+				public long getId() {
+					return id;
+				}
+
+				@Override
+				public Object createLayer() {
+					return layer;
+				}
+			};
 		}
 	}
 
@@ -95,8 +133,8 @@ class TransactionalLeafTypesTest {
 	class VoidTransactionMemoryProducerTest {
 
 		@Test
-		@DisplayName("throws when asked to create a layer and reports the fixed id")
-		void shouldThrowOnCreateLayer() {
+		@DisplayName("owns no layer, so it is not a layer creator at all")
+		void shouldNotBeLayerCreator() {
 			// VoidTransactionMemoryProducer is NOT a functional interface (it leaves both
 			// removeLayer(TransactionalLayerMaintainer) and createCopyWithMergedTransactionalMemory abstract),
 			// so it must be implemented with an anonymous class rather than a lambda.
@@ -104,7 +142,6 @@ class TransactionalLeafTypesTest {
 				@Nonnull
 				@Override
 				public Object createCopyWithMergedTransactionalMemory(
-					@Nullable Void layer,
 					@Nonnull TransactionalLayerMaintainer transactionalLayer
 				) {
 					return new Object();
@@ -116,12 +153,13 @@ class TransactionalLeafTypesTest {
 				}
 			};
 
-			final UnsupportedOperationException ex = assertThrows(
-				UnsupportedOperationException.class,
-				producer::createLayer
+			// having no identity at all is what makes it impossible for such an object to be handed a diff layer
+			// belonging to another object - it cannot be looked up in the id-keyed registry in the first place,
+			// which is stronger than the previous arrangement of reporting a constant id and throwing on createLayer()
+			assertFalse(
+				producer instanceof TransactionalLayerCreator<?>,
+				"a producer that owns no layer must not be a TransactionalLayerCreator!"
 			);
-			assertTrue(ex.getMessage().contains("doesn't handle changes directly"));
-			assertEquals(1L, producer.getId());
 		}
 	}
 
@@ -136,7 +174,7 @@ class TransactionalLeafTypesTest {
 			final RecordingProducer removedOnly = new RecordingProducer();
 			final RecordingProducer both = new RecordingProducer();
 
-			final TransactionalContainerChanges<Void, Object, RecordingProducer> changes =
+			final TransactionalContainerChanges<Object, RecordingProducer> changes =
 				new TransactionalContainerChanges<>();
 			changes.addCreatedItem(createdOnly);
 			changes.addCreatedItem(both);
@@ -157,7 +195,7 @@ class TransactionalLeafTypesTest {
 			final RecordingProducer removedOnly = new RecordingProducer();
 			final RecordingProducer both = new RecordingProducer();
 
-			final TransactionalContainerChanges<Void, Object, RecordingProducer> changes =
+			final TransactionalContainerChanges<Object, RecordingProducer> changes =
 				new TransactionalContainerChanges<>();
 			changes.addCreatedItem(createdOnly);
 			changes.addCreatedItem(both);
@@ -175,7 +213,7 @@ class TransactionalLeafTypesTest {
 		@Test
 		@DisplayName("does nothing when no items were registered")
 		void shouldDoNothingWhenNoItemsRegistered() {
-			final TransactionalContainerChanges<Void, Object, RecordingProducer> changes =
+			final TransactionalContainerChanges<Object, RecordingProducer> changes =
 				new TransactionalContainerChanges<>();
 
 			// neither call must throw when nothing was registered

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/memory/TransactionalMemoryTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/memory/TransactionalMemoryTest.java
@@ -267,7 +267,7 @@ class TransactionalMemoryTest {
 				suppressed -> fail("Lambda must not be executed.")
 			)
 		);
-		assertTrue(ex.getPrivateMessage().contains("doesn't implement TransactionalLayerCreator"));
+		assertTrue(ex.getPrivateMessage().contains("doesn't implement TransactionalLayerCreator nor TransactionalStateProducer"));
 	}
 
 	@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/memory/TransactionalObjectVersionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/memory/TransactionalObjectVersionTest.java
@@ -1,0 +1,185 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.transaction.memory;
+
+import com.carrotsearch.hppc.LongHashSet;
+import io.evitadb.api.exception.IdentifierOverflowException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the identifier sequence contract of {@link TransactionalObjectVersion}.
+ *
+ * The sequence hands out `1L` first, runs up through {@link Long#MAX_VALUE}, wraps in two's
+ * complement to {@link Long#MIN_VALUE} and continues up to `-1L`. **`0L` is reserved and is never
+ * emitted** - it denotes "no transactional layer", which lets an identifier-keyed registry represent
+ * absence without being able to confuse it with a live creator.
+ *
+ * The wrap-around and exhaustion behaviour cannot be reached by counting (it takes 2^64 - 1
+ * increments), so these tests drive a separately seeded sequence instance rather than the JVM-wide
+ * {@link TransactionalObjectVersion#SEQUENCE} singleton.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+class TransactionalObjectVersionTest {
+
+	@Nested
+	@DisplayName("Identifier domain")
+	class DomainTest {
+
+		@Test
+		@DisplayName("first identifier handed out is 1")
+		void shouldStartAtOne() {
+			final TransactionalObjectVersion sequence = new TransactionalObjectVersion();
+
+			assertEquals(1L, sequence.nextId());
+			assertEquals(2L, sequence.nextId());
+			assertEquals(3L, sequence.nextId());
+		}
+
+		@Test
+		@DisplayName("identifiers are unique across successive calls")
+		void shouldHandOutDistinctIdentifiers() {
+			final TransactionalObjectVersion sequence = new TransactionalObjectVersion();
+
+			assertNotEquals(sequence.nextId(), sequence.nextId());
+		}
+
+		@Test
+		@DisplayName("the shared singleton never emits the reserved zero identifier")
+		void shouldNeverEmitZeroFromSharedSequence() {
+			// the singleton is shared with the rest of the test suite, so only the reservation
+			// invariant can be asserted on it - never a concrete value
+			for (int i = 0; i < 1000; i++) {
+				assertNotEquals(0L, TransactionalObjectVersion.SEQUENCE.nextId());
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("Wrap-around")
+	class WrapAroundTest {
+
+		@Test
+		@DisplayName("wrapping from Long.MAX_VALUE to Long.MIN_VALUE is legal, not an overflow")
+		void shouldWrapFromMaxToMinWithoutThrowing() {
+			// seeded so that the very next identifier is Long.MAX_VALUE
+			final TransactionalObjectVersion sequence = new TransactionalObjectVersion(Long.MAX_VALUE - 1L);
+
+			assertEquals(Long.MAX_VALUE, sequence.nextId());
+			// two's complement wrap - the negative domain is the second half of the identifier space
+			// and must keep being handed out rather than being mistaken for exhaustion
+			assertEquals(Long.MIN_VALUE, sequence.nextId());
+			assertEquals(Long.MIN_VALUE + 1L, sequence.nextId());
+		}
+
+		@Test
+		@DisplayName("negative identifiers up to -1 are handed out normally")
+		void shouldHandOutNegativeIdentifiers() {
+			final TransactionalObjectVersion sequence = new TransactionalObjectVersion(-3L);
+
+			assertEquals(-2L, sequence.nextId());
+			assertEquals(-1L, sequence.nextId());
+		}
+	}
+
+	@Nested
+	@DisplayName("Exhaustion")
+	class ExhaustionTest {
+
+		@Test
+		@DisplayName("returning to zero means the whole identifier space was consumed and throws")
+		void shouldThrowWhenSequenceExhausted() {
+			// -1L is the last identifier of the space; the following increment lands back on the
+			// reserved zero, which is the definition of exhaustion
+			final TransactionalObjectVersion sequence = new TransactionalObjectVersion(-2L);
+
+			assertEquals(-1L, sequence.nextId());
+			assertThrows(IdentifierOverflowException.class, sequence::nextId);
+		}
+
+		@Test
+		@DisplayName("an exhausted sequence stays poisoned and never resumes at 1")
+		void shouldRemainPoisonedAfterExhaustion() {
+			final TransactionalObjectVersion sequence = new TransactionalObjectVersion(-1L);
+
+			assertThrows(IdentifierOverflowException.class, sequence::nextId);
+			// without poisoning, the counter would have advanced past zero and silently started
+			// handing out 1, 2, 3... - identifiers that are already in use
+			assertThrows(IdentifierOverflowException.class, sequence::nextId);
+			assertThrows(IdentifierOverflowException.class, sequence::nextId);
+		}
+
+		@Test
+		@DisplayName("concurrent callers keep receiving distinct identifiers away from the boundary")
+		void shouldHandOutDistinctIdentifiersUnderConcurrentAccess() throws InterruptedException {
+			// the exhaustion boundary itself is deliberately not asserted under concurrency - see the
+			// class JavaDoc of TransactionalObjectVersion for why that corner is not guarded
+			final int threadCount = 8;
+			final int idsPerThread = 1000;
+			final TransactionalObjectVersion sequence = new TransactionalObjectVersion();
+			final AtomicReferenceArray<long[]> outcomes = new AtomicReferenceArray<>(threadCount);
+			final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+			try {
+				for (int i = 0; i < threadCount; i++) {
+					final int index = i;
+					executor.submit(() -> {
+						final long[] identifiers = new long[idsPerThread];
+						for (int j = 0; j < idsPerThread; j++) {
+							identifiers[j] = sequence.nextId();
+						}
+						outcomes.set(index, identifiers);
+					});
+				}
+				executor.shutdown();
+				assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+			} finally {
+				executor.shutdownNow();
+			}
+
+			final LongHashSet seen = new LongHashSet(threadCount * idsPerThread);
+			for (int i = 0; i < threadCount; i++) {
+				final long[] identifiers = outcomes.get(i);
+				assertNotNull(identifiers);
+				for (final long identifier : identifiers) {
+					assertNotEquals(0L, identifier);
+					assertTrue(seen.add(identifier), "identifier " + identifier + " was handed out twice");
+				}
+			}
+			assertEquals(threadCount * idsPerThread, seen.size());
+		}
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/AbstractReducedEntityIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/AbstractReducedEntityIndexTest.java
@@ -27,11 +27,9 @@ import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
 import io.evitadb.api.requestResponse.data.structure.RepresentativeReferenceKey;
 import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
-import io.evitadb.core.catalog.Catalog;
 import io.evitadb.dataType.Scope;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.price.PriceListAndCurrencyPriceSuperIndex;
-import io.evitadb.index.price.model.PriceIndexKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -39,12 +37,10 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.Locale;
-import java.util.Optional;
 import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static io.evitadb.test.TestTags.INDEXING;
@@ -67,16 +63,13 @@ abstract class AbstractReducedEntityIndexTest<T extends AbstractReducedEntityInd
 	extends AbstractEntityIndexTest<T> {
 
 	/**
-	 * Attaches a mock catalog to the index after creation so that
-	 * price-related operations (which require catalog attachment) work.
-	 * The mock catalog provides a {@link GlobalEntityIndex} stub that returns
-	 * a {@link PriceListAndCurrencyPriceSuperIndex} for any price index key,
-	 * satisfying the {@link io.evitadb.index.price.PriceListAndCurrencyPriceRefIndex}
-	 * initialization requirement.
+	 * Wires the reduced index's price ref chain to a mocked super price index after creation so
+	 * that price-related operations (which require a wired super index) work. The mocked
+	 * {@link PriceListAndCurrencyPriceSuperIndex} returns empty price records, satisfying the
+	 * {@link io.evitadb.index.price.PriceListAndCurrencyPriceRefIndex} initialization requirement.
 	 */
 	@BeforeEach
 	void attachCatalog() {
-		final GlobalEntityIndex globalEntityIndex = mock(GlobalEntityIndex.class);
 		final PriceListAndCurrencyPriceSuperIndex priceSuperIndex =
 			mock(PriceListAndCurrencyPriceSuperIndex.class);
 		final io.evitadb.index.price.model.priceRecord.PriceRecordContract[] emptyPriceRecords =
@@ -85,15 +78,8 @@ abstract class AbstractReducedEntityIndexTest<T extends AbstractReducedEntityInd
 			.thenReturn(emptyPriceRecords);
 		when(priceSuperIndex.getPriceRecords(any()))
 			.thenReturn(emptyPriceRecords);
-		when(globalEntityIndex.getPriceIndex(any(PriceIndexKey.class)))
-			.thenReturn(priceSuperIndex);
 
-		final Catalog catalog = mock(Catalog.class);
-		when(catalog.getEntityIndexIfExists(
-			eq(ENTITY_TYPE), any(EntityIndexKey.class), eq(GlobalEntityIndex.class)
-		)).thenReturn(Optional.of(globalEntityIndex));
-
-		this.index.attachToCatalog(ENTITY_TYPE, catalog);
+		this.index.getPriceIndex().wireSuperIndexes(key -> priceSuperIndex);
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/CatalogIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/CatalogIndexTest.java
@@ -27,10 +27,14 @@ import io.evitadb.api.exception.EntityLocaleMissingException;
 import io.evitadb.api.exception.UniqueValueViolationException;
 import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.api.requestResponse.schema.GlobalAttributeSchemaContract;
+import io.evitadb.core.buffer.TrappedChanges;
 import io.evitadb.core.catalog.Catalog;
 import io.evitadb.core.collection.EntityCollection;
 import io.evitadb.dataType.Scope;
+import io.evitadb.index.attribute.EntityReferenceWithLocale;
 import io.evitadb.index.attribute.GlobalUniqueIndex;
+import io.evitadb.spi.store.catalog.persistence.storageParts.index.CatalogIndexStoragePart;
+import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -40,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.Set;
 
@@ -68,6 +73,36 @@ class CatalogIndexTest {
 	private static final String ATTR_CODE = "code";
 	private static final String ATTR_URL = "url";
 	private static final int ENTITY_TYPE_PK = 1;
+
+	/**
+	 * Shared {@link EntityTypeClassifierResolver} that resolves the test entity type name and
+	 * primary key by delegating to a mock catalog's collection accessors. Because the catalog is a
+	 * Mockito mock, the resolver wraps it rather than passing the mock directly.
+	 */
+	private static final EntityTypeClassifierResolver CLASSIFIER_RESOLVER = createClassifierResolver();
+
+	/**
+	 * Creates an {@link EntityTypeClassifierResolver} backed by a mock catalog that resolves the
+	 * test entity type name and primary key via the catalog's collection accessors.
+	 *
+	 * @return a configured classifier resolver
+	 */
+	@Nonnull
+	private static EntityTypeClassifierResolver createClassifierResolver() {
+		final Catalog catalog = createMockCatalog(ENTITY_TYPE, ENTITY_TYPE_PK);
+		return new EntityTypeClassifierResolver() {
+			@Override
+			public int toEntityTypePrimaryKey(@Nonnull String entityType) {
+				return catalog.getCollectionForEntityOrThrowException(entityType).getEntityTypePrimaryKey();
+			}
+
+			@Nonnull
+			@Override
+			public String toEntityTypeName(int pk) {
+				return catalog.getCollectionForEntityPrimaryKeyOrThrowException(pk).getEntityType();
+			}
+		};
+	}
 
 	/**
 	 * Creates a mock {@link Catalog} that resolves the given entity type name to
@@ -150,14 +185,13 @@ class CatalogIndexTest {
 	}
 
 	/**
-	 * Creates a new {@link CatalogIndex} for {@link Scope#LIVE} with a mock catalog attached.
+	 * Creates a new {@link CatalogIndex} for {@link Scope#LIVE}.
 	 *
 	 * @return a ready-to-use CatalogIndex
 	 */
 	@Nonnull
 	private static CatalogIndex createLiveCatalogIndex() {
 		final CatalogIndex index = new CatalogIndex(Scope.LIVE);
-		index.attachToCatalog(null, createMockCatalog(ENTITY_TYPE, ENTITY_TYPE_PK));
 		return index;
 	}
 
@@ -219,7 +253,7 @@ class CatalogIndexTest {
 
 			this.index.insertUniqueAttribute(
 				this.entitySchema, attrSchema,
-				Collections.emptySet(), null, "ABC", 1
+				Collections.emptySet(), null, "ABC", 1, CLASSIFIER_RESOLVER
 			);
 
 			final GlobalUniqueIndex globalIndex =
@@ -236,11 +270,11 @@ class CatalogIndexTest {
 
 			this.index.insertUniqueAttribute(
 				this.entitySchema, attrSchema,
-				Collections.emptySet(), null, "ABC", 1
+				Collections.emptySet(), null, "ABC", 1, CLASSIFIER_RESOLVER
 			);
 			this.index.removeUniqueAttribute(
 				this.entitySchema, attrSchema,
-				Collections.emptySet(), null, "ABC", 1
+				Collections.emptySet(), null, "ABC", 1, CLASSIFIER_RESOLVER
 			);
 
 			assertNull(this.index.getGlobalUniqueIndex(attrSchema, null));
@@ -265,11 +299,11 @@ class CatalogIndexTest {
 
 			this.index.insertUniqueAttribute(
 				this.entitySchema, codeSchema,
-				Collections.emptySet(), null, "CODE-1", 1
+				Collections.emptySet(), null, "CODE-1", 1, CLASSIFIER_RESOLVER
 			);
 			this.index.insertUniqueAttribute(
 				this.entitySchema, urlSchema,
-				Collections.emptySet(), null, "/product/1", 2
+				Collections.emptySet(), null, "/product/1", 2, CLASSIFIER_RESOLVER
 			);
 
 			final GlobalUniqueIndex codeIndex =
@@ -304,7 +338,7 @@ class CatalogIndexTest {
 
 			this.index.insertUniqueAttribute(
 				this.entitySchema, attrSchema,
-				Collections.emptySet(), null, "ABC", 1
+				Collections.emptySet(), null, "ABC", 1, CLASSIFIER_RESOLVER
 			);
 
 			// retrieve without locale -- should work for non-localized
@@ -320,7 +354,7 @@ class CatalogIndexTest {
 
 			this.index.insertUniqueAttribute(
 				this.entitySchema, attrSchema,
-				allowedLocales, Locale.ENGLISH, "/product/1", 1
+				allowedLocales, Locale.ENGLISH, "/product/1", 1, CLASSIFIER_RESOLVER
 			);
 
 			// retrieve with matching locale
@@ -367,7 +401,7 @@ class CatalogIndexTest {
 
 			index.insertUniqueAttribute(
 				entitySchema, attrSchema,
-				Collections.emptySet(), null, "ABC", 1
+				Collections.emptySet(), null, "ABC", 1, CLASSIFIER_RESOLVER
 			);
 
 			assertFalse(index.isEmpty());
@@ -383,11 +417,11 @@ class CatalogIndexTest {
 
 			index.insertUniqueAttribute(
 				entitySchema, attrSchema,
-				Collections.emptySet(), null, "ABC", 1
+				Collections.emptySet(), null, "ABC", 1, CLASSIFIER_RESOLVER
 			);
 			index.removeUniqueAttribute(
 				entitySchema, attrSchema,
-				Collections.emptySet(), null, "ABC", 1
+				Collections.emptySet(), null, "ABC", 1, CLASSIFIER_RESOLVER
 			);
 
 			assertTrue(index.isEmpty());
@@ -408,14 +442,14 @@ class CatalogIndexTest {
 
 			index.insertUniqueAttribute(
 				entitySchema, attrSchema,
-				Collections.emptySet(), null, "DUPLICATE", 1
+				Collections.emptySet(), null, "DUPLICATE", 1, CLASSIFIER_RESOLVER
 			);
 
 			final UniqueValueViolationException exception = assertThrows(
 				UniqueValueViolationException.class,
 				() -> index.insertUniqueAttribute(
 					entitySchema, attrSchema,
-					Collections.emptySet(), null, "DUPLICATE", 2
+					Collections.emptySet(), null, "DUPLICATE", 2, CLASSIFIER_RESOLVER
 				)
 			);
 			assertEquals(ATTR_CODE, exception.getAttributeName());
@@ -442,7 +476,7 @@ class CatalogIndexTest {
 				original -> {
 					original.insertUniqueAttribute(
 						entitySchema, attrSchema,
-						Collections.emptySet(), null, "ABC", 1
+						Collections.emptySet(), null, "ABC", 1, CLASSIFIER_RESOLVER
 					);
 				},
 				(original, committed) -> {
@@ -470,7 +504,7 @@ class CatalogIndexTest {
 				original -> {
 					original.insertUniqueAttribute(
 						entitySchema, attrSchema,
-						Collections.emptySet(), null, "ABC", 1
+						Collections.emptySet(), null, "ABC", 1, CLASSIFIER_RESOLVER
 					);
 				},
 				(original, committed) -> {
@@ -518,7 +552,7 @@ class CatalogIndexTest {
 				original -> {
 					original.insertUniqueAttribute(
 						entitySchema, attrSchema,
-						Collections.emptySet(), null, "ABC", 1
+						Collections.emptySet(), null, "ABC", 1, CLASSIFIER_RESOLVER
 					);
 				},
 				(original, committed) -> {
@@ -545,13 +579,99 @@ class CatalogIndexTest {
 						createNonLocalizedAttributeSchema(ATTR_CODE, String.class);
 					original.insertUniqueAttribute(
 						entitySchema, attrSchema,
-						Collections.emptySet(), null, "XYZ", 1
+						Collections.emptySet(), null, "XYZ", 1, CLASSIFIER_RESOLVER
 					);
 				},
 				(original, committed) -> {
 					assertEquals(originalVersion, original.getVersion());
 				}
 			);
+		}
+	}
+
+	@Nested
+	@DisplayName("Catalog version copy")
+	class CatalogVersionCopyTest {
+
+		@Test
+		@DisplayName("should share the same global unique index child instances across a catalog version copy")
+		void shouldShareGlobalUniqueIndexInstancesAcrossCatalogCopy() {
+			// This replaces the former GlobalUniqueIndex shell-copy locale-sequence tests: the shell copy is gone.
+			// createShallowCopyWithResetDirtyFlag now reuses the SAME child global unique index instances by reference, so
+			// the historical shell-sequence-reset bug is structurally impossible rather than merely fixed.
+			final CatalogIndex index = createLiveCatalogIndex();
+			final EntitySchemaContract entitySchema = createEntitySchema(ENTITY_TYPE);
+			final GlobalAttributeSchemaContract codeSchema = createNonLocalizedAttributeSchema(ATTR_CODE, String.class);
+			index.insertUniqueAttribute(
+				entitySchema, codeSchema, Collections.emptySet(), null, "A", 1, CLASSIFIER_RESOLVER
+			);
+
+			final GlobalUniqueIndex source = index.getGlobalUniqueIndex(codeSchema, null);
+			assertNotNull(source);
+
+			// a structural copy for a new catalog version reuses the very same child global unique index instance
+			final CatalogIndex copy = index.createShallowCopyWithResetDirtyFlag();
+			final GlobalUniqueIndex copied = copy.getGlobalUniqueIndex(codeSchema, null);
+			assertSame(source, copied, "the copy must reuse the same global unique index instance (no shell copy)");
+
+			// a value registered before the copy still resolves through the shared instance, decoded via the resolver
+			final EntityReferenceWithLocale reference = copied
+				.getEntityReferenceByUniqueValue("A", null, CLASSIFIER_RESOLVER)
+				.orElseThrow();
+			assertEquals(ENTITY_TYPE, reference.getType());
+			assertEquals(1, reference.getPrimaryKey());
+		}
+
+		@Test
+		@DisplayName("should clear the warm-up dirty latch that nothing else in production resets")
+		void shouldClearDirtyLatchInheritedFromWarmUp() {
+			// Outside a transaction (= warm-up semantics) `dirty` is written straight into the base value, and no
+			// production code path ever calls resetDirty() - it is a latch for the lifetime of the instance. The copy
+			// taken when a new catalog version is built is therefore the ONLY thing that clears it, which is exactly why
+			// this method cannot be replaced by forwarding the original index. Observed through the storage part the
+			// flag gates, since the flag itself is not exposed.
+			final CatalogIndex index = createLiveCatalogIndex();
+			final EntitySchemaContract entitySchema = createEntitySchema(ENTITY_TYPE);
+			final GlobalAttributeSchemaContract codeSchema = createNonLocalizedAttributeSchema(ATTR_CODE, String.class);
+			index.insertUniqueAttribute(
+				entitySchema, codeSchema, Collections.emptySet(), null, "A", 1, CLASSIFIER_RESOLVER
+			);
+
+			assertEquals(
+				1, countCatalogIndexParts(index),
+				"a warm-up insert must latch the index dirty (its own storage part is emitted)!"
+			);
+
+			final CatalogIndex copy = index.createShallowCopyWithResetDirtyFlag();
+			assertEquals(
+				0, countCatalogIndexParts(copy),
+				"the copy must start clean - the latch is cleared exactly here and nowhere else!"
+			);
+			assertEquals(
+				1, countCatalogIndexParts(index),
+				"clearing the latch must not mutate the source index!"
+			);
+		}
+
+		/**
+		 * Counts the {@link CatalogIndexStoragePart} instances the passed index emits - one when the index considers
+		 * itself dirty, none otherwise. Child global unique index parts are ignored, as those children are shared by
+		 * reference and keep their own dirty flags.
+		 *
+		 * @param index index to collect the modified storage parts from
+		 * @return number of own storage parts emitted by the index
+		 */
+		private static int countCatalogIndexParts(@Nonnull CatalogIndex index) {
+			final TrappedChanges trappedChanges = new TrappedChanges();
+			index.getModifiedStorageParts(trappedChanges);
+			int count = 0;
+			final Iterator<StoragePart> it = trappedChanges.getTrappedChangesIterator();
+			while (it.hasNext()) {
+				if (it.next() instanceof CatalogIndexStoragePart) {
+					count++;
+				}
+			}
+			return count;
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/ReducedGroupEntityIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/ReducedGroupEntityIndexTest.java
@@ -23,7 +23,6 @@
 
 package io.evitadb.index;
 
-import io.evitadb.api.CatalogState;
 import io.evitadb.api.requestResponse.data.mutation.reference.ReferenceKey;
 import io.evitadb.api.requestResponse.data.structure.RepresentativeReferenceKey;
 import io.evitadb.api.requestResponse.schema.AttributeSchemaContract;
@@ -1386,69 +1385,35 @@ class ReducedGroupEntityIndexTest
 	}
 
 	/**
-	 * Verifies that the catalog re-attachment copy preserves the per-owner-PK cardinality
-	 * tracking. The copy is produced by {@link ReducedGroupEntityIndex#createCopyForNewCatalogAttachment}
-	 * which hands the live `pkCardinalities` map straight to the preserve-originals constructor,
-	 * so the copy must report the same tracked primary keys and keep the boundary-crossing
-	 * semantics intact: an owner PK reachable through two references stays in the index until the
-	 * second reference is removed.
+	 * Verifies the {@link CardinalityChange} value returned by {@link ReducedGroupEntityIndex#removePrimaryKey}. The
+	 * sibling cardinality tests assert the resulting bitmap contents; these pin the returned signal itself, which is
+	 * what callers use to decide whether an owner primary key actually crossed the 1 -> 0 boundary.
 	 */
 	@Nested
-	@DisplayName("Catalog re-attachment")
-	class CatalogReattachmentTest {
+	@DisplayName("Cardinality change signal")
+	class CardinalityChangeSignalTest {
 
 		@Test
-		@DisplayName("should preserve tracked primary keys in the re-attachment copy")
-		void shouldPreserveTrackedPrimaryKeysInCopy() {
-			// entity 10 is reachable through two references (categories 1 and 2) within the group,
-			// so its cardinality is 2; entity 20 is reachable through a single reference (category 3)
+		@DisplayName("should report boundary crossing only when the last reference is removed")
+		void shouldReportBoundaryCrossingOnlyOnLastReference() {
+			// entity 10 reachable through two references -> cardinality 2
 			ReducedGroupEntityIndexTest.this.index.insertPrimaryKeyIfMissing(10, 1);
 			ReducedGroupEntityIndexTest.this.index.insertPrimaryKeyIfMissing(10, 2);
-			ReducedGroupEntityIndexTest.this.index.insertPrimaryKeyIfMissing(20, 3);
-
-			final ReducedGroupEntityIndex copy =
-				ReducedGroupEntityIndexTest.this.index.createCopyForNewCatalogAttachment(
-					CatalogState.ALIVE
-				);
-
-			assertNotSame(ReducedGroupEntityIndexTest.this.index, copy);
-			// the copy must expose the same owner PKs and referenced (facet) PKs as the source
-			final Bitmap copyPks = copy.getAllPrimaryKeys();
-			assertEquals(2, copyPks.size());
-			assertTrue(copyPks.contains(10));
-			assertTrue(copyPks.contains(20));
-			assertEquals(
-				Set.of(1, 2, 3),
-				copy.getReferencedEntityPrimaryKeys()
-			);
-		}
-
-		@Test
-		@DisplayName("should keep boundary-crossing semantics on the re-attachment copy")
-		void shouldKeepBoundaryCrossingSemanticsOnCopy() {
-			// entity 10 reachable through two references -> cardinality 2 in the source group
-			ReducedGroupEntityIndexTest.this.index.insertPrimaryKeyIfMissing(10, 1);
-			ReducedGroupEntityIndexTest.this.index.insertPrimaryKeyIfMissing(10, 2);
-
-			final ReducedGroupEntityIndex copy =
-				ReducedGroupEntityIndexTest.this.index.createCopyForNewCatalogAttachment(
-					CatalogState.ALIVE
-				);
 
 			// removing the first reference must NOT evict the owner PK: cardinality drops 2 -> 1
 			assertEquals(
 				CardinalityChange.NO_BOUNDARY_CROSSING,
-				copy.removePrimaryKey(10, 1)
+				ReducedGroupEntityIndexTest.this.index.removePrimaryKey(10, 1)
 			);
-			assertTrue(copy.getAllPrimaryKeys().contains(10),
+			assertTrue(ReducedGroupEntityIndexTest.this.index.getAllPrimaryKeys().contains(10),
 				"Owner PK must survive while a second reference still points at the group");
 
 			// removing the last reference crosses the 1 -> 0 boundary and evicts the owner PK
 			assertEquals(
 				CardinalityChange.BOUNDARY_CROSSED,
-				copy.removePrimaryKey(10, 2)
+				ReducedGroupEntityIndexTest.this.index.removePrimaryKey(10, 2)
 			);
-			assertTrue(copy.getAllPrimaryKeys().isEmpty(),
+			assertTrue(ReducedGroupEntityIndexTest.this.index.getAllPrimaryKeys().isEmpty(),
 				"Owner PK must be evicted once its last reference is removed");
 		}
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalComplexObjArrayNoTransactionTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalComplexObjArrayNoTransactionTest.java
@@ -660,14 +660,13 @@ class TransactionalComplexObjArrayNoTransactionTest {
 	 * @param object the wrapped integer value
 	 */
 	private record TransactionalInteger(Integer object)
-		implements TransactionalObject<TransactionalInteger, Void>,
+		implements TransactionalObject<TransactionalInteger>,
 		VoidTransactionMemoryProducer<TransactionalInteger>,
 		Comparable<TransactionalInteger> {
 
 		@Nonnull
 		@Override
 		public TransactionalInteger createCopyWithMergedTransactionalMemory(
-			Void layer,
 			@Nonnull TransactionalLayerMaintainer transactionalLayer
 		) {
 			return this;
@@ -699,7 +698,7 @@ class TransactionalComplexObjArrayNoTransactionTest {
 	 */
 	@Data
 	private static class DistinctValueHolder
-		implements TransactionalObject<DistinctValueHolder, Void>,
+		implements TransactionalObject<DistinctValueHolder>,
 		VoidTransactionMemoryProducer<DistinctValueHolder>,
 		Comparable<DistinctValueHolder> {
 
@@ -714,7 +713,6 @@ class TransactionalComplexObjArrayNoTransactionTest {
 		@Nonnull
 		@Override
 		public DistinctValueHolder createCopyWithMergedTransactionalMemory(
-			Void layer,
 			@Nonnull TransactionalLayerMaintainer transactionalLayer
 		) {
 			return this;

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalComplexObjArrayTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalComplexObjArrayTest.java
@@ -27,7 +27,6 @@ import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.VoidTransactionMemoryProducer;
 import io.evitadb.utils.Assert;
 import lombok.Data;
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -40,7 +39,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.TreeSet;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -1129,7 +1127,7 @@ class TransactionalComplexObjArrayTest {
 	}
 
 	/**
-	 * Tests verifying the {@link TransactionalComplexObjArray#addReturningIndex(T)} method
+	 * Tests verifying the {@link TransactionalComplexObjArray#addReturningIndex(TransactionalObject)} method
 	 * which adds an element and returns the position where it was placed.
 	 */
 	@Nested
@@ -1649,25 +1647,8 @@ class TransactionalComplexObjArrayTest {
 	 * @param object the wrapped integer value
 	 */
 	private record NonProducerTransactionalInteger(Integer object)
-		implements TransactionalObject<NonProducerTransactionalInteger, Void>,
+		implements TransactionalObject<NonProducerTransactionalInteger>,
 		Comparable<NonProducerTransactionalInteger> {
-
-		@Override
-		public long getId() {
-			return 1L;
-		}
-
-		@Override
-		public Void createLayer() {
-			return null;
-		}
-
-		@Override
-		public void removeLayer(
-			@Nonnull TransactionalLayerMaintainer transactionalLayer
-		) {
-			// no-op
-		}
 
 		@Override
 		public int compareTo(@Nonnull NonProducerTransactionalInteger o) {
@@ -1688,14 +1669,13 @@ class TransactionalComplexObjArrayTest {
 	 * @param object the wrapped integer value
 	 */
 	private record TransactionalInteger(Integer object)
-		implements TransactionalObject<TransactionalInteger, Void>,
+		implements TransactionalObject<TransactionalInteger>,
 		VoidTransactionMemoryProducer<TransactionalInteger>,
 		Comparable<TransactionalInteger> {
 
 		@Nonnull
 		@Override
 		public TransactionalInteger createCopyWithMergedTransactionalMemory(
-			Void layer,
 			@Nonnull TransactionalLayerMaintainer transactionalLayer
 		) {
 			return this;
@@ -1727,7 +1707,7 @@ class TransactionalComplexObjArrayTest {
 	 */
 	@Data
 	private static class DistinctValueHolder
-		implements TransactionalObject<DistinctValueHolder, Void>,
+		implements TransactionalObject<DistinctValueHolder>,
 		VoidTransactionMemoryProducer<DistinctValueHolder>,
 		Comparable<DistinctValueHolder> {
 
@@ -1742,7 +1722,6 @@ class TransactionalComplexObjArrayTest {
 		@Nonnull
 		@Override
 		public DistinctValueHolder createCopyWithMergedTransactionalMemory(
-			Void layer,
 			@Nonnull TransactionalLayerMaintainer transactionalLayer
 		) {
 			return this;
@@ -1817,7 +1796,7 @@ class TransactionalComplexObjArrayTest {
 	 * can have a different runtime class from the component type.
 	 */
 	private static class BaseTransactionalObj
-		implements TransactionalObject<BaseTransactionalObj, Void>,
+		implements TransactionalObject<BaseTransactionalObj>,
 		VoidTransactionMemoryProducer<BaseTransactionalObj>,
 		Comparable<BaseTransactionalObj> {
 
@@ -1830,7 +1809,6 @@ class TransactionalComplexObjArrayTest {
 		@Nonnull
 		@Override
 		public BaseTransactionalObj createCopyWithMergedTransactionalMemory(
-			Void layer,
 			@Nonnull TransactionalLayerMaintainer transactionalLayer
 		) {
 			return this;

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexPagingRoundTripTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexPagingRoundTripTest.java
@@ -32,6 +32,7 @@ import io.evitadb.core.collection.EntityCollection;
 import io.evitadb.core.executor.Scheduler;
 import io.evitadb.dataType.Scope;
 import io.evitadb.function.Functions;
+import io.evitadb.index.EntityTypeClassifierResolver;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.spi.store.catalog.persistence.storageParts.DeferredRemovalStoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.KeyCompressor;
@@ -148,6 +149,20 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 	private static final Consumer<Optional<OffsetDateTime>> NO_OP_OLDEST_RECORD_CALLBACK = Functions.noOpConsumer();
 
 	private final Catalog catalog = Mockito.mock(Catalog.class);
+	private final EntityTypeClassifierResolver classifierResolver = new EntityTypeClassifierResolver() {
+		@Override
+		public int toEntityTypePrimaryKey(@Nonnull String entityType) {
+			return GlobalUniqueIndexPagingRoundTripTest.this.catalog
+				.getCollectionForEntityOrThrowException(entityType).getEntityTypePrimaryKey();
+		}
+
+		@Nonnull
+		@Override
+		public String toEntityTypeName(int entityTypePrimaryKey) {
+			return GlobalUniqueIndexPagingRoundTripTest.this.catalog
+				.getCollectionForEntityPrimaryKeyOrThrowException(entityTypePrimaryKey).getEntityType();
+		}
+	};
 	private final OffsetIndexRecordTypeRegistry recordRegistry = new OffsetIndexRecordTypeRegistry();
 	private final StorageSettings storageSettings = new StorageSettings(
 		StorageOptions.temporary(), TransactionOptions.builder().build()
@@ -177,16 +192,15 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 	void shouldRoundTripPagedGlobalUniqueIndexThroughOffsetIndex() {
 		final AttributeKey attributeKey = new AttributeKey("url", Locale.ENGLISH);
 		final GlobalUniqueIndex source = new GlobalUniqueIndex(Scope.LIVE, attributeKey, String.class);
-		source.attachToCatalog(null, this.catalog);
 		// register enough distinct URL-slug keys (alternating two locales) to force the value tree to span many leaves
 		for (int i = 0; i < KEY_COUNT; i++) {
 			final Locale locale = (i % 2 == 0) ? Locale.ENGLISH : Locale.FRENCH;
-			source.registerUniqueKey(keyForIndex(i), ENTITY_TYPE, locale, i + 1);
+			source.registerUniqueKey(keyForIndex(i), ENTITY_TYPE, locale, i + 1, this.classifierResolver);
 		}
 		assertTrue(source.isPaged(), "the index must span multiple leaves to exercise the paged layout");
 
 		final GlobalUniqueIndex.InlineSnapshot expectedSnapshot = source.inlineSnapshot();
-		final Bitmap expectedRecordIds = source.getRecordIds(ENTITY_TYPE);
+		final Bitmap expectedRecordIds = source.getRecordIds(ENTITY_TYPE, this.classifierResolver);
 
 		// collect the granular emission (leaf pages + paged root; no freed-page removals on a first flush)
 		final TrappedChanges trappedChanges = new TrappedChanges();
@@ -230,7 +244,6 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 				orderedPageSequences, perPageValues, perPagePayloads,
 				root.getHighWaterPageSequence(), root.getLocaleIndex()
 			);
-			restored.attachToCatalog(null, this.catalog);
 
 			// every value -> packed (entityType, pk, locale) payload survives the page round-trip, in identical key order
 			final GlobalUniqueIndex.InlineSnapshot restoredSnapshot = restored.inlineSnapshot();
@@ -238,16 +251,16 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 			assertArrayEquals(expectedSnapshot.payloads(), restoredSnapshot.payloads(), "payload column must round-trip identically");
 			// the per-entity-type record set (rebuilt by unpacking every payload) matches
 			assertEquals(
-				expectedRecordIds.getArray().length, restored.getRecordIds(ENTITY_TYPE).getArray().length,
+				expectedRecordIds.getArray().length, restored.getRecordIds(ENTITY_TYPE, this.classifierResolver).getArray().length,
 				"per-type record cardinality must round-trip"
 			);
 			assertTrue(
-				restored.getRecordIds(ENTITY_TYPE).contains(1) && restored.getRecordIds(ENTITY_TYPE).contains(KEY_COUNT),
+				restored.getRecordIds(ENTITY_TYPE, this.classifierResolver).contains(1) && restored.getRecordIds(ENTITY_TYPE, this.classifierResolver).contains(KEY_COUNT),
 				"per-type record set must contain the boundary primary keys"
 			);
 			// a spot-check that a localized lookup resolves to the expected entity reference
 			final EntityReferenceWithLocale resolved =
-				restored.getEntityReferenceByUniqueValue(keyForIndex(0), Locale.ENGLISH).orElseThrow();
+				restored.getEntityReferenceByUniqueValue(keyForIndex(0), Locale.ENGLISH, this.classifierResolver).orElseThrow();
 			assertEquals(ENTITY_TYPE, resolved.getType());
 			assertEquals(1, resolved.getPrimaryKey());
 			assertEquals(Locale.ENGLISH, resolved.locale());
@@ -264,10 +277,9 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 		final AttributeKey attributeKey = new AttributeKey("code");
 		// a small index stays in the inline SINGLE shape (a single embedded leaf): register a handful of non-localized keys
 		final GlobalUniqueIndex source = new GlobalUniqueIndex(Scope.LIVE, attributeKey, String.class);
-		source.attachToCatalog(null, this.catalog);
-		source.registerUniqueKey("alpha", ENTITY_TYPE, null, 1);
-		source.registerUniqueKey("beta", ENTITY_TYPE, null, 2);
-		source.registerUniqueKey("gamma", ENTITY_TYPE, null, 3);
+		source.registerUniqueKey("alpha", ENTITY_TYPE, null, 1, this.classifierResolver);
+		source.registerUniqueKey("beta", ENTITY_TYPE, null, 2, this.classifierResolver);
+		source.registerUniqueKey("gamma", ENTITY_TYPE, null, 3, this.classifierResolver);
 		assertFalse(source.isPaged(), "a small index must stay in the inline SINGLE shape");
 
 		final GlobalUniqueIndex.InlineSnapshot expectedSnapshot = source.inlineSnapshot();
@@ -296,12 +308,11 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 			final GlobalUniqueIndex restored = new GlobalUniqueIndex(
 				Scope.LIVE, attributeKey, String.class, root.getValues(), root.getPayloads(), root.getLocaleIndex()
 			);
-			restored.attachToCatalog(null, this.catalog);
 
 			final GlobalUniqueIndex.InlineSnapshot restoredSnapshot = restored.inlineSnapshot();
 			assertArrayEquals(expectedSnapshot.values(), restoredSnapshot.values(), "inline value column must round-trip identically");
 			assertArrayEquals(expectedSnapshot.payloads(), restoredSnapshot.payloads(), "inline payload column must round-trip identically");
-			assertEquals(3, restored.getRecordIds(ENTITY_TYPE).getArray().length, "per-type record set must be rebuilt from the inline columns");
+			assertEquals(3, restored.getRecordIds(ENTITY_TYPE, this.classifierResolver).getArray().length, "per-type record set must be rebuilt from the inline columns");
 		} finally {
 			if (reloaded != null) {
 				IOUtils.closeQuietly(reloaded::close);
@@ -316,9 +327,8 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 		// a single locale keeps the packed payload column deterministic, so the surviving payloads can be asserted
 		// byte-identical to the directly-built oracle below
 		final GlobalUniqueIndex source = new GlobalUniqueIndex(Scope.LIVE, attributeKey, String.class);
-		source.attachToCatalog(null, this.catalog);
 		for (int i = 0; i < MERGE_KEY_COUNT; i++) {
-			source.registerUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1);
+			source.registerUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1, this.classifierResolver);
 		}
 		assertTrue(source.isPaged(), "the index must span multiple leaves to exercise the paged layout");
 
@@ -342,11 +352,10 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 			assertTrue(firstRoot.isPaged(), "the index must be paged before the merge");
 			final int[] liveBeforeMerge = firstRoot.getLeafPageSequences();
 			final GlobalUniqueIndex restored = loadPagedIndex(offsetIndex, PERSISTED_VERSION, attributeKey, streamId, firstRoot);
-			restored.attachToCatalog(null, this.catalog);
 
 			// merge: drop a long contiguous run of keys so at least one leaf empties and merges into a sibling
 			for (int i = MERGE_REMOVE_FROM; i < MERGE_REMOVE_TO; i++) {
-				restored.unregisterUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1);
+				restored.unregisterUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1, this.classifierResolver);
 			}
 			assertTrue(restored.isPaged(), "the shrunken index must still span multiple leaves (PAGED -> PAGED)");
 
@@ -413,14 +422,12 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 			}
 
 			final GlobalUniqueIndex reloaded = loadPagedIndex(reopened, SECOND_VERSION, attributeKey, streamId, finalRoot);
-			reloaded.attachToCatalog(null, this.catalog);
 
 			// an index built directly from only the surviving values is the oracle
 			final GlobalUniqueIndex expected = new GlobalUniqueIndex(Scope.LIVE, attributeKey, String.class);
-			expected.attachToCatalog(null, this.catalog);
 			for (int i = 0; i < MERGE_KEY_COUNT; i++) {
 				if (i < MERGE_REMOVE_FROM || i >= MERGE_REMOVE_TO) {
-					expected.registerUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1);
+					expected.registerUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1, this.classifierResolver);
 				}
 			}
 
@@ -435,7 +442,8 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 				"the surviving payload column must match the oracle built from only the surviving values"
 			);
 			assertArrayEquals(
-				expected.getRecordIds(ENTITY_TYPE).getArray(), reloaded.getRecordIds(ENTITY_TYPE).getArray(),
+				expected.getRecordIds(ENTITY_TYPE, this.classifierResolver).getArray(),
+				reloaded.getRecordIds(ENTITY_TYPE, this.classifierResolver).getArray(),
 				"the surviving per-type record set must match the oracle"
 			);
 		} finally {
@@ -454,9 +462,8 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 		// published one, which stays empty for the whole warm-up and would silently reclaim NOTHING.
 		final AttributeKey attributeKey = new AttributeKey("url", Locale.ENGLISH);
 		final GlobalUniqueIndex index = new GlobalUniqueIndex(Scope.LIVE, attributeKey, String.class);
-		index.attachToCatalog(null, this.catalog);
 		for (int i = 0; i < COLLAPSE_KEY_COUNT; i++) {
-			index.registerUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1);
+			index.registerUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1, this.classifierResolver);
 		}
 		assertTrue(index.isPaged(), "the index must span multiple leaves to exercise the paged layout");
 
@@ -491,7 +498,7 @@ class GlobalUniqueIndexPagingRoundTripTest implements EvitaTestSupport {
 		// collapse the SAME in-memory index — NO reload in between, exactly what a warm-up catalog does: drop all but a
 		// handful of keys so the survivors fit within a single leaf
 		for (int i = COLLAPSE_KEEP; i < COLLAPSE_KEY_COUNT; i++) {
-			index.unregisterUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1);
+			index.unregisterUniqueKey(keyForIndex(i), ENTITY_TYPE, Locale.ENGLISH, i + 1, this.classifierResolver);
 		}
 		assertFalse(index.isPaged(), "an index that fits a single leaf must collapse out of the PAGED shape");
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexTest.java
@@ -23,13 +23,13 @@
 
 package io.evitadb.index.attribute;
 
-import io.evitadb.api.CatalogState;
 import io.evitadb.api.exception.UniqueValueViolationException;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.core.catalog.Catalog;
 import io.evitadb.core.collection.EntityCollection;
 import io.evitadb.dataType.Scope;
 import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.index.EntityTypeClassifierResolver;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.test.Entities;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import javax.annotation.Nonnull;
+import java.util.HashMap;
 import java.util.Locale;
 
 import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
@@ -53,6 +55,23 @@ import static io.evitadb.test.TestTags.ATTRIBUTE;
 @Tag(ATTRIBUTE)
 class GlobalUniqueIndexTest {
 	private final Catalog catalog = Mockito.mock(Catalog.class);
+	/**
+	 * The entity-type name ↔ compact primary key resolver the index now receives per call instead of holding a catalog
+	 * back-reference. It delegates to the same mock-catalog collection accessors the tests already stub, so no extra
+	 * stubbing is needed.
+	 */
+	private final EntityTypeClassifierResolver classifierResolver = new EntityTypeClassifierResolver() {
+		@Override
+		public int toEntityTypePrimaryKey(@Nonnull String entityType) {
+			return GlobalUniqueIndexTest.this.catalog.getCollectionForEntityOrThrowException(entityType).getEntityTypePrimaryKey();
+		}
+
+		@Nonnull
+		@Override
+		public String toEntityTypeName(int entityTypePrimaryKey) {
+			return GlobalUniqueIndexTest.this.catalog.getCollectionForEntityPrimaryKeyOrThrowException(entityTypePrimaryKey).getEntityType();
+		}
+	};
 	private final EntityReferenceWithLocale productRef = new EntityReferenceWithLocale(Entities.PRODUCT, 1, null);
 	private final EntityReferenceWithLocale localizedProduct2EnglishRef = new EntityReferenceWithLocale(Entities.PRODUCT, 2, Locale.ENGLISH);
 	private final EntityReferenceWithLocale localizedProduct2FrenchRef = new EntityReferenceWithLocale(Entities.PRODUCT, 2, Locale.FRENCH);
@@ -68,104 +87,103 @@ class GlobalUniqueIndexTest {
 		Mockito.when(productCollection.getEntityType()).thenReturn(Entities.PRODUCT);
 		Mockito.when(this.catalog.getCollectionForEntityPrimaryKeyOrThrowException(1)).thenReturn(productCollection);
 		Mockito.when(this.catalog.getCollectionForEntityOrThrowException(Entities.PRODUCT)).thenReturn(productCollection);
-		this.tested.attachToCatalog(null, this.catalog);
 	}
 
 	@Test
 	void shouldRegisterUniqueValueAndRetrieveItBack() {
-		this.tested.registerUniqueKey("A", Entities.PRODUCT, null, 1);
-		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("A", null).orElse(null));
-		assertNull(this.tested.getEntityReferenceByUniqueValue("B", null).orElse(null));
+		this.tested.registerUniqueKey("A", Entities.PRODUCT, null, 1, this.classifierResolver);
+		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("A", null, this.classifierResolver).orElse(null));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("B", null, this.classifierResolver).orElse(null));
 	}
 
 	@Test
 	void shouldRegisterLocalizedUniqueValueAndRetrieveItBack() {
-		this.tested.registerUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 2);
-		this.tested.registerUniqueKey("B", Entities.PRODUCT, Locale.FRENCH, 2);
-		this.tested.registerUniqueKey("C", Entities.PRODUCT, Locale.ENGLISH, 3);
-		assertEquals(this.localizedProduct2EnglishRef, this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH).orElse(null));
-		assertNull(this.tested.getEntityReferenceByUniqueValue("A", Locale.FRENCH).orElse(null));
-		assertEquals(this.localizedProduct2FrenchRef, this.tested.getEntityReferenceByUniqueValue("B", Locale.FRENCH).orElse(null));
-		assertNull(this.tested.getEntityReferenceByUniqueValue("B", Locale.ENGLISH).orElse(null));
-		assertEquals(this.localizedProduct3Ref, this.tested.getEntityReferenceByUniqueValue("C", Locale.ENGLISH).orElse(null));
-		assertNull(this.tested.getEntityReferenceByUniqueValue("E", null).orElse(null));
+		this.tested.registerUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 2, this.classifierResolver);
+		this.tested.registerUniqueKey("B", Entities.PRODUCT, Locale.FRENCH, 2, this.classifierResolver);
+		this.tested.registerUniqueKey("C", Entities.PRODUCT, Locale.ENGLISH, 3, this.classifierResolver);
+		assertEquals(this.localizedProduct2EnglishRef, this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH, this.classifierResolver).orElse(null));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("A", Locale.FRENCH, this.classifierResolver).orElse(null));
+		assertEquals(this.localizedProduct2FrenchRef, this.tested.getEntityReferenceByUniqueValue("B", Locale.FRENCH, this.classifierResolver).orElse(null));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("B", Locale.ENGLISH, this.classifierResolver).orElse(null));
+		assertEquals(this.localizedProduct3Ref, this.tested.getEntityReferenceByUniqueValue("C", Locale.ENGLISH, this.classifierResolver).orElse(null));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("E", null, this.classifierResolver).orElse(null));
 	}
 
 	@Test
 	void shouldFailToRegisterDuplicateValues() {
-		this.tested.registerUniqueKey("A", Entities.PRODUCT, null, 1);
-		assertThrows(UniqueValueViolationException.class, () -> this.tested.registerUniqueKey("A", Entities.PRODUCT, null, 2));
+		this.tested.registerUniqueKey("A", Entities.PRODUCT, null, 1, this.classifierResolver);
+		assertThrows(UniqueValueViolationException.class, () -> this.tested.registerUniqueKey("A", Entities.PRODUCT, null, 2, this.classifierResolver));
 	}
 
 	@Test
 	void shouldFailToRegisterDuplicateLocalizedValues() {
-		this.tested.registerUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 1);
-		assertThrows(UniqueValueViolationException.class, () -> this.tested.registerUniqueKey("A", Entities.PRODUCT, Locale.GERMAN, 2));
+		this.tested.registerUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 1, this.classifierResolver);
+		assertThrows(UniqueValueViolationException.class, () -> this.tested.registerUniqueKey("A", Entities.PRODUCT, Locale.GERMAN, 2, this.classifierResolver));
 	}
 
 	@Test
 	void shouldUnregisterPreviouslyRegisteredValue() {
-		this.tested.registerUniqueKey("A", Entities.PRODUCT, null, 1);
-		assertEquals(this.productRef, this.tested.unregisterUniqueKey("A", Entities.PRODUCT, null, 1));
-		assertNull(this.tested.getEntityReferenceByUniqueValue("A", null).orElse(null));
+		this.tested.registerUniqueKey("A", Entities.PRODUCT, null, 1, this.classifierResolver);
+		assertEquals(this.productRef, this.tested.unregisterUniqueKey("A", Entities.PRODUCT, null, 1, this.classifierResolver));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("A", null, this.classifierResolver).orElse(null));
 	}
 
 	@Test
 	void shouldUnregisterPreviouslyRegisteredLocalizedValue() {
-		this.tested.registerUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 2);
-		this.tested.registerUniqueKey("B", Entities.PRODUCT, Locale.FRENCH, 2);
-		this.tested.registerUniqueKey("C", Entities.PRODUCT, Locale.ENGLISH, 3);
-		assertEquals(this.localizedProduct2EnglishRef, this.tested.unregisterUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 2));
-		assertEquals(this.localizedProduct2FrenchRef, this.tested.unregisterUniqueKey("B", Entities.PRODUCT, Locale.FRENCH, 2));
-		assertEquals(this.localizedProduct3Ref, this.tested.unregisterUniqueKey("C", Entities.PRODUCT, Locale.ENGLISH, 3));
+		this.tested.registerUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 2, this.classifierResolver);
+		this.tested.registerUniqueKey("B", Entities.PRODUCT, Locale.FRENCH, 2, this.classifierResolver);
+		this.tested.registerUniqueKey("C", Entities.PRODUCT, Locale.ENGLISH, 3, this.classifierResolver);
+		assertEquals(this.localizedProduct2EnglishRef, this.tested.unregisterUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 2, this.classifierResolver));
+		assertEquals(this.localizedProduct2FrenchRef, this.tested.unregisterUniqueKey("B", Entities.PRODUCT, Locale.FRENCH, 2, this.classifierResolver));
+		assertEquals(this.localizedProduct3Ref, this.tested.unregisterUniqueKey("C", Entities.PRODUCT, Locale.ENGLISH, 3, this.classifierResolver));
 
-		assertNull(this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH).orElse(null));
-		assertNull(this.tested.getEntityReferenceByUniqueValue("B", Locale.FRENCH).orElse(null));
-		assertNull(this.tested.getEntityReferenceByUniqueValue("C", Locale.ENGLISH).orElse(null));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH, this.classifierResolver).orElse(null));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("B", Locale.FRENCH, this.classifierResolver).orElse(null));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("C", Locale.ENGLISH, this.classifierResolver).orElse(null));
 	}
 
 	@Test
 	void shouldFailToUnregisterUnknownValue() {
-		assertThrows(IllegalArgumentException.class, () -> this.tested.unregisterUniqueKey("B", Entities.PRODUCT, null, 1));
-		assertThrows(IllegalArgumentException.class, () -> this.tested.unregisterUniqueKey("B", Entities.PRODUCT, Locale.ENGLISH, 1));
+		assertThrows(IllegalArgumentException.class, () -> this.tested.unregisterUniqueKey("B", Entities.PRODUCT, null, 1, this.classifierResolver));
+		assertThrows(IllegalArgumentException.class, () -> this.tested.unregisterUniqueKey("B", Entities.PRODUCT, Locale.ENGLISH, 1, this.classifierResolver));
 	}
 
 	@Test
 	void shouldRegisterAndPartialUnregisterValues() {
-		this.tested.registerUniqueKey(new String[]{"A", "B", "C"}, Entities.PRODUCT, null, 1);
-		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("A", null).orElse(null));
-		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("B", null).orElse(null));
-		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("C", null).orElse(null));
+		this.tested.registerUniqueKey(new String[]{"A", "B", "C"}, Entities.PRODUCT, null, 1, this.classifierResolver);
+		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("A", null, this.classifierResolver).orElse(null));
+		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("B", null, this.classifierResolver).orElse(null));
+		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("C", null, this.classifierResolver).orElse(null));
 
-		this.tested.unregisterUniqueKey(new String[]{"B", "C"}, Entities.PRODUCT, null, 1);
-		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("A", null).orElse(null));
-		assertNull(this.tested.getEntityReferenceByUniqueValue("B", null).orElse(null));
-		assertNull(this.tested.getEntityReferenceByUniqueValue("C", null).orElse(null));
+		this.tested.unregisterUniqueKey(new String[]{"B", "C"}, Entities.PRODUCT, null, 1, this.classifierResolver);
+		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("A", null, this.classifierResolver).orElse(null));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("B", null, this.classifierResolver).orElse(null));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("C", null, this.classifierResolver).orElse(null));
 	}
 
 	@Test
 	void shouldRegisterAndPartialUnregisterLocalizedValues() {
-		this.tested.registerUniqueKey(new String[]{"A", "B", "C"}, Entities.PRODUCT, Locale.ENGLISH, 1);
-		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH).orElse(null));
-		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("B", Locale.ENGLISH).orElse(null));
-		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("C", Locale.ENGLISH).orElse(null));
+		this.tested.registerUniqueKey(new String[]{"A", "B", "C"}, Entities.PRODUCT, Locale.ENGLISH, 1, this.classifierResolver);
+		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH, this.classifierResolver).orElse(null));
+		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("B", Locale.ENGLISH, this.classifierResolver).orElse(null));
+		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("C", Locale.ENGLISH, this.classifierResolver).orElse(null));
 
-		this.tested.unregisterUniqueKey(new String[]{"B", "C"}, Entities.PRODUCT, Locale.ENGLISH, 1);
-		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH).orElse(null));
-		assertNull(this.tested.getEntityReferenceByUniqueValue("B", Locale.ENGLISH).orElse(null));
-		assertNull(this.tested.getEntityReferenceByUniqueValue("C", Locale.ENGLISH).orElse(null));
+		this.tested.unregisterUniqueKey(new String[]{"B", "C"}, Entities.PRODUCT, Locale.ENGLISH, 1, this.classifierResolver);
+		assertEquals(this.productRef, this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH, this.classifierResolver).orElse(null));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("B", Locale.ENGLISH, this.classifierResolver).orElse(null));
+		assertNull(this.tested.getEntityReferenceByUniqueValue("C", Locale.ENGLISH, this.classifierResolver).orElse(null));
 	}
 
 	@Test
 	void shouldRoundTripLocalizedTupleThroughPackedPayload() {
 		// the (entityType, primaryKey, locale) tuple must survive the pack/unpack at the long-payload tree boundary
-		this.tested.registerUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 2);
+		this.tested.registerUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 2, this.classifierResolver);
 		assertEquals(
 			this.localizedProduct2EnglishRef,
-			this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH).orElse(null)
+			this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH, this.classifierResolver).orElse(null)
 		);
 		// the resolved reference carries the very same entity type, primary key and locale that were registered
-		final EntityReferenceWithLocale resolved = this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH).orElseThrow();
+		final EntityReferenceWithLocale resolved = this.tested.getEntityReferenceByUniqueValue("A", Locale.ENGLISH, this.classifierResolver).orElseThrow();
 		assertEquals(Entities.PRODUCT, resolved.getType());
 		assertEquals(2, resolved.getPrimaryKey());
 		assertEquals(Locale.ENGLISH, resolved.locale());
@@ -180,7 +198,7 @@ class GlobalUniqueIndexTest {
 		Mockito.when(this.catalog.getCollectionForEntityOrThrowException("BIG")).thenReturn(bigCollection);
 		assertThrows(
 			GenericEvitaInternalError.class,
-			() -> this.tested.registerUniqueKey("A", "BIG", null, 1)
+			() -> this.tested.registerUniqueKey("A", "BIG", null, 1, this.classifierResolver)
 		);
 	}
 
@@ -190,105 +208,96 @@ class GlobalUniqueIndexTest {
 		final GlobalUniqueIndex localized = new GlobalUniqueIndex(
 			Scope.LIVE, new AttributeKey("localizedCode", Locale.ENGLISH), String.class
 		);
-		localized.attachToCatalog(null, this.catalog);
-		localized.registerUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 2);
+		localized.registerUniqueKey("A", Entities.PRODUCT, Locale.ENGLISH, 2, this.classifierResolver);
 		// registering the same value under a different locale must NOT raise a uniqueness violation
-		assertDoesNotThrow(() -> localized.registerUniqueKey("A", Entities.PRODUCT, Locale.FRENCH, 3));
+		assertDoesNotThrow(() -> localized.registerUniqueKey("A", Entities.PRODUCT, Locale.FRENCH, 3, this.classifierResolver));
 		// the value resolves under the last writer's locale (the value-keyed tree overwrites like the HashMap it replaces)
 		assertEquals(
 			new EntityReferenceWithLocale(Entities.PRODUCT, 3, Locale.FRENCH),
-			localized.getEntityReferenceByUniqueValue("A", Locale.FRENCH).orElse(null)
+			localized.getEntityReferenceByUniqueValue("A", Locale.FRENCH, this.classifierResolver).orElse(null)
 		);
 		// both primary keys remain visible in the per-entity-type record set
-		final Bitmap productRecords = localized.getRecordIds(Entities.PRODUCT);
+		final Bitmap productRecords = localized.getRecordIds(Entities.PRODUCT, this.classifierResolver);
 		assertTrue(productRecords.contains(2));
 		assertTrue(productRecords.contains(3));
 	}
 
 	@Test
-	void shouldAssignFreshLocaleIdToShellCopyInsteadOfCollidingWithExisting() {
-		// a localized globally-unique index with two locales already registered: en -> 1, fr -> 2
+	void shouldAssignFreshLocaleIdAfterCommitMergeInsteadOfCollidingWithExisting() {
+		// an index that adopts an existing locale map must start its locale sequence PAST the highest adopted id -
+		// otherwise a newly seen locale is handed an id that already belongs to another locale, overwriting it in the
+		// reverse map and corrupting locale decoding of every tuple carrying the clobbered id. Commit-merge is one of
+		// the two surviving constructors that adopt such a map (the other is the inline restore below).
+		final GlobalUniqueIndex localized = createLocalizedIndexWithEnglishAndFrench();
+
+		assertStateAfterCommit(
+			localized,
+			original -> {
+				// nothing further mutated - the merge alone must carry the assigned locale ids over
+			},
+			(original, committed) -> {
+				assertEquals(Locale.ENGLISH, committed.getLocaleIndex().get(1));
+				assertEquals(Locale.FRENCH, committed.getLocaleIndex().get(2));
+				assertFreshLocaleIdIsAssigned(committed);
+			}
+		);
+	}
+
+	@Test
+	void shouldAssignFreshLocaleIdAfterInlineRestoreInsteadOfCollidingWithExisting() {
+		final GlobalUniqueIndex localized = createLocalizedIndexWithEnglishAndFrench();
+
+		// rebuild the index from its persisted inline columns, exactly as a load from disk does
+		final GlobalUniqueIndex.InlineSnapshot snapshot = localized.inlineSnapshot();
+		final GlobalUniqueIndex restored = new GlobalUniqueIndex(
+			Scope.LIVE, localized.getAttributeKey(), localized.getType(),
+			snapshot.values(), snapshot.payloads(), new HashMap<>(localized.getLocaleIndex())
+		);
+
+		assertEquals(Locale.ENGLISH, restored.getLocaleIndex().get(1));
+		assertEquals(Locale.FRENCH, restored.getLocaleIndex().get(2));
+		assertFreshLocaleIdIsAssigned(restored);
+	}
+
+	/**
+	 * Builds a localized (within-locale-unique) index holding one english and one french value, so that internal locale
+	 * ids 1 and 2 are already taken.
+	 *
+	 * @return the prepared index
+	 */
+	@Nonnull
+	private GlobalUniqueIndex createLocalizedIndexWithEnglishAndFrench() {
 		final GlobalUniqueIndex localized = new GlobalUniqueIndex(
 			Scope.LIVE, new AttributeKey("localizedCode", Locale.ENGLISH), String.class
 		);
-		localized.attachToCatalog(null, this.catalog);
-		localized.registerUniqueKey("en-value", Entities.PRODUCT, Locale.ENGLISH, 1);
-		localized.registerUniqueKey("fr-value", Entities.PRODUCT, Locale.FRENCH, 2);
+		localized.registerUniqueKey("en-value", Entities.PRODUCT, Locale.ENGLISH, 1, this.classifierResolver);
+		localized.registerUniqueKey("fr-value", Entities.PRODUCT, Locale.FRENCH, 2, this.classifierResolver);
 		assertEquals(Locale.ENGLISH, localized.getLocaleIndex().get(1));
 		assertEquals(Locale.FRENCH, localized.getLocaleIndex().get(2));
+		return localized;
+	}
 
-		// the detached shell copy shares the locale maps by reference; its sequence must be primed past id 2
-		final GlobalUniqueIndex shell = localized.createCopyForNewCatalogAttachment(CatalogState.ALIVE);
-		shell.attachToCatalog(null, this.catalog);
+	/**
+	 * Registers a never-before-seen locale on an index that adopted an existing locale map and asserts it received an
+	 * id past every adopted one, leaving the adopted mappings and the values keyed by them intact.
+	 *
+	 * @param index index that adopted a locale map holding ids 1 (english) and 2 (french)
+	 */
+	private void assertFreshLocaleIdIsAssigned(@Nonnull GlobalUniqueIndex index) {
+		index.registerUniqueKey("de-value", Entities.PRODUCT, Locale.GERMAN, 3, this.classifierResolver);
 
-		// registering a never-before-seen locale must receive a FRESH id (3), not collide with the existing id 1
-		shell.registerUniqueKey("de-value", Entities.PRODUCT, Locale.GERMAN, 3);
-		assertEquals(Locale.GERMAN, shell.getLocaleIndex().get(3), "new locale must receive a fresh id");
-		assertEquals(Locale.ENGLISH, shell.getLocaleIndex().get(1), "existing locale id must stay untouched");
+		assertEquals(Locale.GERMAN, index.getLocaleIndex().get(3), "new locale must receive a fresh id");
+		assertEquals(Locale.ENGLISH, index.getLocaleIndex().get(1), "existing locale id must stay untouched");
+		assertEquals(3, index.getLocaleIndex().size(), "exactly three distinct locale ids must be in use");
 
-		// a pre-existing english value still decodes to its original locale rather than the freshly registered one
+		// a value stored under the adopted english id still decodes to english rather than the freshly registered locale
 		assertEquals(
 			new EntityReferenceWithLocale(Entities.PRODUCT, 1, Locale.ENGLISH),
-			shell.getEntityReferenceByUniqueValue("en-value", Locale.ENGLISH).orElse(null)
+			index.getEntityReferenceByUniqueValue("en-value", Locale.ENGLISH, this.classifierResolver).orElse(null)
 		);
-
 		// the same value under the new locale must not trip the within-locale uniqueness guard against the old locale
-		assertDoesNotThrow(() -> shell.registerUniqueKey("en-value", Entities.PRODUCT, Locale.GERMAN, 4));
-	}
-
-	@Test
-	void shouldStartShellCopyLocaleSequencePastHighestExistingId() {
-		// two locales already assigned ids 1 and 2 on the source index
-		final GlobalUniqueIndex localized = new GlobalUniqueIndex(
-			Scope.LIVE, new AttributeKey("localizedCode", Locale.ENGLISH), String.class
-		);
-		localized.attachToCatalog(null, this.catalog);
-		localized.registerUniqueKey("en-value", Entities.PRODUCT, Locale.ENGLISH, 1);
-		localized.registerUniqueKey("fr-value", Entities.PRODUCT, Locale.FRENCH, 2);
-
-		final GlobalUniqueIndex shell = localized.createCopyForNewCatalogAttachment(CatalogState.ALIVE);
-		shell.attachToCatalog(null, this.catalog);
-		shell.registerUniqueKey("de-value", Entities.PRODUCT, Locale.GERMAN, 3);
-
-		// the next assigned locale id equals max(existing ids) + 1, leaving exactly three distinct ids
-		assertEquals(3, shell.getLocaleIndex().size());
-		assertEquals(Locale.GERMAN, shell.getLocaleIndex().get(3));
-	}
-
-	@Test
-	void shouldPersistFreshLocaleIdThroughCommitMergeForShellCopy() {
-		// two locales already assigned ids 1 and 2 on the source index
-		final GlobalUniqueIndex localized = new GlobalUniqueIndex(
-			Scope.LIVE, new AttributeKey("localizedCode", Locale.ENGLISH), String.class
-		);
-		localized.attachToCatalog(null, this.catalog);
-		localized.registerUniqueKey("en-value", Entities.PRODUCT, Locale.ENGLISH, 1);
-		localized.registerUniqueKey("fr-value", Entities.PRODUCT, Locale.FRENCH, 2);
-
-		final GlobalUniqueIndex shell = localized.createCopyForNewCatalogAttachment(CatalogState.ALIVE);
-		shell.attachToCatalog(null, this.catalog);
-		shell.registerUniqueKey("de-value", Entities.PRODUCT, Locale.GERMAN, 3);
-
-		// a full commit-merge must bake the CORRECT locale ids into committed state; the merge re-primes from
-		// idToLocaleIndex, so a broken shell would persist the corruption permanently rather than repair it
-		assertStateAfterCommit(
-			shell,
-			s -> {
-				// nothing further mutated; the merge alone must preserve the primed sequence and locale mapping
-			},
-			(s, committed) -> {
-				committed.attachToCatalog(null, this.catalog);
-				assertEquals(Locale.ENGLISH, committed.getLocaleIndex().get(1));
-				assertEquals(Locale.GERMAN, committed.getLocaleIndex().get(3));
-				assertEquals(
-					new EntityReferenceWithLocale(Entities.PRODUCT, 1, Locale.ENGLISH),
-					committed.getEntityReferenceByUniqueValue("en-value", Locale.ENGLISH).orElse(null)
-				);
-				assertEquals(
-					new EntityReferenceWithLocale(Entities.PRODUCT, 3, Locale.GERMAN),
-					committed.getEntityReferenceByUniqueValue("de-value", Locale.GERMAN).orElse(null)
-				);
-			}
+		assertDoesNotThrow(
+			() -> index.registerUniqueKey("en-value", Entities.PRODUCT, Locale.GERMAN, 4, this.classifierResolver)
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexTest.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.index.attribute;
 
+import io.evitadb.api.CatalogState;
 import io.evitadb.api.exception.UniqueValueViolationException;
 import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.core.catalog.Catalog;
@@ -38,6 +39,7 @@ import org.mockito.Mockito;
 
 import java.util.Locale;
 
+import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
 import static org.junit.jupiter.api.Assertions.*;
 import static io.evitadb.test.TestTags.INDEXING;
 import static io.evitadb.test.TestTags.ATTRIBUTE;
@@ -201,6 +203,93 @@ class GlobalUniqueIndexTest {
 		final Bitmap productRecords = localized.getRecordIds(Entities.PRODUCT);
 		assertTrue(productRecords.contains(2));
 		assertTrue(productRecords.contains(3));
+	}
+
+	@Test
+	void shouldAssignFreshLocaleIdToShellCopyInsteadOfCollidingWithExisting() {
+		// a localized globally-unique index with two locales already registered: en -> 1, fr -> 2
+		final GlobalUniqueIndex localized = new GlobalUniqueIndex(
+			Scope.LIVE, new AttributeKey("localizedCode", Locale.ENGLISH), String.class
+		);
+		localized.attachToCatalog(null, this.catalog);
+		localized.registerUniqueKey("en-value", Entities.PRODUCT, Locale.ENGLISH, 1);
+		localized.registerUniqueKey("fr-value", Entities.PRODUCT, Locale.FRENCH, 2);
+		assertEquals(Locale.ENGLISH, localized.getLocaleIndex().get(1));
+		assertEquals(Locale.FRENCH, localized.getLocaleIndex().get(2));
+
+		// the detached shell copy shares the locale maps by reference; its sequence must be primed past id 2
+		final GlobalUniqueIndex shell = localized.createCopyForNewCatalogAttachment(CatalogState.ALIVE);
+		shell.attachToCatalog(null, this.catalog);
+
+		// registering a never-before-seen locale must receive a FRESH id (3), not collide with the existing id 1
+		shell.registerUniqueKey("de-value", Entities.PRODUCT, Locale.GERMAN, 3);
+		assertEquals(Locale.GERMAN, shell.getLocaleIndex().get(3), "new locale must receive a fresh id");
+		assertEquals(Locale.ENGLISH, shell.getLocaleIndex().get(1), "existing locale id must stay untouched");
+
+		// a pre-existing english value still decodes to its original locale rather than the freshly registered one
+		assertEquals(
+			new EntityReferenceWithLocale(Entities.PRODUCT, 1, Locale.ENGLISH),
+			shell.getEntityReferenceByUniqueValue("en-value", Locale.ENGLISH).orElse(null)
+		);
+
+		// the same value under the new locale must not trip the within-locale uniqueness guard against the old locale
+		assertDoesNotThrow(() -> shell.registerUniqueKey("en-value", Entities.PRODUCT, Locale.GERMAN, 4));
+	}
+
+	@Test
+	void shouldStartShellCopyLocaleSequencePastHighestExistingId() {
+		// two locales already assigned ids 1 and 2 on the source index
+		final GlobalUniqueIndex localized = new GlobalUniqueIndex(
+			Scope.LIVE, new AttributeKey("localizedCode", Locale.ENGLISH), String.class
+		);
+		localized.attachToCatalog(null, this.catalog);
+		localized.registerUniqueKey("en-value", Entities.PRODUCT, Locale.ENGLISH, 1);
+		localized.registerUniqueKey("fr-value", Entities.PRODUCT, Locale.FRENCH, 2);
+
+		final GlobalUniqueIndex shell = localized.createCopyForNewCatalogAttachment(CatalogState.ALIVE);
+		shell.attachToCatalog(null, this.catalog);
+		shell.registerUniqueKey("de-value", Entities.PRODUCT, Locale.GERMAN, 3);
+
+		// the next assigned locale id equals max(existing ids) + 1, leaving exactly three distinct ids
+		assertEquals(3, shell.getLocaleIndex().size());
+		assertEquals(Locale.GERMAN, shell.getLocaleIndex().get(3));
+	}
+
+	@Test
+	void shouldPersistFreshLocaleIdThroughCommitMergeForShellCopy() {
+		// two locales already assigned ids 1 and 2 on the source index
+		final GlobalUniqueIndex localized = new GlobalUniqueIndex(
+			Scope.LIVE, new AttributeKey("localizedCode", Locale.ENGLISH), String.class
+		);
+		localized.attachToCatalog(null, this.catalog);
+		localized.registerUniqueKey("en-value", Entities.PRODUCT, Locale.ENGLISH, 1);
+		localized.registerUniqueKey("fr-value", Entities.PRODUCT, Locale.FRENCH, 2);
+
+		final GlobalUniqueIndex shell = localized.createCopyForNewCatalogAttachment(CatalogState.ALIVE);
+		shell.attachToCatalog(null, this.catalog);
+		shell.registerUniqueKey("de-value", Entities.PRODUCT, Locale.GERMAN, 3);
+
+		// a full commit-merge must bake the CORRECT locale ids into committed state; the merge re-primes from
+		// idToLocaleIndex, so a broken shell would persist the corruption permanently rather than repair it
+		assertStateAfterCommit(
+			shell,
+			s -> {
+				// nothing further mutated; the merge alone must preserve the primed sequence and locale mapping
+			},
+			(s, committed) -> {
+				committed.attachToCatalog(null, this.catalog);
+				assertEquals(Locale.ENGLISH, committed.getLocaleIndex().get(1));
+				assertEquals(Locale.GERMAN, committed.getLocaleIndex().get(3));
+				assertEquals(
+					new EntityReferenceWithLocale(Entities.PRODUCT, 1, Locale.ENGLISH),
+					committed.getEntityReferenceByUniqueValue("en-value", Locale.ENGLISH).orElse(null)
+				);
+				assertEquals(
+					new EntityReferenceWithLocale(Entities.PRODUCT, 3, Locale.GERMAN),
+					committed.getEntityReferenceByUniqueValue("de-value", Locale.GERMAN).orElse(null)
+				);
+			}
+		);
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexWarmUpFlushMergeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/GlobalUniqueIndexWarmUpFlushMergeTest.java
@@ -28,6 +28,7 @@ import io.evitadb.core.buffer.TrappedChanges;
 import io.evitadb.core.catalog.Catalog;
 import io.evitadb.core.collection.EntityCollection;
 import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityTypeClassifierResolver;
 import io.evitadb.spi.store.catalog.persistence.storageParts.StoragePart;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.GlobalUniqueIndexLeafPageRemoval;
 import io.evitadb.spi.store.catalog.persistence.storageParts.index.GlobalUniqueIndexStoragePart;
@@ -77,6 +78,20 @@ class GlobalUniqueIndexWarmUpFlushMergeTest {
 	private static final int VALUE_COUNT = 513;
 
 	private final Catalog catalog = Mockito.mock(Catalog.class);
+	private final EntityTypeClassifierResolver classifierResolver = new EntityTypeClassifierResolver() {
+		@Override
+		public int toEntityTypePrimaryKey(@Nonnull String entityType) {
+			return GlobalUniqueIndexWarmUpFlushMergeTest.this.catalog
+				.getCollectionForEntityOrThrowException(entityType).getEntityTypePrimaryKey();
+		}
+
+		@Nonnull
+		@Override
+		public String toEntityTypeName(int entityTypePrimaryKey) {
+			return GlobalUniqueIndexWarmUpFlushMergeTest.this.catalog
+				.getCollectionForEntityPrimaryKeyOrThrowException(entityTypePrimaryKey).getEntityType();
+		}
+	};
 
 	@BeforeEach
 	void setUp() {
@@ -89,9 +104,8 @@ class GlobalUniqueIndexWarmUpFlushMergeTest {
 	@DisplayName("should free the merged-away leaf page after a second warm-up flush merges a leaf")
 	void shouldFreeStalePageAfterWarmUpFlushMerge() {
 		final GlobalUniqueIndex index = new GlobalUniqueIndex(Scope.LIVE, URL_KEY, Integer.class);
-		index.attachToCatalog(null, this.catalog);
 		for (int i = 1; i <= VALUE_COUNT; i++) {
-			index.registerUniqueKey(i, ENTITY_TYPE, null, i);
+			index.registerUniqueKey(i, ENTITY_TYPE, null, i, this.classifierResolver);
 		}
 
 		// first WARM_UP flush: allocates + stages 4 leaf pages, never publishes them - a warm-up flush never reaches
@@ -111,13 +125,13 @@ class GlobalUniqueIndexWarmUpFlushMergeTest {
 		// second WARM_UP flush: drop exactly enough values to force leaf 0 to merge with leaf 1.
 		// leaves start out [1..128], [129..256], [257..384], [385..513]:
 		// - leaf 1: 128 -> 127, so it sits exactly at the minimum and can no longer donate a key
-		index.unregisterUniqueKey(129, ENTITY_TYPE, null, 129);
+		index.unregisterUniqueKey(129, ENTITY_TYPE, null, 129, this.classifierResolver);
 		// - leaf 0: 128 -> 127 (still at the minimum, no underflow yet)
-		index.unregisterUniqueKey(1, ENTITY_TYPE, null, 1);
+		index.unregisterUniqueKey(1, ENTITY_TYPE, null, 1, this.classifierResolver);
 		// - leaf 0: 127 -> 126 -> underflow. It has no left sibling, the right sibling cannot donate
 		//   (127 > 127 is false) and 127 + 126 = 253 < 256, so consolidate takes mergeWithRight: leaf 0 absorbs
 		//   leaf 1 IN PLACE - it keeps page 0 and is marked dirty, while leaf 1 is detached and its page must be freed
-		index.unregisterUniqueKey(2, ENTITY_TYPE, null, 2);
+		index.unregisterUniqueKey(2, ENTITY_TYPE, null, 2, this.classifierResolver);
 
 		final TrappedChanges secondFlush = new TrappedChanges();
 		index.appendStorageParts(URL_KEY, secondFlush);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/UniqueIndexViewTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/UniqueIndexViewTest.java
@@ -192,7 +192,6 @@ class UniqueIndexViewTest {
 		void shouldExposeInertCommitHooks() {
 			final UniqueIndexView view = (UniqueIndexView) newUniqueView(newFilterView(newPopulatedSharedTree()));
 
-			assertNull(view.createLayer(), "a view must never produce a transactional layer!");
 			assertEquals(0, view.inlineSnapshot().values().length, "a folded view owns no inline values!");
 		}
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/hierarchy/HierarchyIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/hierarchy/HierarchyIndexTest.java
@@ -27,7 +27,6 @@ import io.evitadb.api.query.order.TraversalMode;
 import io.evitadb.core.query.algebra.Formula;
 import io.evitadb.core.query.algebra.base.EmptyFormula;
 import io.evitadb.core.query.algebra.deferred.DeferredFormula;
-import io.evitadb.dataType.array.CompositeIntArray;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.index.bitmap.BaseBitmap;
 import io.evitadb.index.bitmap.Bitmap;
@@ -41,14 +40,15 @@ import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -672,7 +672,7 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 				index -> {
 					// perform no modifications
 				},
-				(orig, committed) -> assertSame(orig, committed)
+				Assertions::assertSame
 			);
 		}
 
@@ -687,7 +687,7 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 				original -> {
 					// no changes, verifying the null layer code path
 				},
-				(original, committed) -> assertSame(original, committed)
+				Assertions::assertSame
 			);
 		}
 
@@ -806,16 +806,6 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 			final HierarchyIndex index2 = new HierarchyIndex();
 			// each instance gets a unique id from TransactionalObjectVersion.SEQUENCE
 			assertNotEquals(index1.getId(), index2.getId());
-		}
-
-		@Test
-		@DisplayName("createLayer() throws UnsupportedOperationException")
-		void shouldThrowOnCreateLayer() {
-			final HierarchyIndex index = new HierarchyIndex();
-			assertThrows(
-				UnsupportedOperationException.class,
-				index::createLayer
-			);
 		}
 
 		@Test
@@ -1522,7 +1512,7 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 		@Test
 		@DisplayName("traverseHierarchyToRoot for node not in index skips silently")
 		void shouldSilentlySkipTraverseToRootForAbsentNode() {
-			final StringBuilder visited = new StringBuilder();
+			final StringBuilder visited = new StringBuilder(128);
 			// node 999 is not in the index
 			HierarchyIndexTest.this.hierarchyIndex.traverseHierarchyToRoot(
 				(node, level, distance, childrenTraverser) -> visited.append(node.entityPrimaryKey()),
@@ -1534,7 +1524,7 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 		@Test
 		@DisplayName("traverseHierarchyFromNode for absent rootNode traverses nothing")
 		void shouldTraverseNothingForAbsentRootNode() {
-			final StringBuilder visited = new StringBuilder();
+			final StringBuilder visited = new StringBuilder(128);
 			// node 999 does not exist
 			HierarchyIndexTest.this.hierarchyIndex.traverseHierarchyFromNode(
 				(node, level, distance, childrenTraverser) -> visited.append(node.entityPrimaryKey()),
@@ -1629,28 +1619,25 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 		}
 	}
 
-	private void setHierarchyFor(HierarchyIndex hierarchyIndex, TestHierarchyNode testRoot, int entityPrimaryKey, Integer parent) {
+	private static void setHierarchyFor(
+		HierarchyIndex hierarchyIndex, TestHierarchyNode testRoot, int entityPrimaryKey, Integer parent
+	) {
 		hierarchyIndex.addNode(entityPrimaryKey, parent);
 		// first remove the node if already exists
-		if (testRoot.find(entityPrimaryKey, testRoot) != null) {
+		if (testRoot.find(entityPrimaryKey) != null) {
 			testRoot.removeNode(entityPrimaryKey, testRoot);
 		}
 		if (parent == null) {
 			testRoot.addChild(entityPrimaryKey, testRoot);
 		} else {
 			// now place it on the proper place
-			final TestHierarchyNode parentNode = testRoot.find(parent, testRoot);
+			final TestHierarchyNode parentNode = testRoot.find(parent);
 			if (parentNode == null) {
 				testRoot.addOrphan(entityPrimaryKey, parent);
 			} else {
 				parentNode.addChild(entityPrimaryKey, testRoot);
 			}
 		}
-	}
-
-	private void removeHierarchyFor(HierarchyIndex hierarchyIndex, TestHierarchyNode testRoot, int entityPrimaryKey) {
-		hierarchyIndex.removeNode(entityPrimaryKey);
-		testRoot.removeNode(entityPrimaryKey, testRoot);
 	}
 
 	@RequiredArgsConstructor
@@ -1679,56 +1666,31 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 			placeOrphansRecursively(newNode, rootNode);
 		}
 
-		public int[] getChildrenIds() {
-			final CompositeIntArray intArray = new CompositeIntArray();
-			appendIdRecursively(this, intArray);
-			this.orphans.keySet().stream().mapToInt(it -> it).forEach(intArray::add);
-			return intArray.toArray();
-		}
-
 		public void removeNode(int nodeId, TestHierarchyNode rootNode) {
 			final TestHierarchyNode removedOrphan = rootNode.orphans.remove(nodeId);
 			if (removedOrphan == null) {
-				final TestHierarchyNode nodeInTree = find(nodeId, rootNode);
+				final TestHierarchyNode nodeInTree = find(nodeId);
 				Assert.notNull(nodeInTree, "Node " + nodeId + " not found in the tree!");
-				final TestHierarchyNode nodeParent = find(nodeInTree.getParentId(), rootNode);
+				final TestHierarchyNode nodeParent = find(nodeInTree.getParentId());
 				Assert.notNull(nodeParent, "Node parent " + nodeId + " not found in the tree!");
 				nodeParent.children.removeIf(it -> it.getId() == nodeId);
 				makeOrphansRecursively(nodeInTree, rootNode);
 			}
 		}
 
-		public boolean contains(int lookedUpId) {
-			if (this.id == lookedUpId) {
-				return true;
-			}
-			for (TestHierarchyNode child : this.children) {
-				if (child.contains(lookedUpId)) {
-					return true;
-				}
-			}
-			return false;
-		}
-
-		public TestHierarchyNode find(int nodeId, TestHierarchyNode rootNode) {
+		@Nullable
+		public TestHierarchyNode find(int nodeId) {
 			if (this.id == nodeId) {
 				return this;
 			} else {
 				for (TestHierarchyNode child : this.children) {
-					final TestHierarchyNode foundNode = child.find(nodeId, rootNode);
+					final TestHierarchyNode foundNode = child.find(nodeId);
 					if (foundNode != null) {
 						return foundNode;
 					}
 				}
 			}
 			return null;
-		}
-
-		public Collection<TestHierarchyNode> getAllChildren() {
-			final List<TestHierarchyNode> result = new LinkedList<>();
-			addChildrenRecursively(this, result);
-			result.addAll(this.orphans.values());
-			return result;
 		}
 
 		public void assertIdentical(HierarchyIndex theIndex, String errorMessage) {
@@ -1746,7 +1708,7 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 
 		@Override
 		public String toString() {
-			final StringBuilder sb = new StringBuilder();
+			final StringBuilder sb = new StringBuilder(128);
 			toStringChildrenRecursively(this.children, 0, sb);
 			sb.append("Orphans: ").append(Arrays.toString(this.orphans.keySet().stream().mapToInt(it -> it).sorted().toArray()));
 			return sb.toString();
@@ -1756,7 +1718,8 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 			this.orphans.put(entityPrimaryKey, new TestHierarchyNode(entityPrimaryKey, parentPrimaryKey));
 		}
 
-		private void assertIdenticalChildrenRecursively(TestHierarchyNode theNode, HierarchyIndex theIndex, String errorMessage) {
+		private static void assertIdenticalChildrenRecursively(
+			TestHierarchyNode theNode, HierarchyIndex theIndex, String errorMessage) {
 			final int[] thisChildrenIds = theNode.children.stream().mapToInt(TestHierarchyNode::getId).sorted().toArray();
 			final int[] thatChildrenIds = theIndex.listHierarchyNodesFromParentDownTo(theNode.getId(), 0).getArray();
 			assertArrayEquals(
@@ -1769,14 +1732,7 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 			}
 		}
 
-		private void addChildrenRecursively(TestHierarchyNode node, List<TestHierarchyNode> result) {
-			result.addAll(node.children);
-			for (TestHierarchyNode child : node.children) {
-				addChildrenRecursively(child, result);
-			}
-		}
-
-		private void toStringChildrenRecursively(List<TestHierarchyNode> nodeIds, int indent, StringBuilder sb) {
+		private static void toStringChildrenRecursively(List<TestHierarchyNode> nodeIds, int indent, StringBuilder sb) {
 			nodeIds
 				.stream()
 				.sorted(Comparator.comparingInt(TestHierarchyNode::getId))
@@ -1786,7 +1742,7 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 				});
 		}
 
-		private void makeOrphansRecursively(TestHierarchyNode nodeInTree, TestHierarchyNode rootNode) {
+		private static void makeOrphansRecursively(TestHierarchyNode nodeInTree, TestHierarchyNode rootNode) {
 			nodeInTree.getChildren()
 				.forEach(it -> {
 					rootNode.orphans.put(it.getId(), new TestHierarchyNode(it.getId(), it.getParentId()));
@@ -1795,7 +1751,7 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 
 		}
 
-		private void placeOrphansRecursively(TestHierarchyNode newNode, TestHierarchyNode rootNode) {
+		private static void placeOrphansRecursively(TestHierarchyNode newNode, TestHierarchyNode rootNode) {
 			final Iterator<TestHierarchyNode> it = rootNode.orphans.values().iterator();
 			while (it.hasNext()) {
 				final TestHierarchyNode orphan = it.next();
@@ -1809,18 +1765,6 @@ class HierarchyIndexTest implements TimeBoundedTestSupport {
 			}
 		}
 
-		private void appendIdRecursively(TestHierarchyNode parentNode, CompositeIntArray intArray) {
-			for (TestHierarchyNode child : parentNode.getChildren()) {
-				intArray.add(child.getId());
-				appendIdRecursively(child, intArray);
-			}
-		}
-	}
-
-	private record TestState(
-		StringBuilder code,
-		HierarchyIndex initialState
-	) {
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/list/TransactionalListTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/list/TransactionalListTest.java
@@ -58,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * wrapper: isolation between transactional and non-transactional state, commit and rollback
  * semantics, the {@link io.evitadb.core.transaction.memory.TransactionalLayerProducer}
  * interface contract, all List API operations both inside and outside transactions, iterator
- * mutation behaviour, equals/hashCode, clone, and edge-case correctness.
+ * mutation behaviour, equals/hashCode, and edge-case correctness.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2018
  */
@@ -106,8 +106,8 @@ class TransactionalListTest {
 			final TransactionalList<Integer> first = new TransactionalList<>(new ArrayList<>());
 			final TransactionalList<Integer> second = new TransactionalList<>(new ArrayList<>());
 
-			// IDs are drawn from TransactionalObjectVersion.SEQUENCE which starts at Long.MIN_VALUE —
-			// never assume > 0, only assert they differ
+			// IDs are drawn from the shared TransactionalObjectVersion.SEQUENCE, so their concrete
+			// values depend on what the rest of the suite already consumed - only assert they differ
 			assertNotEquals(first.getId(), second.getId());
 		}
 
@@ -1311,7 +1311,7 @@ class TransactionalListTest {
 		@Test
 		@DisplayName("equals returns false for non-List objects")
 		void shouldNotBeEqualToNonListObject() {
-			assertNotEquals(TransactionalListTest.this.tested, "not a list");
+			assertNotEquals("not a list", TransactionalListTest.this.tested);
 			assertNotEquals(TransactionalListTest.this.tested, Integer.valueOf(1));
 		}
 
@@ -1333,59 +1333,7 @@ class TransactionalListTest {
 	}
 
 	// -------------------------------------------------------------------------
-	// Group 12: Clone
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Tests verifying the {@link TransactionalList#clone()} behaviour both inside
-	 * and outside a transaction.
-	 */
-	@Nested
-	@DisplayName("Clone")
-	class CloneTest {
-
-		@Test
-		@DisplayName("clone() outside transaction produces independent list with same contents")
-		void shouldCloneOutsideTransaction() throws CloneNotSupportedException {
-			@SuppressWarnings("unchecked")
-			final TransactionalList<Integer> cloned =
-				(TransactionalList<Integer>) TransactionalListTest.this.tested.clone();
-
-			// same observable contents
-			assertListContains(cloned, 1, 2);
-			// but different object identity
-			assertNotSame(TransactionalListTest.this.tested, cloned);
-		}
-
-		@Test
-		@DisplayName("clone() inside transaction copies transactional state to the clone")
-		void shouldCloneInTransactionCopiesState() {
-			assertStateAfterCommit(
-				TransactionalListTest.this.tested,
-				original -> {
-					original.add(3);
-					original.remove(Integer.valueOf(1));
-					// the in-transaction view is [2, 3]
-					assertListContains(original, 2, 3);
-
-					try {
-						@SuppressWarnings("unchecked")
-						final TransactionalList<Integer> cloned =
-							(TransactionalList<Integer>) original.clone();
-						// clone must have the same in-transaction view
-						assertListContains(cloned, 2, 3);
-					} catch (CloneNotSupportedException ex) {
-						fail("Clone should be supported: " + ex.getMessage());
-					}
-				},
-				(original, committedVersion) -> assertListContains(committedVersion, 2, 3)
-			);
-		}
-
-	}
-
-	// -------------------------------------------------------------------------
-	// Group 13: Edge cases
+	// Group 12: Edge cases
 	// -------------------------------------------------------------------------
 
 	/**
@@ -1488,7 +1436,7 @@ class TransactionalListTest {
 	}
 
 	// -------------------------------------------------------------------------
-	// Group 14: Regression tests
+	// Group 13: Regression tests
 	// -------------------------------------------------------------------------
 
 	/**
@@ -1626,7 +1574,7 @@ class TransactionalListTest {
 	}
 
 	// -------------------------------------------------------------------------
-	// Group 15: Bug-fix regression tests
+	// Group 14: Bug-fix regression tests
 	// -------------------------------------------------------------------------
 
 	/**
@@ -1758,10 +1706,6 @@ class TransactionalListTest {
 
 	}
 
-	// -------------------------------------------------------------------------
-	// Group 16: Generational proof test
-	// -------------------------------------------------------------------------
-
 	/**
 	 * Asserts that `list` contains exactly `recordIds` (in order) and that all standard
 	 * List access methods agree: size, element-by-index, contains, forward and backward
@@ -1770,7 +1714,7 @@ class TransactionalListTest {
 	 * @param list      the list to verify — must be non-null
 	 * @param recordIds expected contents in order
 	 */
-	private void assertListContains(@Nonnull List<Integer> list, int... recordIds) {
+	private static void assertListContains(@Nonnull List<Integer> list, int... recordIds) {
 		final String errorMessage = "\nExpected: " + Arrays.toString(recordIds) +
 			"\nActual:   [" + list.stream().map(Object::toString).collect(Collectors.joining(", ")) + "]";
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/map/PersistentTransactionalMapTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/map/PersistentTransactionalMapTest.java
@@ -531,11 +531,11 @@ class PersistentTransactionalMapTest {
 	}
 
 	/**
-	 * equals, hashCode, toString, and clone.
+	 * equals, hashCode and toString.
 	 */
 	@Nested
-	@DisplayName("equals, hashCode, toString and clone")
-	class EqualsHashCodeCloneTest {
+	@DisplayName("equals, hashCode and toString")
+	class EqualsHashCodeTest {
 
 		@Test
 		@DisplayName("equals a plain map with identical entries")
@@ -565,17 +565,6 @@ class PersistentTransactionalMapTest {
 			assertTrue(str.endsWith("}"));
 			assertTrue(str.contains("a=1"));
 			assertTrue(str.contains("b=2"));
-		}
-
-		@Test
-		@DisplayName("clone outside a transaction produces a copy with the same entries")
-		void shouldCloneOutsideTransaction() throws CloneNotSupportedException {
-			@SuppressWarnings("unchecked")
-			final PersistentTransactionalMap<String, Integer> clone =
-				(PersistentTransactionalMap<String, Integer>) PersistentTransactionalMapTest.this.tested.clone();
-
-			assertMapContains(clone, new Tuple("a", 1), new Tuple("b", 2));
-			assertNotSame(PersistentTransactionalMapTest.this.tested, clone);
 		}
 
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/map/PersistentTransactionalProducerMapTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/map/PersistentTransactionalProducerMapTest.java
@@ -566,50 +566,6 @@ class PersistentTransactionalProducerMapTest {
 	}
 
 	/**
-	 * Clone hygiene: cloning inside a transaction must carry this map's diff state — including the producer-specific
-	 * `valueMutatedKeys` set ({@link ProducerMapChanges#copyState}) — into the clone's own layer, and the clone must be an
-	 * independent instance.
-	 */
-	@Nested
-	@DisplayName("Clone")
-	class CloneTest {
-
-		@Test
-		@DisplayName("clone inside a transaction copies the diff state (incl. marked keys) into an independent instance")
-		void shouldCarryMarkingStateOnCloneInsideTransaction() {
-			final Map<String, CountingProducer> seed = seed(new String[]{"a", "b"}, new int[]{1, 2});
-			final PersistentTransactionalProducerMap<String, CountingProducer> map = mapOf(seed);
-
-			assertStateAfterCommit(
-				map,
-				original -> {
-					original.put("c", new CountingProducer(3));
-					// mark (without a per-instance mutation, so no shared layer is double-swept) → copyState must carry
-					// the valueMutatedKeys set into the clone's layer, exercising the producer-specific override
-					original.markValueMutated("a");
-					try {
-						@SuppressWarnings("unchecked")
-						final PersistentTransactionalProducerMap<String, CountingProducer> clone =
-							(PersistentTransactionalProducerMap<String, CountingProducer>) original.clone();
-						// the clone is an independent instance that sees the in-transaction membership
-						assertNotSame(original, clone);
-						assertTrue(clone.containsKey("a"));
-						assertTrue(clone.containsKey("b"));
-						assertTrue(clone.containsKey("c"));
-					} catch (CloneNotSupportedException ex) {
-						throw new IllegalStateException("Clone should be supported!", ex);
-					}
-				},
-				(original, committed) -> {
-					assertEquals(1, committed.get("a").committedValue());
-					assertEquals(2, committed.get("b").committedValue());
-					assertEquals(3, committed.get("c").committedValue());
-				}
-			);
-		}
-	}
-
-	/**
 	 * Minimal {@link TransactionalLayerProducer} that mirrors the identity-preservation contract of the real
 	 * attribute-index producers: an untouched instance merges to itself (`this`), a touched one to a fresh instance
 	 * carrying the new value. Its diff layer is an `int[]{newValue, touchedFlag}`.

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/map/TransactionalMapTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/map/TransactionalMapTest.java
@@ -923,49 +923,6 @@ class TransactionalMapTest {
 	}
 
 	/**
-	 * Tests verifying the clone behaviour of {@link TransactionalMap} both inside and outside a transaction.
-	 */
-	@Nested
-	@DisplayName("Clone")
-	class CloneTest {
-
-		@Test
-		@DisplayName("clone outside a transaction produces a copy with the same entries")
-		void shouldCloneOutsideTransaction() throws CloneNotSupportedException {
-			@SuppressWarnings("unchecked")
-			final TransactionalMap<String, Integer> clone = (TransactionalMap<String, Integer>) TransactionalMapTest.this.tested.clone();
-
-			assertMapContains(clone, new Tuple("a", 1), new Tuple("b", 2));
-			assertNotSame(TransactionalMapTest.this.tested, clone);
-		}
-
-		@Test
-		@DisplayName("clone inside a transaction carries the transactional changes into the clone")
-		void shouldCloneInsideTransaction() {
-			assertStateAfterCommit(
-				TransactionalMapTest.this.tested,
-				original -> {
-					original.put("c", 3);
-
-					try {
-						@SuppressWarnings("unchecked")
-						final TransactionalMap<String, Integer> clone =
-							(TransactionalMap<String, Integer>) original.clone();
-						// clone must see the transactional change
-						assertMapContains(clone, new Tuple("a", 1), new Tuple("b", 2), new Tuple("c", 3));
-					} catch (CloneNotSupportedException ex) {
-						fail("Clone should be supported: " + ex.getMessage());
-					}
-				},
-				(original, committedVersion) -> {
-					assertMapContains(committedVersion, new Tuple("a", 1), new Tuple("b", 2), new Tuple("c", 3));
-				}
-			);
-		}
-
-	}
-
-	/**
 	 * Tests verifying correct behaviour in boundary and edge-case scenarios.
 	 */
 	@Nested

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/AbstractMutatorTestBase.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/AbstractMutatorTestBase.java
@@ -42,6 +42,7 @@ import io.evitadb.dataType.Scope;
 import io.evitadb.index.CatalogIndex;
 import io.evitadb.index.EntityIndexKey;
 import io.evitadb.index.EntityIndexType;
+import io.evitadb.index.EntityTypeClassifierResolver;
 import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.test.TestConstants;
 import io.evitadb.test.generator.DataGenerator;
@@ -70,6 +71,7 @@ abstract class AbstractMutatorTestBase {
 	@Nonnull protected final Catalog catalog;
 	@Nonnull protected final CatalogIndex catalogIndex;
 	@Nonnull protected final CatalogSchema catalogSchema;
+	@Nonnull protected final EntityTypeClassifierResolver classifierResolver;
 	@Nonnull protected final MockStorageContainerAccessor containerAccessor = new MockStorageContainerAccessor();
 	@Nonnull protected final DataGenerator dataGenerator = new DataGenerator();
 	@Nonnull protected final EntityIndexLocalMutationExecutor executor;
@@ -104,7 +106,18 @@ abstract class AbstractMutatorTestBase {
 		this.catalogSchema = (CatalogSchema) catalogSchemaBuilder.toInstance();
 		this.sealedCatalogSchema = new CatalogSchemaDecorator(this.catalogSchema);
 		this.catalogIndex = new CatalogIndex(Scope.LIVE);
-		this.catalogIndex.attachToCatalog(null, this.catalog);
+		this.classifierResolver = new EntityTypeClassifierResolver() {
+			@Override
+			public int toEntityTypePrimaryKey(@Nonnull String entityType) {
+				return AbstractMutatorTestBase.this.catalog.getCollectionForEntityOrThrowException(entityType).getEntityTypePrimaryKey();
+			}
+
+			@Nonnull
+			@Override
+			public String toEntityTypeName(int entityTypePrimaryKey) {
+				return AbstractMutatorTestBase.this.catalog.getCollectionForEntityPrimaryKeyOrThrowException(entityTypePrimaryKey).getEntityType();
+			}
+		};
 
 		final EvitaSession mockSession = Mockito.mock(EvitaSession.class);
 		Mockito.when(this.catalog.getSchema()).thenReturn(this.sealedCatalogSchema);
@@ -130,7 +143,8 @@ abstract class AbstractMutatorTestBase {
 			},
 			null,
 			null,
-			null
+			null,
+			this.classifierResolver
 		);
 
 		final EntityCollection productCollection = Mockito.mock(EntityCollection.class);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/AttributeIndexMutatorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/AttributeIndexMutatorTest.java
@@ -172,7 +172,7 @@ class AttributeIndexMutatorTest extends AbstractMutatorTestBase {
 		assertNotNull(globalUniqueIndex);
 		assertEquals(
 			new EntityReferenceWithLocale(this.productSchema.getName(), 1, null),
-			globalUniqueIndex.getEntityReferenceByUniqueValue("GA", null).orElse(null)
+			globalUniqueIndex.getEntityReferenceByUniqueValue("GA", null, this.classifierResolver).orElse(null)
 		);
 
 		final TrappedChanges trappedChanges1 = new TrappedChanges();
@@ -281,10 +281,10 @@ class AttributeIndexMutatorTest extends AbstractMutatorTestBase {
 
 		final GlobalAttributeSchema attributeSchema = (GlobalAttributeSchema) this.productAttributeSchemaProvider.getAttributeSchema(ATTRIBUTE_GLOBAL_CODE);
 		final GlobalUniqueIndex globalUniqueIndex = this.catalogIndex.getGlobalUniqueIndex(attributeSchema, null);
-		assertNull(globalUniqueIndex.getEntityReferenceByUniqueValue("GA", null).orElse(null));
+		assertNull(globalUniqueIndex.getEntityReferenceByUniqueValue("GA", null, this.classifierResolver).orElse(null));
 		assertEquals(
 			new EntityReferenceWithLocale(this.productSchema.getName(), 1, null),
-			globalUniqueIndex.getEntityReferenceByUniqueValue("GB", null).orElse(null)
+			globalUniqueIndex.getEntityReferenceByUniqueValue("GB", null, this.classifierResolver).orElse(null)
 		);
 
 		final TrappedChanges trappedChanges1 = new TrappedChanges();
@@ -431,7 +431,8 @@ class AttributeIndexMutatorTest extends AbstractMutatorTestBase {
 						UNSUPPORTED_OPERATION,
 						null,
 						null,
-						null
+						null,
+						this.classifierResolver
 					),
 					null,
 					this.productAttributeSchemaProvider,
@@ -458,7 +459,8 @@ class AttributeIndexMutatorTest extends AbstractMutatorTestBase {
 						UNSUPPORTED_OPERATION,
 						null,
 						null,
-						null
+						null,
+						this.classifierResolver
 					),
 					null,
 					this.productAttributeSchemaProvider,
@@ -490,7 +492,8 @@ class AttributeIndexMutatorTest extends AbstractMutatorTestBase {
 				UNSUPPORTED_OPERATION,
 				null,
 				null,
-				null
+				null,
+				this.classifierResolver
 			),
 			null,
 			this.productAttributeSchemaProvider,
@@ -512,7 +515,8 @@ class AttributeIndexMutatorTest extends AbstractMutatorTestBase {
 				UNSUPPORTED_OPERATION,
 				null,
 				null,
-				null
+				null,
+				this.classifierResolver
 			),
 			null,
 			this.productAttributeSchemaProvider,
@@ -532,11 +536,11 @@ class AttributeIndexMutatorTest extends AbstractMutatorTestBase {
 		final GlobalUniqueIndex globalUniqueIndex = this.catalogIndex.getGlobalUniqueIndex(attributeSchema, null);
 		assertEquals(
 			new EntityReferenceWithLocale(this.productSchema.getName(), 2, null),
-			globalUniqueIndex.getEntityReferenceByUniqueValue("GA", null).orElse(null)
+			globalUniqueIndex.getEntityReferenceByUniqueValue("GA", null, this.classifierResolver).orElse(null)
 		);
 		assertEquals(
 			new EntityReferenceWithLocale(this.productSchema.getName(), 1, null),
-			globalUniqueIndex.getEntityReferenceByUniqueValue("GB", null).orElse(null)
+			globalUniqueIndex.getEntityReferenceByUniqueValue("GB", null, this.classifierResolver).orElse(null)
 		);
 
 		final TrappedChanges trappedChanges1 = new TrappedChanges();
@@ -639,7 +643,8 @@ class AttributeIndexMutatorTest extends AbstractMutatorTestBase {
 				UNSUPPORTED_OPERATION,
 				null,
 				null,
-				null
+				null,
+				this.classifierResolver
 			),
 			null,
 			this.productAttributeSchemaProvider,

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/EntityIndexLocalMutationExecutorTriggerTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/EntityIndexLocalMutationExecutorTriggerTest.java
@@ -48,6 +48,7 @@ import io.evitadb.dataType.Scope;
 import io.evitadb.index.CatalogIndex;
 import io.evitadb.index.EntityIndexKey;
 import io.evitadb.index.EntityIndexType;
+import io.evitadb.index.EntityTypeClassifierResolver;
 import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.core.expression.trigger.DependencyType;
 import io.evitadb.index.mutation.EntityIndexMutation;
@@ -112,6 +113,24 @@ class EntityIndexLocalMutationExecutorTriggerTest {
 	private static final String TARGET_ENTITY_TYPE = "product";
 	private static final String REFERENCE_NAME = "parameter";
 	private static final int ENTITY_PK = 99;
+
+	/**
+	 * Entity-type classifier resolver stub. The source-side trigger detection tests never register a
+	 * globally-unique attribute, so the executor never consults this resolver; throwing on use surfaces
+	 * any unexpected invocation rather than silently returning a bogus value.
+	 */
+	private static final EntityTypeClassifierResolver NOOP_CLASSIFIER_RESOLVER = new EntityTypeClassifierResolver() {
+		@Override
+		public int toEntityTypePrimaryKey(@Nonnull String entityType) {
+			throw new UnsupportedOperationException("Not needed for source-side detection tests.");
+		}
+
+		@Nonnull
+		@Override
+		public String toEntityTypeName(int entityTypePrimaryKey) {
+			throw new UnsupportedOperationException("Not needed for source-side detection tests.");
+		}
+	};
 
 	/**
 	 * Simple test implementation of {@link ExpressionIndexTrigger}. Provides the minimum contract
@@ -290,7 +309,8 @@ class EntityIndexLocalMutationExecutorTriggerTest {
 			() -> { throw new UnsupportedOperationException("Not used in trigger test."); },
 			registrySupplier,
 			null,
-			null
+			null,
+			NOOP_CLASSIFIER_RESOLVER
 		);
 	}
 
@@ -1220,7 +1240,8 @@ class EntityIndexLocalMutationExecutorTriggerTest {
 			() -> { throw new UnsupportedOperationException("Not used in trigger test."); },
 			registrySupplier,
 			localTriggerSupplier,
-			null
+			null,
+			NOOP_CLASSIFIER_RESOLVER
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/ReferenceIndexIteratorSemanticsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/ReferenceIndexIteratorSemanticsTest.java
@@ -161,7 +161,8 @@ class ReferenceIndexIteratorSemanticsTest extends AbstractMutatorTestBase {
 			},
 			null,
 			null,
-			null
+			null,
+			this.classifierResolver
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/SharedRgeiMutationMatrixTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/mutation/local/SharedRgeiMutationMatrixTest.java
@@ -32,13 +32,11 @@ import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
 import io.evitadb.api.requestResponse.schema.ReferenceIndexType;
 import io.evitadb.api.requestResponse.schema.ReferenceSchemaContract;
 import io.evitadb.api.requestResponse.schema.dto.AttributeSchema;
-import io.evitadb.core.catalog.Catalog;
 import io.evitadb.dataType.Scope;
 import io.evitadb.exception.EvitaInvalidUsageException;
 import io.evitadb.exception.GenericEvitaInternalError;
 import io.evitadb.index.EntityIndexKey;
 import io.evitadb.index.EntityIndexType;
-import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.index.ReducedGroupEntityIndex;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.index.price.PriceListAndCurrencyPriceRefIndex;
@@ -59,7 +57,6 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Currency;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Set;
 
 import static io.evitadb.test.TestTags.ATTRIBUTE;
@@ -690,29 +687,18 @@ class SharedRgeiMutationMatrixTest {
 	}
 
 	/**
-	 * Attaches the RGEI to a mock catalog so the price ref index can resolve shared price records
-	 * via the super index. Mirrors the wiring used by {@link io.evitadb.core.catalog.Catalog} in
-	 * production.
+	 * Wires the RGEI's price ref chain to the backing super index so the price ref index can
+	 * resolve shared price records via the super index. Mirrors the collection-local super-index
+	 * wiring used in production.
 	 *
-	 * @param target RGEI to attach
+	 * @param target RGEI to wire
 	 * @param superIndex backing super index for price record lookups
 	 */
 	private static void attachToMockCatalog(
 		@Nonnull ReducedGroupEntityIndex target,
 		@Nonnull PriceSuperIndex superIndex
 	) {
-		final GlobalEntityIndex mockGlobalIndex = mock(GlobalEntityIndex.class);
-		when(mockGlobalIndex.getPriceIndex(ArgumentMatchers.any(PriceIndexKey.class)))
-			.thenAnswer(invocation -> superIndex.getPriceIndex(invocation.getArgument(0)));
-
-		final Catalog mockCatalog = mock(Catalog.class);
-		when(mockCatalog.getEntityIndexIfExists(
-			ArgumentMatchers.eq(ENTITY_TYPE),
-			ArgumentMatchers.eq(new EntityIndexKey(EntityIndexType.GLOBAL, Scope.LIVE)),
-			ArgumentMatchers.eq(GlobalEntityIndex.class)
-		)).thenReturn(Optional.of(mockGlobalIndex));
-
-		target.attachToCatalog(ENTITY_TYPE, mockCatalog);
+		target.getPriceIndex().wireSuperIndexes(superIndex::getPriceIndex);
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndexTest.java
@@ -23,15 +23,10 @@
 
 package io.evitadb.index.price;
 
-import io.evitadb.api.CatalogState;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
-import io.evitadb.core.catalog.Catalog;
 import io.evitadb.dataType.DateTimeRange;
 import io.evitadb.dataType.Scope;
 import io.evitadb.exception.GenericEvitaInternalError;
-import io.evitadb.index.EntityIndexKey;
-import io.evitadb.index.EntityIndexType;
-import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.index.price.PriceListAndCurrencyPriceIndex.PriceListAndCurrencyPriceIndexTerminated;
 import io.evitadb.index.price.model.PriceIndexKey;
 import io.evitadb.index.price.model.priceRecord.PriceRecord;
@@ -46,14 +41,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Currency;
-import java.util.Optional;
 
 import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
 import static io.evitadb.utils.AssertionUtils.assertStateAfterRollback;
@@ -81,8 +73,6 @@ import static io.evitadb.test.TestTags.PRICE;
 @Tag(INDEXING)
 @Tag(PRICE)
 class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
-
-	private static final String ENTITY_TYPE = "product";
 	private static final Scope SCOPE = Scope.LIVE;
 	private static final Currency CURRENCY_CZK = Currency.getInstance("CZK");
 	private static final String PRICE_LIST = "basic";
@@ -95,7 +85,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 	/**
 	 * Initializes a fresh super index and an empty ref index before each test. The ref index
 	 * is **not** attached to a catalog by default -- each test decides whether to call
-	 * {@link #attachRefIndexToCatalog(PriceListAndCurrencyPriceRefIndex,
+	 * {@link #wireRefIndexToSuperIndex(PriceListAndCurrencyPriceRefIndex,
 	 * PriceListAndCurrencyPriceSuperIndex)}.
 	 */
 	@BeforeEach
@@ -118,47 +108,19 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 	}
 
 	/**
-	 * Creates a {@link PriceRecord} with the given internal price id, entity primary key,
-	 * and custom price values.
+	 * Wires the given ref index to the provided super index, mirroring how the owning entity collection wires its
+	 * reduced indexes' price ref chains to the super price indexes of its own GLOBAL entity index after re-attachment.
 	 */
-	@Nonnull
-	private static PriceRecordContract createPriceRecordWithPrice(
-		int internalPriceId,
-		int priceId,
-		int entityPrimaryKey,
-		int priceWithTax,
-		int priceWithoutTax
-	) {
-		return new PriceRecord(internalPriceId, priceId, entityPrimaryKey, priceWithTax, priceWithoutTax);
-	}
-
-	/**
-	 * Attaches the given ref index to a mocked catalog that returns the provided super index
-	 * through the standard `Catalog -> GlobalEntityIndex -> PriceSuperIndex` chain.
-	 */
-	private static void attachRefIndexToCatalog(
+	private static void wireRefIndexToSuperIndex(
 		@Nonnull PriceListAndCurrencyPriceRefIndex refIndex,
 		@Nonnull PriceListAndCurrencyPriceSuperIndex superIndex
 	) {
-		final PriceSuperIndex priceSuperIndex = Mockito.mock(PriceSuperIndex.class);
-		Mockito.when(priceSuperIndex.getPriceIndex(PRICE_INDEX_KEY)).thenReturn(superIndex);
-
-		final GlobalEntityIndex globalEntityIndex = Mockito.mock(GlobalEntityIndex.class);
-		Mockito.when(globalEntityIndex.getPriceIndex(PRICE_INDEX_KEY)).thenReturn(superIndex);
-
-		final Catalog catalog = Mockito.mock(Catalog.class);
-		Mockito.when(catalog.getEntityIndexIfExists(
-			ArgumentMatchers.eq(ENTITY_TYPE),
-			ArgumentMatchers.eq(new EntityIndexKey(EntityIndexType.GLOBAL, SCOPE)),
-			ArgumentMatchers.eq(GlobalEntityIndex.class)
-		)).thenReturn(Optional.of(globalEntityIndex));
-
-		refIndex.attachToCatalog(ENTITY_TYPE, catalog);
+		refIndex.wireSuperIndex(superIndex);
 	}
 
 	/**
 	 * Populates the super index with the specified price records (no validity) and returns
-	 * a ref index attached to that super index via catalog mock.
+	 * a ref index wired to that super index.
 	 */
 	@Nonnull
 	private static PriceListAndCurrencyPriceRefIndex createAttachedRefIndex(
@@ -170,13 +132,13 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 		}
 		final PriceListAndCurrencyPriceRefIndex newRefIndex =
 			new PriceListAndCurrencyPriceRefIndex(SCOPE, PRICE_INDEX_KEY);
-		attachRefIndexToCatalog(newRefIndex, superIndex);
+		wireRefIndexToSuperIndex(newRefIndex, superIndex);
 		return newRefIndex;
 	}
 
 	/**
-	 * Creates a ref index from deserialized data (price ids constructor), attaches it to the
-	 * catalog mock, and returns it ready for use.
+	 * Creates a ref index from deserialized data (price ids constructor), wires it to the
+	 * super index, and returns it ready for use.
 	 */
 	@Nonnull
 	private static PriceListAndCurrencyPriceRefIndex createAttachedRefIndexFromPriceIds(
@@ -185,19 +147,19 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 	) {
 		final PriceListAndCurrencyPriceRefIndex newRefIndex =
 			new PriceListAndCurrencyPriceRefIndex(SCOPE, PRICE_INDEX_KEY, new RangeIndex(), priceIds);
-		attachRefIndexToCatalog(newRefIndex, superIndex);
+		wireRefIndexToSuperIndex(newRefIndex, superIndex);
 		return newRefIndex;
 	}
 
 	/**
-	 * Tests verifying the catalog attachment lifecycle of the ref index.
+	 * Tests verifying the super-index wiring lifecycle of the ref index.
 	 */
 	@Nested
-	@DisplayName("Catalog attachment")
+	@DisplayName("Super index wiring")
 	class CatalogAttachmentTest {
 
 		@Test
-		@DisplayName("should attach and populate priceRecords from super index")
+		@DisplayName("should wire and populate priceRecords from super index")
 		void shouldAttachAndPopulatePriceRecordsFromSuperIndex() {
 			final PriceRecordContract price1 = createPriceRecord(1, 1, 100);
 			final PriceRecordContract price2 = createPriceRecord(2, 2, 200);
@@ -220,47 +182,21 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 		}
 
 		@Test
-		@DisplayName("should throw when entity type is null")
-		void shouldThrowWhenEntityTypeIsNull() {
-			final Catalog catalog = Mockito.mock(Catalog.class);
-
-			assertThrows(
-				GenericEvitaInternalError.class,
-				() -> PriceListAndCurrencyPriceRefIndexTest.this.refIndex.attachToCatalog(null, catalog)
-			);
-		}
-
-		@Test
-		@DisplayName("should throw when already attached")
+		@DisplayName("should throw when super index already wired")
 		void shouldThrowWhenAlreadyAttached() {
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(
 				createPriceRecord(1, 1, 100), null
 			);
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
 
-			final Catalog catalog = Mockito.mock(Catalog.class);
 			assertThrows(
 				GenericEvitaInternalError.class,
-				() -> PriceListAndCurrencyPriceRefIndexTest.this.refIndex.attachToCatalog(ENTITY_TYPE, catalog)
-			);
-		}
-
-		@Test
-		@DisplayName("should throw when super index not found in catalog")
-		void shouldThrowWhenSuperIndexNotFound() {
-			final Catalog catalog = Mockito.mock(Catalog.class);
-			Mockito.when(catalog.getEntityIndexIfExists(
-				ArgumentMatchers.eq(ENTITY_TYPE),
-				ArgumentMatchers.eq(new EntityIndexKey(EntityIndexType.GLOBAL, SCOPE)),
-				ArgumentMatchers.eq(GlobalEntityIndex.class)
-			)).thenReturn(Optional.empty());
-
-			assertThrows(
-				GenericEvitaInternalError.class,
-				() -> PriceListAndCurrencyPriceRefIndexTest.this.refIndex.attachToCatalog(ENTITY_TYPE, catalog)
+				() -> PriceListAndCurrencyPriceRefIndexTest.this.refIndex.wireSuperIndex(
+					PriceListAndCurrencyPriceRefIndexTest.this.superIndex
+				)
 			);
 		}
 
@@ -305,7 +241,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price, null);
 
 			// create empty attached ref
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -338,7 +274,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			final PriceRecordContract price = createPriceRecord(10, 10, 42);
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price, validity);
 
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -363,7 +299,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price1, null);
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price2, null);
 
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -393,7 +329,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price1, null);
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price2, null);
 
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -423,7 +359,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price1, null);
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price2, null);
 
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -456,7 +392,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			final PriceRecordContract price = createPriceRecord(10, 10, 42);
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price, null);
 
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -485,7 +421,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			final PriceRecordContract price = createPriceRecord(10, 10, 42);
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price, validity);
 
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -515,7 +451,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price1, null);
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price2, null);
 
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -620,7 +556,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price1, null);
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price2, null);
 
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -640,7 +576,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			final PriceRecordContract price = createPriceRecord(10, 10, 42);
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price, null);
 
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -657,7 +593,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 		@Test
 		@DisplayName("should return null for unknown entity")
 		void shouldReturnNullForUnknownEntity() {
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -684,7 +620,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			final PriceRecordContract price = createPriceRecord(10, 10, 42);
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price, null);
 
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -704,7 +640,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 		@Test
 		@DisplayName("should return null when clean (no mutations)")
 		void shouldReturnNullWhenClean() {
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -721,7 +657,7 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			final PriceRecordContract price = createPriceRecord(10, 10, 42);
 			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price, null);
 
-			attachRefIndexToCatalog(
+			wireRefIndexToSuperIndex(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
 				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
 			);
@@ -737,44 +673,6 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			// clean — should be null
 			assertNull(
 				PriceListAndCurrencyPriceRefIndexTest.this.refIndex.createStoragePart(1)
-			);
-		}
-	}
-
-	/**
-	 * Tests verifying `createCopyForNewCatalogAttachment` produces a fresh detached copy.
-	 */
-	@Nested
-	@DisplayName("Copy for new catalog attachment")
-	class CopyTest {
-
-		@Test
-		@DisplayName("should create a distinct copy with same key and bitmaps")
-		void shouldCreateCopyForNewCatalogAttachment() {
-			final PriceRecordContract price = createPriceRecord(10, 10, 42);
-			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(price, null);
-
-			attachRefIndexToCatalog(
-				PriceListAndCurrencyPriceRefIndexTest.this.refIndex,
-				PriceListAndCurrencyPriceRefIndexTest.this.superIndex
-			);
-			PriceListAndCurrencyPriceRefIndexTest.this.refIndex.addPrice(10, null);
-
-			final PriceListAndCurrencyPriceRefIndex copy =
-				PriceListAndCurrencyPriceRefIndexTest.this.refIndex.createCopyForNewCatalogAttachment(
-					CatalogState.ALIVE
-				);
-
-			assertNotSame(PriceListAndCurrencyPriceRefIndexTest.this.refIndex, copy);
-			assertEquals(
-				PriceListAndCurrencyPriceRefIndexTest.this.refIndex.getPriceIndexKey(),
-				copy.getPriceIndexKey()
-			);
-			// copy does NOT have priceRecords or superIndex until reattached,
-			// but shares indexedPriceEntityIds and indexedPriceIds TransactionalBitmaps
-			assertArrayEquals(
-				PriceListAndCurrencyPriceRefIndexTest.this.refIndex.getIndexedPriceIds(),
-				copy.getIndexedPriceIds()
 			);
 		}
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceListAndCurrencyPriceRefIndexTest.java
@@ -532,6 +532,77 @@ class PriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTestSupport {
 			);
 			assertFalse(PriceListAndCurrencyPriceRefIndexTest.this.refIndex.isEmpty());
 		}
+
+		@Test
+		@DisplayName("should evict entity whose remaining prices live only in the super index")
+		void shouldEvictEntityWhenRemainingPricesAreNotInThisIndex() {
+			// entity 42 owns three prices in the super index, but this ref index tracks only one of
+			// them - the eviction decision must therefore be answered against *this index's* content,
+			// never against the entity's total price count
+			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(createPriceRecord(10, 10, 42), null);
+			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(createPriceRecord(20, 20, 42), null);
+			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(createPriceRecord(30, 30, 42), null);
+
+			final PriceListAndCurrencyPriceRefIndex tested = createAttachedRefIndexFromPriceIds(
+				PriceListAndCurrencyPriceRefIndexTest.this.superIndex,
+				new int[]{20}
+			);
+			assertArrayEquals(new int[]{42}, tested.getIndexedPriceEntityIds().getArray());
+
+			tested.removePrice(20, null);
+
+			// entity 42 still has prices 10 and 30 in the SUPER index, yet none in this one - so it
+			// must be evicted here regardless
+			assertArrayEquals(new int[]{}, tested.getIndexedPriceEntityIds().getArray());
+			assertTrue(tested.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should keep entity until its last price in this index is removed")
+		void shouldKeepEntityUntilLastPriceInThisIndexRemoved() {
+			// the entity's id set stays constant while the index shrinks, so each removal must be
+			// judged against the prices still present rather than against the entity's id set
+			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(createPriceRecord(10, 10, 42), null);
+			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(createPriceRecord(20, 20, 42), null);
+			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(createPriceRecord(30, 30, 42), null);
+
+			final PriceListAndCurrencyPriceRefIndex tested = createAttachedRefIndexFromPriceIds(
+				PriceListAndCurrencyPriceRefIndexTest.this.superIndex,
+				new int[]{10, 20, 30}
+			);
+
+			tested.removePrice(20, null);
+			assertArrayEquals(new int[]{42}, tested.getIndexedPriceEntityIds().getArray());
+			tested.removePrice(10, null);
+			assertArrayEquals(new int[]{42}, tested.getIndexedPriceEntityIds().getArray());
+
+			tested.removePrice(30, null);
+			assertArrayEquals(new int[]{}, tested.getIndexedPriceEntityIds().getArray());
+			assertTrue(tested.isEmpty());
+		}
+
+		@Test
+		@DisplayName("should evict entity irrespective of the order prices are removed in")
+		void shouldEvictEntityIrrespectiveOfRemovalOrder() {
+			// guards against any assumption that the removed price, the entity's id set and the
+			// index content are traversed in a compatible ascending order
+			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(createPriceRecord(5, 5, 42), null);
+			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(createPriceRecord(1000, 1000, 42), null);
+			PriceListAndCurrencyPriceRefIndexTest.this.superIndex.addPrice(createPriceRecord(7, 7, 99), null);
+
+			final PriceListAndCurrencyPriceRefIndex tested = createAttachedRefIndexFromPriceIds(
+				PriceListAndCurrencyPriceRefIndexTest.this.superIndex,
+				new int[]{5, 7, 1000}
+			);
+
+			// remove the highest internal price id first, then the lowest one of the same entity
+			tested.removePrice(1000, null);
+			assertArrayEquals(new int[]{42, 99}, tested.getIndexedPriceEntityIds().getArray());
+
+			tested.removePrice(5, null);
+			assertArrayEquals(new int[]{99}, tested.getIndexedPriceEntityIds().getArray());
+			assertArrayEquals(new int[]{7}, tested.getIndexedPriceIds());
+		}
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceListAndCurrencyPriceSuperIndexTest.java
@@ -208,7 +208,14 @@ class PriceListAndCurrencyPriceSuperIndexTest {
 	}
 
 	/**
-	 * Tests verifying unique ID generation via `TransactionalObjectVersion.SEQUENCE`.
+	 * Tests verifying STM invariants: unique ID generation via `TransactionalObjectVersion.SEQUENCE`, layer cleanup,
+	 * and the commit-time instance-identity contract.
+	 *
+	 * The identity contract pinned by {@link #shouldReturnSameInstanceOnCleanCommit()} (clean commit returns `this`)
+	 * and {@link #shouldCreateNewInstanceOnDirtyCommit()} (dirty commit returns a new instance) is load-bearing beyond
+	 * this class: the reduced-index carry-by-reference wiring relies on super-index instance identity being an exact
+	 * "changed / unchanged" signal across a commit (a clean combo super comes back identical, a dirty one comes back
+	 * new, with no defensive-copy path in between). Do not weaken these two assertions without revisiting that design.
 	 */
 	@Nested
 	@DisplayName("STM invariants")

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceRefIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/price/PriceRefIndexTest.java
@@ -23,16 +23,11 @@
 
 package io.evitadb.index.price;
 
-import io.evitadb.api.CatalogState;
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
 import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
-import io.evitadb.core.catalog.Catalog;
 import io.evitadb.dataType.DateTimeRange;
 import io.evitadb.dataType.Scope;
 import io.evitadb.exception.GenericEvitaInternalError;
-import io.evitadb.index.EntityIndexKey;
-import io.evitadb.index.EntityIndexType;
-import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.index.price.model.PriceIndexKey;
 import io.evitadb.index.price.model.priceRecord.PriceRecordContract;
 import io.evitadb.index.range.RangeIndex;
@@ -42,8 +37,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
 import java.time.OffsetDateTime;
@@ -52,7 +45,6 @@ import java.util.Collection;
 import java.util.Currency;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
@@ -141,34 +133,11 @@ class PriceRefIndexTest implements TimeBoundedTestSupport {
 	}
 
 	/**
-	 * Creates a mock Catalog that resolves `getEntityIndexIfExists` to a `GlobalEntityIndex`
-	 * whose `getPriceIndex(PriceIndexKey)` delegates to the shared super index.
-	 */
-	@Nonnull
-	private Catalog createMockCatalog() {
-		final GlobalEntityIndex mockGlobalIndex = Mockito.mock(GlobalEntityIndex.class);
-		Mockito.when(mockGlobalIndex.getPriceIndex(ArgumentMatchers.any(PriceIndexKey.class)))
-			.thenAnswer(invocation -> {
-				final PriceIndexKey key = invocation.getArgument(0);
-				return PriceRefIndexTest.this.priceSuperIndex.getPriceIndex(key);
-			});
-
-		final Catalog mockCatalog = Mockito.mock(Catalog.class);
-		Mockito.when(mockCatalog.getEntityIndexIfExists(
-			ArgumentMatchers.eq(ENTITY_TYPE),
-			ArgumentMatchers.eq(new EntityIndexKey(EntityIndexType.GLOBAL, SCOPE)),
-			ArgumentMatchers.eq(GlobalEntityIndex.class)
-		)).thenReturn(Optional.of(mockGlobalIndex));
-
-		return mockCatalog;
-	}
-
-	/**
-	 * Attaches the ref index to a mock catalog backed by the shared super index.
+	 * Wires the ref index to a super-index resolver backed by the shared super index, mirroring how the owning entity
+	 * collection resolves super price indexes from its own GLOBAL entity index.
 	 */
 	private void attachRefIndex() {
-		final Catalog mockCatalog = createMockCatalog();
-		this.priceRefIndex.attachToCatalog(ENTITY_TYPE, mockCatalog);
+		this.priceRefIndex.wireSuperIndexes(this.priceSuperIndex::getPriceIndex);
 	}
 
 	/**
@@ -199,7 +168,7 @@ class PriceRefIndexTest implements TimeBoundedTestSupport {
 	 * and newly created child ref indexes.
 	 */
 	@Nested
-	@DisplayName("Catalog attachment")
+	@DisplayName("Super index wiring")
 	class CatalogAttachmentTest {
 
 		@Test
@@ -223,8 +192,8 @@ class PriceRefIndexTest implements TimeBoundedTestSupport {
 			childMap.put(KEY_BASIC_CZK, childRefIndex);
 			PriceRefIndexTest.this.priceRefIndex = new PriceRefIndex(SCOPE, childMap);
 
-			// now attach -- should propagate to the existing child via
-			// `values().forEach(it -> it.attachToCatalog(...))`
+			// now wire -- should propagate to the existing child via
+			// `values().forEach(it -> it.wireSuperIndex(...))`
 			attachRefIndex();
 
 			// after attach, the child should be linked to the super index and have the price
@@ -236,17 +205,18 @@ class PriceRefIndexTest implements TimeBoundedTestSupport {
 		}
 
 		@Test
-		@DisplayName("should throw when already attached")
+		@DisplayName("should throw when super index resolver already wired")
 		void shouldThrowWhenAlreadyAttached() {
 			attachRefIndex();
 
-			final Catalog secondCatalog = createMockCatalog();
 			final GenericEvitaInternalError exception = assertThrows(
 				GenericEvitaInternalError.class,
-				() -> PriceRefIndexTest.this.priceRefIndex.attachToCatalog(ENTITY_TYPE, secondCatalog)
+				() -> PriceRefIndexTest.this.priceRefIndex.wireSuperIndexes(
+					PriceRefIndexTest.this.priceSuperIndex::getPriceIndex
+				)
 			);
 
-			assertTrue(exception.getMessage().contains("already attached"));
+			assertTrue(exception.getMessage().contains("already wired"));
 		}
 
 		@Test
@@ -261,7 +231,7 @@ class PriceRefIndexTest implements TimeBoundedTestSupport {
 				PriceInnerRecordHandling.NONE, 10000, 12100
 			);
 
-			// add price to ref index -- child created and auto-attached via initCallback
+			// add price to ref index -- child created and auto-wired via the super index resolver
 			PriceRefIndexTest.this.priceRefIndex.addPrice(
 				null, 1, internalPriceId,
 				new PriceKey(10, PRICE_LIST_BASIC, CURRENCY_CZK),
@@ -449,38 +419,6 @@ class PriceRefIndexTest implements TimeBoundedTestSupport {
 
 			// the child should be gone
 			assertNull(PriceRefIndexTest.this.priceRefIndex.getPriceIndex(KEY_BASIC_CZK));
-		}
-	}
-
-	/**
-	 * Tests verifying `createCopyForNewCatalogAttachment` produces a proper detached copy.
-	 */
-	@Nested
-	@DisplayName("Copy for new catalog attachment")
-	class CopyTest {
-
-		@Test
-		@DisplayName("should create copy with same number of children, each detached")
-		void shouldCreateCopyForNewCatalogAttachment() {
-			attachRefIndex();
-
-			// add prices to two different keys
-			addPriceToBothIndexes(1, 10, PRICE_LIST_BASIC, CURRENCY_CZK);
-			addPriceToBothIndexes(2, 20, PRICE_LIST_VIP, CURRENCY_CZK);
-
-			final PriceRefIndex copy =
-				PriceRefIndexTest.this.priceRefIndex.createCopyForNewCatalogAttachment(
-					CatalogState.ALIVE
-				);
-
-			assertNotSame(PriceRefIndexTest.this.priceRefIndex, copy);
-			assertFalse(copy.isPriceIndexEmpty());
-
-			final Collection<? extends PriceListAndCurrencyPriceIndex> origIndexes =
-				PriceRefIndexTest.this.priceRefIndex.getPriceListAndCurrencyIndexes();
-			final Collection<? extends PriceListAndCurrencyPriceIndex> copyIndexes =
-				copy.getPriceListAndCurrencyIndexes();
-			assertEquals(origIndexes.size(), copyIndexes.size());
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/set/TransactionalSetTest.java
@@ -42,7 +42,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static io.evitadb.test.TestTags.DATA_TYPE;
 import static io.evitadb.test.TestTags.INDEXING;
@@ -664,7 +663,6 @@ class TransactionalSetTest {
 		@Test
 		@DisplayName("equals returns true for self-reference")
 		void shouldEqualItself() {
-			//noinspection EqualsWithItself
 			assertEquals(
 				TransactionalSetTest.this.tested,
 				TransactionalSetTest.this.tested
@@ -756,51 +754,6 @@ class TransactionalSetTest {
 			assertTrue(str.startsWith("{"));
 			assertTrue(str.endsWith("}"));
 			assertFalse(str.isEmpty());
-		}
-
-	}
-
-	/**
-	 * Tests verifying clone behaviour.
-	 */
-	@Nested
-	@DisplayName("Clone")
-	class CloneTest {
-
-		@Test
-		@DisplayName("clone outside a transaction produces a copy")
-		void shouldCloneOutsideTransaction()
-			throws CloneNotSupportedException {
-
-			@SuppressWarnings("unchecked") final TransactionalSet<String> clone =
-				(TransactionalSet<String>)
-					TransactionalSetTest.this.tested.clone();
-
-			assertSetContains(clone, "a", "b");
-			assertNotSame(TransactionalSetTest.this.tested, clone);
-		}
-
-		@Test
-		@DisplayName("clone inside a transaction carries changes")
-		void shouldCloneInsideTransaction() {
-			assertStateAfterCommit(
-				TransactionalSetTest.this.tested,
-				original -> {
-					original.add("c");
-
-					try {
-						@SuppressWarnings("unchecked") final TransactionalSet<String> clone =
-							(TransactionalSet<String>) original.clone();
-						assertSetContains(clone, "a", "b", "c");
-					} catch (CloneNotSupportedException ex) {
-						fail("Clone should be supported: "
-							     + ex.getMessage());
-					}
-				},
-				(original, committedVersion) -> {
-					assertSetContains(committedVersion, "a", "b", "c");
-				}
-			);
 		}
 
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/AssertionUtils.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/AssertionUtils.java
@@ -32,7 +32,7 @@ import io.evitadb.core.transaction.Transaction;
 import io.evitadb.core.transaction.TransactionHandler;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer;
 import io.evitadb.core.transaction.memory.TransactionalLayerMaintainer.Savepoint;
-import io.evitadb.core.transaction.memory.TransactionalLayerProducer;
+import io.evitadb.core.transaction.memory.TransactionalStateProducer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -109,12 +109,12 @@ public class AssertionUtils {
 	 * This method executes operation in lambda `doInTransaction` on `tested` instance and verifies the results visible
 	 * after transactional memory is committed in `verifyAfterCommit` lambda.
 	 */
-	public static <S, X, T extends TransactionalLayerProducer<X, S>> void assertStateAfterCommit(
+	public static <S, T extends TransactionalStateProducer<S>> void assertStateAfterCommit(
 		@Nonnull T tested,
 		@Nonnull Consumer<T> doInTransaction,
 		@Nonnull BiConsumer<T, S> verifyAfterCommit
 	) {
-		final TestTransactionHandler<S, X, T> transactionHandler = new TestTransactionHandler<>(tested);
+		final TestTransactionHandler<S, T> transactionHandler = new TestTransactionHandler<>(tested);
 		Transaction.executeInTransactionIfProvided(
 			new Transaction(
 				UUID.randomUUID(),
@@ -141,12 +141,12 @@ public class AssertionUtils {
 	 * This method executes operation in lambda `doInTransaction` on `tested` instance and verifies the results visible
 	 * after transactional memory is committed in `verifyAfterCommit` lambda.
 	 */
-	public static <S, X, T extends TransactionalLayerProducer<X, S>> void assertStateAfterCommit(
+	public static <S, T extends TransactionalStateProducer<S>> void assertStateAfterCommit(
 		@Nonnull List<T> tested,
 		@Nonnull Consumer<List<T>> doInTransaction,
 		@Nonnull BiConsumer<List<T>, List<S>> verifyAfterCommit
 	) {
-		final TestTransactionHandlerWithMultipleValues<S, X, T> transactionHandler = new TestTransactionHandlerWithMultipleValues<>(tested);
+		final TestTransactionHandlerWithMultipleValues<S, T> transactionHandler = new TestTransactionHandlerWithMultipleValues<>(tested);
 		Transaction.executeInTransactionIfProvided(
 			new Transaction(
 				UUID.randomUUID(),
@@ -173,12 +173,12 @@ public class AssertionUtils {
 	 * This method executes operation in lambda `doInTransaction` on `tested` instance and verifies the results visible
 	 * after transactional memory is rollbacked in `verifyAfterRollback` lambda.
 	 */
-	public static <S, X, T extends TransactionalLayerProducer<X, S>> void assertStateAfterRollback(
+	public static <S, T extends TransactionalStateProducer<S>> void assertStateAfterRollback(
 		@Nonnull T tested,
 		@Nonnull Consumer<T> doInTransaction,
 		@Nonnull BiConsumer<T, S> verifyAfterRollback
 	) {
-		final TestTransactionHandler<S, X, T> transactionHandler = new TestTransactionHandler<>(tested);
+		final TestTransactionHandler<S, T> transactionHandler = new TestTransactionHandler<>(tested);
 		Transaction.executeInTransactionIfProvided(
 			new Transaction(
 				UUID.randomUUID(),
@@ -202,12 +202,12 @@ public class AssertionUtils {
 	 * This method executes operation in lambda `doInTransaction` on `tested` instance and verifies the results visible
 	 * after transactional memory is rollbacked in `verifyAfterRollback` lambda.
 	 */
-	public static <S, X, T extends TransactionalLayerProducer<X, S>> void assertStateAfterRollback(
+	public static <S, T extends TransactionalStateProducer<S>> void assertStateAfterRollback(
 		@Nonnull List<T> tested,
 		@Nonnull Consumer<List<T>> doInTransaction,
 		@Nonnull BiConsumer<List<T>, List<S>> verifyAfterRollback
 	) {
-		final TestTransactionHandlerWithMultipleValues<S, X, T> transactionHandler = new TestTransactionHandlerWithMultipleValues<>(tested);
+		final TestTransactionHandlerWithMultipleValues<S, T> transactionHandler = new TestTransactionHandlerWithMultipleValues<>(tested);
 		Transaction.executeInTransactionIfProvided(
 			new Transaction(
 				UUID.randomUUID(),
@@ -248,13 +248,13 @@ public class AssertionUtils {
 	 * @param oracleReader reads the structure's logical content into an `.equals`-comparable reference value
 	 * @param savepointOps mutations applied while the savepoint is open (must be reverted)
 	 */
-	public static <S, X, T extends TransactionalLayerProducer<X, S>, R> void assertSavepointRollbackRestores(
+	public static <S, T extends TransactionalStateProducer<S>, R> void assertSavepointRollbackRestores(
 		@Nonnull T tested,
 		@Nonnull Consumer<T> baselineOps,
 		@Nonnull Function<T, R> oracleReader,
 		@Nonnull Consumer<T> savepointOps
 	) {
-		final TestTransactionHandler<S, X, T> transactionHandler = new TestTransactionHandler<>(tested);
+		final TestTransactionHandler<S, T> transactionHandler = new TestTransactionHandler<>(tested);
 		Transaction.executeInTransactionIfProvided(
 			new Transaction(UUID.randomUUID(), transactionHandler, false),
 			() -> {
@@ -291,13 +291,13 @@ public class AssertionUtils {
 	 * @param oracleReader reads the structure's logical content into an `.equals`-comparable reference value
 	 * @param savepointOps mutations applied while the savepoint is open (must be kept)
 	 */
-	public static <S, X, T extends TransactionalLayerProducer<X, S>, R> void assertSavepointCommitKeeps(
+	public static <S, T extends TransactionalStateProducer<S>, R> void assertSavepointCommitKeeps(
 		@Nonnull T tested,
 		@Nonnull Consumer<T> baselineOps,
 		@Nonnull Function<T, R> oracleReader,
 		@Nonnull Consumer<T> savepointOps
 	) {
-		final TestTransactionHandler<S, X, T> transactionHandler = new TestTransactionHandler<>(tested);
+		final TestTransactionHandler<S, T> transactionHandler = new TestTransactionHandler<>(tested);
 		Transaction.executeInTransactionIfProvided(
 			new Transaction(UUID.randomUUID(), transactionHandler, false),
 			() -> {
@@ -407,10 +407,9 @@ public class AssertionUtils {
 	 * It simply creates instance of the tested item in case of commit and provides access to it in `committed` field.
 	 *
 	 * @param <S> the type of the state
-	 * @param <X> the type of the transactional layer producer
-	 * @param <T> a subtype of {@link TransactionalLayerProducer}
+	 * @param <T> a subtype of {@link TransactionalStateProducer}
 	 */
-	private static class TestTransactionHandler<S, X, T extends TransactionalLayerProducer<X, S>> implements TransactionHandler {
+	private static class TestTransactionHandler<S, T extends TransactionalStateProducer<S>> implements TransactionHandler {
 		private final T tested;
 		private S committed;
 
@@ -445,10 +444,9 @@ public class AssertionUtils {
 	 * New versions of those items are provided in `committed` field.
 	 *
 	 * @param <S> the type of state
-	 * @param <X> the type of difference piece
-	 * @param <T> a transactional layer producer that extends TransactionalLayerProducer<X, S>
+	 * @param <T> a transactional state producer that extends TransactionalStateProducer<S>
 	 */
-	private static class TestTransactionHandlerWithMultipleValues<S, X, T extends TransactionalLayerProducer<X, S>> implements TransactionHandler {
+	private static class TestTransactionHandlerWithMultipleValues<S, T extends TransactionalStateProducer<S>> implements TransactionHandler {
 		private final List<T> tested;
 		private List<S> committed;
 

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/core/transaction/memory/LongRunningSavepointContainerChangesTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/core/transaction/memory/LongRunningSavepointContainerChangesTest.java
@@ -222,9 +222,9 @@ class LongRunningSavepointContainerChangesTest implements TimeBoundedTestSupport
 	 */
 	private static void applyRandomOps(@Nonnull LayerHolder<?> holder, @Nonnull Random random, int count, @Nonnull List<RecordingProducer> pool) {
 		final Object layer = Transaction.getOrCreateTransactionalMemoryLayer(holder);
-		final List<TransactionalContainerChanges<?, ?, ?>> containers = containersOf(layer);
+		final List<TransactionalContainerChanges<?, ?>> containers = containersOf(layer);
 		for (int i = 0; i < count; i++) {
-			final TransactionalContainerChanges<?, ?, ?> container = containers.get(random.nextInt(containers.size()));
+			final TransactionalContainerChanges<?, ?> container = containers.get(random.nextInt(containers.size()));
 			final boolean created = random.nextBoolean();
 			final RecordingProducer item = (!pool.isEmpty() && random.nextInt(100) < REUSE_PERCENT)
 				? pool.get(random.nextInt(pool.size()))
@@ -254,7 +254,7 @@ class LongRunningSavepointContainerChangesTest implements TimeBoundedTestSupport
 		}
 		final Map<String, List<Long>> result = new LinkedHashMap<>();
 		final List<String> names = containerNamesOf(layer);
-		final List<TransactionalContainerChanges<?, ?, ?>> containers = containersOf(layer);
+		final List<TransactionalContainerChanges<?, ?>> containers = containersOf(layer);
 		for (int i = 0; i < containers.size(); i++) {
 			result.put(names.get(i) + "#created", idsOf(containers.get(i), "createdItems"));
 			result.put(names.get(i) + "#removed", idsOf(containers.get(i), "removedItems"));
@@ -267,16 +267,16 @@ class LongRunningSavepointContainerChangesTest implements TimeBoundedTestSupport
 	 * is one, or every declared field of that type on an aggregate.
 	 */
 	@Nonnull
-	private static List<TransactionalContainerChanges<?, ?, ?>> containersOf(@Nonnull Object layer) {
-		if (layer instanceof final TransactionalContainerChanges<?, ?, ?> self) {
+	private static List<TransactionalContainerChanges<?, ?>> containersOf(@Nonnull Object layer) {
+		if (layer instanceof final TransactionalContainerChanges<?, ?> self) {
 			return List.of(self);
 		}
-		final List<TransactionalContainerChanges<?, ?, ?>> result = new ArrayList<>();
+		final List<TransactionalContainerChanges<?, ?>> result = new ArrayList<>();
 		for (final Field field : layer.getClass().getDeclaredFields()) {
 			if (field.getType() == TransactionalContainerChanges.class) {
 				field.setAccessible(true);
 				try {
-					result.add((TransactionalContainerChanges<?, ?, ?>) field.get(layer));
+					result.add((TransactionalContainerChanges<?, ?>) field.get(layer));
 				} catch (IllegalAccessException e) {
 					throw new IllegalStateException(e);
 				}
@@ -293,7 +293,7 @@ class LongRunningSavepointContainerChangesTest implements TimeBoundedTestSupport
 	 */
 	@Nonnull
 	private static List<String> containerNamesOf(@Nonnull Object layer) {
-		if (layer instanceof TransactionalContainerChanges<?, ?, ?>) {
+		if (layer instanceof TransactionalContainerChanges<?, ?>) {
 			return List.of("self");
 		}
 		final List<String> names = new ArrayList<>();
@@ -309,7 +309,7 @@ class LongRunningSavepointContainerChangesTest implements TimeBoundedTestSupport
 	 * Reads the producer ids tracked in the named list field of a container (empty when the lazy list is still null).
 	 */
 	@Nonnull
-	private static List<Long> idsOf(@Nonnull TransactionalContainerChanges<?, ?, ?> container, @Nonnull String listField) {
+	private static List<Long> idsOf(@Nonnull TransactionalContainerChanges<?, ?> container, @Nonnull String listField) {
 		try {
 			final Field field = TransactionalContainerChanges.class.getDeclaredField(listField);
 			field.setAccessible(true);
@@ -331,7 +331,7 @@ class LongRunningSavepointContainerChangesTest implements TimeBoundedTestSupport
 	 * Invokes the container's real {@code addCreatedItem} / {@code addRemovedItem} (reflectively, to bypass the
 	 * per-container generic producer type — erased to {@link TransactionalLayerProducer}).
 	 */
-	private static void register(@Nonnull TransactionalContainerChanges<?, ?, ?> container, boolean created, @Nonnull RecordingProducer item) {
+	private static void register(@Nonnull TransactionalContainerChanges<?, ?> container, boolean created, @Nonnull RecordingProducer item) {
 		try {
 			final Method method = TransactionalContainerChanges.class.getMethod(
 				created ? "addCreatedItem" : "addRemovedItem", TransactionalLayerProducer.class

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/core/transaction/memory/LongRunningSavepointLeafDeltaTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/core/transaction/memory/LongRunningSavepointLeafDeltaTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -644,13 +643,13 @@ class LongRunningSavepointLeafDeltaTest implements TimeBoundedTestSupport {
 	 * @param object the integer value
 	 */
 	private record TxInteger(@Nonnull Integer object)
-		implements TransactionalObject<TxInteger, Void>,
+		implements TransactionalObject<TxInteger>,
 		VoidTransactionMemoryProducer<TxInteger>,
 		Comparable<TxInteger> {
 
 		@Nonnull
 		@Override
-		public TxInteger createCopyWithMergedTransactionalMemory(@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
+		public TxInteger createCopyWithMergedTransactionalMemory(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 			return this;
 		}
 

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/LongRunningCatalogIndexTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/LongRunningCatalogIndexTest.java
@@ -86,6 +86,29 @@ class LongRunningCatalogIndexTest implements TimeBoundedTestSupport {
 	static final String[] ATTR_NAMES = {"code", "url", "sku", "ean"};
 
 	/**
+	 * Mock catalog backing {@link #CLASSIFIER_RESOLVER}; resolves {@link #ENTITY_TYPE} to {@link #ENTITY_TYPE_PK}.
+	 */
+	private static final Catalog CLASSIFIER_CATALOG = createMockCatalog(ENTITY_TYPE, ENTITY_TYPE_PK);
+
+	/**
+	 * Translates between entity type name and primary key by delegating to {@link #CLASSIFIER_CATALOG}. Threaded into
+	 * every global-unique operation that now requires it; shared statically so the {@link #snapshot} oracle (used as a
+	 * method reference by the sibling savepoint test) can reach it.
+	 */
+	private static final EntityTypeClassifierResolver CLASSIFIER_RESOLVER = new EntityTypeClassifierResolver() {
+		@Override
+		public int toEntityTypePrimaryKey(@Nonnull String entityType) {
+			return CLASSIFIER_CATALOG.getCollectionForEntityOrThrowException(entityType).getEntityTypePrimaryKey();
+		}
+
+		@Nonnull
+		@Override
+		public String toEntityTypeName(int entityTypePrimaryKey) {
+			return CLASSIFIER_CATALOG.getCollectionForEntityPrimaryKeyOrThrowException(entityTypePrimaryKey).getEntityType();
+		}
+	};
+
+	/**
 	 * Creates a mock {@link Catalog} that resolves the given entity type name to
 	 * the given entity type primary key.
 	 *
@@ -151,9 +174,7 @@ class LongRunningCatalogIndexTest implements TimeBoundedTestSupport {
 	 */
 	@Nonnull
 	private static CatalogIndex createLiveCatalogIndex() {
-		final CatalogIndex index = new CatalogIndex(Scope.LIVE);
-		index.attachToCatalog(null, createMockCatalog(ENTITY_TYPE, ENTITY_TYPE_PK));
-		return index;
+		return new CatalogIndex(Scope.LIVE);
 	}
 
 	/**
@@ -270,12 +291,8 @@ class LongRunningCatalogIndexTest implements TimeBoundedTestSupport {
 			}
 		);
 
-		// carry committed CatalogIndex forward; re-attach catalog
+		// carry committed CatalogIndex forward
 		final CatalogIndex committed = committedHolder[0];
-		committed.attachToCatalog(
-			null,
-			createMockCatalog(ENTITY_TYPE, ENTITY_TYPE_PK)
-		);
 
 		return new TestState(committed, reference, nextId[0]);
 	}
@@ -315,7 +332,7 @@ class LongRunningCatalogIndexTest implements TimeBoundedTestSupport {
 			index.insertUniqueAttribute(
 				entitySchema, attrSchema,
 				Collections.emptySet(), null,
-				value, recordId
+				value, recordId, CLASSIFIER_RESOLVER
 			);
 
 			// update reference
@@ -329,7 +346,7 @@ class LongRunningCatalogIndexTest implements TimeBoundedTestSupport {
 			index.removeUniqueAttribute(
 				entitySchema, attrSchema,
 				Collections.emptySet(), null,
-				keyToRemove, recordId
+				keyToRemove, recordId, CLASSIFIER_RESOLVER
 			);
 
 			// update reference
@@ -403,7 +420,7 @@ class LongRunningCatalogIndexTest implements TimeBoundedTestSupport {
 				index.insertUniqueAttribute(
 					entitySchema, attributeSchema,
 					Collections.emptySet(), null,
-					valueEntry.getKey(), valueEntry.getValue()
+					valueEntry.getKey(), valueEntry.getValue(), CLASSIFIER_RESOLVER
 				);
 			}
 		}
@@ -425,7 +442,7 @@ class LongRunningCatalogIndexTest implements TimeBoundedTestSupport {
 				createNonLocalizedAttributeSchema(attributeName, String.class);
 			final GlobalUniqueIndex globalUniqueIndex = index.getGlobalUniqueIndex(attributeSchema, null);
 			if (globalUniqueIndex != null) {
-				recordIdsByAttribute.put(attributeName, toList(globalUniqueIndex.getRecordIds(ENTITY_TYPE)));
+				recordIdsByAttribute.put(attributeName, toList(globalUniqueIndex.getRecordIds(ENTITY_TYPE, CLASSIFIER_RESOLVER)));
 				sizeByAttribute.put(attributeName, globalUniqueIndex.size());
 			}
 		}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/LongRunningSavepointCatalogIndexTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/LongRunningSavepointCatalogIndexTest.java
@@ -181,6 +181,7 @@ class LongRunningSavepointCatalogIndexTest implements TimeBoundedTestSupport {
 	 */
 	private static final class CatalogState {
 		private final CatalogIndex index;
+		private final EntityTypeClassifierResolver classifierResolver;
 		private final EntitySchemaContract entitySchema = createEntitySchema();
 		private final Map<String, Map<Object, Integer>> reference = new HashMap<>();
 		private int nextRecordId = 1;
@@ -189,7 +190,19 @@ class LongRunningSavepointCatalogIndexTest implements TimeBoundedTestSupport {
 
 		CatalogState(@Nonnull Random random) {
 			this.index = new CatalogIndex(Scope.LIVE);
-			this.index.attachToCatalog(null, createMockCatalog());
+			final Catalog catalog = createMockCatalog();
+			this.classifierResolver = new EntityTypeClassifierResolver() {
+				@Override
+				public int toEntityTypePrimaryKey(@Nonnull String entityType) {
+					return catalog.getCollectionForEntityOrThrowException(entityType).getEntityTypePrimaryKey();
+				}
+
+				@Nonnull
+				@Override
+				public String toEntityTypeName(int entityTypePrimaryKey) {
+					return catalog.getCollectionForEntityPrimaryKeyOrThrowException(entityTypePrimaryKey).getEntityType();
+				}
+			};
 			final int seedOperations = 20 + random.nextInt(20);
 			for (int i = 0; i < seedOperations; i++) {
 				insertRandomAttribute(random);
@@ -219,7 +232,7 @@ class LongRunningSavepointCatalogIndexTest implements TimeBoundedTestSupport {
 			final String value = attributeName + "-forced-" + recordId;
 			this.index.insertUniqueAttribute(
 				this.entitySchema, createNonLocalizedAttributeSchema(attributeName),
-				Collections.emptySet(), null, value, recordId
+				Collections.emptySet(), null, value, recordId, this.classifierResolver
 			);
 			this.reference.computeIfAbsent(attributeName, k -> new HashMap<>()).put(value, recordId);
 		}
@@ -233,7 +246,7 @@ class LongRunningSavepointCatalogIndexTest implements TimeBoundedTestSupport {
 			final String value = attributeName + "-" + recordId;
 			this.index.insertUniqueAttribute(
 				this.entitySchema, createNonLocalizedAttributeSchema(attributeName),
-				Collections.emptySet(), null, value, recordId
+				Collections.emptySet(), null, value, recordId, this.classifierResolver
 			);
 			this.reference.computeIfAbsent(attributeName, k -> new HashMap<>()).put(value, recordId);
 		}
@@ -251,7 +264,7 @@ class LongRunningSavepointCatalogIndexTest implements TimeBoundedTestSupport {
 			final int recordId = values.get(value);
 			this.index.removeUniqueAttribute(
 				this.entitySchema, createNonLocalizedAttributeSchema(attributeName),
-				Collections.emptySet(), null, value, recordId
+				Collections.emptySet(), null, value, recordId, this.classifierResolver
 			);
 			values.remove(value);
 			if (values.isEmpty()) {

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/array/LongRunningTransactionalComplexObjArrayTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/array/LongRunningTransactionalComplexObjArrayTest.java
@@ -294,7 +294,7 @@ class LongRunningTransactionalComplexObjArrayTest implements TimeBoundedTestSupp
 	 */
 	@Data
 	private static class DistinctValueHolder
-		implements TransactionalObject<DistinctValueHolder, Void>,
+		implements TransactionalObject<DistinctValueHolder>,
 		VoidTransactionMemoryProducer<DistinctValueHolder>,
 		Comparable<DistinctValueHolder> {
 
@@ -309,7 +309,6 @@ class LongRunningTransactionalComplexObjArrayTest implements TimeBoundedTestSupp
 		@Nonnull
 		@Override
 		public DistinctValueHolder createCopyWithMergedTransactionalMemory(
-			Void layer,
 			@Nonnull TransactionalLayerMaintainer transactionalLayer
 		) {
 			return this;

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/attribute/LongRunningGlobalUniqueIndexTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/attribute/LongRunningGlobalUniqueIndexTest.java
@@ -28,12 +28,12 @@ import io.evitadb.api.requestResponse.data.structure.EntityReference;
 import io.evitadb.core.catalog.Catalog;
 import io.evitadb.core.collection.EntityCollection;
 import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityTypeClassifierResolver;
 import io.evitadb.index.bitmap.Bitmap;
 import io.evitadb.test.Entities;
 import io.evitadb.test.duration.TimeArgumentProvider;
 import io.evitadb.test.duration.TimeArgumentProvider.GenerationalTestInput;
 import io.evitadb.test.duration.TimeBoundedTestSupport;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -76,15 +76,42 @@ import static org.junit.jupiter.api.Assertions.fail;
 @Tag(INDEXING)
 @Tag(ATTRIBUTE)
 class LongRunningGlobalUniqueIndexTest implements TimeBoundedTestSupport {
-	private final Catalog catalog = Mockito.mock(Catalog.class);
+	/**
+	 * Mock catalog backing {@link #CLASSIFIER_RESOLVER}; resolves {@link Entities#PRODUCT} to its primary key `1`.
+	 */
+	private static final Catalog CLASSIFIER_CATALOG = createClassifierCatalog();
 
-	@BeforeEach
-	void setUp() {
+	/**
+	 * Translates between entity type name and primary key by delegating to {@link #CLASSIFIER_CATALOG}. Threaded into
+	 * every global-unique operation that now requires it; shared statically so the {@link #snapshot} oracle (used as a
+	 * method reference by the sibling savepoint test) can reach it.
+	 */
+	private static final EntityTypeClassifierResolver CLASSIFIER_RESOLVER = new EntityTypeClassifierResolver() {
+		@Override
+		public int toEntityTypePrimaryKey(@Nonnull String entityType) {
+			return CLASSIFIER_CATALOG.getCollectionForEntityOrThrowException(entityType).getEntityTypePrimaryKey();
+		}
+
+		@Nonnull
+		@Override
+		public String toEntityTypeName(int entityTypePrimaryKey) {
+			return CLASSIFIER_CATALOG.getCollectionForEntityPrimaryKeyOrThrowException(entityTypePrimaryKey).getEntityType();
+		}
+	};
+
+	/**
+	 * Builds the mock catalog that {@link #CLASSIFIER_RESOLVER} delegates to, mapping {@link Entities#PRODUCT} to
+	 * primary key `1` in both directions.
+	 */
+	@Nonnull
+	private static Catalog createClassifierCatalog() {
 		final EntityCollection productCollection = Mockito.mock(EntityCollection.class);
 		Mockito.when(productCollection.getEntityTypePrimaryKey()).thenReturn(1);
 		Mockito.when(productCollection.getEntityType()).thenReturn(Entities.PRODUCT);
-		Mockito.when(this.catalog.getCollectionForEntityPrimaryKeyOrThrowException(1)).thenReturn(productCollection);
-		Mockito.when(this.catalog.getCollectionForEntityOrThrowException(Entities.PRODUCT)).thenReturn(productCollection);
+		final Catalog catalog = Mockito.mock(Catalog.class);
+		Mockito.when(catalog.getCollectionForEntityPrimaryKeyOrThrowException(1)).thenReturn(productCollection);
+		Mockito.when(catalog.getCollectionForEntityOrThrowException(Entities.PRODUCT)).thenReturn(productCollection);
+		return catalog;
 	}
 
 	@ParameterizedTest(name = "GlobalUniqueIndex should survive generational randomized test applying modifications on it")
@@ -95,7 +122,6 @@ class LongRunningGlobalUniqueIndexTest implements TimeBoundedTestSupport {
 		final Map<String, Integer> mapToCompare = new HashMap<>();
 		final Set<Integer> currentRecordSet = new HashSet<>();
 		final GlobalUniqueIndex initialUniqueIndex = new GlobalUniqueIndex(Scope.LIVE, new AttributeKey("code"), String.class);
-		initialUniqueIndex.attachToCatalog(null, this.catalog);
 
 		runFor(
 			input,
@@ -127,12 +153,11 @@ class LongRunningGlobalUniqueIndexTest implements TimeBoundedTestSupport {
 							.sorted()
 							.toArray(EntityReference[]::new);
 
-						committed.attachToCatalog(null, this.catalog);
 						assertArrayEquals(
 							expected,
-							committed.getEntityReferences(),
+							committed.getEntityReferences(CLASSIFIER_RESOLVER),
 							"\nExpected: " + Arrays.toString(expected) + "\n" +
-								"Actual:  " + Arrays.toString(committed.getEntityReferences()) + "\n\n" +
+								"Actual:  " + Arrays.toString(committed.getEntityReferences(CLASSIFIER_RESOLVER)) + "\n\n" +
 								codeBuffer
 						);
 
@@ -145,7 +170,6 @@ class LongRunningGlobalUniqueIndexTest implements TimeBoundedTestSupport {
 							snapshot.payloads(),
 							new HashMap<>(committed.getLocaleIndex())
 						);
-						newGlobalUniqueIndex.attachToCatalog(null, this.catalog);
 						committedResult.set(newGlobalUniqueIndex);
 					}
 				);
@@ -232,7 +256,7 @@ class LongRunningGlobalUniqueIndexTest implements TimeBoundedTestSupport {
 					currentRecordSet.add(newRecId);
 
 					codeBuffer.append("uniqueIndex.registerUniqueKey(\"").append(newValue).append("\", product, ").append(newRecId).append(");\n");
-					uniqueIndex.registerUniqueKey(newValue, Entities.PRODUCT, null, newRecId);
+					uniqueIndex.registerUniqueKey(newValue, Entities.PRODUCT, null, newRecId, CLASSIFIER_RESOLVER);
 				} else {
 					// remove existing item
 					final Iterator<Entry<String, Integer>> it = mapToCompare.entrySet().iterator();
@@ -244,7 +268,7 @@ class LongRunningGlobalUniqueIndexTest implements TimeBoundedTestSupport {
 					currentRecordSet.remove(valueToRemove.getValue());
 
 					codeBuffer.append("uniqueIndex.unregisterUniqueKey(\"").append(valueToRemove.getKey()).append("\", product,").append(valueToRemove.getValue()).append(");\n");
-					uniqueIndex.unregisterUniqueKey(valueToRemove.getKey(), Entities.PRODUCT, null, valueToRemove.getValue());
+					uniqueIndex.unregisterUniqueKey(valueToRemove.getKey(), Entities.PRODUCT, null, valueToRemove.getValue(), CLASSIFIER_RESOLVER);
 				}
 			}
 		} catch (Exception ex) {
@@ -264,10 +288,9 @@ class LongRunningGlobalUniqueIndexTest implements TimeBoundedTestSupport {
 		@Nonnull StringBuilder codeBuffer
 	) {
 		final GlobalUniqueIndex uniqueIndex = new GlobalUniqueIndex(Scope.LIVE, new AttributeKey("code"), String.class);
-		uniqueIndex.attachToCatalog(null, this.catalog);
 		for (final Entry<String, Integer> entry : mapToCompare.entrySet()) {
 			codeBuffer.append("uniqueIndex.registerUniqueKey(\"").append(entry.getKey()).append("\", ").append(entry.getValue()).append(");\n");
-			uniqueIndex.registerUniqueKey(entry.getKey(), Entities.PRODUCT, null, entry.getValue());
+			uniqueIndex.registerUniqueKey(entry.getKey(), Entities.PRODUCT, null, entry.getValue(), CLASSIFIER_RESOLVER);
 		}
 		return uniqueIndex;
 	}
@@ -277,8 +300,7 @@ class LongRunningGlobalUniqueIndexTest implements TimeBoundedTestSupport {
 	 * tuple mapping (read off the transaction-aware inline snapshot) plus the per-entity-type record-id bitmap for
 	 * {@link Entities#PRODUCT} (a separate transactional structure). Packed payloads are stable within a transaction —
 	 * the entity-type id and locale id assignments do not change — so two snapshots taken before and after a rollback
-	 * can be compared with `.equals` to prove exact restoration. Requires the index to be attached to a catalog; the
-	 * same helper doubles as the savepoint oracle reader.
+	 * can be compared with `.equals` to prove exact restoration. The same helper doubles as the savepoint oracle reader.
 	 */
 	@Nonnull
 	static GlobalUniqueSnapshot snapshot(@Nonnull GlobalUniqueIndex index) {
@@ -289,7 +311,7 @@ class LongRunningGlobalUniqueIndexTest implements TimeBoundedTestSupport {
 		for (int i = 0; i < values.length; i++) {
 			valueToPayload.put(String.valueOf(values[i]), payloads[i]);
 		}
-		return new GlobalUniqueSnapshot(valueToPayload, toList(index.getRecordIds(Entities.PRODUCT)));
+		return new GlobalUniqueSnapshot(valueToPayload, toList(index.getRecordIds(Entities.PRODUCT, CLASSIFIER_RESOLVER)));
 	}
 
 	/**

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/attribute/LongRunningSavepointGlobalUniqueIndexTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/attribute/LongRunningSavepointGlobalUniqueIndexTest.java
@@ -27,6 +27,7 @@ import io.evitadb.api.requestResponse.data.AttributesContract.AttributeKey;
 import io.evitadb.core.catalog.Catalog;
 import io.evitadb.core.collection.EntityCollection;
 import io.evitadb.dataType.Scope;
+import io.evitadb.index.EntityTypeClassifierResolver;
 import io.evitadb.test.Entities;
 import io.evitadb.test.duration.TimeArgumentProvider;
 import io.evitadb.test.duration.TimeArgumentProvider.GenerationalTestInput;
@@ -137,6 +138,7 @@ class LongRunningSavepointGlobalUniqueIndexTest implements TimeBoundedTestSuppor
 	 */
 	private static final class GlobalUniqueState {
 		private final GlobalUniqueIndex index;
+		private final EntityTypeClassifierResolver classifierResolver;
 		// value → owning record id
 		private final Map<String, Integer> valueToRecord = new HashMap<>();
 		// monotonic sequence for random unique values / record ids
@@ -146,7 +148,18 @@ class LongRunningSavepointGlobalUniqueIndexTest implements TimeBoundedTestSuppor
 
 		GlobalUniqueState(@Nonnull Random random, @Nonnull Catalog catalog) {
 			this.index = new GlobalUniqueIndex(Scope.LIVE, new AttributeKey("code"), String.class);
-			this.index.attachToCatalog(null, catalog);
+			this.classifierResolver = new EntityTypeClassifierResolver() {
+				@Override
+				public int toEntityTypePrimaryKey(@Nonnull String entityType) {
+					return catalog.getCollectionForEntityOrThrowException(entityType).getEntityTypePrimaryKey();
+				}
+
+				@Nonnull
+				@Override
+				public String toEntityTypeName(int entityTypePrimaryKey) {
+					return catalog.getCollectionForEntityPrimaryKeyOrThrowException(entityTypePrimaryKey).getEntityType();
+				}
+			};
 			final int seedOperations = 20 + random.nextInt(20);
 			for (int i = 0; i < seedOperations; i++) {
 				addRandomUniqueKey();
@@ -173,7 +186,7 @@ class LongRunningSavepointGlobalUniqueIndexTest implements TimeBoundedTestSuppor
 		void forceMutation() {
 			final int id = ++this.forcedSeq;
 			final String value = "F_" + id;
-			this.index.registerUniqueKey(value, Entities.PRODUCT, null, id);
+			this.index.registerUniqueKey(value, Entities.PRODUCT, null, id, this.classifierResolver);
 			this.valueToRecord.put(value, id);
 		}
 
@@ -183,7 +196,7 @@ class LongRunningSavepointGlobalUniqueIndexTest implements TimeBoundedTestSuppor
 		private void addRandomUniqueKey() {
 			final int id = ++this.seq;
 			final String value = "V_" + id;
-			this.index.registerUniqueKey(value, Entities.PRODUCT, null, id);
+			this.index.registerUniqueKey(value, Entities.PRODUCT, null, id, this.classifierResolver);
 			this.valueToRecord.put(value, id);
 		}
 
@@ -197,7 +210,7 @@ class LongRunningSavepointGlobalUniqueIndexTest implements TimeBoundedTestSuppor
 			final List<String> values = new ArrayList<>(this.valueToRecord.keySet());
 			final String value = values.get(random.nextInt(values.size()));
 			final int id = this.valueToRecord.remove(value);
-			this.index.unregisterUniqueKey(value, Entities.PRODUCT, null, id);
+			this.index.unregisterUniqueKey(value, Entities.PRODUCT, null, id, this.classifierResolver);
 		}
 	}
 

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/map/LongRunningSavepointProducerMapTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/map/LongRunningSavepointProducerMapTest.java
@@ -271,7 +271,7 @@ class LongRunningSavepointProducerMapTest implements TimeBoundedTestSupport {
 
 		@Nonnull
 		@Override
-		public MapValue createCopyWithMergedTransactionalMemory(@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
+		public MapValue createCopyWithMergedTransactionalMemory(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 			return this;
 		}
 

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/price/LongRunningPriceListAndCurrencyPriceRefIndexTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/price/LongRunningPriceListAndCurrencyPriceRefIndexTest.java
@@ -24,12 +24,8 @@
 package io.evitadb.index.price;
 
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
-import io.evitadb.core.catalog.Catalog;
 import io.evitadb.dataType.DateTimeRange;
 import io.evitadb.dataType.Scope;
-import io.evitadb.index.EntityIndexKey;
-import io.evitadb.index.EntityIndexType;
-import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.index.price.model.PriceIndexKey;
 import io.evitadb.index.price.model.priceRecord.PriceRecord;
 import io.evitadb.index.price.model.priceRecord.PriceRecordContract;
@@ -42,8 +38,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
 import java.time.OffsetDateTime;
@@ -52,7 +46,6 @@ import java.util.Arrays;
 import java.util.Currency;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -103,32 +96,20 @@ class LongRunningPriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTes
 	}
 
 	/**
-	 * Attaches the given ref index to a mocked catalog that returns the provided super index
-	 * through the standard `Catalog -> GlobalEntityIndex -> PriceSuperIndex` chain.
+	 * Wires the given ref index directly to the provided super index, mirroring how the owning
+	 * entity collection wires its reduced indexes' price ref chains to the super price indexes of
+	 * its own GLOBAL entity index after re-attachment.
 	 */
-	private static void attachRefIndexToCatalog(
+	private static void wireRefIndexToSuperIndex(
 		@Nonnull PriceListAndCurrencyPriceRefIndex refIndex,
 		@Nonnull PriceListAndCurrencyPriceSuperIndex superIndex
 	) {
-		final PriceSuperIndex priceSuperIndex = Mockito.mock(PriceSuperIndex.class);
-		Mockito.when(priceSuperIndex.getPriceIndex(PRICE_INDEX_KEY)).thenReturn(superIndex);
-
-		final GlobalEntityIndex globalEntityIndex = Mockito.mock(GlobalEntityIndex.class);
-		Mockito.when(globalEntityIndex.getPriceIndex(PRICE_INDEX_KEY)).thenReturn(superIndex);
-
-		final Catalog catalog = Mockito.mock(Catalog.class);
-		Mockito.when(catalog.getEntityIndexIfExists(
-			ArgumentMatchers.eq(ENTITY_TYPE),
-			ArgumentMatchers.eq(new EntityIndexKey(EntityIndexType.GLOBAL, SCOPE)),
-			ArgumentMatchers.eq(GlobalEntityIndex.class)
-		)).thenReturn(Optional.of(globalEntityIndex));
-
-		refIndex.attachToCatalog(ENTITY_TYPE, catalog);
+		refIndex.wireSuperIndex(superIndex);
 	}
 
 	/**
 	 * Populates the super index with the specified price records (no validity) and returns
-	 * a ref index attached to that super index via catalog mock.
+	 * a ref index wired to that super index.
 	 */
 	@Nonnull
 	private static PriceListAndCurrencyPriceRefIndex createAttachedRefIndex(
@@ -140,13 +121,13 @@ class LongRunningPriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTes
 		}
 		final PriceListAndCurrencyPriceRefIndex newRefIndex =
 			new PriceListAndCurrencyPriceRefIndex(SCOPE, PRICE_INDEX_KEY);
-		attachRefIndexToCatalog(newRefIndex, superIndex);
+		wireRefIndexToSuperIndex(newRefIndex, superIndex);
 		return newRefIndex;
 	}
 
 	/**
-	 * Creates a ref index from deserialized data (price ids constructor), attaches it to the
-	 * catalog mock, and returns it ready for use.
+	 * Creates a ref index from deserialized data (price ids constructor), wires it to the
+	 * super index, and returns it ready for use.
 	 */
 	@Nonnull
 	private static PriceListAndCurrencyPriceRefIndex createAttachedRefIndexFromPriceIds(
@@ -155,7 +136,7 @@ class LongRunningPriceListAndCurrencyPriceRefIndexTest implements TimeBoundedTes
 	) {
 		final PriceListAndCurrencyPriceRefIndex newRefIndex =
 			new PriceListAndCurrencyPriceRefIndex(SCOPE, PRICE_INDEX_KEY, new RangeIndex(), priceIds);
-		attachRefIndexToCatalog(newRefIndex, superIndex);
+		wireRefIndexToSuperIndex(newRefIndex, superIndex);
 		return newRefIndex;
 	}
 

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/price/LongRunningPriceRefIndexTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/price/LongRunningPriceRefIndexTest.java
@@ -25,11 +25,7 @@ package io.evitadb.index.price;
 
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
 import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
-import io.evitadb.core.catalog.Catalog;
 import io.evitadb.dataType.Scope;
-import io.evitadb.index.EntityIndexKey;
-import io.evitadb.index.EntityIndexType;
-import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.index.price.model.PriceIndexKey;
 import io.evitadb.index.price.model.priceRecord.PriceRecordContract;
 import io.evitadb.test.duration.TimeArgumentProvider;
@@ -39,8 +35,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -49,7 +43,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -262,9 +255,9 @@ class LongRunningPriceRefIndexTest implements TimeBoundedTestSupport {
 	}
 
 	/**
-	 * Builds a fresh {@link PriceRefIndex} attached to a mocked catalog that resolves the passed super index through the
-	 * standard `Catalog -> GlobalEntityIndex -> PriceSuperIndex` chain, then populates it from the tracked state. The
-	 * population happens outside any transaction, so the base index carries the seeded prices directly.
+	 * Builds a fresh {@link PriceRefIndex} wired to a super-index resolver backed by the passed super index, then
+	 * populates it from the tracked state. The population happens outside any transaction, so the base index carries
+	 * the seeded prices directly.
 	 */
 	@Nonnull
 	private static PriceRefIndex buildAttachedRefIndex(
@@ -272,16 +265,7 @@ class LongRunningPriceRefIndexTest implements TimeBoundedTestSupport {
 		@Nonnull Map<PriceIndexKey, Set<Integer>> currentState
 	) {
 		final PriceRefIndex priceRefIndex = new PriceRefIndex(SCOPE);
-		final GlobalEntityIndex mockGlobalIndex = Mockito.mock(GlobalEntityIndex.class);
-		Mockito.when(mockGlobalIndex.getPriceIndex(ArgumentMatchers.any(PriceIndexKey.class)))
-			.thenAnswer(inv -> superIndex.getPriceIndex(inv.getArgument(0)));
-		final Catalog mockCatalog = Mockito.mock(Catalog.class);
-		Mockito.when(mockCatalog.getEntityIndexIfExists(
-			ArgumentMatchers.eq(ENTITY_TYPE),
-			ArgumentMatchers.eq(new EntityIndexKey(EntityIndexType.GLOBAL, SCOPE)),
-			ArgumentMatchers.eq(GlobalEntityIndex.class)
-		)).thenReturn(Optional.of(mockGlobalIndex));
-		priceRefIndex.attachToCatalog(ENTITY_TYPE, mockCatalog);
+		priceRefIndex.wireSuperIndexes(superIndex::getPriceIndex);
 
 		// populate the ref index from state
 		for (final Map.Entry<PriceIndexKey, Set<Integer>> entry : currentState.entrySet()) {

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/price/LongRunningSavepointPriceListAndCurrencyPriceRefIndexTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/price/LongRunningSavepointPriceListAndCurrencyPriceRefIndexTest.java
@@ -24,12 +24,8 @@
 package io.evitadb.index.price;
 
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
-import io.evitadb.core.catalog.Catalog;
 import io.evitadb.dataType.DateTimeRange;
 import io.evitadb.dataType.Scope;
-import io.evitadb.index.EntityIndexKey;
-import io.evitadb.index.EntityIndexType;
-import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.index.price.model.PriceIndexKey;
 import io.evitadb.index.price.model.priceRecord.PriceRecord;
 import io.evitadb.test.duration.TimeArgumentProvider;
@@ -39,8 +35,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
 import java.time.OffsetDateTime;
@@ -50,7 +44,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 
@@ -70,8 +63,8 @@ import static io.evitadb.utils.AssertionUtils.assertSavepointRollbackRestores;
  * entity ids and the ascending price records) via
  * {@link LongRunningPriceListAndCurrencyPriceRefIndexTest#snapshot(PriceListAndCurrencyPriceRefIndex)}.
  *
- * Each generation seeds a fresh random non-empty ref index outside any transaction (attached to a mocked catalog that
- * resolves a super index pre-populated with a fixed price pool), then within one real transaction applies a random
+ * Each generation seeds a fresh random non-empty ref index outside any transaction (wired directly to a super index
+ * pre-populated with a fixed price pool), then within one real transaction applies a random
  * baseline batch of price mutations (standing for *prior* entities in the same transaction — these must SURVIVE the
  * savepoint rollback), opens a savepoint, applies a random in-savepoint batch preceded by a guaranteed-visible marker
  * mutation (standing for the *failing* entity — these must be REVERTED on rollback / KEPT on commit), and asserts the
@@ -137,7 +130,7 @@ class LongRunningSavepointPriceListAndCurrencyPriceRefIndexTest implements TimeB
 	}
 
 	/**
-	 * A {@link PriceListAndCurrencyPriceRefIndex} attached to a mocked catalog resolving a
+	 * A {@link PriceListAndCurrencyPriceRefIndex} wired directly to a
 	 * {@link PriceListAndCurrencyPriceSuperIndex} pre-populated with a fixed price pool, paired with an in-test model
 	 * (`tracked`: the internal price ids currently in the ref) so randomized mutations can be generated that keep the
 	 * model and index in lockstep. Every internal price id equals its price id (a fresh slot). The pool (and a reserved
@@ -236,23 +229,14 @@ class LongRunningSavepointPriceListAndCurrencyPriceRefIndexTest implements TimeB
 		}
 
 		/**
-		 * Builds a {@link PriceListAndCurrencyPriceRefIndex} attached to a mocked catalog that resolves the passed super
-		 * index through the standard `Catalog -> GlobalEntityIndex -> PriceListAndCurrencyPriceSuperIndex` chain (no prices
-		 * are added to the ref here).
+		 * Builds a {@link PriceListAndCurrencyPriceRefIndex} wired directly to the passed super index (no prices are added
+		 * to the ref here).
 		 */
 		@Nonnull
 		private static PriceListAndCurrencyPriceRefIndex attach(@Nonnull PriceListAndCurrencyPriceSuperIndex superIndex) {
 			final PriceListAndCurrencyPriceRefIndex refIndex =
 				new PriceListAndCurrencyPriceRefIndex(SCOPE, PRICE_INDEX_KEY);
-			final GlobalEntityIndex globalEntityIndex = Mockito.mock(GlobalEntityIndex.class);
-			Mockito.when(globalEntityIndex.getPriceIndex(PRICE_INDEX_KEY)).thenReturn(superIndex);
-			final Catalog catalog = Mockito.mock(Catalog.class);
-			Mockito.when(catalog.getEntityIndexIfExists(
-				ArgumentMatchers.eq(ENTITY_TYPE),
-				ArgumentMatchers.eq(new EntityIndexKey(EntityIndexType.GLOBAL, SCOPE)),
-				ArgumentMatchers.eq(GlobalEntityIndex.class)
-			)).thenReturn(Optional.of(globalEntityIndex));
-			refIndex.attachToCatalog(ENTITY_TYPE, catalog);
+			refIndex.wireSuperIndex(superIndex);
 			return refIndex;
 		}
 	}

--- a/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/price/LongRunningSavepointPriceRefIndexTest.java
+++ b/evita_test/evita_long_running_tests/src/test/java/io/evitadb/index/price/LongRunningSavepointPriceRefIndexTest.java
@@ -25,11 +25,7 @@ package io.evitadb.index.price;
 
 import io.evitadb.api.requestResponse.data.PriceInnerRecordHandling;
 import io.evitadb.api.requestResponse.data.structure.Price.PriceKey;
-import io.evitadb.core.catalog.Catalog;
 import io.evitadb.dataType.Scope;
-import io.evitadb.index.EntityIndexKey;
-import io.evitadb.index.EntityIndexType;
-import io.evitadb.index.GlobalEntityIndex;
 import io.evitadb.index.price.model.PriceIndexKey;
 import io.evitadb.test.duration.TimeArgumentProvider;
 import io.evitadb.test.duration.TimeArgumentProvider.GenerationalTestInput;
@@ -38,8 +34,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -48,7 +42,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 
@@ -67,8 +60,8 @@ import static io.evitadb.utils.AssertionUtils.assertSavepointRollbackRestores;
  * contents (each price key mapped to its child index contents) via
  * {@link LongRunningPriceRefIndexTest#snapshot(PriceRefIndex)}.
  *
- * Each generation seeds a fresh random non-empty ref index outside any transaction (attached to a mocked catalog that
- * resolves a super index pre-populated with a fixed price pool), then within one real transaction applies a random
+ * Each generation seeds a fresh random non-empty ref index outside any transaction (wired to a super-index resolver
+ * backed by a super index pre-populated with a fixed price pool), then within one real transaction applies a random
  * baseline batch of price mutations (standing for *prior* entities in the same transaction — these must SURVIVE the
  * savepoint rollback), opens a savepoint, applies a random in-savepoint batch preceded by a guaranteed-visible marker
  * mutation (standing for the *failing* entity — these must be REVERTED on rollback / KEPT on commit), and asserts the
@@ -143,8 +136,8 @@ class LongRunningSavepointPriceRefIndexTest implements TimeBoundedTestSupport {
 	}
 
 	/**
-	 * A {@link PriceRefIndex} attached to a mocked catalog resolving a {@link PriceSuperIndex} pre-populated with a fixed
-	 * price pool, paired with an in-test model (`tracked`: price key → internal price ids currently in the ref) so
+	 * A {@link PriceRefIndex} wired to a super-index resolver backed by a {@link PriceSuperIndex} pre-populated with a
+	 * fixed price pool, paired with an in-test model (`tracked`: price key → internal price ids currently in the ref) so
 	 * randomized mutations can be generated that keep the model and index in lockstep. Every internal price id maps to a
 	 * single price key and is used as both the entity primary key and the price id (matching the sibling proof's
 	 * convention), so every add uses a fresh slot. The pool (and a reserved block for forced mutations) is added to the
@@ -286,22 +279,13 @@ class LongRunningSavepointPriceRefIndexTest implements TimeBoundedTestSupport {
 		}
 
 		/**
-		 * Builds a {@link PriceRefIndex} attached to a mocked catalog that resolves the passed super index through the
-		 * standard `Catalog -> GlobalEntityIndex -> PriceSuperIndex` chain (no prices are added to the ref here).
+		 * Builds a {@link PriceRefIndex} wired to a super-index resolver backed by the passed super index (no prices are
+		 * added to the ref here).
 		 */
 		@Nonnull
 		private static PriceRefIndex attach(@Nonnull PriceSuperIndex superIndex) {
 			final PriceRefIndex refIndex = new PriceRefIndex(SCOPE);
-			final GlobalEntityIndex mockGlobalIndex = Mockito.mock(GlobalEntityIndex.class);
-			Mockito.when(mockGlobalIndex.getPriceIndex(ArgumentMatchers.any(PriceIndexKey.class)))
-				.thenAnswer(inv -> superIndex.getPriceIndex(inv.getArgument(0)));
-			final Catalog mockCatalog = Mockito.mock(Catalog.class);
-			Mockito.when(mockCatalog.getEntityIndexIfExists(
-				ArgumentMatchers.eq(ENTITY_TYPE),
-				ArgumentMatchers.eq(new EntityIndexKey(EntityIndexType.GLOBAL, SCOPE)),
-				ArgumentMatchers.eq(GlobalEntityIndex.class)
-			)).thenReturn(Optional.of(mockGlobalIndex));
-			refIndex.attachToCatalog(ENTITY_TYPE, mockCatalog);
+			refIndex.wireSuperIndexes(superIndex::getPriceIndex);
 			return refIndex;
 		}
 	}

--- a/evita_test/evita_performance_tests/pom.xml
+++ b/evita_test/evita_performance_tests/pom.xml
@@ -161,7 +161,17 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>${maven.compiler.version}</version>
 				<configuration>
+					<!--
+						Declaring annotationProcessorPaths here REPLACES the parent's list wholesale, and any processor
+						present only on the regular classpath is then ignored - so Lombok has to be repeated alongside
+						the JMH generator. Dropping it silently removes every @Getter-generated accessor in this module.
+					-->
 					<annotationProcessorPaths>
+						<annotationProcessorPath>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</annotationProcessorPath>
 						<annotationProcessorPath>
 							<groupId>org.openjdk.jmh</groupId>
 							<artifactId>jmh-generator-annprocess</artifactId>

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockPriceListAndCurrencyPriceIndex.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockPriceListAndCurrencyPriceIndex.java
@@ -89,19 +89,9 @@ public class MockPriceListAndCurrencyPriceIndex implements PriceListAndCurrencyP
 		throw new UnsupportedOperationException();
 	}
 
-	@Override
-	public long getId() {
-		return 0;
-	}
-
-	@Override
-	public Void createLayer() {
-		throw new UnsupportedOperationException();
-	}
-
 	@Nonnull
 	@Override
-	public MockPriceListAndCurrencyPriceIndex createCopyWithMergedTransactionalMemory(@Nullable Void layer, @Nonnull TransactionalLayerMaintainer transactionalLayer) {
+	public MockPriceListAndCurrencyPriceIndex createCopyWithMergedTransactionalMemory(@Nonnull TransactionalLayerMaintainer transactionalLayer) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockPriceListAndCurrencyPriceIndex.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/mock/MockPriceListAndCurrencyPriceIndex.java
@@ -56,7 +56,7 @@ import java.util.function.IntConsumer;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
-public class MockPriceListAndCurrencyPriceIndex implements PriceListAndCurrencyPriceIndex<Void, MockPriceListAndCurrencyPriceIndex> {
+public class MockPriceListAndCurrencyPriceIndex implements PriceListAndCurrencyPriceIndex<MockPriceListAndCurrencyPriceIndex> {
 	@Serial private static final long serialVersionUID = -1343396298549809991L;
 	private final transient IntObjectHashMap<int[]> priceIdsIndex;
 	private int[] priceRecordIds;


### PR DESCRIPTION
Batch of pending fixes accumulated on `pending-fixes-2026-07-20` (11 commits). Grouped by area below.

## Query correctness

- **`fix: replace dropped NOT branch with EmptyFormula in FormulaOptimizer`** — a query combining an unsatisfiable branch with a `not()` returned rows matching none of the requested constraints. `FormulaOptimizer` removed the `NotFormula` node when its superset collapsed to `EmptyFormula`; `null` is the `FormulaCloner` signal for "remove this child from the parent", which widens an enclosing conjunction instead of emptying it. Confirmed present on `release_2026-1` as well and backported in #1310. Closes #1309.
- **`test: clarify why the NOT superset must be a reducible container`** — addresses the Copilot review note on the above (applied to this line only, by design).

## Index layer

- **`refactor: retire attachToCatalog from the index layer`** — `CatalogRelatedDataStructure` now has `EntityCollection` as its sole implementor.
- **`fix: prime locale-id sequence in GlobalUniqueIndex shell copy`** — a shell copy left `localePkSequence` at zero, so a new locale collided on the shared map.
- **`refactor: split transactional-layer ownership from state production`**
- **`refactor: share merge-operation selection via ChangePlan.planNextOperation`**

## Performance

- **`perf: probe the price tree on removal instead of materializing it`**
- **`perf: derive collation-key cache size from heap instead of fixed 8192`**

## Robustness

- **`fix: report zero size for absent directory instead of failing`** — listing catalog statistics crashed whenever a catalog folder was absent; also closes the race windows around transitional catalog states.

## Build & docs

- **`fix: restore Lombok processor path and mock index generic arity`** — a module declaring its own `annotationProcessorPaths` replaced the parent's and killed classpath discovery.
- **`docs: document three surefire result-reading traps in testing rules`**

---

Ref: #1309
