### PR TITLE
feat: export configurable query labels as Prometheus dimensions

### DIFF
--- a/documentation/user/cs/operate/configure.md
+++ b/documentation/user/cs/operate/configure.md
@@ -182,6 +182,7 @@ api:                                              # [viz konfigurace API](#konfi
         endpoint: null
         protocol: grpc
       allowedEvents: null
+      exportedQueryLabels: null
       mTLS:
         enabled: null
         allowedClientCertificatePaths: null
@@ -1432,6 +1433,17 @@ pro scraping Prometheus metrik, OTEL trace exporter a záznam událostí Java Fl
         <p>**Výchozí:** `grpc`</p>
         <p>Určuje protokol použitý mezi aplikací a OTEL collectorem pro předávání trace záznamů. Možné
         hodnoty jsou `grpc` a `http`. gRPC je výrazně výkonnější a je preferovanou možností.</p>
+    </dd>
+    <dt>exportedQueryLabels</dt>
+    <dd>
+        <p>**Výchozí:** `null` (nic se neexportuje)</p>
+        <p>Seznam názvů [štítků dotazu](../query/header/label.md#štítek), jejichž hodnota se zpřístupní jako dimenze
+        Prometheus metrik dotazů. Názvy jsou libovolné a volí je operátor - evitaDB žádné nevyhrazuje - a každý se
+        zpřístupní ve své podobě upravené pro Prometheus. Na rozdíl od většiny ostatních konfiguračních seznamů v
+        evitaDB znamená nenastavený nebo prázdný seznam, že se *nic* neexportuje - nikoliv vše; důvod tohoto obráceného
+        výchozího chování je popsán v poznámkách o
+        [bezpečné kardinalitě štítků](../query/header/label.md#kardinalita-štítků-a-export-do-prometheus). Inherentně
+        vysokokardinální štítky (`trace-id`, `client-id`, `ip-address`, `uri`) jsou vyhrazené a při startu odmítnuté.</p>
     </dd>
     <dt>mTls.enabled</dt>
     <dd>

--- a/documentation/user/cs/operate/observe.md
+++ b/documentation/user/cs/operate/observe.md
@@ -225,6 +225,38 @@ Lze také zadat konkrétní metriky uvedením plného názvu jejich třídy (*pa
 
 Interní metriky jsou popsány v sekci [Reference metrik](#referenční-dokumentace).
 
+### Export štítků dotazu do Prometheus
+
+Štítky [dotazu](../query/header/label.md) jsou standardně vidět pouze v trasování, záznamech provozu a JFR
+událostech - nikoliv v Prometheus - protože hodnoty štítků jsou libovolná klientská data a často neomezené (viz
+[poznámky o bezpečné kardinalitě štítků](../query/header/label.md#kardinalita-štítků-a-export-do-prometheus)).
+Jednotlivé názvy štítků můžete zpřístupnit jako dimenze Prometheus metrik dotazů jejich uvedením v konfiguraci
+`exportedQueryLabels` (`job_name` a `rest_method` níže jsou pouze příklady - názvy jsou zcela na vás):
+
+```yaml
+api:
+  endpoints:
+    observability:
+      enabled: ${api.endpoints.observability.enabled:true}
+      host: ${api.endpoints.observability.host:":5555"}
+      exposeOn: ${api.endpoints.observability.exposeOn:"localhost:5555"}
+      tlsMode: ${api.endpoints.observability.tlsMode:FORCE_NO_TLS}
+      exportedQueryLabels:
+        - job_name
+        - rest_method
+```
+
+evitaDB žádné názvy štítků nevyhrazuje - každý nakonfigurovaný název pouze porovnává se štítky, které daný dotaz nese,
+a stane se dimenzí metriky pojmenovanou podle své podoby upravené pro Prometheus (znaky mimo `[a-zA-Z0-9_]` se nahradí
+`_`). Dotaz, který nakonfigurovaný štítek nenese, vykreslí tuto dimenzi jako `N/A`.
+
+Na rozdíl od `allowedEvents` znamená nenastavený nebo prázdný `exportedQueryLabels`, že se *nic* neexportuje - toto je
+bezpečné výchozí chování, protože neomezený štítek povýšený na dimenzi by roztrhal kardinalitu časových řad Prometheus.
+Uvedení názvu zde je vaším explicitním potvrzením, že jeho hodnoty jsou omezené. Několik inherentně vysokokardinálních
+štítků automaticky připojovaných systémem - `trace-id`, `client-id`, `ip-address` a `uri` - je vyhrazených a nelze je
+nikdy exportovat; server se s jasnou chybou odmítne spustit, pokud se kterýkoli z nich (nebo dva názvy, které se upraví
+na stejnou dimenzi) v seznamu objeví.
+
 ### JFR události
 
 [JFR události](https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm#JFRUH170) mohou být také

--- a/documentation/user/cs/operate/observe.md
+++ b/documentation/user/cs/operate/observe.md
@@ -257,6 +257,13 @@ Uvedení názvu zde je vaším explicitním potvrzením, že jeho hodnoty jsou o
 nikdy exportovat; server se s jasnou chybou odmítne spustit, pokud se kterýkoli z nich (nebo dva názvy, které se upraví
 na stejnou dimenzi) v seznamu objeví.
 
+Dvě další poznámky k exportovaným štítkům dotazu:
+- Nakonfigurovaný název, jehož upravená podoba koliduje s vlastní vestavěnou dimenzí metriky (u metrik dotazů
+  `entityType` nebo `prefetched`), je odmítnut při registraci metrik krátce po startu - to se zaloguje a sběr metrik se
+  neinicializuje, na rozdíl od obou konfiguračních kontrol výše nepřeruší start serveru.
+- Hodnoty se čtou z čárkou/rovnítkem oddělovaného balíku, proto se v hodnotách exportovaných štítků vyhněte čárkám
+  (`,`) a rovnítkům (`=`); udržujte je omezené a jednoduché, jak to jejich bezpečná kardinalita stejně vyžaduje.
+
 ### JFR události
 
 [JFR události](https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm#JFRUH170) mohou být také

--- a/documentation/user/cs/query/header/label.md
+++ b/documentation/user/cs/query/header/label.md
@@ -60,3 +60,25 @@ Existují také automatické štítky, které jsou k dotazu přidávány systém
 <LS to="g">Pokud používáte GraphQL API, je zde také štítek `operation-name` odvozený z názvu dotazu (pokud je nějaký název definován).</LS>
 
 </Note>
+
+### Kardinalita štítků a export do Prometheus
+
+Štítky jsou navrženy pro označení dotazu za účelem jeho pozdější identifikace v trasování a záznamech provozu, kde je
+neomezený počet různých hodnot očekávaný a neškodný - každé trasování nebo zaznamenaný dotaz se stejně ukládá
+samostatně. To ale neplatí pro [Prometheus metriky](../../operate/observe.md#metriky): každá odlišná kombinace hodnot
+štítků se stane vlastní časovou řadou, takže štítek s neomezenými nebo unikátními hodnotami pro každý požadavek (ID
+uživatele, ID session, časové razítko, celá URL, libovolný text) by donekonečna vytvářel nové časové řady a mohl by
+zahltit Prometheus i libovolný dashboard nad ním postavený.
+
+Z tohoto důvodu se ve výchozím stavu do Prometheus neexportuje žádný štítek. Operátor může jednotlivé názvy štítků
+povolit pomocí nastavení `exportedQueryLabels` Observability API (viz
+[konfigurace Observability](../../operate/configure.md#konfigurace-observability)) - názvy štítků jsou libovolné a volí
+je operátor, který tím přebírá odpovědnost za udržení jejich hodnot omezených. Dokud není název nakonfigurován, jsou
+jeho hodnoty vidět pouze v trasování, záznamech provozu a JFR událostech, nikdy v Prometheus.
+
+Několik inherentně vysokokardinálních štítků automaticky připojovaných systémem - `trace-id`, `client-id`,
+`ip-address` a `uri` - je vyhrazených a nelze je do Prometheus nikdy exportovat, bez ohledu na konfiguraci. Při volbě
+štítků k exportu (nebo při rozhodování, zda je vůbec bezpečné danou hodnotu k dotazu připojit) dbejte na to, aby byly
+omezené a výčtového charakteru - identifikátor dávkové úlohy, název REST endpointu nebo metody kontroleru - a nikoli
+odvozené od uživatelského vstupu, identifikátorů požadavků nebo časových razítek.
+

--- a/documentation/user/en/operate/configure.md
+++ b/documentation/user/en/operate/configure.md
@@ -184,6 +184,7 @@ api:                                              # [see API configuration](#api
         endpoint: null
         protocol: grpc
       allowedEvents: null
+      exportedQueryLabels: null
       mTLS:
         enabled: null
         allowedClientCertificatePaths: null
@@ -1471,6 +1472,16 @@ pro scraping Prometheus metrics, OTEL trace exporter and Java Flight Recorder ev
         <p>**Default:** `grpc`</p>
         <p>Specifies the protocol used between the application and the OTEL collector to pass the traces. Possible 
         values are `grpc` and `http`. gRPC is much more performant and is the preferred option.</p>
+    </dd>
+    <dt>exportedQueryLabels</dt>
+    <dd>
+        <p>**Default:** `null` (nothing exported)</p>
+        <p>List of [query label](../query/header/label.md) names whose value is exposed as a Prometheus dimension on
+        query metrics. The names are arbitrary and operator-chosen - evitaDB reserves none - and each is exposed under
+        its Prometheus-sanitized form. Unlike most other configuration lists in evitaDB, an unset or empty list means
+        *nothing* is exported, not everything - see the [label cardinality safety notes](../query/header/label.md#label-cardinality-and-prometheus-export)
+        for why this default is inverted. Inherently high-cardinality labels (`trace-id`, `client-id`, `ip-address`,
+        `uri`) are reserved and rejected at startup.</p>
     </dd>
     <dt>mTls.enabled</dt>
     <dd>

--- a/documentation/user/en/operate/observe.md
+++ b/documentation/user/en/operate/observe.md
@@ -238,6 +238,38 @@ metrics by specifying the full name of their corresponding class (*package_path.
 
 Internal metrics are documented in the [Metrics reference](#reference-documentation) section.
 
+### Exporting query labels to Prometheus
+
+Query [labels](../query/header/label.md) are, by default, only visible in traces, traffic recordings and JFR events -
+not in Prometheus - because label values are arbitrary client-supplied data and often unbounded (see the
+[label cardinality safety notes](../query/header/label.md#label-cardinality-and-prometheus-export)). You can opt
+individual label names in as Prometheus dimensions on query metrics by listing them in the `exportedQueryLabels`
+configuration (`job_name` and `rest_method` below are just examples - the names are entirely up to you):
+
+```yaml
+api:
+  endpoints:
+    observability:
+      enabled: ${api.endpoints.observability.enabled:true}
+      host: ${api.endpoints.observability.host:":5555"}
+      exposeOn: ${api.endpoints.observability.exposeOn:"localhost:5555"}
+      tlsMode: ${api.endpoints.observability.tlsMode:FORCE_NO_TLS}
+      exportedQueryLabels:
+        - job_name
+        - rest_method
+```
+
+evitaDB reserves no label names - each configured name is simply matched against whatever labels a query carries and
+becomes a metric dimension named after its Prometheus-sanitized form (characters outside `[a-zA-Z0-9_]` become `_`). A
+query that doesn't carry a configured label renders that dimension as `N/A`.
+
+Unlike `allowedEvents`, an unset or empty `exportedQueryLabels` means *nothing* is exported - this is the safe default,
+because an unbounded label promoted to a dimension would blow up Prometheus time-series cardinality. Listing a name
+here is your explicit assertion that its values are bounded. A handful of inherently high-cardinality labels attached
+automatically by the system - `trace-id`, `client-id`, `ip-address` and `uri` - are reserved and can never be exported;
+the server fails to start with a clear error if any of them (or two names that sanitize to the same dimension) appear
+in the list.
+
 ### JFR events
 
 The [JFR events](https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm#JFRUH170) can also be

--- a/documentation/user/en/operate/observe.md
+++ b/documentation/user/en/operate/observe.md
@@ -270,6 +270,14 @@ automatically by the system - `trace-id`, `client-id`, `ip-address` and `uri` - 
 the server fails to start with a clear error if any of them (or two names that sanitize to the same dimension) appear
 in the list.
 
+Two further notes on exported query labels:
+- A configured name whose sanitized form collides with a metric's own built-in dimension (for query metrics,
+  `entityType` or `prefetched`) is rejected when metrics are registered shortly after startup - this is logged and
+  metric collection fails to initialize, rather than aborting server startup the way the two configuration guards above
+  do.
+- Values are read from a comma/equals-delimited bag, so avoid commas (`,`) or equals signs (`=`) inside the values of
+  exported labels; keep them bounded and simple, as their cardinality safety requires anyway.
+
 ### JFR events
 
 The [JFR events](https://docs.oracle.com/javacomponents/jmc-5-4/jfr-runtime-guide/about.htm#JFRUH170) can also be

--- a/documentation/user/en/query/header/label.md
+++ b/documentation/user/en/query/header/label.md
@@ -59,3 +59,25 @@ There are also automatic labels that are added to the query by the system, such 
 <LS to="g">If you use GraphQL API there is also `operation-name` label derived from the query name (if any name is defined).</LS>
 
 </Note>
+
+### Label cardinality and Prometheus export
+
+Labels are designed to tag a query for later identification in traces and traffic recordings, where an unbounded
+number of distinct values is expected and harmless - every trace or recorded query is stored individually anyway.
+This is **not** true for [Prometheus metrics](../../operate/observe.md#metrics): each distinct combination of label
+values becomes its own time series, so a label with unbounded or per-request values (a user ID, a session ID, a
+timestamp, a full URL, a free-text string) would keep creating new time series forever and can overwhelm Prometheus
+and any dashboard built on top of it.
+
+For this reason no label is exported to Prometheus by default. An operator can opt individual label names in via the
+observability API's `exportedQueryLabels` setting (see
+[Observability configuration](../../operate/configure.md#observability-configuration)) - the label names are arbitrary
+and chosen by the operator, who thereby takes responsibility for keeping their values bounded. Until a name is
+configured, its values are only ever visible in traces, traffic recordings and JFR events, never in Prometheus.
+
+A few inherently high-cardinality labels attached automatically by the system - `trace-id`, `client-id`, `ip-address`
+and `uri` - are reserved and can never be exported to Prometheus, regardless of configuration. When choosing which
+labels to export (or when deciding whether a value is safe to attach to a query at all), keep them bounded and
+enum-like - a batch job identifier, a REST endpoint or controller method name - rather than anything derived from user
+input, request identifiers or timestamps.
+

--- a/evita_api/src/main/java/io/evitadb/api/observability/annotation/ExportConfigurableLabels.java
+++ b/evita_api/src/main/java/io/evitadb/api/observability/annotation/ExportConfigurableLabels.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.observability.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a `String` field of a JFR event as a bag of arbitrary, client-supplied labels that may be selectively
+ * surfaced as Prometheus dimensions.
+ *
+ * Unlike {@link ExportMetricLabel} - which pins one dimension per annotated field, with a name known at compile
+ * time - this annotation does not itself add any dimension. The set of dimensions it contributes is decided at
+ * runtime by the observability API's `exportedQueryLabels` configuration: for each label name the operator opts in,
+ * the metric handler adds one dimension whose value is looked up (by that name) from this field's bag. evitaDB does
+ * not know or reserve any specific label name - the names come entirely from configuration.
+ *
+ * The bag is encoded as pairs `name=value` joined by a comma, e.g. `job_name=feed,tenant=acme` (the same encoding
+ * the annotated field's own description documents for human consumption). When `exportedQueryLabels` is unset or
+ * empty - the safe default - this field contributes no dimensions at all and is never parsed.
+ *
+ * Because label values are arbitrary client data, exporting an unbounded label as a Prometheus dimension would blow
+ * up time-series cardinality; opting a label in via configuration is therefore an explicit statement by the operator
+ * that its values are bounded. See `ObservabilityOptions#getExportedQueryLabels()` in the observability external API
+ * module for the configuration contract (including the reserved names that can never be exported).
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ * @see ExportMetricLabel
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExportConfigurableLabels {
+}

--- a/evita_engine/src/main/java/io/evitadb/core/metric/event/query/FinishedEvent.java
+++ b/evita_engine/src/main/java/io/evitadb/core/metric/event/query/FinishedEvent.java
@@ -24,6 +24,7 @@
 package io.evitadb.core.metric.event.query;
 
 import io.evitadb.api.configuration.metric.MetricType;
+import io.evitadb.api.observability.annotation.ExportConfigurableLabels;
 import io.evitadb.api.observability.annotation.ExportDurationMetric;
 import io.evitadb.api.observability.annotation.ExportInvocationMetric;
 import io.evitadb.api.observability.annotation.ExportMetric;
@@ -36,8 +37,6 @@ import lombok.Getter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 /**
  * Event that is fired when an evitaDB query is finished.
@@ -59,6 +58,7 @@ public class FinishedEvent extends AbstractQueryEvent {
 
 	@Label("Labels")
 	@Description("Zero or more client labels associated with the query. Labels are delimited by comma, label consists of name and value separated by equals sign.")
+	@ExportConfigurableLabels
 	private final String labels;
 
 	@Label("Query planning duration in milliseconds")
@@ -135,11 +135,21 @@ public class FinishedEvent extends AbstractQueryEvent {
 		this.entityType = entityType;
 		this.begin();
 		this.created = System.currentTimeMillis();
-		this.labels = labels == null ?
-			"" :
-			Arrays.stream(labels)
-				.map(label -> label.getLabelName() + "=" + label.getLabelValue())
-				.collect(Collectors.joining(","));
+		if (labels == null) {
+			this.labels = "";
+		} else {
+			// build the "name=value,name=value" bag without streams - this runs on the query path (see the
+			// `labels` field's @ExportConfigurableLabels contract consumed by the observability module)
+			final StringBuilder labelsBuilder = new StringBuilder(labels.length * 32);
+			for (int i = 0; i < labels.length; i++) {
+				final io.evitadb.api.query.head.Label label = labels[i];
+				if (i > 0) {
+					labelsBuilder.append(',');
+				}
+				labelsBuilder.append(label.getLabelName()).append('=').append(label.getLabelValue());
+			}
+			this.labels = labelsBuilder.toString();
+		}
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/configuration/ObservabilityOptions.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/configuration/ObservabilityOptions.java
@@ -25,15 +25,19 @@ package io.evitadb.externalApi.observability.configuration;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.evitadb.core.traffic.TrafficRecordingEngine;
 import io.evitadb.externalApi.configuration.AbstractApiOptions;
 import io.evitadb.externalApi.configuration.ApiWithSpecificPrefix;
 import io.evitadb.externalApi.configuration.MtlsConfiguration;
+import io.evitadb.externalApi.observability.metric.PrometheusLabelNames;
+import io.evitadb.utils.Assert;
 import lombok.Getter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Observability API specific configuration.
@@ -48,6 +52,19 @@ public class ObservabilityOptions extends AbstractApiOptions implements ApiWithS
 	private static final String BASE_OBSERVABILITY_PATH = "observability";
 
 	/**
+	 * Query label names that can never be exported to Prometheus, regardless of {@link #exportedQueryLabels}, because
+	 * they are inherently high-cardinality (per-request or per-client). These mirror the reserved traffic-recording
+	 * labels ({@link TrafficRecordingEngine}); listing any of them in {@code exportedQueryLabels} fails fast at
+	 * startup. evitaDB otherwise attaches no meaning to label names - the exportable set is entirely operator-defined.
+	 */
+	private static final Set<String> FORBIDDEN_QUERY_LABELS = Set.of(
+		TrafficRecordingEngine.LABEL_TRACE_ID,
+		TrafficRecordingEngine.LABEL_CLIENT_ID,
+		TrafficRecordingEngine.LABEL_IP_ADDRESS,
+		TrafficRecordingEngine.LABEL_URI
+	);
+
+	/**
 	 * Controls the prefix Metrics API will react on.
 	 * Default value is `metrics`.
 	 */
@@ -56,11 +73,25 @@ public class ObservabilityOptions extends AbstractApiOptions implements ApiWithS
 
 	@Getter @Nullable private final List<String> allowedEvents;
 
+	/**
+	 * Operator-defined list of query label names (the `label` query head constraint) whose values are surfaced as
+	 * Prometheus dimensions on query metrics. The names are arbitrary - evitaDB reserves none - so each name maps to a
+	 * dimension named after its Prometheus-sanitized form (see {@link PrometheusLabelNames}).
+	 *
+	 * Unlike {@link #allowedEvents}, an unset or empty list means nothing is exported (the safe default) - not
+	 * "everything" - because query labels are arbitrary client-supplied data and an unbounded label would blow up
+	 * Prometheus time-series cardinality. Opting a label in here is the operator's explicit assertion that its values
+	 * are bounded. Names in {@link #FORBIDDEN_QUERY_LABELS}, or two names collapsing to the same sanitized dimension,
+	 * are rejected at startup.
+	 */
+	@Getter @Nullable private final List<String> exportedQueryLabels;
+
 	public ObservabilityOptions() {
 		super(true, "0.0.0.0:" + DEFAULT_OBSERVABILITY_PORT, null, null, null, null);
 		this.prefix = BASE_OBSERVABILITY_PATH;
 		this.tracing = new TracingConfig();
 		this.allowedEvents = null;
+		this.exportedQueryLabels = null;
 	}
 
 	public ObservabilityOptions(@Nonnull String host) {
@@ -68,6 +99,7 @@ public class ObservabilityOptions extends AbstractApiOptions implements ApiWithS
 		this.prefix = BASE_OBSERVABILITY_PATH;
 		this.tracing = new TracingConfig();
 		this.allowedEvents = null;
+		this.exportedQueryLabels = null;
 	}
 
 	@JsonCreator
@@ -79,11 +111,25 @@ public class ObservabilityOptions extends AbstractApiOptions implements ApiWithS
 	                            @Nullable @JsonProperty("prefix") String prefix,
 	                            @Nullable @JsonProperty("tracing") TracingConfig tracing,
 	                            @Nullable @JsonProperty("allowedEvents") List<String> allowedEvents,
+	                            @Nullable @JsonProperty("exportedQueryLabels") List<String> exportedQueryLabels,
 	                            @Nullable @JsonProperty("mTLS") MtlsConfiguration mtlsConfiguration
 	) {
 		super(enabled, host, exposeOn, tlsMode, keepAlive, mtlsConfiguration);
 		this.prefix = Optional.ofNullable(prefix).orElse(BASE_OBSERVABILITY_PATH);
 		this.tracing = Optional.ofNullable(tracing).orElse(new TracingConfig());
 		this.allowedEvents = allowedEvents;
+		if (exportedQueryLabels != null) {
+			for (final String label : exportedQueryLabels) {
+				Assert.isTrue(
+					!FORBIDDEN_QUERY_LABELS.contains(label),
+					() -> "Query label `" + label + "` cannot be exported to Prometheus via `exportedQueryLabels` - it " +
+						"is a reserved high-cardinality label (one of: " + String.join(", ", FORBIDDEN_QUERY_LABELS) + ")."
+				);
+			}
+			// reject two labels collapsing onto the same Prometheus dimension; a clash with a built-in dimension can
+			// only be caught later, at metric registration, where the event's fixed dimensions are known
+			PrometheusLabelNames.assignDimensions(exportedQueryLabels, Set.of());
+		}
+		this.exportedQueryLabels = exportedQueryLabels;
 	}
 }

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/configuration/ObservabilityOptions.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/configuration/ObservabilityOptions.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Observability API specific configuration.
@@ -63,6 +64,11 @@ public class ObservabilityOptions extends AbstractApiOptions implements ApiWithS
 		TrafficRecordingEngine.LABEL_IP_ADDRESS,
 		TrafficRecordingEngine.LABEL_URI
 	);
+	/**
+	 * {@link #FORBIDDEN_QUERY_LABELS} rendered as a stable, alphabetically-sorted comma-separated list, so validation
+	 * error messages are deterministic (the {@link Set#of set} itself has no defined iteration order).
+	 */
+	private static final String FORBIDDEN_QUERY_LABELS_DISPLAY = String.join(", ", new TreeSet<>(FORBIDDEN_QUERY_LABELS));
 
 	/**
 	 * Controls the prefix Metrics API will react on.
@@ -120,10 +126,17 @@ public class ObservabilityOptions extends AbstractApiOptions implements ApiWithS
 		this.allowedEvents = allowedEvents;
 		if (exportedQueryLabels != null) {
 			for (final String label : exportedQueryLabels) {
+				// a bare `-` item in the YAML list yields a null element; reject it up front with a clear message
+				// rather than letting it NPE inside the forbidden-name check or dimension sanitization
+				Assert.isTrue(
+					label != null,
+					"A `null` query label name was found in `exportedQueryLabels` configuration - " +
+						"check for empty list items (a bare `-`) in the YAML."
+				);
 				Assert.isTrue(
 					!FORBIDDEN_QUERY_LABELS.contains(label),
 					() -> "Query label `" + label + "` cannot be exported to Prometheus via `exportedQueryLabels` - it " +
-						"is a reserved high-cardinality label (one of: " + String.join(", ", FORBIDDEN_QUERY_LABELS) + ")."
+						"is a reserved high-cardinality label (one of: " + FORBIDDEN_QUERY_LABELS_DISPLAY + ")."
 				);
 			}
 			// reject two labels collapsing onto the same Prometheus dimension; a clash with a built-in dimension can

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/MetricHandler.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/MetricHandler.java
@@ -25,6 +25,7 @@ package io.evitadb.externalApi.observability.metric;
 
 import io.evitadb.api.configuration.metric.LoggedMetric;
 import io.evitadb.api.configuration.metric.MetricType;
+import io.evitadb.api.observability.annotation.ExportConfigurableLabels;
 import io.evitadb.api.observability.annotation.ExportDurationMetric;
 import io.evitadb.api.observability.annotation.ExportInvocationMetric;
 import io.evitadb.api.observability.annotation.ExportMetric;
@@ -62,7 +63,9 @@ import javax.annotation.Nonnull;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -76,7 +79,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
@@ -211,8 +213,9 @@ public class MetricHandler {
 	private static MetricLabelExporter convertGetterToMetricLabelExporter(@Nonnull Method getter) {
 		final String propertyName = ReflectionLookup.getPropertyNameFromMethodName(getter.getName());
 		final ExportMetricLabel exportMetricLabel = getter.getAnnotation(ExportMetricLabel.class);
+		final String labelName = of(exportMetricLabel.value()).filter(it -> !it.isBlank()).orElse(propertyName);
 		return new MetricLabelExporter(
-			of(exportMetricLabel.value()).filter(it -> !it.isBlank()).orElse(propertyName),
+			labelName,
 			recordedEvent -> recordedEvent.getString(propertyName)
 		);
 	}
@@ -227,10 +230,51 @@ public class MetricHandler {
 	private static MetricLabelExporter convertFieldToMetricLabelExporter(@Nonnull Field field) {
 		final ExportMetricLabel exportMetricLabel = field.getAnnotation(ExportMetricLabel.class);
 		final String fieldName = field.getName();
+		final String labelName = of(exportMetricLabel.value()).filter(it -> !it.isBlank()).orElse(fieldName);
 		return new MetricLabelExporter(
-			of(exportMetricLabel.value()).filter(it -> !it.isBlank()).orElse(fieldName),
+			labelName,
 			recordedEvent -> recordedEvent.getString(fieldName)
 		);
+	}
+
+	/**
+	 * Expands a {@link ExportConfigurableLabels}-annotated label bag field into one metric label exporter per
+	 * operator-configured query label name. Each configured name maps to a Prometheus dimension named after its
+	 * {@link PrometheusLabelNames#sanitize(String) sanitized} form; the dimension's value is looked up (by the
+	 * original, unsanitized name) from the bag carried on each recorded event. evitaDB reserves no label names - the
+	 * set comes entirely from {@link ObservabilityOptions#getExportedQueryLabels()}.
+	 *
+	 * @param bagField             the {@link ExportConfigurableLabels}-annotated `String` field carrying the label bag
+	 * @param configuredLabelNames operator-configured query label names to export
+	 * @param reservedDimensions   dimension names already taken by this event's built-in {@link ExportMetricLabel}
+	 *                             dimensions; a configured label colliding with one of these is rejected here (it
+	 *                             cannot be caught at config load, which does not know the event's fixed dimensions)
+	 * @return one exporter per configured name (empty when none are configured)
+	 */
+	@Nonnull
+	private static List<MetricLabelExporter> buildConfigurableLabelExporters(
+		@Nonnull Field bagField,
+		@Nonnull Set<String> configuredLabelNames,
+		@Nonnull Set<String> reservedDimensions
+	) {
+		final String bagFieldName = bagField.getName();
+		// deterministic dimension order across restarts
+		final List<String> sortedNames = new ArrayList<>(configuredLabelNames);
+		Collections.sort(sortedNames);
+
+		final Map<String, String> dimensionByLabel = PrometheusLabelNames.assignDimensions(sortedNames, reservedDimensions);
+		final List<MetricLabelExporter> exporters = new ArrayList<>(dimensionByLabel.size());
+		for (final Entry<String, String> entry : dimensionByLabel.entrySet()) {
+			final String originalName = entry.getKey();
+			final String dimension = entry.getValue();
+			exporters.add(
+				new MetricLabelExporter(
+					dimension,
+					recordedEvent -> QueryLabelBag.extractValue(recordedEvent.getString(bagFieldName), originalName)
+				)
+			);
+		}
+		return exporters;
 	}
 
 	/**
@@ -376,8 +420,9 @@ public class MetricHandler {
 
 		registerJvmMetrics();
 		final Set<Class<? extends CustomMetricsExecutionEvent>> allowedMetrics = getAllowedEventSet();
+		final Set<String> exportedQueryLabels = getExportedQueryLabelSet();
 
-		final MetricTask metricTask = new MetricTask(allowedMetrics);
+		final MetricTask metricTask = new MetricTask(allowedMetrics, exportedQueryLabels);
 		scheduler.submit((ServerTask<?,?>) metricTask);
 
 		try {
@@ -387,7 +432,9 @@ public class MetricHandler {
 					evita.emitStartObservabilityEvents();
 				}).get(1, TimeUnit.MINUTES);
 		} catch (Exception e) {
-			log.error("Failed to initialize metric handler in time. Metrics might not work. Start events are not emitted.");
+			// log the cause - it carries the actionable message, e.g. a configured query label colliding with a
+			// built-in metric dimension (see MetricHandler#buildConfigurableLabelExporters)
+			log.error("Failed to initialize metric handler in time. Metrics might not work. Start events are not emitted.", e);
 		}
 	}
 
@@ -442,6 +489,20 @@ public class MetricHandler {
 	}
 
 	/**
+	 * Resolves the operator-configured query label names eligible for Prometheus export (see
+	 * {@link #buildConfigurableLabelExporters(Field, Set, Set)}. Unlike {@link #getAllowedEventSet()}, an unset (or empty)
+	 * configuration means nothing is exported - see {@link ObservabilityOptions#getExportedQueryLabels()} for the
+	 * reasoning behind the inverted default.
+	 *
+	 * @return the configured query label names, or an empty set if none were configured
+	 */
+	@Nonnull
+	private Set<String> getExportedQueryLabelSet() {
+		final List<String> exportedQueryLabelsFromConfig = this.observabilityConfig.getExportedQueryLabels();
+		return exportedQueryLabelsFromConfig == null ? Set.of() : new HashSet<>(exportedQueryLabelsFromConfig);
+	}
+
+	/**
 	 * Task that listens for JFR events and transforms them into Prometheus metrics.
 	 */
 	private static class MetricTask extends ClientInfiniteCallableTask<Void, Void> {
@@ -449,7 +510,8 @@ public class MetricHandler {
 		@Getter private final CompletableFuture<Boolean> initialized = new CompletableFuture<>();
 
 		public MetricTask(
-			@Nonnull Set<Class<? extends CustomMetricsExecutionEvent>> allowedMetrics
+			@Nonnull Set<Class<? extends CustomMetricsExecutionEvent>> allowedMetrics,
+			@Nonnull Set<String> exportedQueryLabels
 		) {
 			super(
 				MetricHandler.class.getSimpleName(),
@@ -468,16 +530,32 @@ public class MetricHandler {
 							AtomicReference<ChainableConsumer<RecordedEvent>> lambdaRef = new AtomicReference<>();
 
 							final Map<Field, List<Annotation>> fieldsAnnotations = lookup.getFields(eventClass);
-							final List<MetricLabelExporter> labelExporters = Stream.concat(
-								lookup.findAllGettersHavingAnnotationDeeply(eventClass, ExportMetricLabel.class)
-									.stream()
-									.map(MetricHandler::convertGetterToMetricLabelExporter),
+							final List<MetricLabelExporter> labelExporters = new ArrayList<>();
+							// fixed dimensions declared at compile time via @ExportMetricLabel getters ...
+							lookup.findAllGettersHavingAnnotationDeeply(eventClass, ExportMetricLabel.class)
+								.forEach(getter -> labelExporters.add(MetricHandler.convertGetterToMetricLabelExporter(getter)));
+							// ... and @ExportMetricLabel fields
+							fieldsAnnotations.entrySet()
+								.stream()
+								.filter(it -> it.getValue().stream().anyMatch(ExportMetricLabel.class::isInstance))
+								.map(Entry::getKey)
+								.forEach(field -> labelExporters.add(MetricHandler.convertFieldToMetricLabelExporter(field)));
+							// ... plus operator-configured dimensions expanded from @ExportConfigurableLabels bag fields;
+							// skipped entirely (no parsing, no dimensions) when nothing is configured - the safe default
+							if (!exportedQueryLabels.isEmpty()) {
+								// the fixed dimensions collected so far are reserved: a configured label must not
+								// collide with a built-in dimension (e.g. entityType, prefetched) either
+								final Set<String> reservedDimensions = new HashSet<>();
+								for (final MetricLabelExporter fixedExporter : labelExporters) {
+									reservedDimensions.add(fixedExporter.labelName());
+								}
 								fieldsAnnotations.entrySet()
 									.stream()
-									.filter(it -> it.getValue().stream().anyMatch(ExportMetricLabel.class::isInstance))
+									.filter(it -> it.getValue().stream().anyMatch(ExportConfigurableLabels.class::isInstance))
 									.map(Entry::getKey)
-									.map(MetricHandler::convertFieldToMetricLabelExporter)
-							).toList();
+									.forEach(field -> labelExporters.addAll(
+										MetricHandler.buildConfigurableLabelExporters(field, exportedQueryLabels, reservedDimensions)));
+							}
 
 							final String[] labelNames = labelExporters
 								.stream()

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/MetricHandler.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/MetricHandler.java
@@ -39,6 +39,8 @@ import io.evitadb.core.metric.event.CustomMetricsExecutionEvent;
 import io.evitadb.externalApi.observability.configuration.ObservabilityOptions;
 import io.evitadb.function.ChainableConsumer;
 import io.evitadb.utils.ArrayUtils;
+import io.evitadb.utils.Assert;
+import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.ReflectionLookup;
 import io.evitadb.utils.StringUtils;
 import io.evitadb.utils.VersionUtils;
@@ -117,7 +119,7 @@ public class MetricHandler {
 		.labelNames("api_type")
 		.help("Status of the API readiness (internal HTTP call check)")
 		.register();
-	private static final Map<String, Metric> REGISTERED_METRICS = new HashMap<>(64);
+	private static final Map<String, RegisteredMetric> REGISTERED_METRICS = new HashMap<>(64);
 	private static final Pattern EVENT = Pattern.compile("Event");
 	private static final Map<String, Runnable> DEFAULT_JVM_METRICS;
 	private static final String DEFAULT_JVM_METRICS_NAME = "AllMetrics";
@@ -354,10 +356,25 @@ public class MetricHandler {
 	 * @return built and registered metric
 	 */
 	@Nonnull
-	private static Metric buildAndRegisterMetric(@Nonnull LoggedMetric metric, @Nonnull Map<String, Metric> registeredMetrics) {
+	private static Metric buildAndRegisterMetric(@Nonnull LoggedMetric metric, @Nonnull Map<String, RegisteredMetric> registeredMetrics) {
 		final String name = StringUtils.toSnakeCase(metric.name());
-		if (registeredMetrics.containsKey(name)) {
-			return registeredMetrics.get(name);
+		final RegisteredMetric existing = registeredMetrics.get(name);
+		if (existing != null) {
+			// a metric's dimension set must stay stable for its lifetime. Before configurable query labels every
+			// metric's labels were fixed at compile time, so re-registration under the same name was always
+			// shape-identical. Now that query-metric dimensions depend on `exportedQueryLabels`, a re-registration
+			// with a different shape (e.g. a second observability handler booted in the same JVM with a different
+			// config) is rejected loudly here instead of silently reusing the first shape and later throwing a
+			// cryptic IllegalArgumentException from the Prometheus client when an event fires.
+			Assert.isTrue(
+				Arrays.equals(existing.labelNames(), metric.labels()),
+				() -> "Prometheus metric `" + name + "` is already registered with dimensions " +
+					Arrays.toString(existing.labelNames()) + " and cannot be re-registered with " +
+					Arrays.toString(metric.labels()) + ". A metric's dimension set must be stable; this usually means " +
+					"the observability handler was initialized more than once in the same JVM with different " +
+					"`exportedQueryLabels` configurations."
+			);
+			return existing.metric();
 		} else {
 			final Metric newMetric = switch (metric.type()) {
 				case GAUGE -> Gauge.builder()
@@ -394,7 +411,7 @@ public class MetricHandler {
 					.help(metric.helpMessage())
 					.register();
 			};
-			registeredMetrics.put(name, newMetric);
+			registeredMetrics.put(name, new RegisteredMetric(newMetric, metric.labels()));
 			return newMetric;
 		}
 	}
@@ -545,7 +562,7 @@ public class MetricHandler {
 							if (!exportedQueryLabels.isEmpty()) {
 								// the fixed dimensions collected so far are reserved: a configured label must not
 								// collide with a built-in dimension (e.g. entityType, prefetched) either
-								final Set<String> reservedDimensions = new HashSet<>();
+								final Set<String> reservedDimensions = CollectionUtils.createHashSet(labelExporters.size());
 								for (final MetricLabelExporter fixedExporter : labelExporters) {
 									reservedDimensions.add(fixedExporter.labelName());
 								}
@@ -704,6 +721,21 @@ public class MetricHandler {
 	private record MetricLabelExporter(
 		@Nonnull String labelName,
 		@Nonnull Function<RecordedEvent, String> labelValueAccessor
+	) {
+	}
+
+	/**
+	 * A registered Prometheus {@link Metric} together with the dimension names it was registered with. Retained so a
+	 * re-registration under the same metric name can verify the dimension set has not changed - it must be stable for
+	 * the metric's lifetime, which is no longer guaranteed by construction now that query-metric dimensions depend on
+	 * the {@code exportedQueryLabels} configuration.
+	 *
+	 * @param metric     the registered Prometheus metric
+	 * @param labelNames the dimension names the metric was registered with
+	 */
+	private record RegisteredMetric(
+		@Nonnull Metric metric,
+		@Nonnull String[] labelNames
 	) {
 	}
 

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/PrometheusLabelNames.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/PrometheusLabelNames.java
@@ -24,11 +24,11 @@
 package io.evitadb.externalApi.observability.metric;
 
 import io.evitadb.exception.EvitaInvalidUsageException;
+import io.evitadb.utils.CollectionUtils;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -68,7 +68,7 @@ public final class PrometheusLabelNames {
 		@Nonnull Collection<String> labelNames,
 		@Nonnull Set<String> reservedDimensions
 	) {
-		final Map<String, String> dimensionByLabel = new LinkedHashMap<>(labelNames.size());
+		final Map<String, String> dimensionByLabel = CollectionUtils.createLinkedHashMap(labelNames.size());
 		final Set<String> usedDimensions = new HashSet<>(reservedDimensions);
 		for (final String labelName : labelNames) {
 			final String dimension = sanitize(labelName);

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/PrometheusLabelNames.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/PrometheusLabelNames.java
@@ -1,0 +1,114 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.observability.metric;
+
+import io.evitadb.exception.EvitaInvalidUsageException;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Helper for turning an arbitrary, client-supplied query label name into a legal Prometheus dimension name.
+ *
+ * Prometheus label names must match `[a-zA-Z_][a-zA-Z0-9_]*`, whereas query labels (the `label` query head
+ * constraint) may carry any string - including characters like `-` or `.` that are illegal in a dimension name.
+ * This single source of truth is shared by the configuration layer (to detect two configured labels collapsing to
+ * the same dimension) and by the metric handler (to name the dimension it registers), so the two never drift.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public final class PrometheusLabelNames {
+
+	private PrometheusLabelNames() {
+		throw new UnsupportedOperationException("This class cannot be instantiated.");
+	}
+
+	/**
+	 * Maps each label name to its {@link #sanitize(String) sanitized} Prometheus dimension, rejecting any clash - both
+	 * among the label names themselves and against the {@code reservedDimensions} already occupied by a metric's
+	 * built-in dimensions (e.g. `entityType`, `prefetched`). A clash is a misconfiguration the operator must fix (two
+	 * different label names cannot share a Prometheus dimension), hence {@link EvitaInvalidUsageException}.
+	 *
+	 * The configuration layer calls this with an empty {@code reservedDimensions} to validate the operator's list in
+	 * isolation; the metric handler calls it again at registration seeded with the event's fixed dimension names,
+	 * where a clash with a built-in dimension - undetectable at config-load time - is finally caught.
+	 *
+	 * @param labelNames         the label names to map, in the desired dimension order
+	 * @param reservedDimensions dimension names already in use that a label must not collide with (may be empty)
+	 * @return an insertion-ordered map from each label name to its Prometheus dimension
+	 * @throws EvitaInvalidUsageException if two label names, or a label name and a reserved dimension, collide
+	 */
+	@Nonnull
+	public static Map<String, String> assignDimensions(
+		@Nonnull Collection<String> labelNames,
+		@Nonnull Set<String> reservedDimensions
+	) {
+		final Map<String, String> dimensionByLabel = new LinkedHashMap<>(labelNames.size());
+		final Set<String> usedDimensions = new HashSet<>(reservedDimensions);
+		for (final String labelName : labelNames) {
+			final String dimension = sanitize(labelName);
+			if (!usedDimensions.add(dimension)) {
+				final String reason = reservedDimensions.contains(dimension) ?
+					"it is already a built-in dimension of this metric" :
+					"another exported query label already maps to it";
+				throw new EvitaInvalidUsageException(
+					"Query label `" + labelName + "` cannot be exported to Prometheus: its dimension `" + dimension +
+						"` clashes - " + reason + ". Rename or remove it from `exportedQueryLabels`."
+				);
+			}
+			dimensionByLabel.put(labelName, dimension);
+		}
+		return dimensionByLabel;
+	}
+
+	/**
+	 * Sanitizes an arbitrary label name into a legal Prometheus dimension name matching `[a-zA-Z_][a-zA-Z0-9_]*`.
+	 * Every character outside `[a-zA-Z0-9_]` is replaced by an underscore, and a leading digit (or an empty result)
+	 * is prefixed with an underscore so the name always starts with a letter or underscore.
+	 *
+	 * @param rawName the raw, possibly-illegal label name (as configured / as carried by the query)
+	 * @return a legal Prometheus dimension name
+	 */
+	@Nonnull
+	public static String sanitize(@Nonnull String rawName) {
+		final StringBuilder result = new StringBuilder(rawName.length() + 1);
+		for (int i = 0; i < rawName.length(); i++) {
+			final char character = rawName.charAt(i);
+			final boolean alphaNumeric =
+				(character >= 'a' && character <= 'z') ||
+					(character >= 'A' && character <= 'Z') ||
+					(character >= '0' && character <= '9');
+			result.append(alphaNumeric || character == '_' ? character : '_');
+		}
+		if (result.isEmpty() || (result.charAt(0) >= '0' && result.charAt(0) <= '9')) {
+			result.insert(0, '_');
+		}
+		return result.toString();
+	}
+
+}

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/QueryLabelBag.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/QueryLabelBag.java
@@ -1,0 +1,80 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.observability.metric;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Reads a single label's value out of the comma-delimited `name=value` label bag carried by
+ * {@link io.evitadb.api.observability.annotation.ExportConfigurableLabels}-annotated JFR event fields (e.g.
+ * `FinishedEvent#labels`).
+ *
+ * A given label is looked up on demand rather than the whole bag being parsed into a map: the lookup runs on the
+ * background metric-recording thread (never on the query path), the bag is short, the configured set of exported
+ * labels is tiny, and a targeted scan allocates nothing but the returned value - while avoiding any assumption about
+ * recorded-event identity reuse that a cross-invocation cache would rely on.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public final class QueryLabelBag {
+
+	private QueryLabelBag() {
+		throw new UnsupportedOperationException("This class cannot be instantiated.");
+	}
+
+	/**
+	 * Extracts the value of a single label from a comma-delimited `name=value` label bag.
+	 *
+	 * @param labelBag   the label bag, or {@code null}/empty when the query carried no labels
+	 * @param targetName the exact (unsanitized) label name to look up
+	 * @return the label's value, or {@code null} when the bag does not carry it
+	 */
+	@Nullable
+	public static String extractValue(@Nullable String labelBag, @Nonnull String targetName) {
+		if (labelBag == null || labelBag.isEmpty()) {
+			return null;
+		}
+		final int length = labelBag.length();
+		final int targetLength = targetName.length();
+		int cursor = 0;
+		while (cursor < length) {
+			int pairEnd = labelBag.indexOf(',', cursor);
+			if (pairEnd < 0) {
+				pairEnd = length;
+			}
+			final int equals = labelBag.indexOf('=', cursor);
+			// the name region is [cursor, equals); accept only when it matches targetName exactly and the '=' lies
+			// within the current pair (a pair without '=' - or whose '=' belongs to the next pair - is not a match)
+			if (equals >= 0 && equals < pairEnd
+				&& equals - cursor == targetLength
+				&& labelBag.regionMatches(cursor, targetName, 0, targetLength)) {
+				return labelBag.substring(equals + 1, pairEnd);
+			}
+			cursor = pairEnd + 1;
+		}
+		return null;
+	}
+
+}

--- a/evita_server/src/main/resources/evita-configuration.yaml
+++ b/evita_server/src/main/resources/evita-configuration.yaml
@@ -171,6 +171,7 @@ api:
         endpoint: ${api.endpoints.observability.tracing.endpoint:null}
         protocol: ${api.endpoints.observability.tracing.protocol:grpc}
       allowedEvents: !include ${api.endpoints.observability.allowedEvents:null}
+      exportedQueryLabels: !include ${api.endpoints.observability.exportedQueryLabels:null}
       mTLS:
         enabled: ${api.endpoints.observability.mTLS.enabled:null}
         allowedClientCertificatePaths: ${api.endpoints.observability.mTLS.allowedClientCertificatesPaths:null}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/metric/event/query/FinishedEventTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/metric/event/query/FinishedEventTest.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.metric.event.query;
+
+import io.evitadb.api.query.head.Label;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that {@link FinishedEvent} encodes the query's labels into the comma-delimited `name=value` bag that the
+ * observability layer later reads to surface operator-configured query labels as Prometheus dimensions (via
+ * `QueryLabelBag`). This is the producer side of that format contract - a regression in the encoding here would
+ * silently break query-label export downstream.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("FinishedEvent label bag encoding")
+@Tag(ENGINE)
+@Tag(OBSERVABILITY)
+class FinishedEventTest {
+
+	@Test
+	@DisplayName("Should encode labels as a comma-delimited name=value bag, in order")
+	void shouldEncodeLabelsAsBag() {
+		final FinishedEvent event = new FinishedEvent(
+			"testCatalog",
+			"Product",
+			new Label[]{
+				new Label("job_name", "feed-job"),
+				new Label("rest_method", "GET /products"),
+				new Label("tenant", "acme")
+			}
+		);
+		assertEquals("job_name=feed-job,rest_method=GET /products,tenant=acme", event.getLabels());
+	}
+
+	@Test
+	@DisplayName("Should produce an empty bag when the query carries no labels")
+	void shouldProduceEmptyBagForNullLabels() {
+		assertEquals("", new FinishedEvent("testCatalog", "Product", null).getLabels());
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/configuration/ObservabilityOptionsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/configuration/ObservabilityOptionsTest.java
@@ -1,0 +1,99 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.observability.configuration;
+
+import io.evitadb.exception.EvitaInvalidUsageException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static io.evitadb.test.TestTags.OBSERVABILITY_API;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the `exportedQueryLabels` contract of {@link ObservabilityOptions}: the names are arbitrary and
+ * operator-chosen (evitaDB reserves none), an unset configuration means nothing is exported (unlike
+ * {@link ObservabilityOptions#getAllowedEvents()}), and two guards fail fast at startup - reserved high-cardinality
+ * names, and two names that collapse onto the same Prometheus dimension.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("ObservabilityOptions exportedQueryLabels contract")
+@Tag(OBSERVABILITY_API)
+@Tag(OBSERVABILITY)
+class ObservabilityOptionsTest {
+
+	@Nonnull
+	private static ObservabilityOptions withExportedQueryLabels(@Nullable List<String> exportedQueryLabels) {
+		return new ObservabilityOptions(
+			null, "localhost:5555", null, null, null, null, null,
+			null, exportedQueryLabels, null
+		);
+	}
+
+	@Test
+	@DisplayName("Should default exportedQueryLabels to null (nothing exported) when not configured")
+	void shouldDefaultToNullWhenNotConfigured() {
+		assertNull(new ObservabilityOptions().getExportedQueryLabels());
+		assertNull(new ObservabilityOptions("localhost:5555").getExportedQueryLabels());
+	}
+
+	@Test
+	@DisplayName("Should accept arbitrary, operator-chosen label names (including ones needing sanitization)")
+	void shouldAcceptArbitraryLabelNames() {
+		final List<String> labels = List.of("job_name", "rest_method", "tenant", "some-custom.name");
+		assertEquals(labels, withExportedQueryLabels(labels).getExportedQueryLabels());
+	}
+
+	@Test
+	@DisplayName("Should reject each reserved high-cardinality label name with a clear message")
+	void shouldRejectReservedLabelNames() {
+		for (final String reserved : List.of("trace-id", "client-id", "ip-address", "uri")) {
+			final EvitaInvalidUsageException exception = assertThrows(
+				EvitaInvalidUsageException.class,
+				() -> withExportedQueryLabels(List.of("job_name", reserved))
+			);
+			assertTrue(exception.getMessage().contains(reserved), "message should mention `" + reserved + "`");
+		}
+	}
+
+	@Test
+	@DisplayName("Should reject two labels that collapse onto the same Prometheus dimension")
+	void shouldRejectCollidingLabelNames() {
+		final EvitaInvalidUsageException exception = assertThrows(
+			EvitaInvalidUsageException.class,
+			() -> withExportedQueryLabels(List.of("rest-method", "rest.method"))
+		);
+		assertTrue(exception.getMessage().contains("rest_method"), "message should mention the shared dimension");
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/configuration/ObservabilityOptionsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/configuration/ObservabilityOptionsTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 
 import static io.evitadb.test.TestTags.OBSERVABILITY;
@@ -94,6 +95,19 @@ class ObservabilityOptionsTest {
 			() -> withExportedQueryLabels(List.of("rest-method", "rest.method"))
 		);
 		assertTrue(exception.getMessage().contains("rest_method"), "message should mention the shared dimension");
+	}
+
+	@Test
+	@DisplayName("Should reject a null query label name (a bare `-` list item in YAML)")
+	void shouldRejectNullLabelName() {
+		final List<String> withNullItem = new ArrayList<>();
+		withNullItem.add("job_name");
+		withNullItem.add(null);
+		final EvitaInvalidUsageException exception = assertThrows(
+			EvitaInvalidUsageException.class,
+			() -> withExportedQueryLabels(withNullItem)
+		);
+		assertTrue(exception.getMessage().toLowerCase().contains("null"), "message should mention the null item");
 	}
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/metric/PrometheusLabelNamesTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/metric/PrometheusLabelNamesTest.java
@@ -1,0 +1,132 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.observability.metric;
+
+import io.evitadb.exception.EvitaInvalidUsageException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static io.evitadb.test.TestTags.OBSERVABILITY_API;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies {@link PrometheusLabelNames#sanitize(String)} turns arbitrary, operator-chosen query label names into
+ * legal Prometheus dimension names (`[a-zA-Z_][a-zA-Z0-9_]*`). This is the shared rule the configuration layer uses to
+ * detect two labels colliding on the same dimension, and the metric handler uses to name the dimension it registers.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("PrometheusLabelNames sanitization")
+@Tag(OBSERVABILITY_API)
+@Tag(OBSERVABILITY)
+class PrometheusLabelNamesTest {
+
+	@Test
+	@DisplayName("Should leave already-legal names unchanged")
+	void shouldLeaveLegalNamesUnchanged() {
+		assertEquals("job_name", PrometheusLabelNames.sanitize("job_name"));
+		assertEquals("rest_method", PrometheusLabelNames.sanitize("rest_method"));
+		assertEquals("_private", PrometheusLabelNames.sanitize("_private"));
+		assertEquals("Tenant2", PrometheusLabelNames.sanitize("Tenant2"));
+	}
+
+	@Test
+	@DisplayName("Should replace illegal characters with underscores")
+	void shouldReplaceIllegalCharacters() {
+		assertEquals("rest_method", PrometheusLabelNames.sanitize("rest-method"));
+		assertEquals("a_b_c", PrometheusLabelNames.sanitize("a.b-c"));
+		assertEquals("source_query", PrometheusLabelNames.sanitize("source-query"));
+	}
+
+	@Test
+	@DisplayName("Should prefix names that would otherwise start with a digit")
+	void shouldPrefixLeadingDigit() {
+		assertEquals("_1st", PrometheusLabelNames.sanitize("1st"));
+		assertEquals("_2_tenants", PrometheusLabelNames.sanitize("2-tenants"));
+	}
+
+	@Test
+	@DisplayName("Should turn an empty name into a single underscore")
+	void shouldHandleEmptyName() {
+		assertEquals("_", PrometheusLabelNames.sanitize(""));
+	}
+
+	@Test
+	@DisplayName("Distinct raw names may collapse onto the same sanitized dimension")
+	void distinctNamesMayCollide() {
+		assertEquals(
+			PrometheusLabelNames.sanitize("rest.method"),
+			PrometheusLabelNames.sanitize("rest-method")
+		);
+	}
+
+	@Test
+	@DisplayName("assignDimensions should map each label to its sanitized dimension, preserving order")
+	void assignDimensionsShouldMapAndPreserveOrder() {
+		final Map<String, String> dimensions = PrometheusLabelNames.assignDimensions(
+			List.of("job_name", "rest-method", "tenant"), Set.of()
+		);
+		assertEquals(Map.of("job_name", "job_name", "rest-method", "rest_method", "tenant", "tenant"), dimensions);
+		assertEquals(List.of("job_name", "rest-method", "tenant"), List.copyOf(dimensions.keySet()));
+	}
+
+	@Test
+	@DisplayName("assignDimensions should reject two labels that collapse onto the same dimension")
+	void assignDimensionsShouldRejectMutualCollision() {
+		final EvitaInvalidUsageException exception = assertThrows(
+			EvitaInvalidUsageException.class,
+			() -> PrometheusLabelNames.assignDimensions(List.of("rest-method", "rest.method"), Set.of())
+		);
+		assertTrue(exception.getMessage().contains("rest_method"), "should mention the shared dimension");
+	}
+
+	@Test
+	@DisplayName("assignDimensions should reject a label that collides with a reserved built-in dimension")
+	void assignDimensionsShouldRejectReservedCollision() {
+		final EvitaInvalidUsageException exception = assertThrows(
+			EvitaInvalidUsageException.class,
+			() -> PrometheusLabelNames.assignDimensions(List.of("prefetched"), Set.of("entityType", "prefetched"))
+		);
+		assertTrue(exception.getMessage().contains("prefetched"), "should mention the clashing dimension");
+		assertTrue(exception.getMessage().contains("built-in"), "should explain it is a built-in dimension");
+	}
+
+	@Test
+	@DisplayName("assignDimensions should accept labels that don't collide with reserved dimensions")
+	void assignDimensionsShouldAcceptNonCollidingWithReserved() {
+		final Map<String, String> dimensions = PrometheusLabelNames.assignDimensions(
+			List.of("job_name", "tenant"), Set.of("entityType", "prefetched", "catalogName")
+		);
+		assertEquals(Map.of("job_name", "job_name", "tenant", "tenant"), dimensions);
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/metric/QueryLabelBagTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/observability/metric/QueryLabelBagTest.java
@@ -1,0 +1,87 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2024-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.observability.metric;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.evitadb.test.TestTags.OBSERVABILITY;
+import static io.evitadb.test.TestTags.OBSERVABILITY_API;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Verifies {@link QueryLabelBag#extractValue(String, String)} - the lookup that surfaces the value of one configured
+ * query label out of the comma-delimited `name=value` bag carried by each query event. The "not carried" cases matter
+ * most: they are what makes the exported dimension render as `N/A` when a query simply didn't tag itself with that
+ * label.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("QueryLabelBag extraction")
+@Tag(OBSERVABILITY_API)
+@Tag(OBSERVABILITY)
+class QueryLabelBagTest {
+
+	private static final String BAG = "job_name=feed-job,rest_method=GET /products,tenant=acme";
+
+	@Test
+	@DisplayName("Should extract a label's value from any position in the bag")
+	void shouldExtractFromAnyPosition() {
+		assertEquals("feed-job", QueryLabelBag.extractValue(BAG, "job_name"));         // first
+		assertEquals("GET /products", QueryLabelBag.extractValue(BAG, "rest_method")); // middle
+		assertEquals("acme", QueryLabelBag.extractValue(BAG, "tenant"));               // last
+	}
+
+	@Test
+	@DisplayName("Should return null when the bag does not carry the requested label")
+	void shouldReturnNullForAbsentLabel() {
+		assertNull(QueryLabelBag.extractValue(BAG, "missing"));
+		// a prefix of an existing name must not match
+		assertNull(QueryLabelBag.extractValue(BAG, "job"));
+		// a suffix of an existing name must not match either
+		assertNull(QueryLabelBag.extractValue(BAG, "name"));
+	}
+
+	@Test
+	@DisplayName("Should return null for an empty or null bag")
+	void shouldReturnNullForEmptyBag() {
+		assertNull(QueryLabelBag.extractValue(null, "job_name"));
+		assertNull(QueryLabelBag.extractValue("", "job_name"));
+	}
+
+	@Test
+	@DisplayName("Should keep everything after the first '=' as the value")
+	void shouldKeepValueAfterFirstEquals() {
+		assertEquals("a=b=c", QueryLabelBag.extractValue("expr=a=b=c,tenant=acme", "expr"));
+	}
+
+	@Test
+	@DisplayName("Should extract a single-pair bag with no trailing delimiter")
+	void shouldExtractSinglePair() {
+		assertEquals("feed", QueryLabelBag.extractValue("job_name=feed", "job_name"));
+	}
+
+}


### PR DESCRIPTION
## Summary

Bridges the generic `label()` query-head constraint to Prometheus. Query label values were previously visible only in traces, traffic recordings and JFR events; operators can now opt specific label names in as dimensions on query metrics via a new observability option.

## Mechanism

- New `exportedQueryLabels` option in `ObservabilityOptions`. The names are **arbitrary and operator-defined** — evitaDB reserves none.
- `@ExportConfigurableLabels` marks the JFR event's label bag (`FinishedEvent.labels`). At metric registration each configured name is matched against the bag and exposed as a Prometheus dimension (`QueryLabelBag` extraction on the background recording-stream thread, never the query path). With nothing configured (the default) no dimension is added and the bag is never parsed.

## Safety

- **Inverted default polarity**: unset/empty exports nothing (unlike `allowedEvents`), because query labels are arbitrary client data.
- **Reserved names** `trace-id` / `client-id` / `ip-address` / `uri` can never be exported (reused from `TrafficRecordingEngine`).
- Names are **sanitized** to legal Prometheus dimensions; **collisions** — between two configured labels, or a configured label and a built-in dimension (`entityType` / `prefetched` / …) — are rejected (`PrometheusLabelNames.assignDimensions`).

## Docs & tests

- User docs (en + cs): `observe.md` (config walkthrough), `label.md` (cardinality-safety notes), `configure.md` (option reference). Generated `metrics.md` is intentionally unchanged — config-driven dimensions don't exist at doc-gen time.
- Unit tests: `PrometheusLabelNamesTest`, `QueryLabelBagTest`, `ObservabilityOptionsTest`, `FinishedEventTest`.
