### PR TITLE
feat: dedicated traffic-recorder metrics; opt MemoryNotAvailableException out of error monitoring

### DIFF
--- a/documentation/user/en/operate/reference/jfr-events.md
+++ b/documentation/user/en/operate/reference/jfr-events.md
@@ -75,6 +75,8 @@
   <dd>Event fired when an entity is directly fetched.</dd>
   <dt><SourceClass>evita_engine/src/main/java/io/evitadb/core/metric/event/query/FinishedEvent.java</SourceClass> Query finished</dt>
   <dd>Event that is fired when a query is finished.</dd>
+  <dt><SourceClass>evita_engine/src/main/java/io/evitadb/store/traffic/event/TrafficRecorderSkippedRecordsEvent.java</SourceClass> Traffic recorder skipped records</dt>
+  <dd>Event that reports traffic records and sessions skipped or dropped, broken down by reason.</dd>
   <dt><SourceClass>evita_engine/src/main/java/io/evitadb/store/traffic/event/TrafficRecorderStatisticsEvent.java</SourceClass> Traffic recorder statistics</dt>
   <dd>Event that regularly monitors traffic recorder statistics.</dd>
 </dl>

--- a/documentation/user/en/operate/reference/metrics.md
+++ b/documentation/user/en/operate/reference/metrics.md
@@ -61,6 +61,8 @@
     <dd><strong>Prospective (client/server)</strong>: Identifies whether the event represents whether event represents server or client view of readiness.
 Client view is the duration viewed from the HTTP client side affected by timeouts, server view is the real
 duration of the probe.</dd>
+    <dt>reason</dt>
+    <dd><strong>Reason</strong>: Why the records/sessions were not persisted (e.g. SAMPLING, MEMORY_SHORTAGE, DISK_SHORTAGE, IO_ERROR, SERIALIZATION_ERROR).</dd>
     <dt>recordType</dt>
     <dd><strong>Record type</strong>: Type of records that changed in the OffsetIndex.</dd>
     <dt>requestResult</dt>
@@ -267,14 +269,32 @@ duration of the probe.</dd>
   <dd><strong>Records scanned total</strong>: The total number of records scanned (included in the calculation).<br/><br/><strong>Labels:</strong> <Term>entityType</Term>, <Term>prefetched</Term><br/></dd>
   <dt><code>io_evitadb_query_finished_total</code> (COUNTER)</dt>
   <dd>Query finished<br/><br/><strong>Labels:</strong> <Term>entityType</Term>, <Term>prefetched</Term><br/></dd>
+  <dt><code>io_evitadb_store_traffic_traffic_recorder_skipped_records_dropped_sessions</code> (COUNTER)</dt>
+  <dd><strong>Dropped sessions</strong>: Number of whole sessions dropped for this reason since the previous emission.<br/><br/><strong>Labels:</strong> <Term>reason</Term><br/></dd>
+  <dt><code>io_evitadb_store_traffic_traffic_recorder_skipped_records_missed_records</code> (COUNTER)</dt>
+  <dd><strong>Missed records</strong>: Number of traffic records not persisted for this reason since the previous emission.<br/><br/><strong>Labels:</strong> <Term>reason</Term><br/></dd>
+  <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_active_sessions</code> (GAUGE)</dt>
+  <dd><strong>Active sessions</strong>: Number of live in-flight sessions currently holding off-heap blocks.</dd>
+  <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_blocks_allocated</code> (COUNTER)</dt>
+  <dd><strong>Memory blocks allocated</strong>: Number of off-heap memory blocks allocated since the previous emission.</dd>
   <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_created_sessions</code> (COUNTER)</dt>
-  <dd><strong>Created sessions</strong>: Created sessions.</dd>
-  <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_dropped_sessions</code> (COUNTER)</dt>
-  <dd><strong>Dropped sessions</strong>: Counter of dropped sessions due to memory shortage.</dd>
+  <dd><strong>Created sessions</strong>: Number of sessions admitted for recording since the previous emission.</dd>
+  <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_disk_buffer_used_bytes</code> (GAUGE)</dt>
+  <dd><strong>Disk buffer used bytes</strong>: Number of bytes currently occupied by resident sessions in the disk ring buffer.</dd>
+  <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_disk_bytes_appended</code> (COUNTER)</dt>
+  <dd><strong>Disk bytes appended</strong>: Number of bytes appended to the disk ring buffer since the previous emission.</dd>
+  <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_disk_resident_sessions</code> (GAUGE)</dt>
+  <dd><strong>Disk resident sessions</strong>: Number of sessions currently resident in the disk ring buffer.</dd>
+  <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_finalized_sessions_backlog</code> (GAUGE)</dt>
+  <dd><strong>Finalized sessions backlog</strong>: Number of closed sessions waiting to be drained to disk (flush backlog).</dd>
   <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_finished_sessions</code> (COUNTER)</dt>
-  <dd><strong>Finished sessions</strong>: Recorded sessions.</dd>
-  <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_missed_records</code> (COUNTER)</dt>
-  <dd><strong>Missed records</strong>: Counter of missed records due to memory shortage or sampling.</dd>
+  <dd><strong>Finished sessions</strong>: Number of sessions closed cleanly and queued to disk since the previous emission.</dd>
+  <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_recorded_records</code> (COUNTER)</dt>
+  <dd><strong>Recorded records</strong>: Number of traffic records successfully captured since the previous emission.</dd>
+  <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_total_memory_blocks</code> (GAUGE)</dt>
+  <dd><strong>Total memory blocks</strong>: Total number of off-heap memory blocks available to the recorder.</dd>
+  <dt><code>io_evitadb_store_traffic_traffic_recorder_statistics_used_memory_blocks</code> (GAUGE)</dt>
+  <dd><strong>Used memory blocks</strong>: Number of off-heap memory blocks currently in use (primary memory-pressure signal).</dd>
 </dl>
 
 #### Session

--- a/evita_common/src/main/java/io/evitadb/exception/NotMonitored.java
+++ b/evita_common/src/main/java/io/evitadb/exception/NotMonitored.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.exception;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@link Throwable} (typically an {@link EvitaInternalError} subtype) that is used purely for
+ * control flow / signalling rather than to report a genuine fault. evitaDB's observability
+ * error-monitoring agent (`ErrorMonitoringAgent`) intercepts every constructor of the monitored
+ * exception hierarchies and reports it as an error metric (`io_evitadb_errors_total` and siblings);
+ * annotating a type with this marker excludes it from that interception, so a benign,
+ * expected-and-handled condition does not masquerade as a serious engine error.
+ *
+ * A prime example is the traffic recorder's memory-shortage signal, which merely means a single
+ * intercepted statement will not be captured - a situation the traffic engine is designed to cope
+ * with, and which is tracked properly through dedicated traffic-recorder metrics instead.
+ *
+ * Retention is {@link RetentionPolicy#RUNTIME}: the agent reads the annotation from the class-file
+ * type pool at premain time (Byte Buddy `isAnnotatedWith`), for which `CLASS` retention would already
+ * suffice, but `RUNTIME` also keeps the marker discoverable via reflection and removes any ambiguity.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface NotMonitored {
+}

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/agent/ErrorMonitoringAgent.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/agent/ErrorMonitoringAgent.java
@@ -25,6 +25,7 @@ package io.evitadb.externalApi.observability.agent;
 
 import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.exception.EvitaInvalidUsageException;
+import io.evitadb.exception.NotMonitored;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.OnMethodExit;
@@ -57,21 +58,24 @@ public class ErrorMonitoringAgent {
 			.with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
 			.ignore(none())
 			.ignore(nameStartsWith("net.bytebuddy."))
-			.type(isSubTypeOf(VirtualMachineError.class).and(not(isAbstract())))
+			// a type may opt out of error monitoring by carrying the @NotMonitored marker - used for
+			// control-flow signalling throwables that are expected and handled, so they must not be
+			// reported as engine/JVM errors (e.g. the traffic recorder's memory-shortage signal).
+			.type(isSubTypeOf(VirtualMachineError.class).and(not(isAbstract())).and(not(isAnnotatedWith(NotMonitored.class))))
 			.transform((builder, typeDescription, classLoader, module, protectionDomain) -> builder
 				.visit(
 					Advice
 						.to(JavaErrorConstructorInterceptAdvice.class)
 						.on(isConstructor())
 				))
-			.type(isSubTypeOf(EvitaInternalError.class).and(not(isAbstract())))
+			.type(isSubTypeOf(EvitaInternalError.class).and(not(isAbstract())).and(not(isAnnotatedWith(NotMonitored.class))))
 			.transform((builder, typeDescription, classLoader, module, protectionDomain) -> builder
 				.visit(
 					Advice
 						.to(EvitaDbErrorConstructorInterceptAdvice.class)
 						.on(isConstructor())
 				))
-			.type(isSubTypeOf(EvitaInvalidUsageException.class).and(not(isAbstract())))
+			.type(isSubTypeOf(EvitaInvalidUsageException.class).and(not(isAbstract())).and(not(isAnnotatedWith(NotMonitored.class))))
 			.transform((builder, typeDescription, classLoader, module, protectionDomain) -> builder
 				.visit(
 					Advice

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/EvitaJfrEventRegistry.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/EvitaJfrEventRegistry.java
@@ -59,6 +59,7 @@ import io.evitadb.externalApi.event.ReadinessEvent;
 import io.evitadb.externalApi.event.RequestEvent;
 import io.evitadb.externalApi.grpc.metric.event.EvitaProcedureCalledEvent;
 import io.evitadb.externalApi.grpc.metric.event.SessionProcedureCalledEvent;
+import io.evitadb.store.traffic.event.TrafficRecorderSkippedRecordsEvent;
 import io.evitadb.store.traffic.event.TrafficRecorderStatisticsEvent;
 import io.evitadb.utils.ArrayUtils;
 import io.evitadb.utils.Assert;
@@ -119,6 +120,7 @@ public class EvitaJfrEventRegistry {
 		ReadOnlyHandleClosedEvent.class,
 		CatalogStatisticsEvent.class,
 		TrafficRecorderStatisticsEvent.class,
+		TrafficRecorderSkippedRecordsEvent.class,
 
 		// query events
 		FinishedEvent.class,

--- a/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/DiskRingBuffer.java
+++ b/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/DiskRingBuffer.java
@@ -182,6 +182,11 @@ public class DiskRingBuffer {
 	 */
 	private final AtomicLong exportIdentityMismatchSkipCount = new AtomicLong();
 	/**
+	 * Cumulative number of bytes appended to the disk ring buffer over the lifetime of this buffer
+	 * (monotonic, including per-session lead descriptors). Surfaced for disk write-throughput metrics.
+	 */
+	private final AtomicLong bytesAppendedTotal = new AtomicLong();
+	/**
 	 * Head of the ring buffer. Volatile because it's written by the writer thread - at most one at a time,
 	 * since {@code OffHeapTrafficRecorder}'s {@code freeMemory()}/{@code drainFinalizedSessionsToDisk()} are
 	 * both {@code synchronized} on the same monitor, so writer-vs-writer can never race this field - and read
@@ -477,6 +482,8 @@ public class DiskRingBuffer {
 					() -> writeDataToFileChannel(memoryByteBuffer, totalBytesToWrite)
 				);
 			}
+			// count only fully written bytes (a mid-write IOException throws before reaching here)
+			this.bytesAppendedTotal.addAndGet(totalBytesToWrite);
 		} catch (IOException e) {
 			throw new UnexpectedIOException(
 				"Failed to append traffic recording buffer file: " + e.getMessage(),
@@ -484,6 +491,40 @@ public class DiskRingBuffer {
 				e
 			);
 		}
+	}
+
+	/**
+	 * Returns the cumulative number of bytes appended to the disk ring buffer over the lifetime of this
+	 * buffer (monotonic, including per-session lead descriptors). Exposed for disk write-throughput metrics.
+	 *
+	 * @return cumulative number of bytes appended
+	 */
+	public long getBytesAppendedTotal() {
+		return this.bytesAppendedTotal.get();
+	}
+
+	/**
+	 * Returns the number of sessions currently resident in the disk ring buffer window.
+	 *
+	 * @return number of resident sessions
+	 */
+	public int getResidentSessionCount() {
+		return this.sessionLocations.size();
+	}
+
+	/**
+	 * Returns the number of bytes currently occupied by resident sessions in the disk ring buffer,
+	 * computed as the sum of the resident sessions' on-disk lengths. Iterating the weakly-consistent
+	 * session deque yields an approximate snapshot, which is sufficient for a periodically sampled gauge.
+	 *
+	 * @return number of bytes occupied by resident sessions
+	 */
+	public long getUsedBytes() {
+		long usedBytes = 0L;
+		for (final SessionLocation sessionLocation : this.sessionLocations) {
+			usedBytes += sessionLocation.location().recordLength();
+		}
+		return usedBytes;
 	}
 
 	/**

--- a/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/OffHeapTrafficRecorder.java
+++ b/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/OffHeapTrafficRecorder.java
@@ -355,8 +355,9 @@ public class OffHeapTrafficRecorder
 				}
 			);
 		} else {
-			// deliberate sampling skip: the session is not admitted because the recorded fraction already
-			// meets the configured target - benign, tracked under the SAMPLING reason
+			// deliberate sampling skip: the session is not admitted either because sampling is disabled
+			// (samplingPercentage <= 0) or because the recorded fraction already meets the configured target -
+			// benign in both cases, tracked under the SAMPLING reason
 			this.missedRecordsByReason.get(TrafficRecorderMissReason.SAMPLING).incrementAndGet();
 		}
 	}

--- a/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/OffHeapTrafficRecorder.java
+++ b/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/OffHeapTrafficRecorder.java
@@ -52,6 +52,7 @@ import io.evitadb.core.executor.Scheduler;
 import io.evitadb.core.management.FileManagementService;
 import io.evitadb.exception.EvitaInternalError;
 import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.exception.NotMonitored;
 import io.evitadb.exception.UnexpectedIOException;
 import io.evitadb.spi.store.catalog.trafficRecorder.RandomAccessFileSessionSink;
 import io.evitadb.spi.store.catalog.trafficRecorder.SessionSink;
@@ -62,6 +63,8 @@ import io.evitadb.store.kryo.ObservableInput;
 import io.evitadb.store.offsetIndex.model.StorageRecord;
 import io.evitadb.store.query.QuerySerializationKryoConfigurer;
 import io.evitadb.store.shared.kryo.KryoFactory;
+import io.evitadb.store.traffic.event.TrafficRecorderMissReason;
+import io.evitadb.store.traffic.event.TrafficRecorderSkippedRecordsEvent;
 import io.evitadb.store.traffic.event.TrafficRecorderStatisticsEvent;
 import io.evitadb.store.traffic.serializer.CurrentSessionRecordContext;
 import io.evitadb.store.traffic.stream.RingBufferInputStream;
@@ -79,6 +82,7 @@ import java.io.Serial;
 import java.nio.ByteBuffer;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.Queue;
@@ -138,23 +142,36 @@ public class OffHeapTrafficRecorder
 	 */
 	private final Queue<SessionTraffic> finalizedSessions = new ConcurrentLinkedQueue<>();
 	/**
-	 * Counter of records used in sampling calculation.
+	 * Enumerates the miss reasons once so per-reason counters and the periodic delta bookkeeping can be
+	 * indexed by {@link TrafficRecorderMissReason#ordinal()} without recomputing {@code values()}.
+	 */
+	private static final TrafficRecorderMissReason[] MISS_REASONS = TrafficRecorderMissReason.values();
+	/**
+	 * Counter of records successfully captured. Monotonic (never reset) so the periodic metric emission
+	 * can publish it as a delta; the sampling ratio uses it relative to {@link #samplingRecordedBaseline}.
 	 */
 	private final AtomicLong recordedRecords = new AtomicLong();
 	/**
-	 * Counter of missed records due to memory shortage or sampling.
+	 * Per-reason counters of records that were not persisted (see {@link TrafficRecorderMissReason}).
+	 * Monotonic; pre-populated with one {@link AtomicLong} per reason at construction time so only atomic
+	 * reads/updates of the values ever happen afterwards (no structural modification -> concurrent-safe).
 	 */
-	private final AtomicLong missedRecords = new AtomicLong();
+	private final Map<TrafficRecorderMissReason, AtomicLong> missedRecordsByReason = createReasonCounters();
 	/**
-	 * Counter of dropped sessions due to memory shortage.
+	 * Per-reason counters of whole sessions that were dropped (see {@link TrafficRecorderMissReason}).
+	 * Same monotonic/pre-populated contract as {@link #missedRecordsByReason}.
 	 */
-	private final AtomicLong droppedSessions = new AtomicLong();
+	private final Map<TrafficRecorderMissReason, AtomicLong> droppedSessionsByReason = createReasonCounters();
 	/**
-	 * Counter of created sessions.
+	 * Counter of off-heap memory blocks allocated over the recorder's lifetime (monotonic, delta-emitted).
+	 */
+	private final AtomicLong blocksAllocated = new AtomicLong();
+	/**
+	 * Counter of created (admitted) sessions. Monotonic, delta-emitted.
 	 */
 	private final AtomicLong createdSessions = new AtomicLong();
 	/**
-	 * Counter of finished sessions.
+	 * Counter of finished (cleanly closed and queued to disk) sessions. Monotonic, delta-emitted.
 	 */
 	private final AtomicLong finishedSessions = new AtomicLong();
 	/**
@@ -169,6 +186,11 @@ public class OffHeapTrafficRecorder
 	 * Queue contains indexes of free blocks available for usage.
 	 */
 	private Queue<Integer> freeBlocks;
+	/**
+	 * Total number of off-heap memory blocks the buffer is divided into (capacity / blockSizeBytes). Set
+	 * once in {@link #init}; used together with {@code freeBlocks.size()} to derive the used-blocks gauge.
+	 */
+	private int totalMemoryBlocks;
 	/**
 	 * Ring buffer used for storing traffic data when they are completed in the memory buffer.
 	 */
@@ -185,6 +207,15 @@ public class OffHeapTrafficRecorder
 	 */
 	private int samplingPercentage;
 	/**
+	 * Baselines captured at the last {@link #setSamplingPercentage} call so the sampling ratio restarts
+	 * fresh for a new target WITHOUT resetting the monotonic metric counters (resetting them would make
+	 * the periodic delta emission go negative). The ratio is
+	 * {@code (recordedRecords - samplingRecordedBaseline) / ((recordedRecords - samplingRecordedBaseline) +
+	 * (sampledOut - samplingSampledOutBaseline))}, where {@code sampledOut} is the SAMPLING-reason counter.
+	 */
+	private volatile long samplingRecordedBaseline;
+	private volatile long samplingSampledOutBaseline;
+	/**
 	 * Contains reference to the asynchronous task executor that clears finalized session memory blocks and writes
 	 * them to disk buffer.
 	 */
@@ -197,6 +228,22 @@ public class OffHeapTrafficRecorder
 	 * Last time when the data from the {@link #diskBuffer} was read.
 	 */
 	private long lastRead = -1;
+	/**
+	 * Last emitted cumulative counter values, captured after each {@link #freeMemory()} emission so the
+	 * next emission can publish the delta since the previous one. Only ever touched inside the
+	 * {@code synchronized} {@link #freeMemory()}, so plain fields are sufficient.
+	 */
+	private long lastCreatedSessionsEmitted;
+	private long lastFinishedSessionsEmitted;
+	private long lastRecordedRecordsEmitted;
+	private long lastBlocksAllocatedEmitted;
+	private long lastDiskBytesAppendedEmitted;
+	/**
+	 * Per-reason last-emitted values (indexed by {@link TrafficRecorderMissReason#ordinal()}) backing the
+	 * delta emission of {@link TrafficRecorderSkippedRecordsEvent}. Only touched inside {@link #freeMemory()}.
+	 */
+	private final long[] lastMissedRecordsEmitted = new long[MISS_REASONS.length];
+	private final long[] lastDroppedSessionsEmitted = new long[MISS_REASONS.length];
 
 	/**
 	 * Converts an {@link OffsetDateTime} to epoch milliseconds without allocating an intermediate
@@ -211,6 +258,22 @@ public class OffHeapTrafficRecorder
 	 */
 	private static long epochMillis(@Nonnull OffsetDateTime offsetDateTime) {
 		return offsetDateTime.toEpochSecond() * 1000L + offsetDateTime.getNano() / 1_000_000;
+	}
+
+	/**
+	 * Creates a fully pre-populated map holding one {@link AtomicLong} per {@link TrafficRecorderMissReason}.
+	 * Because every key is present from the start and no key is ever added or removed afterwards, concurrent
+	 * {@code get(...)} reads on the returned {@link EnumMap} are safe without additional synchronization.
+	 *
+	 * @return an enum map with a zeroed counter for every reason
+	 */
+	@Nonnull
+	private static Map<TrafficRecorderMissReason, AtomicLong> createReasonCounters() {
+		final Map<TrafficRecorderMissReason, AtomicLong> counters = new EnumMap<>(TrafficRecorderMissReason.class);
+		for (final TrafficRecorderMissReason reason : MISS_REASONS) {
+			counters.put(reason, new AtomicLong());
+		}
+		return counters;
 	}
 
 	public OffHeapTrafficRecorder() {
@@ -241,8 +304,10 @@ public class OffHeapTrafficRecorder
 
 	@Override
 	public void setSamplingPercentage(int samplingPercentage) {
-		this.recordedRecords.set(0);
-		this.missedRecords.set(0);
+		// rebaseline the sampling ratio so it restarts fresh for the new target, WITHOUT resetting the
+		// monotonic metric counters - resetting them would make the periodic delta emission go negative
+		this.samplingRecordedBaseline = this.recordedRecords.get();
+		this.samplingSampledOutBaseline = this.missedRecordsByReason.get(TrafficRecorderMissReason.SAMPLING).get();
 		this.samplingPercentage = samplingPercentage;
 	}
 
@@ -279,9 +344,9 @@ public class OffHeapTrafficRecorder
 					catalogVersion,
 					created
 				),
-				ex -> discardSession(sessionTraffic),
+				ex -> discardSession(sessionTraffic, TrafficRecorderMissReason.MEMORY_SHORTAGE),
 				ex -> {
-					discardSession(sessionTraffic);
+					discardSession(sessionTraffic, TrafficRecorderMissReason.SERIALIZATION_ERROR);
 					log.error("Failed to record session start for session {}.", sessionId, ex);
 				},
 				() -> {
@@ -290,7 +355,9 @@ public class OffHeapTrafficRecorder
 				}
 			);
 		} else {
-			this.missedRecords.incrementAndGet();
+			// deliberate sampling skip: the session is not admitted because the recorded fraction already
+			// meets the configured target - benign, tracked under the SAMPLING reason
+			this.missedRecordsByReason.get(TrafficRecorderMissReason.SAMPLING).incrementAndGet();
 		}
 	}
 
@@ -316,9 +383,9 @@ public class OffHeapTrafficRecorder
 					sessionTraffic.getMutationCount(),
 					finishedWithError
 				),
-				ex -> discardSession(sessionTraffic),
+				ex -> discardSession(sessionTraffic, TrafficRecorderMissReason.MEMORY_SHORTAGE),
 				ex -> {
-					discardSession(sessionTraffic);
+					discardSession(sessionTraffic, TrafficRecorderMissReason.SERIALIZATION_ERROR);
 					log.error("Failed to record session close for session {}.", sessionId, ex);
 				},
 				() -> {
@@ -330,7 +397,9 @@ public class OffHeapTrafficRecorder
 				}
 			);
 		} else {
-			this.missedRecords.incrementAndGet();
+			// closing a session that was never tracked (it was sampled out at creation, or already
+			// discarded) - benign, tracked under the SAMPLING reason
+			this.missedRecordsByReason.get(TrafficRecorderMissReason.SAMPLING).incrementAndGet();
 		}
 	}
 
@@ -648,6 +717,7 @@ public class OffHeapTrafficRecorder
 		final int capacity = (int) (trafficMemoryBufferSizeInBytes - (trafficMemoryBufferSizeInBytes % this.blockSizeBytes));
 		this.memoryBlock.set(ByteBuffer.allocateDirect(capacity));
 		final int blockCount = capacity / this.blockSizeBytes;
+		this.totalMemoryBlocks = blockCount;
 		// initialize free blocks queue, all blocks are free at the beginning
 		this.freeBlocks = new ArrayBlockingQueue<>(blockCount, true);
 		// initialize observable outputs for each memory block
@@ -758,8 +828,12 @@ public class OffHeapTrafficRecorder
 									this.freeBlocks.offer(block);
 								}
 							}
-							this.droppedSessions.incrementAndGet();
-							this.missedRecords.addAndGet(finalizedSession.getRecordCount());
+							// classify the drop cause: DATA_TOO_LARGE from appendSession (session larger than the
+							// whole disk ring buffer) is DISK_SHORTAGE, a failed disk write is IO_ERROR
+							final TrafficRecorderMissReason reason = ex instanceof MemoryNotAvailableException ?
+								TrafficRecorderMissReason.DISK_SHORTAGE : TrafficRecorderMissReason.IO_ERROR;
+							this.droppedSessionsByReason.get(reason).incrementAndGet();
+							this.missedRecordsByReason.get(reason).addAndGet(finalizedSession.getRecordCount());
 							log.warn(
 								"Finalized session {} ({} bytes) could not be persisted to the traffic disk buffer and was dropped: {}",
 								finalizedSession.getSessionId(), totalSize, ex.getMessage()
@@ -773,16 +847,17 @@ public class OffHeapTrafficRecorder
 
 	/**
 	 * Discards the current session by freeing associated memory resources and
-	 * incrementing relevant counters for dropped sessions and missed records.
-	 * This is typically invoked in scenarios where there's a memory shortage,
-	 * and the session needs to be closed with its data being discarded.
+	 * incrementing the per-reason dropped-session and missed-record counters.
+	 * This is typically invoked when a session cannot be recorded (memory shortage)
+	 * or its serialization failed, and the session needs to be closed with its data discarded.
 	 *
 	 * @param sessionTraffic the session traffic containing memory block IDs and record count
+	 * @param reason         the reason the session is being discarded (drives the metric dimension)
 	 */
-	private void discardSession(@Nonnull SessionTraffic sessionTraffic) {
+	private void discardSession(@Nonnull SessionTraffic sessionTraffic, @Nonnull TrafficRecorderMissReason reason) {
 		this.copyBufferPool.free(sessionTraffic.discard());
-		this.droppedSessions.incrementAndGet();
-		this.missedRecords.addAndGet(sessionTraffic.getRecordCount());
+		this.droppedSessionsByReason.get(reason).incrementAndGet();
+		this.missedRecordsByReason.get(reason).addAndGet(sessionTraffic.getRecordCount());
 		// when there is memory shortage, when session is closed - free the memory and throw away the data
 		final OfInt memoryBlockIds = sessionTraffic.getMemoryBlockIds();
 		while (memoryBlockIds.hasNext()) {
@@ -795,19 +870,24 @@ public class OffHeapTrafficRecorder
 	}
 
 	/**
-	 * Calculates the current sampling rate as a percentage.
-	 * The sampling rate is determined based on the ratio of recorded records to the total of recorded and missed records.
-	 * If no records have been recorded or missed yet, the method returns 0 - this makes the very first session pass
-	 * the {@code currentRate <= samplingPercentage} gate in {@link #createSession} (for any target above zero) and
-	 * start recording, after which the ratio tracks the configured target.
+	 * Calculates the current sampling rate as a percentage since the last {@link #setSamplingPercentage}
+	 * rebaseline. The rate is the ratio of recorded records to the total of recorded records and records
+	 * deliberately skipped for SAMPLING - failure drops (memory/disk shortage, IO, serialization errors)
+	 * are intentionally EXCLUDED: counting them here would lower the computed rate and make the sampling
+	 * gate in {@link #createSession} admit MORE sessions exactly when the recorder is already under
+	 * pressure (a positive-feedback loop). If nothing has been recorded or sampled out yet, the method
+	 * returns 0 - this makes the very first session pass the {@code currentRate <= samplingPercentage}
+	 * gate (for any target above zero) and start recording, after which the ratio tracks the target.
 	 *
 	 * @return the current sampling rate as an integer percentage (0-100)
 	 */
 	private int computeCurrentSamplingRate() {
-		final long recorded = this.recordedRecords.get();
-		final long missed = this.missedRecords.get();
-		final long recordedAndMissed = recorded + missed;
-		return recordedAndMissed == 0 ? 0 : (int) (((double) recorded / (double) recordedAndMissed) * 100.0);
+		final long recorded = this.recordedRecords.get() - this.samplingRecordedBaseline;
+		final long sampledOut = this.missedRecordsByReason.get(TrafficRecorderMissReason.SAMPLING).get() -
+			this.samplingSampledOutBaseline;
+		final long recordedAndSampledOut = recorded + sampledOut;
+		return recordedAndSampledOut <= 0 ?
+			0 : (int) (((double) recorded / (double) recordedAndSampledOut) * 100.0);
 	}
 
 	/**
@@ -872,10 +952,10 @@ public class OffHeapTrafficRecorder
 			final T container = containerFactory.apply(sessionTraffic);
 			sessionTraffic.record(
 				container,
-				ex -> discardSession(sessionTraffic),
+				ex -> discardSession(sessionTraffic, TrafficRecorderMissReason.MEMORY_SHORTAGE),
 				ex -> {
 					log.error("Failed to record traffic data for session {}.", sessionTraffic.getSessionId(), ex);
-					discardSession(sessionTraffic);
+					discardSession(sessionTraffic, TrafficRecorderMissReason.SERIALIZATION_ERROR);
 				},
 				this.recordedRecords::incrementAndGet
 			);
@@ -883,7 +963,9 @@ public class OffHeapTrafficRecorder
 			if (sessionTraffic != null) {
 				sessionTraffic.registerRecordMissedOut();
 			}
-			this.missedRecords.incrementAndGet();
+			// no active recording session for this record (sampled out or already finished) - benign,
+			// tracked under the SAMPLING reason
+			this.missedRecordsByReason.get(TrafficRecorderMissReason.SAMPLING).incrementAndGet();
 		}
 	}
 
@@ -904,6 +986,7 @@ public class OffHeapTrafficRecorder
 		if (freeBlockId == null) {
 			throw MemoryNotAvailableException.NO_SLOT_FREE;
 		} else {
+			this.blocksAllocated.incrementAndGet();
 			return new NumberedByteBuffer(
 				freeBlockId,
 				this.memoryBlock.get()
@@ -934,16 +1017,12 @@ public class OffHeapTrafficRecorder
 	 * @return Always returns -1 as a placeholder for future implementations or changes.
 	 */
 	private synchronized long freeMemory() {
+		// capture the drain backlog BEFORE draining - after the drain it is ~0 and would never show buildup
+		final int finalizedSessionsBacklog = this.finalizedSessions.size();
 		drainFinalizedSessionsToDisk();
 
-		// publish statistic information
-		new TrafficRecorderStatisticsEvent(
-			this.catalogName,
-			this.missedRecords.get(),
-			this.droppedSessions.get(),
-			this.createdSessions.get(),
-			this.finishedSessions.get()
-		).commit();
+		// publish throughput/memory/churn snapshot + per-reason skip breakdown
+		publishStatisticsEvents(finalizedSessionsBacklog);
 
 		// if the disk buffer wasn't read for a long time, we can purge it
 		if (this.lastRead > 0 && System.currentTimeMillis() - this.lastRead > INDEX_INACTIVITY_DURATION) {
@@ -951,6 +1030,66 @@ public class OffHeapTrafficRecorder
 		}
 
 		return -1L;
+	}
+
+	/**
+	 * Publishes the periodic traffic-recorder metrics: a {@link TrafficRecorderStatisticsEvent} snapshot
+	 * (throughput counters as deltas since the previous emission, memory/churn state as instantaneous
+	 * gauges) followed by one {@link TrafficRecorderSkippedRecordsEvent} per {@link TrafficRecorderMissReason}
+	 * that saw activity (its missed/dropped counters as deltas). Emitting deltas is required because the
+	 * metric pipeline increments the Prometheus counter by the committed value on each event; emitting the
+	 * cumulative totals would over-count. Idle reasons are skipped to avoid emitting no-op zero increments.
+	 *
+	 * Invoked only while holding this recorder's monitor (from the {@code synchronized} {@link #freeMemory()}
+	 * and marked {@code synchronized} itself so a direct test call is equally safe), which is what makes the
+	 * plain {@code lastXxxEmitted} delta bookkeeping race-free.
+	 *
+	 * @param finalizedSessionsBacklog drain backlog sampled by the caller before the preceding drain, so the
+	 *                                 gauge reflects accumulation rather than the post-drain (near-zero) state
+	 */
+	synchronized void publishStatisticsEvents(int finalizedSessionsBacklog) {
+		final long createdSessionsNow = this.createdSessions.get();
+		final long finishedSessionsNow = this.finishedSessions.get();
+		final long recordedRecordsNow = this.recordedRecords.get();
+		final long blocksAllocatedNow = this.blocksAllocated.get();
+		final long diskBytesAppendedNow = this.diskBuffer.getBytesAppendedTotal();
+
+		new TrafficRecorderStatisticsEvent(
+			this.catalogName,
+			createdSessionsNow - this.lastCreatedSessionsEmitted,
+			finishedSessionsNow - this.lastFinishedSessionsEmitted,
+			recordedRecordsNow - this.lastRecordedRecordsEmitted,
+			blocksAllocatedNow - this.lastBlocksAllocatedEmitted,
+			diskBytesAppendedNow - this.lastDiskBytesAppendedEmitted,
+			this.totalMemoryBlocks - this.freeBlocks.size(),
+			this.totalMemoryBlocks,
+			this.trackedSessionsIndex.size(),
+			finalizedSessionsBacklog,
+			this.diskBuffer.getUsedBytes(),
+			this.diskBuffer.getResidentSessionCount()
+		).commit();
+
+		this.lastCreatedSessionsEmitted = createdSessionsNow;
+		this.lastFinishedSessionsEmitted = finishedSessionsNow;
+		this.lastRecordedRecordsEmitted = recordedRecordsNow;
+		this.lastBlocksAllocatedEmitted = blocksAllocatedNow;
+		this.lastDiskBytesAppendedEmitted = diskBytesAppendedNow;
+
+		// one event per reason that changed since the previous emission (idle reasons are skipped)
+		for (final TrafficRecorderMissReason reason : MISS_REASONS) {
+			final int ordinal = reason.ordinal();
+			final long missedNow = this.missedRecordsByReason.get(reason).get();
+			final long droppedNow = this.droppedSessionsByReason.get(reason).get();
+			final long missedDelta = missedNow - this.lastMissedRecordsEmitted[ordinal];
+			final long droppedDelta = droppedNow - this.lastDroppedSessionsEmitted[ordinal];
+			if (missedDelta != 0 || droppedDelta != 0) {
+				new TrafficRecorderSkippedRecordsEvent(
+					this.catalogName, reason.name(), missedDelta, droppedDelta
+				).commit();
+				this.lastMissedRecordsEmitted[ordinal] = missedNow;
+				this.lastDroppedSessionsEmitted[ordinal] = droppedNow;
+			}
+		}
 	}
 
 	/**
@@ -985,7 +1124,12 @@ public class OffHeapTrafficRecorder
 	 * (never surfaced to a client), so the fact that their captured stack traces point at class-load
 	 * time rather than the actual throw site is intentional and acceptable - it avoids the cost of
 	 * filling in a stack trace on every memory-shortage occurrence on the hot recording path.
+	 *
+	 * The type is marked {@link NotMonitored} because it is a benign, expected-and-handled control-flow
+	 * signal (a skipped intercept), not an engine fault - it is tracked through the traffic-recorder skip
+	 * metrics ({@link TrafficRecorderSkippedRecordsEvent}) rather than the internal-error metric.
 	 */
+	@NotMonitored
 	public static class MemoryNotAvailableException extends EvitaInternalError {
 		public static final MemoryNotAvailableException NO_SLOT_FREE = new MemoryNotAvailableException(
 			"No free slot in memory buffer!");

--- a/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/event/TrafficRecorderMissReason.java
+++ b/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/event/TrafficRecorderMissReason.java
@@ -1,0 +1,64 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.traffic.event;
+
+/**
+ * Classifies why a traffic record or an entire session was not persisted by the traffic recorder.
+ * The value is exported as the `reason` dimension of the traffic-recorder skip metrics so operators
+ * can tell benign sampling from genuine resource pressure at a glance.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+public enum TrafficRecorderMissReason {
+
+	/**
+	 * The record/session was deliberately not recorded because the current recorded fraction already
+	 * meets the configured sampling target - this is expected, healthy behaviour and NOT a problem.
+	 */
+	SAMPLING,
+
+	/**
+	 * The session was dropped because no free off-heap memory block was available while it was being
+	 * recorded - the in-memory buffer is under pressure (too small for the current write throughput).
+	 */
+	MEMORY_SHORTAGE,
+
+	/**
+	 * The finalized session was dropped because it was larger than the whole disk ring buffer and thus
+	 * could never be appended - the disk buffer is too small for such large sessions.
+	 */
+	DISK_SHORTAGE,
+
+	/**
+	 * The finalized session was dropped because a disk write failed part-way through persisting it.
+	 */
+	IO_ERROR,
+
+	/**
+	 * The session was dropped because serializing one of its records failed unexpectedly - a genuine
+	 * error worth investigating (as opposed to the resource-pressure reasons above).
+	 */
+	SERIALIZATION_ERROR
+
+}

--- a/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/event/TrafficRecorderSkippedRecordsEvent.java
+++ b/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/event/TrafficRecorderSkippedRecordsEvent.java
@@ -1,0 +1,102 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.traffic.event;
+
+
+import io.evitadb.api.configuration.metric.MetricType;
+import io.evitadb.api.observability.annotation.EventGroup;
+import io.evitadb.api.observability.annotation.ExportMetric;
+import io.evitadb.api.observability.annotation.ExportMetricLabel;
+import io.evitadb.core.metric.event.CatalogRelatedEvent;
+import io.evitadb.core.metric.event.CustomMetricsExecutionEvent;
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static io.evitadb.store.traffic.event.TrafficRecorderStatisticsEvent.PACKAGE_NAME;
+
+/**
+ * Event that reports how many traffic records and whole sessions the recorder did NOT persist, broken
+ * down by the {@code reason} dimension ({@link TrafficRecorderMissReason}). It is emitted once per
+ * reason per memory-buffer flush cycle so a single `reason` label distinguishes benign sampling from
+ * genuine memory/disk pressure or serialization errors.
+ *
+ * The two COUNTER fields carry the DELTA since the previous emission for that reason (not the
+ * cumulative total), because the metric pipeline increments the Prometheus counter by the emitted
+ * value on every commit; emitting the cumulative value would over-count.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+@Name(PACKAGE_NAME + ".SkippedRecords")
+@Description("Event that reports traffic records and sessions skipped or dropped, broken down by reason.")
+@Label("Traffic recorder skipped records")
+@EventGroup(
+	value = PACKAGE_NAME,
+	name = "evitaDB - Traffic Recorder",
+	description = "evitaDB events related to traffic recording."
+)
+@Category({"evitaDB", "Query"})
+@RequiredArgsConstructor
+@Getter
+public class TrafficRecorderSkippedRecordsEvent extends CustomMetricsExecutionEvent implements CatalogRelatedEvent {
+
+	/**
+	 * The name of the catalog the traffic recorder relates to.
+	 */
+	@Label("Catalog")
+	@Name("catalogName")
+	@Description("The name of the catalog to which this event/metric is associated.")
+	final String catalogName;
+
+	/**
+	 * The reason the records/sessions were not persisted - exported as the `reason` metric dimension.
+	 */
+	@Label("Reason")
+	@Name("reason")
+	@Description("Why the records/sessions were not persisted (e.g. SAMPLING, MEMORY_SHORTAGE, DISK_SHORTAGE, IO_ERROR, SERIALIZATION_ERROR).")
+	@ExportMetricLabel
+	private final String reason;
+
+	/**
+	 * Number of traffic records not persisted for this reason since the previous emission.
+	 */
+	@Label("Missed records")
+	@Name("missedRecords")
+	@Description("Number of traffic records not persisted for this reason since the previous emission.")
+	@ExportMetric(metricType = MetricType.COUNTER)
+	private final long missedRecords;
+
+	/**
+	 * Number of whole sessions dropped for this reason since the previous emission.
+	 */
+	@Label("Dropped sessions")
+	@Name("droppedSessions")
+	@Description("Number of whole sessions dropped for this reason since the previous emission.")
+	@ExportMetric(metricType = MetricType.COUNTER)
+	private final long droppedSessions;
+
+}

--- a/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/event/TrafficRecorderStatisticsEvent.java
+++ b/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/event/TrafficRecorderStatisticsEvent.java
@@ -39,7 +39,14 @@ import lombok.RequiredArgsConstructor;
 import static io.evitadb.store.traffic.event.TrafficRecorderStatisticsEvent.PACKAGE_NAME;
 
 /**
- * Event that regularly monitors traffic recorder statistics
+ * Event that regularly monitors traffic recorder throughput and memory/churn state. It is emitted once
+ * per memory-buffer flush cycle and carries a snapshot of the recorder's health.
+ *
+ * The COUNTER fields carry the DELTA since the previous emission (not the cumulative total), because
+ * the metric pipeline increments the Prometheus counter by the emitted value on every commit; emitting
+ * the cumulative value would over-count. The GAUGE fields carry the instantaneous value at flush time.
+ *
+ * Per-reason skip/drop breakdown lives in the sibling {@link TrafficRecorderSkippedRecordsEvent}.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
@@ -58,7 +65,7 @@ public class TrafficRecorderStatisticsEvent extends CustomMetricsExecutionEvent 
 	public static final String PACKAGE_NAME = "io.evitadb.store.traffic";
 
 	/**
-	 * The name of the catalog the transaction relates to.
+	 * The name of the catalog the traffic recorder relates to.
 	 */
 	@Label("Catalog")
 	@Name("catalogName")
@@ -66,38 +73,104 @@ public class TrafficRecorderStatisticsEvent extends CustomMetricsExecutionEvent 
 	final String catalogName;
 
 	/**
-	 * Counter of missed records due to memory shortage or sampling.
-	 */
-	@Label("Missed records")
-	@Name("missedRecords")
-	@Description("Counter of missed records due to memory shortage or sampling.")
-	@ExportMetric(metricType = MetricType.COUNTER)
-	private final long missedRecords;
-
-	/**
-	 * Counter of dropped sessions due to memory shortage.
-	 */
-	@Label("Dropped sessions")
-	@Name("droppedSessions")
-	@Description("Counter of dropped sessions due to memory shortage.")
-	@ExportMetric(metricType = MetricType.COUNTER)
-	private final long droppedSessions;
-	/**
-	 * Counter of created sessions.
+	 * Number of sessions successfully admitted for recording since the previous emission.
 	 */
 	@Label("Created sessions")
 	@Name("createdSessions")
-	@Description("Created sessions.")
+	@Description("Number of sessions admitted for recording since the previous emission.")
 	@ExportMetric(metricType = MetricType.COUNTER)
 	private final long createdSessions;
 
 	/**
-	 * Counter of finished sessions.
+	 * Number of sessions closed cleanly and queued to disk since the previous emission.
 	 */
 	@Label("Finished sessions")
 	@Name("finishedSessions")
-	@Description("Recorded sessions.")
+	@Description("Number of sessions closed cleanly and queued to disk since the previous emission.")
 	@ExportMetric(metricType = MetricType.COUNTER)
 	private final long finishedSessions;
+
+	/**
+	 * Number of traffic records successfully captured since the previous emission (ingest throughput).
+	 */
+	@Label("Recorded records")
+	@Name("recordedRecords")
+	@Description("Number of traffic records successfully captured since the previous emission.")
+	@ExportMetric(metricType = MetricType.COUNTER)
+	private final long recordedRecords;
+
+	/**
+	 * Number of off-heap memory blocks allocated since the previous emission (off-heap churn rate).
+	 */
+	@Label("Memory blocks allocated")
+	@Name("blocksAllocated")
+	@Description("Number of off-heap memory blocks allocated since the previous emission.")
+	@ExportMetric(metricType = MetricType.COUNTER)
+	private final long blocksAllocated;
+
+	/**
+	 * Number of bytes appended to the disk ring buffer since the previous emission (disk write throughput).
+	 */
+	@Label("Disk bytes appended")
+	@Name("diskBytesAppended")
+	@Description("Number of bytes appended to the disk ring buffer since the previous emission.")
+	@ExportMetric(metricType = MetricType.COUNTER)
+	private final long diskBytesAppended;
+
+	/**
+	 * Number of off-heap memory blocks currently in use - the primary memory-pressure signal (compare
+	 * with {@link #totalMemoryBlocks}; approaching it foreshadows memory-shortage drops).
+	 */
+	@Label("Used memory blocks")
+	@Name("usedMemoryBlocks")
+	@Description("Number of off-heap memory blocks currently in use (primary memory-pressure signal).")
+	@ExportMetric(metricType = MetricType.GAUGE)
+	private final long usedMemoryBlocks;
+
+	/**
+	 * Total number of off-heap memory blocks available to the recorder (denominator for the utilization ratio).
+	 */
+	@Label("Total memory blocks")
+	@Name("totalMemoryBlocks")
+	@Description("Total number of off-heap memory blocks available to the recorder.")
+	@ExportMetric(metricType = MetricType.GAUGE)
+	private final long totalMemoryBlocks;
+
+	/**
+	 * Number of live in-flight sessions currently holding off-heap blocks.
+	 */
+	@Label("Active sessions")
+	@Name("activeSessions")
+	@Description("Number of live in-flight sessions currently holding off-heap blocks.")
+	@ExportMetric(metricType = MetricType.GAUGE)
+	private final long activeSessions;
+
+	/**
+	 * Number of closed sessions waiting to be drained to disk (backlog - indicates whether the flush
+	 * task keeps up with the close rate).
+	 */
+	@Label("Finalized sessions backlog")
+	@Name("finalizedSessionsBacklog")
+	@Description("Number of closed sessions waiting to be drained to disk (flush backlog).")
+	@ExportMetric(metricType = MetricType.GAUGE)
+	private final long finalizedSessionsBacklog;
+
+	/**
+	 * Number of bytes currently occupied by resident sessions in the disk ring buffer.
+	 */
+	@Label("Disk buffer used bytes")
+	@Name("diskBufferUsedBytes")
+	@Description("Number of bytes currently occupied by resident sessions in the disk ring buffer.")
+	@ExportMetric(metricType = MetricType.GAUGE)
+	private final long diskBufferUsedBytes;
+
+	/**
+	 * Number of sessions currently resident in the disk ring buffer.
+	 */
+	@Label("Disk resident sessions")
+	@Name("diskResidentSessions")
+	@Description("Number of sessions currently resident in the disk ring buffer.")
+	@ExportMetric(metricType = MetricType.GAUGE)
+	private final long diskResidentSessions;
 
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/DiskRingBufferTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/DiskRingBufferTest.java
@@ -932,6 +932,37 @@ class DiskRingBufferTest {
 	}
 
 	/**
+	 * Tests for the disk-write accounting gauges: {@link DiskRingBuffer#getBytesAppendedTotal()},
+	 * {@link DiskRingBuffer#getResidentSessionCount()} and {@link DiskRingBuffer#getUsedBytes()}.
+	 */
+	@Nested
+	@DisplayName("Byte accounting gauges")
+	class ByteAccountingTest {
+
+		@Test
+		@DisplayName("Should account appended bytes, resident session count and used bytes after a single session")
+		void shouldAccountBytesAndResidentSessionAfterSingleAppend() {
+			final int bodySize = 512;
+			final SessionLocation session = writeSession(DiskRingBufferTest.this.diskRingBuffer, bodySize, (byte) 'Z');
+
+			// getBytesAppendedTotal counts the lead descriptor plus the body of the one appended session
+			assertEquals(
+				bodySize + LEAD_DESCRIPTOR_BYTE_SIZE, DiskRingBufferTest.this.diskRingBuffer.getBytesAppendedTotal(),
+				"appended-byte total must equal the descriptor plus body of the single session"
+			);
+			// exactly one session is resident in the ring buffer window
+			assertEquals(1, DiskRingBufferTest.this.diskRingBuffer.getResidentSessionCount());
+			// used bytes equals the resident session's on-disk length and is strictly positive
+			assertTrue(DiskRingBufferTest.this.diskRingBuffer.getUsedBytes() > 0L);
+			assertEquals(
+				session.location().recordLength(), DiskRingBufferTest.this.diskRingBuffer.getUsedBytes(),
+				"used bytes must equal the resident session's on-disk record length"
+			);
+		}
+
+	}
+
+	/**
 	 * Tests for {@link DiskRingBuffer#close(java.util.function.Consumer)} resource cleanup.
 	 */
 	@Nested

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/OffHeapTrafficRecorderMetricsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/OffHeapTrafficRecorderMetricsTest.java
@@ -81,6 +81,14 @@ public class OffHeapTrafficRecorderMetricsTest implements EvitaTestSupport {
 	private static final String STATISTICS_EVENT = "io.evitadb.store.traffic.Statistics";
 	private static final String SKIPPED_EVENT = "io.evitadb.store.traffic.SkippedRecords";
 
+	/**
+	 * A globally unique catalog name for this test instance. JFR recordings are JVM-wide, so a recording
+	 * enabled by event name also captures the statistics/skipped events emitted by every other traffic
+	 * recorder alive in the fork under the parallel test suite. Filtering captured events by this unique
+	 * name (see {@link #eventsNamed}) isolates exactly the events this recorder emitted, keeping the
+	 * exact-count assertions deterministic regardless of concurrent recorders.
+	 */
+	private final String catalogName = "trafficMetricsTest_" + UUID.randomUUID().toString().replace("-", "");
 	private final Path workDirectory = getPathInTargetDirectory(UUID.randomUUID() + "/work");
 	private OffHeapTrafficRecorder trafficRecorder;
 
@@ -104,7 +112,7 @@ public class OffHeapTrafficRecorderMetricsTest implements EvitaTestSupport {
 			.build();
 		final Scheduler scheduler = new Scheduler(new ImmediateScheduledThreadPoolExecutor());
 		this.trafficRecorder.init(
-			TEST_CATALOG,
+			this.catalogName,
 			new FileManagementService(storageOptions),
 			scheduler,
 			storageOptions,
@@ -315,10 +323,16 @@ public class OffHeapTrafficRecorderMetricsTest implements EvitaTestSupport {
 		}
 	}
 
+	/**
+	 * Returns the captured events of the given type that belong to THIS recorder instance, matched by the
+	 * unique {@link #catalogName}. The catalog-name filter is essential: JFR recordings are JVM-wide, so
+	 * without it a concurrently running traffic recorder's events would inflate the exact-count assertions.
+	 */
 	@Nonnull
-	private static List<RecordedEvent> eventsNamed(@Nonnull List<RecordedEvent> events, @Nonnull String eventName) {
+	private List<RecordedEvent> eventsNamed(@Nonnull List<RecordedEvent> events, @Nonnull String eventName) {
 		return events.stream()
 			.filter(event -> eventName.equals(event.getEventType().getName()))
+			.filter(event -> this.catalogName.equals(event.getString("catalogName")))
 			.toList();
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/OffHeapTrafficRecorderMetricsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/OffHeapTrafficRecorderMetricsTest.java
@@ -1,0 +1,351 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.traffic;
+
+
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.TrafficRecordingOptions;
+import io.evitadb.api.query.Query;
+import io.evitadb.core.executor.ImmediateScheduledThreadPoolExecutor;
+import io.evitadb.core.executor.Scheduler;
+import io.evitadb.core.management.FileManagementService;
+import io.evitadb.exception.NotMonitored;
+import io.evitadb.store.traffic.OffHeapTrafficRecorder.MemoryNotAvailableException;
+import io.evitadb.store.traffic.event.TrafficRecorderMissReason;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import io.evitadb.utils.FileUtils;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.*;
+import static io.evitadb.test.TestTags.STORAGE;
+import static io.evitadb.test.TestTags.TRAFFIC_ENGINE;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the {@link OffHeapTrafficRecorder} observability behaviour: that the periodic metric event
+ * emits DELTAS (not cumulative totals), that skips/drops are attributed to the correct
+ * {@link TrafficRecorderMissReason}, that {@link MemoryNotAvailableException} is opted out of error
+ * monitoring, and that the sampling rate no longer folds in involuntary failure drops.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+@Tag(STORAGE)
+@Tag(TRAFFIC_ENGINE)
+public class OffHeapTrafficRecorderMetricsTest implements EvitaTestSupport {
+	private static final String STATISTICS_EVENT = "io.evitadb.store.traffic.Statistics";
+	private static final String SKIPPED_EVENT = "io.evitadb.store.traffic.SkippedRecords";
+
+	private final Path workDirectory = getPathInTargetDirectory(UUID.randomUUID() + "/work");
+	private OffHeapTrafficRecorder trafficRecorder;
+
+	@Nonnull
+	private static Query simpleQuery() {
+		return query(
+			collection(Entities.PRODUCT),
+			filterBy(entityPrimaryKeyInSet(1)),
+			require(entityFetchAll())
+		);
+	}
+
+	@BeforeEach
+	void setUp() {
+		// 2 048 B blocks over a 32 768 B buffer => exactly 16 off-heap memory blocks
+		this.trafficRecorder = new OffHeapTrafficRecorder(2_048);
+		this.workDirectory.toFile().mkdirs();
+		final StorageOptions storageOptions = StorageOptions.builder()
+			.outputBufferSize(2_048)
+			.workDirectory(this.workDirectory)
+			.build();
+		final Scheduler scheduler = new Scheduler(new ImmediateScheduledThreadPoolExecutor());
+		this.trafficRecorder.init(
+			TEST_CATALOG,
+			new FileManagementService(storageOptions),
+			scheduler,
+			storageOptions,
+			TrafficRecordingOptions.builder()
+				.enabled(true)
+				.trafficSamplingPercentage(100)
+				.trafficMemoryBufferSizeInBytes(32768L)
+				.trafficDiskBufferSizeInBytes(65536L)
+				.build(),
+			0
+		);
+	}
+
+	@AfterEach
+	void tearDown() throws IOException {
+		this.trafficRecorder.close();
+		FileUtils.deleteDirectory(this.workDirectory);
+	}
+
+	@Test
+	@DisplayName("MemoryNotAvailableException is opted out of error monitoring via @NotMonitored")
+	void shouldOptMemoryNotAvailableOutOfErrorMonitoring() {
+		assertTrue(
+			MemoryNotAvailableException.class.isAnnotationPresent(NotMonitored.class),
+			"MemoryNotAvailableException must carry @NotMonitored so the error-monitoring agent skips it"
+		);
+		// the marker must be readable by the byte-buddy agent at premain and applicable to types
+		assertEquals(RetentionPolicy.RUNTIME, NotMonitored.class.getAnnotation(Retention.class).value());
+		assertArrayEquals(new ElementType[]{ElementType.TYPE}, NotMonitored.class.getAnnotation(Target.class).value());
+	}
+
+	@Test
+	@DisplayName("Statistics counters are emitted as deltas, never cumulative")
+	void shouldEmitDeltaNotCumulativeCounters() throws IOException {
+		final UUID sessionId = UUID.randomUUID();
+		// known workload BEFORE the recording window: 1 created session + 3 recorded records, no close
+		// (createSession / record* never trigger an automatic flush, so nothing is emitted yet)
+		this.trafficRecorder.createSession(sessionId, 1L, OffsetDateTime.now());
+		for (int i = 0; i < 3; i++) {
+			this.trafficRecorder.recordFetch(sessionId, simpleQuery(), OffsetDateTime.now(), 1, 1, i + 1, null);
+		}
+
+		final List<RecordedEvent> events = recordAndCapture(
+			() -> {
+				this.trafficRecorder.publishStatisticsEvents(0);
+				this.trafficRecorder.publishStatisticsEvents(0);
+			},
+			STATISTICS_EVENT
+		);
+
+		final List<RecordedEvent> stats = eventsNamed(events, STATISTICS_EVENT);
+		assertEquals(2, stats.size(), "expected exactly two statistics emissions");
+		// first emission carries the accumulated-so-far deltas ...
+		assertEquals(1L, stats.get(0).getLong("createdSessions"));
+		assertEquals(3L, stats.get(0).getLong("recordedRecords"));
+		// ... the second, with no new activity, must be zero - it would repeat the totals if cumulative
+		assertEquals(0L, stats.get(1).getLong("createdSessions"));
+		assertEquals(0L, stats.get(1).getLong("recordedRecords"));
+		// gauges are instantaneous, not deltas: the session still holds at least one block on both emissions
+		assertEquals(16L, stats.get(0).getLong("totalMemoryBlocks"));
+		assertTrue(stats.get(1).getLong("usedMemoryBlocks") >= 1L);
+		// no counter delta may ever be negative
+		for (final RecordedEvent event : stats) {
+			assertTrue(event.getLong("recordedRecords") >= 0L);
+			assertTrue(event.getLong("createdSessions") >= 0L);
+			assertTrue(event.getLong("finishedSessions") >= 0L);
+			assertTrue(event.getLong("blocksAllocated") >= 0L);
+		}
+	}
+
+	@Test
+	@DisplayName("Sampling skips are attributed to SAMPLING, emitted once as a delta, with no repeat on an idle publish")
+	void shouldClassifySampledOutRecordsUnderSamplingReason() throws IOException {
+		final List<RecordedEvent> events = recordAndCapture(
+			() -> {
+				// record into sessions that were never created -> the deliberate sampling-miss path
+				for (int i = 0; i < 4; i++) {
+					this.trafficRecorder.recordFetch(UUID.randomUUID(), simpleQuery(), OffsetDateTime.now(), 1, 1, i, null);
+				}
+				this.trafficRecorder.publishStatisticsEvents(0);
+				// a second publish with no new activity: the SAMPLING delta is now zero, so the idle-reason
+				// skip must suppress any further SkippedRecords event (deltas are emitted, never cumulative)
+				this.trafficRecorder.publishStatisticsEvents(0);
+			},
+			SKIPPED_EVENT
+		);
+
+		final List<RecordedEvent> sampling = eventsNamed(events, SKIPPED_EVENT).stream()
+			.filter(event -> "SAMPLING".equals(event.getString("reason")))
+			.toList();
+		assertEquals(
+			1, sampling.size(),
+			"exactly one SAMPLING skip event expected - the first publish emits the delta, the second idle " +
+				"publish must emit nothing"
+		);
+		assertEquals(4L, sampling.get(0).getLong("missedRecords"));
+		assertEquals(0L, sampling.get(0).getLong("droppedSessions"), "sampling never drops whole sessions");
+	}
+
+	@Test
+	@DisplayName("Sessions dropped because the off-heap buffer is exhausted are attributed to MEMORY_SHORTAGE")
+	void shouldClassifyMemoryShortageDropsUnderReason() {
+		// open far more sessions than there are memory blocks, without closing, to exhaust the buffer
+		for (int i = 0; i < 200; i++) {
+			this.trafficRecorder.createSession(UUID.randomUUID(), 1L, OffsetDateTime.now());
+		}
+
+		final Map<TrafficRecorderMissReason, AtomicLong> dropped = reasonCounters("droppedSessionsByReason");
+		assertTrue(
+			dropped.get(TrafficRecorderMissReason.MEMORY_SHORTAGE).get() > 0L,
+			"expected sessions dropped due to memory shortage once the 16 blocks are exhausted"
+		);
+		assertEquals(0L, dropped.get(TrafficRecorderMissReason.SAMPLING).get(), "sampling never drops whole sessions");
+	}
+
+	@Test
+	@DisplayName("Sampling rate excludes involuntary failure drops (positive-feedback fix)")
+	void shouldExcludeFailureDropsFromSamplingRate() throws Exception {
+		final UUID sessionId = UUID.randomUUID();
+		this.trafficRecorder.createSession(sessionId, 1L, OffsetDateTime.now());
+		for (int i = 0; i < 3; i++) {
+			this.trafficRecorder.recordFetch(sessionId, simpleQuery(), OffsetDateTime.now(), 1, 1, i, null);
+		}
+		// 3 recorded, 0 sampled out -> 100 %
+		assertEquals(100, currentSamplingRate());
+
+		// inject heavy failure drops of every non-sampling reason: they must NOT drag the rate down
+		// (folding them in was the positive-feedback bug that made the recorder admit MORE under pressure)
+		final Map<TrafficRecorderMissReason, AtomicLong> missed = reasonCounters("missedRecordsByReason");
+		missed.get(TrafficRecorderMissReason.MEMORY_SHORTAGE).addAndGet(1_000);
+		missed.get(TrafficRecorderMissReason.DISK_SHORTAGE).addAndGet(500);
+		missed.get(TrafficRecorderMissReason.IO_ERROR).addAndGet(250);
+		missed.get(TrafficRecorderMissReason.SERIALIZATION_ERROR).addAndGet(250);
+		assertEquals(100, currentSamplingRate(), "failure drops must be excluded from the sampling ratio");
+
+		// deliberate sampling skips DO count: 3 sampled out against 3 recorded -> 50 %
+		missed.get(TrafficRecorderMissReason.SAMPLING).addAndGet(3);
+		assertEquals(50, currentSamplingRate());
+	}
+
+	@Test
+	@DisplayName("setSamplingPercentage rebaselines the sampling ratio without resetting the delta counters")
+	void shouldRebaselineSamplingRateWithoutResettingDeltaCounters() throws Exception {
+		final UUID sessionId = UUID.randomUUID();
+		this.trafficRecorder.createSession(sessionId, 1L, OffsetDateTime.now());
+		for (int i = 0; i < 3; i++) {
+			this.trafficRecorder.recordFetch(sessionId, simpleQuery(), OffsetDateTime.now(), 1, 1, i, null);
+		}
+		// 3 recorded, 0 sampled out -> 100 %
+		assertEquals(100, currentSamplingRate());
+		// advance the delta bookkeeping so lastRecordedRecordsEmitted == recordedRecords (both 3)
+		this.trafficRecorder.publishStatisticsEvents(0);
+
+		// re-target the sampler: the ratio must restart fresh (recorded / sampled-out baselines := current)
+		this.trafficRecorder.setSamplingPercentage(50);
+
+		// (a) fresh rebaseline: recorded-baseline == recorded and sampledOut-baseline == sampledOut, so the
+		// ratio reads 0 immediately, which lets the next session pass the gate under any non-zero target
+		assertEquals(0, currentSamplingRate(), "the sampling ratio must restart from zero after a rebaseline");
+
+		// (b) the rebaseline must NOT reset the monotonic recordedRecords counter: an idle publish must emit a
+		// Statistics event whose recordedRecords delta is exactly 0 and never negative (the old counter-reset
+		// behaviour would leave lastRecordedRecordsEmitted above the counter and drive the delta below zero)
+		final List<RecordedEvent> events = recordAndCapture(
+			() -> this.trafficRecorder.publishStatisticsEvents(0),
+			STATISTICS_EVENT
+		);
+		final List<RecordedEvent> stats = eventsNamed(events, STATISTICS_EVENT);
+		assertEquals(1, stats.size(), "exactly one statistics emission expected");
+		assertEquals(
+			0L, stats.get(0).getLong("recordedRecords"),
+			"no records were recorded since the last emission, so the delta must be zero"
+		);
+		assertTrue(
+			stats.get(0).getLong("recordedRecords") >= 0L,
+			"a rebaseline must never drive the recordedRecords delta negative"
+		);
+
+		// (c) the new ratio is computed against the NEW baseline: 3 freshly recorded records + 3 freshly
+		// sampled-out records -> 50 %, proving the 3 pre-rebaseline records no longer count towards the ratio
+		for (int i = 0; i < 3; i++) {
+			this.trafficRecorder.recordFetch(sessionId, simpleQuery(), OffsetDateTime.now(), 1, 1, i, null);
+		}
+		reasonCounters("missedRecordsByReason").get(TrafficRecorderMissReason.SAMPLING).addAndGet(3);
+		assertEquals(50, currentSamplingRate());
+	}
+
+	/**
+	 * Runs {@code actions} inside a JFR recording that has the given event types enabled and returns every
+	 * captured event. The recording is dumped to a temporary file that is deleted before returning.
+	 */
+	@Nonnull
+	private static List<RecordedEvent> recordAndCapture(@Nonnull Runnable actions, @Nonnull String... eventNames) throws IOException {
+		try (final Recording recording = new Recording()) {
+			for (final String eventName : eventNames) {
+				recording.enable(eventName);
+			}
+			recording.start();
+			actions.run();
+			recording.stop();
+			final Path dump = Files.createTempFile("traffic-metrics", ".jfr");
+			try {
+				recording.dump(dump);
+				return RecordingFile.readAllEvents(dump);
+			} finally {
+				Files.deleteIfExists(dump);
+			}
+		}
+	}
+
+	@Nonnull
+	private static List<RecordedEvent> eventsNamed(@Nonnull List<RecordedEvent> events, @Nonnull String eventName) {
+		return events.stream()
+			.filter(event -> eventName.equals(event.getEventType().getName()))
+			.toList();
+	}
+
+	/**
+	 * Reflectively reads one of the recorder's per-reason counter maps so a test can assert on the exact
+	 * classification without depending on the (asynchronously flushed) emitted metrics.
+	 */
+	@Nonnull
+	@SuppressWarnings("unchecked")
+	private Map<TrafficRecorderMissReason, AtomicLong> reasonCounters(@Nonnull String fieldName) {
+		try {
+			final Field field = OffHeapTrafficRecorder.class.getDeclaredField(fieldName);
+			field.setAccessible(true);
+			return (Map<TrafficRecorderMissReason, AtomicLong>) field.get(this.trafficRecorder);
+		} catch (ReflectiveOperationException ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+	/**
+	 * Reflectively invokes the private {@code computeCurrentSamplingRate()} so the sampling-rate computation
+	 * can be asserted directly and deterministically.
+	 */
+	private int currentSamplingRate() throws ReflectiveOperationException {
+		final Method method = OffHeapTrafficRecorder.class.getDeclaredMethod("computeCurrentSamplingRate");
+		method.setAccessible(true);
+		return (int) method.invoke(this.trafficRecorder);
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/OffHeapTrafficRecorderTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/OffHeapTrafficRecorderTest.java
@@ -44,6 +44,7 @@ import io.evitadb.exception.UnexpectedIOException;
 import io.evitadb.externalApi.graphql.GraphQLProvider;
 import io.evitadb.externalApi.rest.RestProvider;
 import io.evitadb.spi.store.catalog.trafficRecorder.model.SessionLocation;
+import io.evitadb.store.traffic.event.TrafficRecorderMissReason;
 import io.evitadb.test.Entities;
 import io.evitadb.test.EvitaTestSupport;
 import io.evitadb.utils.FileUtils;
@@ -65,8 +66,10 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -642,6 +645,50 @@ public class OffHeapTrafficRecorderTest implements EvitaTestSupport {
 		field.set(target, value);
 	}
 
+	/**
+	 * Reflectively sums one of the recorder's per-reason counter maps ({@code missedRecordsByReason} /
+	 * {@code droppedSessionsByReason}) across all reasons - the total equals the single aggregate counter
+	 * these tests used before the miss/drop counters were split by reason.
+	 */
+	@SuppressWarnings("unchecked")
+	private static long sumReasonCounters(@Nonnull Object recorder, @Nonnull String fieldName) throws Exception {
+		final Map<?, AtomicLong> counters = (Map<?, AtomicLong>) readField(recorder, fieldName);
+		long total = 0L;
+		for (final AtomicLong counter : counters.values()) {
+			total += counter.get();
+		}
+		return total;
+	}
+
+	/**
+	 * Reflectively reads a single per-reason counter (one entry of {@code missedRecordsByReason} or
+	 * {@code droppedSessionsByReason}), so a test can assert that a drop/miss was attributed to a specific
+	 * {@link TrafficRecorderMissReason} rather than only checking the aggregate across all reasons (which
+	 * cannot detect a misclassification into the wrong bucket).
+	 */
+	@SuppressWarnings("unchecked")
+	private static long readReasonCounter(
+		@Nonnull Object recorder, @Nonnull String fieldName, @Nonnull TrafficRecorderMissReason reason) throws Exception {
+		final Map<TrafficRecorderMissReason, AtomicLong> counters =
+			(Map<TrafficRecorderMissReason, AtomicLong>) readField(recorder, fieldName);
+		return counters.get(reason).get();
+	}
+
+	/**
+	 * Reflectively snapshots every per-reason counter of the given map field into an {@link EnumMap}, so a
+	 * test can later assert the exact per-reason deltas a drain produced - in particular that the reasons it
+	 * did not touch stayed at a zero delta.
+	 */
+	@Nonnull
+	private static EnumMap<TrafficRecorderMissReason, Long> captureReasonBaseline(
+		@Nonnull Object recorder, @Nonnull String fieldName) throws Exception {
+		final EnumMap<TrafficRecorderMissReason, Long> baseline = new EnumMap<>(TrafficRecorderMissReason.class);
+		for (final TrafficRecorderMissReason reason : TrafficRecorderMissReason.values()) {
+			baseline.put(reason, readReasonCounter(recorder, fieldName, reason));
+		}
+		return baseline;
+	}
+
 	@Test
 	void shouldRecordMoreDataThanBufferSizeForcingWrapAround() {
 		final UUID sessionId = writeBunchOfData(10, 100);
@@ -749,8 +796,11 @@ public class OffHeapTrafficRecorderTest implements EvitaTestSupport {
 
 			// the finalized session is queued and still holding its memory blocks (no auto-drain)
 			assertTrue(freeBlocks.size() < totalBlocks, "The finalized session must still be holding memory blocks");
-			final AtomicLong droppedSessions = (AtomicLong) readField(recorder, "droppedSessions");
-			final long droppedBefore = droppedSessions.get();
+			final long droppedBefore = sumReasonCounters(recorder, "droppedSessionsByReason");
+			final EnumMap<TrafficRecorderMissReason, Long> droppedBaseline = captureReasonBaseline(
+				recorder, "droppedSessionsByReason");
+			final EnumMap<TrafficRecorderMissReason, Long> missedBaseline = captureReasonBaseline(
+				recorder, "missedRecordsByReason");
 
 			// drain: the session is larger than the whole disk buffer, so it must be dropped - but every
 			// one of its memory blocks must be returned to the free pool (no leak)
@@ -760,7 +810,28 @@ public class OffHeapTrafficRecorderTest implements EvitaTestSupport {
 				totalBlocks, freeBlocks.size(),
 				"All memory blocks of the dropped oversized session must be returned to the free pool"
 			);
-			assertEquals(droppedBefore + 1, droppedSessions.get(), "The oversized session must be counted as dropped");
+			assertEquals(
+				droppedBefore + 1, sumReasonCounters(recorder, "droppedSessionsByReason"),
+				"The oversized session must be counted as dropped");
+
+			// the drop must be attributed to DISK_SHORTAGE specifically, not misclassified into another
+			// bucket: exactly one dropped session and the whole session's record count missed under
+			// DISK_SHORTAGE, with every other reason bucket left untouched
+			for (final TrafficRecorderMissReason reason : TrafficRecorderMissReason.values()) {
+				final long droppedDelta =
+					readReasonCounter(recorder, "droppedSessionsByReason", reason) - droppedBaseline.get(reason);
+				final long missedDelta =
+					readReasonCounter(recorder, "missedRecordsByReason", reason) - missedBaseline.get(reason);
+				if (reason == TrafficRecorderMissReason.DISK_SHORTAGE) {
+					assertEquals(1L, droppedDelta, "the oversized session must be counted as dropped under DISK_SHORTAGE");
+					assertTrue(
+						missedDelta > 0L,
+						"the dropped session's records must all be counted as missed under DISK_SHORTAGE");
+				} else {
+					assertEquals(0L, droppedDelta, "no session may be dropped under " + reason);
+					assertEquals(0L, missedDelta, "no record may be missed under " + reason);
+				}
+			}
 
 			// and no partial / torn session may have reached the disk buffer
 			final DiskRingBuffer diskBuffer = (DiskRingBuffer) readField(recorder, "diskBuffer");
@@ -808,22 +879,29 @@ public class OffHeapTrafficRecorderTest implements EvitaTestSupport {
 			// the finalized session is queued and still holding more than one memory block (no auto-drain)
 			assertTrue(
 				freeBlocks.size() < totalBlocks - 1, "Sanity: the finalized session must span more than one block");
-			final AtomicLong droppedSessions = (AtomicLong) readField(recorder, "droppedSessions");
-			final long droppedBefore = droppedSessions.get();
+			final long droppedBefore = sumReasonCounters(recorder, "droppedSessionsByReason");
 
 			// swap in a disk buffer spy that fails the second per-block append with a disk I/O error, leaving
 			// the remaining blocks unwritten - the exact path the plain MemoryNotAvailableException catch missed
 			final DiskRingBuffer realDiskBuffer = (DiskRingBuffer) readField(recorder, "diskBuffer");
 			final DiskRingBuffer spyDiskBuffer = Mockito.spy(realDiskBuffer);
 			final AtomicInteger appendCalls = new AtomicInteger();
+			// snapshot of the appended-byte counter taken at the instant of the failing append, so the test
+			// can assert the failing block's bytes were never counted (only fully-written bytes count)
+			final AtomicLong bytesAppendedBeforeFailingWrite = new AtomicLong(-1L);
 			Mockito.doAnswer(invocation -> {
 				if (appendCalls.incrementAndGet() == 2) {
+					bytesAppendedBeforeFailingWrite.set(spyDiskBuffer.getBytesAppendedTotal());
 					throw new UnexpectedIOException(
 						"Injected disk write failure.", "Injected disk write failure.");
 				}
 				return invocation.callRealMethod();
 			}).when(spyDiskBuffer).append(Mockito.any());
 			writeField(recorder, "diskBuffer", spyDiskBuffer);
+			final EnumMap<TrafficRecorderMissReason, Long> droppedBaseline = captureReasonBaseline(
+				recorder, "droppedSessionsByReason");
+			final EnumMap<TrafficRecorderMissReason, Long> missedBaseline = captureReasonBaseline(
+				recorder, "missedRecordsByReason");
 
 			// drain: the second block write fails, so the session must be dropped - but every one of its
 			// memory blocks (the one already written before the failure and all not-yet-written ones) must be
@@ -836,9 +914,39 @@ public class OffHeapTrafficRecorderTest implements EvitaTestSupport {
 				"Every memory block of the failed session must be returned to the free pool (no leak, no double-free)"
 			);
 			assertEquals(
-				droppedBefore + 1, droppedSessions.get(),
+				droppedBefore + 1, sumReasonCounters(recorder, "droppedSessionsByReason"),
 				"A session that fails to persist mid-drain must be counted as dropped exactly once"
 			);
+
+			// the failing append must throw before counting its bytes: the counter observed at the instant of
+			// the failure must be unchanged after the aborted drain (the "count only fully-written bytes" contract)
+			assertTrue(
+				bytesAppendedBeforeFailingWrite.get() >= 0L,
+				"The injected failure must have been reached, snapshotting the appended-byte counter"
+			);
+			assertEquals(
+				bytesAppendedBeforeFailingWrite.get(), spyDiskBuffer.getBytesAppendedTotal(),
+				"A mid-write failure must not advance the appended-byte counter beyond the last fully-written block"
+			);
+
+			// the drop must be attributed to IO_ERROR specifically, not misclassified into another bucket:
+			// exactly one dropped session and the whole session's record count missed under IO_ERROR, with
+			// every other reason bucket left untouched
+			for (final TrafficRecorderMissReason reason : TrafficRecorderMissReason.values()) {
+				final long droppedDelta =
+					readReasonCounter(recorder, "droppedSessionsByReason", reason) - droppedBaseline.get(reason);
+				final long missedDelta =
+					readReasonCounter(recorder, "missedRecordsByReason", reason) - missedBaseline.get(reason);
+				if (reason == TrafficRecorderMissReason.IO_ERROR) {
+					assertEquals(1L, droppedDelta, "the mid-drain write failure must be counted as a drop under IO_ERROR");
+					assertTrue(
+						missedDelta > 0L,
+						"the failed session's records must all be counted as missed under IO_ERROR");
+				} else {
+					assertEquals(0L, droppedDelta, "no session may be dropped under " + reason);
+					assertEquals(0L, missedDelta, "no record may be missed under " + reason);
+				}
+			}
 		} finally {
 			FileUtils.deleteDirectory(work);
 		}
@@ -858,9 +966,7 @@ public class OffHeapTrafficRecorderTest implements EvitaTestSupport {
 			@SuppressWarnings("unchecked") final Collection<Integer> freeBlocks = (Collection<Integer>) readField(
 				recorder, "freeBlocks");
 			final int totalBlocks = freeBlocks.size();
-			final AtomicLong droppedSessions = (AtomicLong) readField(recorder, "droppedSessions");
 			final AtomicLong createdSessions = (AtomicLong) readField(recorder, "createdSessions");
-			final AtomicLong missedRecords = (AtomicLong) readField(recorder, "missedRecords");
 
 			final UUID sessionId = UUIDUtil.randomUUID();
 			recorder.createSession(sessionId, 1, OffsetDateTime.now());
@@ -888,8 +994,11 @@ public class OffHeapTrafficRecorderTest implements EvitaTestSupport {
 			// balanced create/drop pair, and its records are counted as missed
 			assertEquals(1L, createdSessions.get(), "The session start record fit, so the session was created");
 			assertEquals(
-				1L, droppedSessions.get(), "The memory-shortage session must be counted as dropped exactly once");
-			assertTrue(missedRecords.get() > 0, "The discarded session's records must be counted as missed");
+				1L, sumReasonCounters(recorder, "droppedSessionsByReason"),
+				"The memory-shortage session must be counted as dropped exactly once");
+			assertTrue(
+				sumReasonCounters(recorder, "missedRecordsByReason") > 0,
+				"The discarded session's records must be counted as missed");
 
 			// nothing may have been drained to disk for a discarded (never finalized) session
 			recorder.drainFinalizedSessionsToDisk();
@@ -911,14 +1020,15 @@ public class OffHeapTrafficRecorderTest implements EvitaTestSupport {
 			OffHeapTrafficRecorder recorder = newIsolatedRecorder(2_048, 32_768L, 65_536L, 0, work)
 		) {
 			final AtomicLong createdSessions = (AtomicLong) readField(recorder, "createdSessions");
-			final AtomicLong missedRecords = (AtomicLong) readField(recorder, "missedRecords");
 
 			final UUID sessionId = UUIDUtil.randomUUID();
 			recorder.createSession(sessionId, 1, OffsetDateTime.now());
 			recorder.closeSession(sessionId, null);
 
 			assertEquals(0L, createdSessions.get(), "No session may be recorded when the sampling percentage is 0.");
-			assertTrue(missedRecords.get() > 0, "Traffic must be counted as missed when the sampling percentage is 0.");
+			assertTrue(
+				sumReasonCounters(recorder, "missedRecordsByReason") > 0,
+				"Traffic must be counted as missed when the sampling percentage is 0.");
 
 			// and nothing may reach disk
 			recorder.drainFinalizedSessionsToDisk();


### PR DESCRIPTION
## Why

`OffHeapTrafficRecorder.MemoryNotAvailableException` is a **control-flow signal** the traffic engine is designed to cope with — when it fires, a single intercepted statement simply isn't captured. But because it extends `EvitaInternalError`, the byte-buddy `ErrorMonitoringAgent` counted every construction as a serious engine fault under `io_evitadb_errors_total{error_type="MemoryNotAvailableException"}`. The information (traffic is being skipped) was right; the form (an engine-error metric) was misleading.

## What

**1 — Opt the exception out of error monitoring.**
New `@NotMonitored` marker in `evita_common` (`io.evitadb.exception`, `@Retention(RUNTIME) @Target(TYPE)`). The agent now excludes `isAnnotatedWith(NotMonitored)` from all three monitored hierarchies (JVM / evitaDB / client errors); `MemoryNotAvailableException` carries the marker. The exception never escapes the traffic module, so the change is contained.

**2 — Replace the signal with a proper traffic-recorder metric set.**
- `TrafficRecorderStatisticsEvent` now emits its throughput counters as **deltas**. It was publishing cumulative `AtomicLong` values every flush, which the Prometheus pipeline `inc()`-ed — an over-count fixed here. It also gained memory/churn **gauges**: used/total off-heap blocks (the primary memory-pressure signal), active sessions, drain backlog, disk-buffer used bytes and resident sessions, plus recorded-records / blocks-allocated / disk-bytes-appended throughput counters.
- New reason-labeled `TrafficRecorderSkippedRecordsEvent` splits the previously **conflated** missed-records / dropped-sessions counters by `TrafficRecorderMissReason` — `SAMPLING`, `MEMORY_SHORTAGE`, `DISK_SHORTAGE`, `IO_ERROR`, `SERIALIZATION_ERROR` — so benign sampling is distinguishable from resource pressure via the `reason` dimension.
- `DiskRingBuffer` exposes bytes-appended / resident-session-count / used-bytes accessors backing the new metrics.

**3 — Fix the sampling positive-feedback loop.**
`computeCurrentSamplingRate()` divided `recorded` by `recorded + missed`, and `missed` folded in involuntary failure drops. Under memory pressure, drops raised `missed`, lowered the computed rate, and made the gate admit **more** traffic — worsening the pressure. It now counts only deliberate `SAMPLING` skips (rebaselined on `setSamplingPercentage` instead of resetting the monotonic counters, which would have driven the periodic delta negative).

## Breaking change to existing series

The traffic `statistics` counters change value (delta, not cumulative) and the conflated `missed_records` / `dropped_sessions` move to the new reason-labeled `skipped_records` event. Any dashboard on the old `..._statistics_missed_records` / `..._statistics_dropped_sessions` series must switch to `..._skipped_records_{missed_records,dropped_sessions}{reason=...}`.

## Testing

- New `OffHeapTrafficRecorderMetricsTest` (6): `@NotMonitored` opt-out; delta-not-cumulative and negative-delta guards (JFR capture); SAMPLING classification + idle-skip; `setSamplingPercentage` rebaseline; sampling rate excludes failure drops.
- Strengthened existing recorder tests with per-reason `DISK_SHORTAGE` / `IO_ERROR` assertions and the "count only fully-written bytes" contract; new `DiskRingBuffer` byte-accounting test.
- `metrics.md` / `jfr-events.md` regenerated via the `JfrDocumentation` generator (not hand-edited).
- `evita_functional_tests` traffic suite: 59 tests green; registry + observability metric tests green; `-P full` compiles perf tests + client_all_in_one.

## Follow-up (not in this PR)

`SERIALIZATION_ERROR` reason classification is exercised only via a counter poke, not an end-to-end serialization failure (the only seam is fragile) — deferred.
