### PR TITLE
fix: attribute post-discard traffic to the real discard reason

### DIFF
--- a/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/OffHeapTrafficRecorder.java
+++ b/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/OffHeapTrafficRecorder.java
@@ -138,6 +138,25 @@ public class OffHeapTrafficRecorder
 	 */
 	private final Map<UUID, SessionTraffic> trackedSessionsIndex = new ConcurrentHashMap<>(256);
 	/**
+	 * Upper bound on {@link #discardedSessionReasons}. An entry is added when a session is discarded and
+	 * removed when that session's {@link #closeSession} arrives, so a mid-flight discard self-drains once the
+	 * session is closed. Two cases leave an entry until {@link #close()}: a session discarded during its own
+	 * close record (no later close will arrive to evict it) and a discarded session that is never closed at
+	 * all. This guard bounds both, at the cost of falling back to {@link TrafficRecorderMissReason#SAMPLING}
+	 * for the trailing records of any session discarded past the cap.
+	 */
+	private static final int MAX_DISCARDED_SESSION_REASONS = 1024;
+	/**
+	 * Remembers, per session id, the reason a session was discarded (see {@link #discardSession}) after it has
+	 * already been removed from {@link #trackedSessionsIndex}. It lets the trailing records that still arrive
+	 * for a discarded session, and its eventual {@link #closeSession}, be attributed to the real discard reason
+	 * (e.g. {@link TrafficRecorderMissReason#MEMORY_SHORTAGE}) instead of the benign
+	 * {@link TrafficRecorderMissReason#SAMPLING}. Entries are evicted on close and bounded by
+	 * {@link #MAX_DISCARDED_SESSION_REASONS}. A {@link ConcurrentHashMap} because {@link #discardSession} and
+	 * the {@code record*} paths run on different threads.
+	 */
+	private final Map<UUID, TrafficRecorderMissReason> discardedSessionReasons = new ConcurrentHashMap<>();
+	/**
 	 * Queue of all sessions that were finished and are waiting to be written to disk buffer.
 	 */
 	private final Queue<SessionTraffic> finalizedSessions = new ConcurrentLinkedQueue<>();
@@ -398,9 +417,13 @@ public class OffHeapTrafficRecorder
 				}
 			);
 		} else {
-			// closing a session that was never tracked (it was sampled out at creation, or already
-			// discarded) - benign, tracked under the SAMPLING reason
-			this.missedRecordsByReason.get(TrafficRecorderMissReason.SAMPLING).incrementAndGet();
+			// closing a session that is no longer tracked: either it was sampled out at creation (benign
+			// SAMPLING), or it was discarded under resource pressure - in which case attribute the close to the
+			// real discard reason and evict the now-consumed entry (see discardedSessionReasons)
+			final TrafficRecorderMissReason closeReason = this.discardedSessionReasons.remove(sessionId);
+			this.missedRecordsByReason
+				.get(closeReason != null ? closeReason : TrafficRecorderMissReason.SAMPLING)
+				.incrementAndGet();
 		}
 	}
 
@@ -418,6 +441,7 @@ public class OffHeapTrafficRecorder
 		@Nullable String finishedWithError
 	) {
 		doRecord(
+			sessionId,
 			this.trackedSessionsIndex.get(sessionId),
 			sessionTraffic -> {
 				final HeadConstraint head = query.getHead();
@@ -477,6 +501,7 @@ public class OffHeapTrafficRecorder
 		@Nullable String finishedWithError
 	) {
 		doRecord(
+			sessionId,
 			this.trackedSessionsIndex.get(sessionId),
 			sessionTraffic -> new EntityFetchContainer(
 				sessionId,
@@ -501,6 +526,7 @@ public class OffHeapTrafficRecorder
 		@Nullable String finishedWithError
 	) {
 		doRecord(
+			sessionId,
 			this.trackedSessionsIndex.get(sessionId),
 			sessionTraffic -> new EntityEnrichmentContainer(
 				sessionId,
@@ -522,6 +548,7 @@ public class OffHeapTrafficRecorder
 		@Nullable String finishedWithError
 	) {
 		doRecord(
+			sessionId,
 			this.trackedSessionsIndex.get(sessionId),
 			sessionTraffic -> new MutationContainer(
 				sessionId,
@@ -544,6 +571,7 @@ public class OffHeapTrafficRecorder
 		@Nullable String finishedWithError
 	) {
 		doRecord(
+			sessionId,
 			this.trackedSessionsIndex.get(sessionId),
 			sessionTraffic
 				-> {
@@ -573,6 +601,7 @@ public class OffHeapTrafficRecorder
 		@Nullable String finishedWithError
 	) {
 		doRecord(
+			sessionId,
 			this.trackedSessionsIndex.get(sessionId),
 			sessionTraffic -> sessionTraffic.closeSourceQuery(sourceQueryId, finishedWithError)
 		);
@@ -583,6 +612,7 @@ public class OffHeapTrafficRecorder
 		this.freeMemory();
 		this.memoryBlock.set(null);
 		this.trackedSessionsIndex.clear();
+		this.discardedSessionReasons.clear();
 		IOUtils.closeQuietly(
 			this.freeMemoryTask::close,
 			this.indexTask::close
@@ -864,6 +894,13 @@ public class OffHeapTrafficRecorder
 		while (memoryBlockIds.hasNext()) {
 			this.freeBlocks.offer(memoryBlockIds.nextInt());
 		}
+		// remember why this session was discarded BEFORE removing it from the tracked index, so trailing
+		// records and the eventual close of the now-removed session are attributed to the real reason instead
+		// of the benign SAMPLING (bounded: closeSession evicts the entry; the size guard caps the pathological
+		// never-closed case, whose trailing records then fall back to SAMPLING)
+		if (this.discardedSessionReasons.size() < MAX_DISCARDED_SESSION_REASONS) {
+			this.discardedSessionReasons.put(sessionTraffic.getSessionId(), reason);
+		}
 		// remove the session from the tracked sessions index
 		this.trackedSessionsIndex.remove(sessionTraffic.getSessionId());
 		// schedule memory cleaning
@@ -941,11 +978,14 @@ public class OffHeapTrafficRecorder
 	 * a missed record is counted. In cases where memory is not available, the write buffer is
 	 * released and a missed record is incremented.
 	 *
+	 * @param sessionId        id of the session the record belongs to; used to recover the discard reason
+	 *                         when a record arrives after its session was already discarded
 	 * @param sessionTraffic   the session traffic object containing the data to be recorded
 	 * @param containerFactory the traffic recording container object containing the data to be recorded
 	 *                         and its associated metadata
 	 */
 	private <T extends TrafficRecording> void doRecord(
+		@Nonnull UUID sessionId,
 		@Nullable SessionTraffic sessionTraffic,
 		@Nonnull Function<SessionTraffic, T> containerFactory
 	) {
@@ -964,9 +1004,14 @@ public class OffHeapTrafficRecorder
 			if (sessionTraffic != null) {
 				sessionTraffic.registerRecordMissedOut();
 			}
-			// no active recording session for this record (sampled out or already finished) - benign,
-			// tracked under the SAMPLING reason
-			this.missedRecordsByReason.get(TrafficRecorderMissReason.SAMPLING).incrementAndGet();
+			// no active recording session for this record: it was either sampled out / never admitted (benign
+			// SAMPLING), or already discarded under resource pressure - in which case attribute the record to the
+			// real discard reason instead of masking it as SAMPLING. The isEmpty() guard keeps the common
+			// no-discard-outstanding miss path free of the extra lookup.
+			final TrafficRecorderMissReason reason = this.discardedSessionReasons.isEmpty()
+				? TrafficRecorderMissReason.SAMPLING
+				: this.discardedSessionReasons.getOrDefault(sessionId, TrafficRecorderMissReason.SAMPLING);
+			this.missedRecordsByReason.get(reason).incrementAndGet();
 		}
 	}
 

--- a/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/OffHeapTrafficRecorder.java
+++ b/evita_store/evita_traffic_engine/src/main/java/io/evitadb/store/traffic/OffHeapTrafficRecorder.java
@@ -71,6 +71,7 @@ import io.evitadb.store.traffic.stream.RingBufferInputStream;
 import io.evitadb.store.wal.WalKryoConfigurer;
 import io.evitadb.stream.RandomAccessFileInputStream;
 import io.evitadb.utils.Assert;
+import io.evitadb.utils.CollectionUtils;
 import io.evitadb.utils.IOUtils;
 import lombok.extern.slf4j.Slf4j;
 
@@ -138,12 +139,14 @@ public class OffHeapTrafficRecorder
 	 */
 	private final Map<UUID, SessionTraffic> trackedSessionsIndex = new ConcurrentHashMap<>(256);
 	/**
-	 * Upper bound on {@link #discardedSessionReasons}. An entry is added when a session is discarded and
-	 * removed when that session's {@link #closeSession} arrives, so a mid-flight discard self-drains once the
-	 * session is closed. Two cases leave an entry until {@link #close()}: a session discarded during its own
-	 * close record (no later close will arrive to evict it) and a discarded session that is never closed at
-	 * all. This guard bounds both, at the cost of falling back to {@link TrafficRecorderMissReason#SAMPLING}
-	 * for the trailing records of any session discarded past the cap.
+	 * Best-effort soft cap on {@link #discardedSessionReasons} - the guard in {@link #discardSession} reads a
+	 * non-atomic {@code mappingCount()} snapshot, so concurrent discards may momentarily push the map slightly
+	 * past this value; it is a memory backstop, not a strict bound. An entry is added when a session is
+	 * discarded and removed when that session's {@link #closeSession} arrives, so a mid-flight discard
+	 * self-drains once the session is closed. Two cases leave an entry until {@link #close()}: a session
+	 * discarded during its own close record (no later close will arrive to evict it) and a discarded session
+	 * that is never closed at all. Once the map is at the cap, further discards simply fall back to
+	 * {@link TrafficRecorderMissReason#SAMPLING} for their trailing records rather than growing it unboundedly.
 	 */
 	private static final int MAX_DISCARDED_SESSION_REASONS = 1024;
 	/**
@@ -155,7 +158,8 @@ public class OffHeapTrafficRecorder
 	 * {@link #MAX_DISCARDED_SESSION_REASONS}. A {@link ConcurrentHashMap} because {@link #discardSession} and
 	 * the {@code record*} paths run on different threads.
 	 */
-	private final Map<UUID, TrafficRecorderMissReason> discardedSessionReasons = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<UUID, TrafficRecorderMissReason> discardedSessionReasons =
+		CollectionUtils.createConcurrentHashMap(64);
 	/**
 	 * Queue of all sessions that were finished and are waiting to be written to disk buffer.
 	 */
@@ -898,7 +902,7 @@ public class OffHeapTrafficRecorder
 		// records and the eventual close of the now-removed session are attributed to the real reason instead
 		// of the benign SAMPLING (bounded: closeSession evicts the entry; the size guard caps the pathological
 		// never-closed case, whose trailing records then fall back to SAMPLING)
-		if (this.discardedSessionReasons.size() < MAX_DISCARDED_SESSION_REASONS) {
+		if (this.discardedSessionReasons.mappingCount() < MAX_DISCARDED_SESSION_REASONS) {
 			this.discardedSessionReasons.put(sessionTraffic.getSessionId(), reason);
 		}
 		// remove the session from the tracked sessions index

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/OffHeapTrafficRecorderTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/traffic/OffHeapTrafficRecorderTest.java
@@ -1012,6 +1012,75 @@ public class OffHeapTrafficRecorderTest implements EvitaTestSupport {
 	}
 
 	@Test
+	@DisplayName("Should attribute a discarded session's trailing records and close to the discard reason, not SAMPLING")
+	void shouldAttributePostDiscardTrailingRecordsAndCloseToDiscardReason() throws Exception {
+		// a session discarded mid-flight under memory shortage is removed from the tracked index; any records
+		// that still arrive for it, and its eventual close, must be attributed to the real discard reason
+		// (MEMORY_SHORTAGE) instead of the benign SAMPLING reason (regression guard for the post-discard leak).
+		final Path work = getPathInTargetDirectory(UUID.randomUUID() + "/work");
+		try (
+			OffHeapTrafficRecorder recorder = newIsolatedRecorder(2_048, 4_096L, 8_192L, work)
+		) {
+			final UUID sessionId = UUIDUtil.randomUUID();
+			recorder.createSession(sessionId, 1, OffsetDateTime.now());
+
+			// force a MEMORY_SHORTAGE discard mid-session: a payload far larger than the 2-block buffer
+			final String[] hugePayload = new String[512];
+			for (int i = 0; i < hugePayload.length; i++) {
+				hugePayload[i] = "traffic-recording-payload-chunk-" + i;
+			}
+			recorder.recordMutation(
+				sessionId,
+				OffsetDateTime.now(),
+				new EntityUpsertMutation(
+					Entities.PRODUCT, 1, EntityExistence.MUST_NOT_EXIST,
+					new UpsertAssociatedDataMutation("payload", hugePayload)
+				),
+				null
+			);
+			assertEquals(
+				1L, readReasonCounter(recorder, "droppedSessionsByReason", TrafficRecorderMissReason.MEMORY_SHORTAGE),
+				"the mid-session shortage must drop the session under MEMORY_SHORTAGE");
+
+			// baseline the miss counters AFTER the discard, so only the trailing activity is measured
+			final EnumMap<TrafficRecorderMissReason, Long> missedBaseline =
+				captureReasonBaseline(recorder, "missedRecordsByReason");
+
+			// a record that still arrives for the already-discarded (removed) session
+			recorder.recordMutation(
+				sessionId,
+				OffsetDateTime.now(),
+				new EntityUpsertMutation(
+					Entities.PRODUCT, 2, EntityExistence.MUST_NOT_EXIST,
+					new UpsertAssociatedDataMutation("trailing", "value")
+				),
+				null
+			);
+			// and the eventual close of that discarded session
+			recorder.closeSession(sessionId, null);
+
+			final long memoryShortageDelta =
+				readReasonCounter(recorder, "missedRecordsByReason", TrafficRecorderMissReason.MEMORY_SHORTAGE)
+					- missedBaseline.get(TrafficRecorderMissReason.MEMORY_SHORTAGE);
+			// the SAMPLING counter is also the sole miss term in computeCurrentSamplingRate()'s denominator,
+			// so asserting it does not move for post-discard activity simultaneously proves that trailing
+			// failure records can no longer inflate the computed sampling rate / over-admit under pressure
+			final long samplingDelta =
+				readReasonCounter(recorder, "missedRecordsByReason", TrafficRecorderMissReason.SAMPLING)
+					- missedBaseline.get(TrafficRecorderMissReason.SAMPLING);
+
+			assertEquals(
+				2L, memoryShortageDelta,
+				"the trailing record and the close of a memory-discarded session must both be booked under MEMORY_SHORTAGE");
+			assertEquals(
+				0L, samplingDelta,
+				"post-discard trailing activity must not be misattributed to the benign SAMPLING reason");
+		} finally {
+			FileUtils.deleteDirectory(work);
+		}
+	}
+
+	@Test
 	@DisplayName("A sampling percentage of 0 records nothing - recording is disabled")
 	void shouldRecordNothingWhenSamplingPercentageIsZero() throws Exception {
 		// pins the intended semantics: 0% = record nothing (NOT "store everything" as an old javadoc claimed)


### PR DESCRIPTION
Follow-up to #1313.

## Problem
A session discarded under resource pressure (`MEMORY_SHORTAGE` / `SERIALIZATION_ERROR`) is removed from the tracked-sessions index. Afterwards:
- trailing `record*` calls (the miss branch of `doRecord`), and
- the eventual `closeSession`

were booked under the benign `SAMPLING` reason. This (1) masked genuine resource-pressure fallout as benign sampling in `io_evitadb_store_traffic_skipped_records{reason="SAMPLING"}`, and (2) let those failure-trailing records feed the `SAMPLING` term of `computeCurrentSamplingRate()`'s denominator (nudging the admission gate). #1313 already excluded the bulk failure-drop from the rate; only the trailing tail leaked.

## Fix (side discard-reason map)
- New bounded `ConcurrentHashMap<UUID, TrafficRecorderMissReason> discardedSessionReasons`, populated in `discardSession` **before** the index removal, read via an `isEmpty()`-guarded lookup in the `doRecord` miss branch, remove-and-evicted in `closeSession`, cleared in `close()`, with a `MAX_DISCARDED_SESSION_REASONS = 1024` backstop for a session discarded during its own close (or never re-closed).
- `sessionId` is threaded into the **private** `doRecord`; the public `TrafficRecorder` API is unchanged, so there is no downstream impact.
- Chosen over a tombstone-in-the-index approach so the live index and the `activeSessions` gauge (shipped in #1313) stay correct by construction and off-heap memory is freed at discard exactly as before.

## Tests
- New `OffHeapTrafficRecorderTest#shouldAttributePostDiscardTrailingRecordsAndCloseToDiscardReason`: forces a mid-session `MEMORY_SHORTAGE` discard, then asserts the trailing record + close are booked under `MEMORY_SHORTAGE` and **not** `SAMPLING`. Verified failing before the fix, passing after.
- The `samplingDelta == 0` assertion also covers the sampling-rate side effect — the `SAMPLING` counter is the sole miss term of the rate denominator, so it can no longer be inflated by trailing failure records.
- No metric / JFR / `metrics.md` changes: the fix only shifts existing counters across existing `reason` values.

## Verification
- RED → GREEN TDD; both traffic test classes pass (`OffHeapTrafficRecorderTest` 14/14, `OffHeapTrafficRecorderMetricsTest` 6/6).
- `mvn -P full install` BUILD SUCCESS (incl. performance tests + `client_all_in_one`).

Closes #1314
