### PR TITLE
perf: sync RoaringBitmap vendoring through ba92f497 (review 2)

### DIFF
--- a/evita_roaring_bitmap/NOTICE
+++ b/evita_roaring_bitmap/NOTICE
@@ -8,8 +8,8 @@ module for the original copyright and contributor list.
 
 Synced from fork github.com/novoj/RoaringBitmap, commit f27cd538,
 which corresponds to upstream RoaringBitmap v1.6.12 (base commit 952f8ce7).
-Upstream master has been reviewed through commit 2863e96d (effective
-coverage v1.6.14); see UPSTREAM_SYNC.md for the per-commit sync ledger.
+Upstream master has been reviewed through commit ba92f497 (effective
+coverage v1.6.16); see UPSTREAM_SYNC.md for the per-commit sync ledger.
 
 Modifications by FG Forrest, a.s. for evitaDB:
   - Vendored only the subset of classes required by evitaDB (see CLOSURE.md).

--- a/evita_roaring_bitmap/NOTICE
+++ b/evita_roaring_bitmap/NOTICE
@@ -9,7 +9,9 @@ module for the original copyright and contributor list.
 Synced from fork github.com/novoj/RoaringBitmap, commit f27cd538,
 which corresponds to upstream RoaringBitmap v1.6.12 (base commit 952f8ce7).
 Upstream master has been reviewed through commit ba92f497 (effective
-coverage v1.6.16); see UPSTREAM_SYNC.md for the per-commit sync ledger.
+coverage v1.6.15, the newest release; ba92f497 is master's tip and only
+bumps gradle.properties to the next development version, 1.6.16, which
+has not been released); see UPSTREAM_SYNC.md for the per-commit ledger.
 
 Modifications by FG Forrest, a.s. for evitaDB:
   - Vendored only the subset of classes required by evitaDB (see CLOSURE.md).

--- a/evita_roaring_bitmap/UPSTREAM_SYNC.md
+++ b/evita_roaring_bitmap/UPSTREAM_SYNC.md
@@ -93,15 +93,16 @@ classes we dropped or paths we already satisfy.
 
 ### Review 2 — `2863e96d` → `ba92f497`
 
-9 upstream commits triaged. **Two functional changes incorporated** (#840 the O(N²) union/xor fix,
-#831 an ART-traversal allocation cut); two more were already satisfied by pre-existing evita
-divergences; **one real change to kept classes (#837) was deliberately deferred** — see its row.
+9 upstream commits triaged. **Three functional changes incorporated** (#840 the O(N²) union/xor fix,
+#831 an ART-traversal allocation cut, #837 the reverse peekable iterators); two more were already
+satisfied by pre-existing evita divergences; the rest are build/docs. Porting #837 also surfaced a
+live correctness bug in the reverse array cursor — see its row.
 
 | upstream | kind | touches | disposition |
 |---|---|---|---|
 | `c7bd6849` fix: ReverseIntIteratorFlyweight short overflow (>32768 containers) (#836) | code | `ReverseIntIteratorFlyweight` (+`buffer/*`, test) | **Already satisfied.** Our `ReverseIntIteratorFlyweight.pos` is already an `int` and the `>Short.MAX_VALUE` regression already ships as `TestReverseIntIteratorFlyweightManyContainers` (the fix originated here — authored by J. Novotný — and was upstreamed). No-op. |
 | `593d65a1` fix: static orNot must not mutate input x1 (ior→or) (#833) | code | `RoaringBitmap` (+`buffer/*`, test) | **Already satisfied.** #833 swaps the static `orNot`'s `ior(RunContainer.rangeOfOnes(…))` for `or(…)` so it stops mutating `x1`. Our static `orNot` already clones before the in-place `ior` (`getContainerAtIndex(pos1).clone().ior(…)`) for the same reason (copy-on-write: never corrupt the input or a co-owner) — a stronger guarantee that subsumes the fix. No-op. |
-| `f98b5dd3` fix the reverse iterators + update gradle (#837) | code | `ReverseIntIteratorFlyweight`, `RoaringBitmap`, `Util`, `ArrayContainer`, `BitmapContainer`, `ImmutableBitmapDataProvider` (+`buffer/*`, gradle, tests) | **DEFERRED — real, un-ported upstream change to kept classes (not N/A).** Widens the reverse iterators to `PeekableIntIterator` (adds `advanceIfNeeded`/`peekNext`) and drops the dead `length` parameter from `Util.reverseUntil`. evita has **no** caller of `getReverseIntIterator()` (only the vendored test suite exercises reverse iteration), so this is an unused API enhancement, not a correctness fix. Deferred to keep this sync focused on the perf fix; port it if evita ever adopts reverse peekable iteration. |
+| `f98b5dd3` fix the reverse iterators + update gradle (#837) | code | `ReverseIntIteratorFlyweight`, `RoaringBitmap`, `Util`, `ArrayContainer`, `BitmapContainer`, `ImmutableBitmapDataProvider` (+`buffer/*`, gradle, tests) | **Incorporated.** Widens the reverse iterators to `PeekableIntIterator`: `RoaringReverseIntIterator` and `ReverseIntIteratorFlyweight` gained `advanceIfNeeded(int)`/`peekNext()`, and `ImmutableBitmapDataProvider.getReverseIntIterator()` narrowed its return type accordingly (source-compatible — the only callers assign to `IntIterator` or consume the iterator directly). `Util.reverseUntil` lost its unused `length` parameter. The two `BitmapContainer`/`ArrayContainer` signature hunks were already satisfied: all three reverse char cursors here already implement `PeekableCharIterator`. **Ported despite evita having no caller of `getReverseIntIterator()`, and that turned out to matter** — see the reverse-cursor fix below. |
 | `b40a7734` Release v1.6.15 | build | `gradle.properties` | N/A. |
 | `941c09a8` Remove Stars section from README | docs | `README.md` | N/A. |
 | `46d5e104` Reuse ART shuttle stack entries instead of allocating per node (#831) | code | `art/AbstractShuttle` | **Incorporated.** ART traversal (`select` / `rankLong` / ordered iteration, all used by `PersistentLongRoaringBitmap`) allocated a `NodeEntry` on every node visited. Ported the `useEntry(depth, node)` slot-reuse helper — it resets exactly the five `NodeEntry` fields a fresh entry would have (verified field parity) — replacing all 5 `new NodeEntry()` push sites. Behaviour unchanged (upstream reports −36…−65 % traversal allocation). |
@@ -109,9 +110,68 @@ divergences; **one real change to kept classes (#837) was deliberately deferred*
 | `ef131a71` Avoid O(N^2) operations in some cases (#840) | code | `RoaringArray`, `RoaringBitmap` (+`buffer/*`, jmh) | **Incorporated (COW-adapted).** In-place `or`/`xor`/`naivelazyor` did a per-key `insertNewKeyValueAt`/`removeAtIndex` shift that is O(N²) when the operands' keys interleave; upstream collapses the remaining suffix into a single-pass `mergeBulk` at the first structural divergence. Ported — **but as a `PersistentRoaringBitmap` method, not a `RoaringArray` one** (see divergence note below): source-only chunks are borrowed by structural sharing (not cloned), a shared receiver container is cloned before the in-place overlap op, and the parallel `shared[]` flag array is rebuilt in lockstep. Added `RoaringArray.adopt(keys, values, size)` to install the rebuilt arrays and clear `frozen`. Instance `lazyor` is **left on the per-key path**, matching upstream (PR #840 did not touch it). Covered by `MergeBulkCopyOnWriteTest` (interleaved keys × `clone()` COW peer, incl. the xor cancelled-pair drop and a 2000-key large-interleaved case). |
 | `ba92f497` Release v1.6.16 | build | `gradle.properties` | N/A. |
 
-**Net result:** incorporated #840 (O(N²) union/xor fix) and #831 (ART allocation cut); #833 and #836
-were already satisfied by pre-existing evita divergences; #837 deferred (recorded above, not N/A); the
-rest are build/docs. Effective upstream version coverage: **v1.6.16**.
+**Net result:** incorporated #840 (O(N²) union/xor fix), #831 (ART allocation cut) and #837 (reverse
+peekable iterators, plus the reverse-cursor fix it surfaced); #833 and #836 were already satisfied by
+pre-existing evita divergences; the rest are build/docs. Effective upstream version coverage:
+**v1.6.16**.
+
+#### Reverse-cursor exhaustion fix surfaced by the #837 port (evita divergence — preserve on re-sync)
+
+`PeekableCharIterator.advanceIfNeeded` is direction-aware: after the call a reverse cursor must be
+either exhausted or positioned at a value `<=` the bound. The three reverse cursors did not agree on
+the case where a container holds **no** value at or below the bound:
+
+- `ReverseBitmapContainerCharIterator` — correct here (it sets `position = -1`). Note this is already
+  an evita divergence: upstream neither exhausts nor reads `bitmap[0]`, so it can both park above the
+  bound and drop a value stored in word 0.
+- `ReverseRunContainerCharIterator` — correct (walks `pos` down to `-1`).
+- `ReverseArrayContainerCharIterator` — **was wrong.** `Util.reverseUntil` saturates at index `0`
+  rather than reporting "no match", so the cursor stayed at index 0 with `hasNext() == true` and
+  `peekNext()` **above** the requested bound. Fixed by re-testing `content[0]` and exhausting instead.
+
+This was not merely a latent flaw in the newly-ported API: `PersistentLongRoaringBitmap`'s
+`getReverseLongIterator()` has always been a `PeekableLongIterator` and forwards its seek straight
+down to these cursors, so a reverse seek that had to cross out of an array-backed chunk returned a
+value greater than the requested bound. Pinned by `ReverseAdvanceIfNeededContractTest`, which asserts
+the post-condition per container shape (upstream's own tests only ever probe values that are present
+in the bitmap, which is why neither upstream nor Review 1 caught it).
+
+Deliberately **not** changed: `advanceIfNeeded` (both directions, every shape) assumes a monotonic
+probe sequence, and probing backwards can re-emit already-consumed values. That is upstream's
+documented intersection idiom, shared by the forward cursors, and no caller violates it.
+
+#### Flyweight `clone()` independence fix (evita divergence — preserve on re-sync)
+
+`IntIteratorFlyweight` and `ReverseIntIteratorFlyweight` cache one reusable char cursor per container
+shape (`arrIter` / `bitmapIter` / `runIter`) so that stepping between chunks allocates nothing.
+Upstream's `clone()` delegates to `Object.clone()`, a **shallow** copy — the fork and its origin end
+up holding the *same* three cursor objects. The explicit `x.iter = this.iter.clone()` repairs only
+the currently-active cursor, so the pair stays independent exactly until one side crosses a chunk
+boundary and `nextContainer()` re-wraps a cached cursor the other is still reading through. The
+victim then emits a value assembled from one chunk's low bits and another chunk's high bits — a value
+not present in the bitmap at all.
+
+Both are fixed here by building the fork from the no-arg constructor (which allocates its own cached
+cursors) and copying only the position state — `roaringBitmap`, `pos`, `hs`, plus a deep copy of the
+active cursor. The three cached fields are `final`, so a post-`super.clone()` reassignment would not
+compile in any case. Costs three allocations per `clone()` and nothing on `next()`, the path the
+flyweight exists to optimise. Covered by `IteratorCloneIndependenceTest`.
+
+The per-bitmap `RoaringIntIterator` / `RoaringReverseIntIterator` inner classes are **not** affected —
+they allocate a fresh char cursor per chunk, so `super.clone()` plus `iter.clone()` is sufficient
+there. Both are covered by the same test to stop the two families from drifting apart again.
+
+If upstream ever fixes this, drop the divergence; until then re-apply it after any re-sync of these
+two files.
+
+#### `orNot` installs rebuilt arrays through `adopt` (evita divergence — preserve on re-sync)
+
+`orNot` rebuilds `keys`/`values` wholesale and previously assigned the three `RoaringArray` fields
+directly, which left the array-level `frozen` guard set even though the installed arrays are freshly
+allocated and privately owned. That was safe — every reader of `frozen` copies defensively, so the
+only cost was a redundant `Arrays.copyOf` on the next structural write — but it made `orNot` the one
+rebuild path not going through the `adopt(keys, values, size)` sink. It now uses `adopt`, matching
+`mergeBulk`.
 
 #### Copy-on-write divergence introduced by the #840 port (preserve on re-sync)
 

--- a/evita_roaring_bitmap/UPSTREAM_SYNC.md
+++ b/evita_roaring_bitmap/UPSTREAM_SYNC.md
@@ -12,7 +12,7 @@ incorporated. Update it on every sync — see the `roaring-bitmap-sync` skill fo
 | Upstream repo | https://github.com/RoaringBitmap/RoaringBitmap |
 | Upstream default branch | `master` |
 | **Base commit** (fork point our sources derive from) | `952f8ce7aef1510eff07a3f325a5f8093151d993` — release **v1.6.12** (2026-02-26) |
-| **Reviewed through** (last upstream commit inspected) | `2863e96d6715113dd32b9f2582bf962fdb57bbe6` — "Update AGENTS.md" (2026-06-11) |
+| **Reviewed through** (last upstream commit inspected) | `ba92f4978cb3f4c2f0d6e26342040fc59fe25508` — "[Gradle Release Plugin] 1.6.16" (2026-07-23) |
 | Vendored via fork | github.com/novoj/RoaringBitmap @ `f27cd538` (= v1.6.12 + CopyOnWriteRoaringBitmapV2 prototype) |
 
 > The **base commit** is the upstream point our vendored `.java` sources branched from. The
@@ -90,3 +90,36 @@ classes we dropped or paths we already satisfy.
 
 **Net result:** vendored subset remains byte-for-behavior current with upstream `master` through
 `2863e96d`. Effective upstream version coverage: **v1.6.14**.
+
+### Review 2 — `2863e96d` → `ba92f497`
+
+9 upstream commits triaged. **Two functional changes incorporated** (#840 the O(N²) union/xor fix,
+#831 an ART-traversal allocation cut); two more were already satisfied by pre-existing evita
+divergences; **one real change to kept classes (#837) was deliberately deferred** — see its row.
+
+| upstream | kind | touches | disposition |
+|---|---|---|---|
+| `c7bd6849` fix: ReverseIntIteratorFlyweight short overflow (>32768 containers) (#836) | code | `ReverseIntIteratorFlyweight` (+`buffer/*`, test) | **Already satisfied.** Our `ReverseIntIteratorFlyweight.pos` is already an `int` and the `>Short.MAX_VALUE` regression already ships as `TestReverseIntIteratorFlyweightManyContainers` (the fix originated here — authored by J. Novotný — and was upstreamed). No-op. |
+| `593d65a1` fix: static orNot must not mutate input x1 (ior→or) (#833) | code | `RoaringBitmap` (+`buffer/*`, test) | **Already satisfied.** #833 swaps the static `orNot`'s `ior(RunContainer.rangeOfOnes(…))` for `or(…)` so it stops mutating `x1`. Our static `orNot` already clones before the in-place `ior` (`getContainerAtIndex(pos1).clone().ior(…)`) for the same reason (copy-on-write: never corrupt the input or a co-owner) — a stronger guarantee that subsumes the fix. No-op. |
+| `f98b5dd3` fix the reverse iterators + update gradle (#837) | code | `ReverseIntIteratorFlyweight`, `RoaringBitmap`, `Util`, `ArrayContainer`, `BitmapContainer`, `ImmutableBitmapDataProvider` (+`buffer/*`, gradle, tests) | **DEFERRED — real, un-ported upstream change to kept classes (not N/A).** Widens the reverse iterators to `PeekableIntIterator` (adds `advanceIfNeeded`/`peekNext`) and drops the dead `length` parameter from `Util.reverseUntil`. evita has **no** caller of `getReverseIntIterator()` (only the vendored test suite exercises reverse iteration), so this is an unused API enhancement, not a correctness fix. Deferred to keep this sync focused on the perf fix; port it if evita ever adopts reverse peekable iteration. |
+| `b40a7734` Release v1.6.15 | build | `gradle.properties` | N/A. |
+| `941c09a8` Remove Stars section from README | docs | `README.md` | N/A. |
+| `46d5e104` Reuse ART shuttle stack entries instead of allocating per node (#831) | code | `art/AbstractShuttle` | **Incorporated.** ART traversal (`select` / `rankLong` / ordered iteration, all used by `PersistentLongRoaringBitmap`) allocated a `NodeEntry` on every node visited. Ported the `useEntry(depth, node)` slot-reuse helper — it resets exactly the five `NodeEntry` fields a fresh entry would have (verified field parity) — replacing all 5 `new NodeEntry()` push sites. Behaviour unchanged (upstream reports −36…−65 % traversal allocation). |
+| `e140aee9` Declare junit as a dependency of jmh (#839) | build | `build.gradle.kts` | N/A. |
+| `ef131a71` Avoid O(N^2) operations in some cases (#840) | code | `RoaringArray`, `RoaringBitmap` (+`buffer/*`, jmh) | **Incorporated (COW-adapted).** In-place `or`/`xor`/`naivelazyor` did a per-key `insertNewKeyValueAt`/`removeAtIndex` shift that is O(N²) when the operands' keys interleave; upstream collapses the remaining suffix into a single-pass `mergeBulk` at the first structural divergence. Ported — **but as a `PersistentRoaringBitmap` method, not a `RoaringArray` one** (see divergence note below): source-only chunks are borrowed by structural sharing (not cloned), a shared receiver container is cloned before the in-place overlap op, and the parallel `shared[]` flag array is rebuilt in lockstep. Added `RoaringArray.adopt(keys, values, size)` to install the rebuilt arrays and clear `frozen`. Instance `lazyor` is **left on the per-key path**, matching upstream (PR #840 did not touch it). Covered by `MergeBulkCopyOnWriteTest` (interleaved keys × `clone()` COW peer, incl. the xor cancelled-pair drop and a 2000-key large-interleaved case). |
+| `ba92f497` Release v1.6.16 | build | `gradle.properties` | N/A. |
+
+**Net result:** incorporated #840 (O(N²) union/xor fix) and #831 (ART allocation cut); #833 and #836
+were already satisfied by pre-existing evita divergences; #837 deferred (recorded above, not N/A); the
+rest are build/docs. Effective upstream version coverage: **v1.6.16**.
+
+#### Copy-on-write divergence introduced by the #840 port (preserve on re-sync)
+
+Upstream added `mergeBulk` as a package-private method on **`RoaringArray`**. In the vendored copy the
+port lives on **`PersistentRoaringBitmap.mergeBulk(...)`** instead, because the copy-on-write `shared[]`
+flag array is owned by `PersistentRoaringBitmap` (RoaringArray "does not track container sharing
+itself", per its class comment) and the merge needs both operands' flags to borrow-vs-clone correctly.
+`RoaringArray` only gained a small `adopt(keys, values, size)` sink to receive the rebuilt arrays. When
+a future sync touches upstream `RoaringArray.mergeBulk`, apply the change to
+`PersistentRoaringBitmap.mergeBulk` here. The three op selectors (`MERGE_OR`/`MERGE_XOR`/
+`MERGE_LAZY_OR`) are likewise private constants on `PersistentRoaringBitmap`, not `RoaringArray`.

--- a/evita_roaring_bitmap/UPSTREAM_SYNC.md
+++ b/evita_roaring_bitmap/UPSTREAM_SYNC.md
@@ -183,3 +183,67 @@ itself", per its class comment) and the merge needs both operands' flags to borr
 a future sync touches upstream `RoaringArray.mergeBulk`, apply the change to
 `PersistentRoaringBitmap.mergeBulk` here. The three op selectors (`MERGE_OR`/`MERGE_XOR`/
 `MERGE_LAZY_OR`) are likewise private constants on `PersistentRoaringBitmap`, not `RoaringArray`.
+
+#### Static `or`/`xor`/`andNot`: precise result flags, deliberately coarse operand flags (evita divergence — preserve on re-sync)
+
+Upstream's static binary operations carry a chunk that exists in only one operand into the result with
+`appendCopy`, i.e. an eager `Container.clone()`. The vendored copy carries it **by reference** and
+records the co-ownership in the `shared[]` flag array instead, which is the whole point of the
+persistent reshaping.
+
+That bookkeeping used to be a blunt over-approximation on both sides: `markAllShared(x1)` /
+`markAllShared(x2)` plus an all-`true` result array (`newAllSharedResult`). It was safe — a spurious
+`true` only ever buys an extra clone, never corruption — but a `shared` flag is a promise to clone
+before the next in-place write, so promising on a chunk nobody co-owns means paying for a clone
+(8 KiB for a bitmap chunk) that buys nothing.
+
+**The result side is now tracked per slot.** A chunk present in both operands is recombined into a
+private container (`c1.or(c2)` and friends allocate; they never hand back an operand) and is left
+unflagged; a chunk lent from a single operand is flagged, via `flagLentLast` / `appendLentRange`.
+`newAllSharedResult` is gone. The result is reachable only by the caller until it is published, so
+per-slot tracking is unconditionally safe there.
+
+**The operand side is deliberately left as the wholesale `markAllShared` fill**, and that is now
+documented on the method so it is not "optimised" later. `TransactionalBitmap` is `@ThreadSafe` and
+hands the same live `PersistentRoaringBitmap` to every concurrent read-only query thread, so one
+bitmap can be an operand of two queries at once while `shared[]` is written without synchronisation.
+A full fill is idempotent: an update lost to a racing `ensureSharedCapacity` reallocation is
+re-established by the next caller, and the value it converges on is the conservative one. Sparse
+per-slot writes have no such convergence, and the value a lost sparse write leaves behind is the
+*unsafe* one — an unflagged slot over a container the result aliases, which is exactly the
+precondition for silent cross-bitmap corruption. Narrowing this side was measured at −32 % allocation
+on the diff-layer shape and is therefore worth revisiting, but only behind two things it does not have
+today: a hard `shared.length >= size` invariant (so `ensureSharedCapacity` can never reallocate a
+published bitmap out from under a concurrent writer) and a decision about publishing those writes.
+
+`andNot` still never marks its subtrahend, since no container is ever carried out of it. Sizing note:
+the result flag array is allocated once at the operation's upper bound (`length1 + length2`, or
+`length1` for `andNot`) and never grown — a `shared[]` longer than the container array is legal, only
+shorter is not. That over-allocates by up to `length1 + length2 - resultSize` bytes versus the old
+exactly-sized array; measured at +64 bytes per `or` on a 64-chunk operand pair, against a 24 % cut
+where the result is written.
+
+In the same spirit, `runOptimize()` and `removeRunCompression()` now clear the flag of any slot whose
+container they re-encoded: the replacement was allocated for this bitmap alone, so the co-ownership
+the slot recorded belonged to the container that was just dropped from it.
+
+Measured A/B (two JVMs, thread-allocation counters, bit-for-bit reproducible), 64-chunk operands:
+
+| shape | allocation | best-of-9 wall clock |
+|---|---|---|
+| `or(a, b)` then writes into the result | 217,095,792 → 164,417,392 bytes/cycle (**−24.3 %**) | 12.2 → 10.3 ms (best of 5 runs × 9) |
+| diff-layer `andNot(or(baseline, insertions), removals)` then writes into the deltas | 325,415,688 → 325,428,488 bytes/cycle (**+0.004 %**) | unchanged |
+
+The second row is the honest counterpart of the first: that shape's cost sits entirely in the operand
+flags, which this change deliberately does not touch.
+
+The precondition — that the out-of-place container operators never return an operand or anything
+aliasing one — is pinned by `ContainerBinaryOpFreshnessTest` across all nine shape pairs in both
+operand orders (identity *and* a scribble-the-result check, which catches a distinct object wrapping
+an operand's backing array). The flags are pinned by `SharedFlagPrecisionTest` and by
+`SharedContainerLockstepFuzzTest`, whose alias-graph check now drives the static `xor` and `andNot`
+producers too; deliberately dropping a lent chunk's flag makes that fuzz fail at seed 0, step 26.
+
+**Not applicable upstream.** `shared[]` has no upstream counterpart — upstream `RoaringBitmap` results
+are freely mutable by contract, which is exactly why it clones on carry-over instead of sharing. There
+is nothing to report or contribute here.

--- a/evita_roaring_bitmap/UPSTREAM_SYNC.md
+++ b/evita_roaring_bitmap/UPSTREAM_SYNC.md
@@ -12,7 +12,7 @@ incorporated. Update it on every sync — see the `roaring-bitmap-sync` skill fo
 | Upstream repo | https://github.com/RoaringBitmap/RoaringBitmap |
 | Upstream default branch | `master` |
 | **Base commit** (fork point our sources derive from) | `952f8ce7aef1510eff07a3f325a5f8093151d993` — release **v1.6.12** (2026-02-26) |
-| **Reviewed through** (last upstream commit inspected) | `ba92f4978cb3f4c2f0d6e26342040fc59fe25508` — "[Gradle Release Plugin] 1.6.16" (2026-07-23) |
+| **Reviewed through** (last upstream commit inspected) | `ba92f4978cb3f4c2f0d6e26342040fc59fe25508` — the post-release bump of `gradle.properties` to the next development version `1.6.16` (2026-07-23). It is `master`'s tip and the only commit after the `1.6.15` tag; **there is no 1.6.16 release.** |
 | Vendored via fork | github.com/novoj/RoaringBitmap @ `f27cd538` (= v1.6.12 + CopyOnWriteRoaringBitmapV2 prototype) |
 
 > The **base commit** is the upstream point our vendored `.java` sources branched from. The
@@ -103,17 +103,18 @@ live correctness bug in the reverse array cursor — see its row.
 | `c7bd6849` fix: ReverseIntIteratorFlyweight short overflow (>32768 containers) (#836) | code | `ReverseIntIteratorFlyweight` (+`buffer/*`, test) | **Already satisfied.** Our `ReverseIntIteratorFlyweight.pos` is already an `int` and the `>Short.MAX_VALUE` regression already ships as `TestReverseIntIteratorFlyweightManyContainers` (the fix originated here — authored by J. Novotný — and was upstreamed). No-op. |
 | `593d65a1` fix: static orNot must not mutate input x1 (ior→or) (#833) | code | `RoaringBitmap` (+`buffer/*`, test) | **Already satisfied.** #833 swaps the static `orNot`'s `ior(RunContainer.rangeOfOnes(…))` for `or(…)` so it stops mutating `x1`. Our static `orNot` already clones before the in-place `ior` (`getContainerAtIndex(pos1).clone().ior(…)`) for the same reason (copy-on-write: never corrupt the input or a co-owner) — a stronger guarantee that subsumes the fix. No-op. |
 | `f98b5dd3` fix the reverse iterators + update gradle (#837) | code | `ReverseIntIteratorFlyweight`, `RoaringBitmap`, `Util`, `ArrayContainer`, `BitmapContainer`, `ImmutableBitmapDataProvider` (+`buffer/*`, gradle, tests) | **Incorporated.** Widens the reverse iterators to `PeekableIntIterator`: `RoaringReverseIntIterator` and `ReverseIntIteratorFlyweight` gained `advanceIfNeeded(int)`/`peekNext()`, and `ImmutableBitmapDataProvider.getReverseIntIterator()` narrowed its return type accordingly (source-compatible — the only callers assign to `IntIterator` or consume the iterator directly). `Util.reverseUntil` lost its unused `length` parameter. The two `BitmapContainer`/`ArrayContainer` signature hunks were already satisfied: all three reverse char cursors here already implement `PeekableCharIterator`. **Ported despite evita having no caller of `getReverseIntIterator()`, and that turned out to matter** — see the reverse-cursor fix below. |
-| `b40a7734` Release v1.6.15 | build | `gradle.properties` | N/A. |
+| `b40a7734` post-release bump to next dev version 1.6.15 | build | `gradle.properties` | N/A. |
 | `941c09a8` Remove Stars section from README | docs | `README.md` | N/A. |
 | `46d5e104` Reuse ART shuttle stack entries instead of allocating per node (#831) | code | `art/AbstractShuttle` | **Incorporated.** ART traversal (`select` / `rankLong` / ordered iteration, all used by `PersistentLongRoaringBitmap`) allocated a `NodeEntry` on every node visited. Ported the `useEntry(depth, node)` slot-reuse helper — it resets exactly the five `NodeEntry` fields a fresh entry would have (verified field parity) — replacing all 5 `new NodeEntry()` push sites. Behaviour unchanged (upstream reports −36…−65 % traversal allocation). |
 | `e140aee9` Declare junit as a dependency of jmh (#839) | build | `build.gradle.kts` | N/A. |
 | `ef131a71` Avoid O(N^2) operations in some cases (#840) | code | `RoaringArray`, `RoaringBitmap` (+`buffer/*`, jmh) | **Incorporated (COW-adapted).** In-place `or`/`xor`/`naivelazyor` did a per-key `insertNewKeyValueAt`/`removeAtIndex` shift that is O(N²) when the operands' keys interleave; upstream collapses the remaining suffix into a single-pass `mergeBulk` at the first structural divergence. Ported — **but as a `PersistentRoaringBitmap` method, not a `RoaringArray` one** (see divergence note below): source-only chunks are borrowed by structural sharing (not cloned), a shared receiver container is cloned before the in-place overlap op, and the parallel `shared[]` flag array is rebuilt in lockstep. Added `RoaringArray.adopt(keys, values, size)` to install the rebuilt arrays and clear `frozen`. Instance `lazyor` is **left on the per-key path**, matching upstream (PR #840 did not touch it). Covered by `MergeBulkCopyOnWriteTest` (interleaved keys × `clone()` COW peer, incl. the xor cancelled-pair drop and a 2000-key large-interleaved case). |
-| `ba92f497` Release v1.6.16 | build | `gradle.properties` | N/A. |
+| `ba92f497` post-release bump to next dev version 1.6.16 | build | `gradle.properties` | N/A. Sets `version = 1.6.16` after the `1.6.15` release; no 1.6.16 artifact exists. |
 
 **Net result:** incorporated #840 (O(N²) union/xor fix), #831 (ART allocation cut) and #837 (reverse
 peekable iterators, plus the reverse-cursor fix it surfaced); #833 and #836 were already satisfied by
 pre-existing evita divergences; the rest are build/docs. Effective upstream version coverage:
-**v1.6.16**.
+**v1.6.15** — the newest actual release, whose tag `1.6.15` points at `ef131a71` (#840, incorporated).
+The reviewed-through commit sits one purely-editorial commit beyond it.
 
 #### Reverse-cursor exhaustion fix surfaced by the #837 port (evita divergence — preserve on re-sync)
 

--- a/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/ArrayContainer.java
+++ b/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/ArrayContainer.java
@@ -2118,11 +2118,16 @@ final class ReverseArrayContainerCharIterator implements PeekableCharIterator {
 	}
 
 	/**
-	 * Advances downward to the first value `<=` `maxval`.
+	 * Advances downward to the first value `<=` `maxval`, exhausting the cursor when this container
+	 * holds no such value.
 	 */
 	@Override
 	public void advanceIfNeeded(final char maxval) {
-		this.pos = Util.reverseUntil(this.parent.content, this.pos + 1, this.parent.cardinality, maxval);
+		final int candidate = Util.reverseUntil(this.parent.content, this.pos + 1, maxval);
+		// reverseUntil saturates at index 0 instead of reporting "no match", so a container whose
+		// smallest value still exceeds maxval would leave the cursor parked above the requested
+		// bound; the iterator contract requires exhaustion there, as the bitmap and run cursors do
+		this.pos = candidate == 0 && this.parent.content[0] > maxval ? -1 : candidate;
 	}
 
 	/**

--- a/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/ImmutableBitmapDataProvider.java
+++ b/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/ImmutableBitmapDataProvider.java
@@ -88,7 +88,7 @@ public interface ImmutableBitmapDataProvider {
 	 * @return iterator over set bits in unsigned descending order
 	 */
 	@Nonnull
-	IntIterator getReverseIntIterator();
+	PeekableIntIterator getReverseIntIterator();
 
 	/**
 	 * Returns an `ORDERED`, `DISTINCT`, `SORTED`, `SIZED` stream of the set bits in

--- a/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/IntIteratorFlyweight.java
+++ b/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/IntIteratorFlyweight.java
@@ -85,20 +85,25 @@ public class IntIteratorFlyweight implements PeekableIntIterator {
 	/**
 	 * Forks an independent iterator, deep-copying the active char cursor so the fork advances without
 	 * disturbing this one.
+	 *
+	 * A shallow `Object.clone()` will not do here: it would hand the fork the very same cached
+	 * per-shape cursors this instance recycles, and the first chunk boundary either side crosses would
+	 * re-target a cursor the other one is still reading from. The fork therefore starts from a fresh
+	 * instance — with its own cached cursors — onto which only the position state is copied.
 	 */
+	// the cached per-shape cursors must not be aliased into the fork, so this cannot delegate to super
+	@SuppressWarnings("CloneDoesntCallSuperClone")
 	@Nonnull
 	@Override
 	public PeekableIntIterator clone() {
-		try {
-			final IntIteratorFlyweight x = (IntIteratorFlyweight) super.clone();
-			if (this.iter != null) {
-				x.iter = this.iter.clone();
-			}
-			return x;
-		} catch (CloneNotSupportedException e) {
-			// unreachable: IntIteratorFlyweight implements Cloneable
-			throw new IllegalStateException(e);
+		final IntIteratorFlyweight x = new IntIteratorFlyweight();
+		x.roaringBitmap = this.roaringBitmap;
+		x.pos = this.pos;
+		x.hs = this.hs;
+		if (this.iter != null) {
+			x.iter = this.iter.clone();
 		}
+		return x;
 	}
 
 	/**

--- a/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/PersistentRoaringBitmap.java
+++ b/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/PersistentRoaringBitmap.java
@@ -359,12 +359,14 @@ public class PersistentRoaringBitmap
 	@Nonnull
 	public static PersistentRoaringBitmap andNot(
 		@Nonnull final PersistentRoaringBitmap x1, @Nonnull final PersistentRoaringBitmap x2) {
-		// non-overlapping containers from x1 are shared by reference with the result
-		markAllShared(x1);
-
 		final RoaringArray answer = new RoaringArray();
 		int pos1 = 0, pos2 = 0;
 		final int length1 = x1.highLowContainer.size(), length2 = x2.highLowContainer.size();
+		// only chunks of x1 can reach the result, so it never holds more than length1 entries; a
+		// shared[] longer than the container array is legal, so this is sized once and never grown
+		final boolean[] resultShared = new boolean[length1];
+		// operand: conservative, idempotent marking - see markAllShared for why it is not per-slot
+		markAllShared(x1);
 
 		while (pos1 < length1 && pos2 < length2) {
 			final char s1 = x1.highLowContainer.getKeyAtIndex(pos1);
@@ -374,23 +376,24 @@ public class PersistentRoaringBitmap
 				final Container c2 = x2.highLowContainer.getContainerAtIndex(pos2);
 				final Container c = c1.andNot(c2);
 				if (!c.isEmpty()) {
+					// recombined from both operands, so privately owned - deliberately left unflagged
 					answer.append(s1, c);
 				}
 				++pos1;
 				++pos2;
 			} else if (s1 < s2) {
 				final int nextPos1 = x1.highLowContainer.advanceUntil(s2, pos1);
-				answer.append(x1.highLowContainer, pos1, nextPos1);
+				appendLentRange(answer, resultShared, x1.highLowContainer, pos1, nextPos1);
 				pos1 = nextPos1;
 			} else {
 				pos2 = x2.highLowContainer.advanceUntil(s1, pos2);
 			}
 		}
 		if (pos2 == length2) {
-			answer.append(x1.highLowContainer, pos1, length1);
+			appendLentRange(answer, resultShared, x1.highLowContainer, pos1, length1);
 		}
 
-		return newAllSharedResult(answer);
+		return new PersistentRoaringBitmap(answer, resultShared);
 	}
 
 	/**
@@ -608,13 +611,16 @@ public class PersistentRoaringBitmap
 	@Nonnull
 	public static PersistentRoaringBitmap or(
 		@Nonnull final PersistentRoaringBitmap x1, @Nonnull final PersistentRoaringBitmap x2) {
-		// non-overlapping containers are shared by reference with the result
-		markAllShared(x1);
-		markAllShared(x2);
-
 		final RoaringArray answer = new RoaringArray();
 		int pos1 = 0, pos2 = 0;
 		final int length1 = x1.highLowContainer.size(), length2 = x2.highLowContainer.size();
+		// the union holds one entry per distinct chunk key, so never more than length1 + length2; a
+		// shared[] longer than the container array is legal, so this is sized once and never grown
+		final boolean[] resultShared = new boolean[length1 + length2];
+		// operands: conservative, idempotent marking - see markAllShared for why it is not per-slot
+		markAllShared(x1);
+		markAllShared(x2);
+
 		main:
 		if (pos1 < length1 && pos2 < length2) {
 			char s1 = x1.highLowContainer.getKeyAtIndex(pos1);
@@ -622,6 +628,7 @@ public class PersistentRoaringBitmap
 
 			while (true) {
 				if (s1 == s2) {
+					// recombined from both operands, so privately owned - deliberately left unflagged
 					answer.append(
 						s1,
 						x1.highLowContainer
@@ -637,6 +644,7 @@ public class PersistentRoaringBitmap
 					s2 = x2.highLowContainer.getKeyAtIndex(pos2);
 				} else if (s1 < s2) {
 					answer.append(s1, x1.highLowContainer.getContainerAtIndex(pos1));
+					flagLentLast(answer, resultShared);
 					pos1++;
 					if (pos1 == length1) {
 						break main;
@@ -644,6 +652,7 @@ public class PersistentRoaringBitmap
 					s1 = x1.highLowContainer.getKeyAtIndex(pos1);
 				} else {
 					answer.append(s2, x2.highLowContainer.getContainerAtIndex(pos2));
+					flagLentLast(answer, resultShared);
 					pos2++;
 					if (pos2 == length2) {
 						break main;
@@ -653,12 +662,12 @@ public class PersistentRoaringBitmap
 			}
 		}
 		if (pos1 == length1) {
-			answer.append(x2.highLowContainer, pos2, length2);
+			appendLentRange(answer, resultShared, x2.highLowContainer, pos2, length2);
 		} else if (pos2 == length2) {
-			answer.append(x1.highLowContainer, pos1, length1);
+			appendLentRange(answer, resultShared, x1.highLowContainer, pos1, length1);
 		}
 
-		return newAllSharedResult(answer);
+		return new PersistentRoaringBitmap(answer, resultShared);
 	}
 
 	/**
@@ -843,13 +852,15 @@ public class PersistentRoaringBitmap
 	@Nonnull
 	public static PersistentRoaringBitmap xor(
 		@Nonnull final PersistentRoaringBitmap x1, @Nonnull final PersistentRoaringBitmap x2) {
-		// non-overlapping containers from both inputs are shared by reference with the result
-		markAllShared(x1);
-		markAllShared(x2);
-
 		final RoaringArray answer = new RoaringArray();
 		int pos1 = 0, pos2 = 0;
 		final int length1 = x1.highLowContainer.size(), length2 = x2.highLowContainer.size();
+		// the result holds at most one entry per distinct chunk key across both operands; a shared[]
+		// longer than the container array is legal, so this is sized once up front and never grown
+		final boolean[] resultShared = new boolean[length1 + length2];
+		// operands: conservative, idempotent marking - see markAllShared for why it is not per-slot
+		markAllShared(x1);
+		markAllShared(x2);
 
 		main:
 		if (pos1 < length1 && pos2 < length2) {
@@ -863,6 +874,7 @@ public class PersistentRoaringBitmap
 							.getContainerAtIndex(pos1)
 							.xor(x2.highLowContainer.getContainerAtIndex(pos2));
 					if (!c.isEmpty()) {
+						// recombined from both operands, so privately owned - deliberately left unflagged
 						answer.append(s1, c);
 					}
 					pos1++;
@@ -874,6 +886,7 @@ public class PersistentRoaringBitmap
 					s2 = x2.highLowContainer.getKeyAtIndex(pos2);
 				} else if (s1 < s2) {
 					answer.append(s1, x1.highLowContainer.getContainerAtIndex(pos1));
+					flagLentLast(answer, resultShared);
 					pos1++;
 					if (pos1 == length1) {
 						break main;
@@ -881,6 +894,7 @@ public class PersistentRoaringBitmap
 					s1 = x1.highLowContainer.getKeyAtIndex(pos1);
 				} else {
 					answer.append(s2, x2.highLowContainer.getContainerAtIndex(pos2));
+					flagLentLast(answer, resultShared);
 					pos2++;
 					if (pos2 == length2) {
 						break main;
@@ -890,12 +904,12 @@ public class PersistentRoaringBitmap
 			}
 		}
 		if (pos1 == length1) {
-			answer.append(x2.highLowContainer, pos2, length2);
+			appendLentRange(answer, resultShared, x2.highLowContainer, pos2, length2);
 		} else if (pos2 == length2) {
-			answer.append(x1.highLowContainer, pos1, length1);
+			appendLentRange(answer, resultShared, x1.highLowContainer, pos1, length1);
 		}
 
-		return newAllSharedResult(answer);
+		return new PersistentRoaringBitmap(answer, resultShared);
 	}
 
 	/**
@@ -1352,6 +1366,15 @@ public class PersistentRoaringBitmap
 
 	/**
 	 * Marks ALL containers in a bitmap as shared.
+	 *
+	 * Deliberately an idempotent full fill rather than a per-slot record of what a caller actually
+	 * lent. A `PersistentRoaringBitmap` reachable through the engine's transactional bitmap can be an
+	 * operand of two concurrent queries at once, and this array is written without synchronisation:
+	 * re-asserting every slot converges on the conservative value, so an update lost to a racing
+	 * writer (or to the reallocation inside {@link #ensureSharedCapacity}) is re-established by the
+	 * next caller. Sparse writes would have no such convergence, and the value a lost sparse write
+	 * leaves behind is the unsafe one - an unflagged slot over a container the result aliases. The
+	 * result side carries no such constraint and IS tracked per slot; see {@link #flagLentLast}.
 	 */
 	private static void markAllShared(@Nonnull final PersistentRoaringBitmap bitmap) {
 		final int size = bitmap.highLowContainer.size();
@@ -1360,14 +1383,42 @@ public class PersistentRoaringBitmap
 	}
 
 	/**
-	 * Creates a new PersistentRoaringBitmap from a RoaringArray with all containers
-	 * marked as shared. Used by static binary operations that produce shared results.
+	 * Appends the chunks `src` holds in `[from, to)` to `answer` by structural sharing and flags the
+	 * result slots they land in as co-owned. An empty range is a no-op. The source side of the
+	 * aliasing is covered by the caller's {@link #markAllShared}.
+	 *
+	 * @param answer       the result container array being built
+	 * @param resultShared the result's copy-on-write flags, parallel to `answer`
+	 * @param src          the container array lending the chunks
+	 * @param from         first lent slot in `src` (inclusive)
+	 * @param to           end slot in `src` (exclusive)
 	 */
-	@Nonnull
-	private static PersistentRoaringBitmap newAllSharedResult(@Nonnull final RoaringArray answer) {
-		final boolean[] resultShared = new boolean[answer.size()];
-		Arrays.fill(resultShared, true);
-		return new PersistentRoaringBitmap(answer, resultShared);
+	private static void appendLentRange(
+		@Nonnull final RoaringArray answer, @Nonnull final boolean[] resultShared,
+		@Nonnull final RoaringArray src, final int from, final int to
+	) {
+		if (to <= from) {
+			return;
+		}
+		final int at = answer.size();
+		answer.append(src, from, to);
+		Arrays.fill(resultShared, at, answer.size(), true);
+	}
+
+	/**
+	 * Flags the chunk just appended to `answer` as co-owned with the operand it was lent from. Must be
+	 * called immediately AFTER the append, from which it reads the destination slot.
+	 *
+	 * Kept apart from {@link #appendLentRange} because the single-chunk
+	 * {@link RoaringArray#append(char, Container)} carries an ascending-key guard that the range
+	 * overload does not, and the merge loops are worth keeping under it.
+	 *
+	 * @param answer       the result container array just appended to
+	 * @param resultShared the result's copy-on-write flags, parallel to `answer`
+	 */
+	private static void flagLentLast(
+		@Nonnull final RoaringArray answer, @Nonnull final boolean[] resultShared) {
+		resultShared[answer.size() - 1] = true;
 	}
 
 	/**
@@ -3334,6 +3385,9 @@ public class PersistentRoaringBitmap
 			if (c instanceof RunContainer) {
 				Container newc = ((RunContainer) c).toBitmapOrArrayContainer(c.getCardinality());
 				this.highLowContainer.setContainerAtIndex(i, newc);
+				// the re-encoded chunk was allocated for this bitmap alone, so whatever co-ownership
+				// the slot recorded belonged to the container just dropped from it
+				clearSharedAt(i);
 				answer = true;
 			}
 		}
@@ -3348,11 +3402,17 @@ public class PersistentRoaringBitmap
 	public boolean runOptimize() {
 		boolean answer = false;
 		for (int i = 0; i < this.highLowContainer.size(); i++) {
-			Container c = this.highLowContainer.getContainerAtIndex(i).runOptimize();
+			final Container previous = this.highLowContainer.getContainerAtIndex(i);
+			final Container c = previous.runOptimize();
 			if (c instanceof RunContainer) {
 				answer = true;
 			}
 			this.highLowContainer.setContainerAtIndex(i, c);
+			if (c != previous) {
+				// re-encoding allocated a container for this bitmap alone, so the slot's co-ownership
+				// record belonged to the container just dropped from it
+				clearSharedAt(i);
+			}
 		}
 		return answer;
 	}
@@ -3723,6 +3783,17 @@ public class PersistentRoaringBitmap
 				i,
 				this.highLowContainer.getContainerAtIndex(i).clone()
 			);
+			this.shared[i] = false;
+		}
+	}
+
+	/**
+	 * Drops the copy-on-write flag of slot `i`, i.e. records that this bitmap is now the sole owner of
+	 * whatever container the slot holds. Tolerates a `shared[]` shorter than the container array, since
+	 * an absent entry already means owned.
+	 */
+	private void clearSharedAt(final int i) {
+		if (i < this.shared.length) {
 			this.shared[i] = false;
 		}
 	}

--- a/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/PersistentRoaringBitmap.java
+++ b/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/PersistentRoaringBitmap.java
@@ -3223,14 +3223,10 @@ public class PersistentRoaringBitmap
 					}
 					s1 = this.highLowContainer.getKeyAtIndex(pos1);
 				} else {
-					borrowAndInsert(pos1, s2, x2, pos2, length2);
-					pos1++;
-					length1++;
-					pos2++;
-					if (pos2 == length2) {
-						break main;
-					}
-					s2 = x2.highLowContainer.getKeyAtIndex(pos2);
+					// source-only chunk: bulk-merge the remaining suffix in one pass (inserting per
+					// key here would be quadratic when the operands' keys are interleaved)
+					mergeBulk(x2, pos1, pos1, pos2, MERGE_OR);
+					return;
 				}
 			}
 		}
@@ -3523,9 +3519,10 @@ public class PersistentRoaringBitmap
 						this.highLowContainer.setContainerAtIndex(pos1, c);
 						pos1++;
 					} else {
-						this.highLowContainer.removeAtIndex(pos1);
-						sharedRemoveAt(pos1);
-						--length1;
+						// cancelled pair: bulk-merge the remaining suffix, dropping this emptied container
+						// (removing per key here would be quadratic when the operands' keys are interleaved)
+						mergeBulk(x2, pos1, pos1 + 1, pos2 + 1, MERGE_XOR);
+						return;
 					}
 					pos2++;
 					if ((pos1 == length1) || (pos2 == length2)) {
@@ -3540,14 +3537,10 @@ public class PersistentRoaringBitmap
 					}
 					s1 = this.highLowContainer.getKeyAtIndex(pos1);
 				} else {
-					borrowAndInsert(pos1, s2, x2, pos2, length2);
-					pos1++;
-					length1++;
-					pos2++;
-					if (pos2 == length2) {
-						break main;
-					}
-					s2 = x2.highLowContainer.getKeyAtIndex(pos2);
+					// source-only chunk: bulk-merge the remaining suffix in one pass (inserting per
+					// key here would be quadratic when the operands' keys are interleaved)
+					mergeBulk(x2, pos1, pos1, pos2, MERGE_XOR);
+					return;
 				}
 			}
 		}
@@ -3661,14 +3654,10 @@ public class PersistentRoaringBitmap
 					}
 					s1 = this.highLowContainer.getKeyAtIndex(pos1);
 				} else {
-					borrowAndInsert(pos1, s2, x2, pos2, length2);
-					pos1++;
-					length1++;
-					pos2++;
-					if (pos2 == length2) {
-						break main;
-					}
-					s2 = x2.highLowContainer.getKeyAtIndex(pos2);
+					// source-only chunk: bulk-merge the remaining suffix in one pass (inserting per
+					// key here would be quadratic when the operands' keys are interleaved)
+					mergeBulk(x2, pos1, pos1, pos2, MERGE_LAZY_OR);
+					return;
 				}
 			}
 		}
@@ -3824,6 +3813,147 @@ public class PersistentRoaringBitmap
 		Arrays.fill(this.shared, startSize, newSize, true);
 		x2.ensureSharedCapacity(length2);
 		Arrays.fill(x2.shared, pos2, length2, true);
+	}
+
+	/** Op selector for {@link #mergeBulk}: in-place union (or). */
+	private static final int MERGE_OR = 0;
+	/** Op selector for {@link #mergeBulk}: in-place symmetric difference (xor). */
+	private static final int MERGE_XOR = 1;
+	/** Op selector for {@link #mergeBulk}: in-place lazy union, promoting overlaps to bitmap containers. */
+	private static final int MERGE_LAZY_OR = 2;
+
+	/**
+	 * Finishes an in-place union / xor / lazy-union (selected by `op`) once the receiver's structure
+	 * must change, merging the two operands' remaining suffixes into fresh backing arrays in a single
+	 * pass. This replaces the per-key {@link RoaringArray#insertNewKeyValueAt} /
+	 * {@link RoaringArray#removeAtIndex} shift, which is quadratic when the operands' keys are
+	 * interleaved (the O(N^2) case fixed upstream in RoaringBitmap PR #840).
+	 *
+	 * The receiver's `[0, dst)` prefix is already final and is copied over verbatim (keys, container
+	 * references and their {@link #shared} flags). `left` / `right` are the receiver / source scan
+	 * positions of the first not-yet-merged entry. For a union `dst == left`; xor may pass
+	 * `dst < left` at the entry point to drop the container it just emptied.
+	 *
+	 * Copy-on-write is preserved rather than upstream's clone-everything approach: a source-only chunk
+	 * is borrowed by structural sharing and both operands' {@link #shared} flag is raised for it
+	 * (mirroring {@link #borrowAndInsert}); a receiver-only chunk keeps its existing ownership flag; an
+	 * overlapping chunk whose receiver container is shared is cloned before the in-place op, so its
+	 * result is always owned. `x2` is not mutated apart from its {@link #shared} flags.
+	 *
+	 * @param x2    the source bitmap being merged into this one
+	 * @param dst   number of already-final leading entries copied over verbatim
+	 * @param left  first not-yet-merged entry index in this receiver
+	 * @param right first not-yet-merged entry index in `x2`
+	 * @param op    one of {@link #MERGE_OR}, {@link #MERGE_XOR}, {@link #MERGE_LAZY_OR}
+	 */
+	private void mergeBulk(
+		@Nonnull final PersistentRoaringBitmap x2, final int dst, final int left, final int right,
+		final int op
+	) {
+		final RoaringArray a1 = this.highLowContainer;
+		final RoaringArray a2 = x2.highLowContainer;
+		final int length1 = a1.size;
+		final int length2 = a2.size;
+		final char[] keys1 = a1.keys;
+		final Container[] values1 = a1.values;
+		final char[] keys2 = a2.keys;
+		final Container[] values2 = a2.values;
+
+		// exact result size for union / lazy-union, tight upper bound for xor (emptied overlaps drop)
+		int distinct = 0;
+		int l = left;
+		int r = right;
+		while (l < length1 && r < length2) {
+			final char k1 = keys1[l];
+			final char k2 = keys2[r];
+			if (k1 < k2) {
+				l++;
+			} else if (k1 > k2) {
+				r++;
+			} else {
+				l++;
+				r++;
+			}
+			distinct++;
+		}
+		distinct += (length1 - l) + (length2 - r);
+		final int total = dst + distinct;
+
+		final char[] newKeys = new char[total];
+		final Container[] newValues = new Container[total];
+		final boolean[] newShared = new boolean[total];
+		System.arraycopy(keys1, 0, newKeys, 0, dst);
+		System.arraycopy(values1, 0, newValues, 0, dst);
+		// carry the already-final prefix's sharing flags; an all-owned builder may leave shared[]
+		// shorter than the container array, in which case the absent tail is owned (false)
+		System.arraycopy(this.shared, 0, newShared, 0, Math.min(dst, this.shared.length));
+
+		// x2's shared[] must be able to record every source container we may borrow below
+		x2.ensureSharedCapacity(length2);
+
+		int pos = dst;
+		int i = left;
+		int j = right;
+		while (i < length1 && j < length2) {
+			final char k1 = keys1[i];
+			final char k2 = keys2[j];
+			if (k1 < k2) {
+				// receiver-only chunk: keep as-is, preserving its ownership flag
+				newKeys[pos] = k1;
+				newValues[pos] = values1[i];
+				newShared[pos] = i < this.shared.length && this.shared[i];
+				pos++;
+				i++;
+			} else if (k1 > k2) {
+				// source-only chunk: borrow by structural sharing (both operands flagged shared)
+				newKeys[pos] = k2;
+				newValues[pos] = values2[j];
+				newShared[pos] = true;
+				x2.shared[j] = true;
+				pos++;
+				j++;
+			} else {
+				// overlapping chunk: clone if the receiver's container is shared, then op in place
+				Container base = values1[i];
+				if (i < this.shared.length && this.shared[i]) {
+					base = base.clone();
+				}
+				final Container c;
+				if (op == MERGE_XOR) {
+					c = base.ixor(values2[j]);
+				} else if (op == MERGE_LAZY_OR) {
+					c = base.toBitmapContainer().lazyIOR(values2[j]);
+				} else {
+					c = base.ior(values2[j]);
+				}
+				if (op != MERGE_XOR || !c.isEmpty()) {
+					newKeys[pos] = k1;
+					newValues[pos] = c;
+					newShared[pos] = false;
+					pos++;
+				}
+				i++;
+				j++;
+			}
+		}
+		while (i < length1) {
+			newKeys[pos] = keys1[i];
+			newValues[pos] = values1[i];
+			newShared[pos] = i < this.shared.length && this.shared[i];
+			pos++;
+			i++;
+		}
+		while (j < length2) {
+			newKeys[pos] = keys2[j];
+			newValues[pos] = values2[j];
+			newShared[pos] = true;
+			x2.shared[j] = true;
+			pos++;
+			j++;
+		}
+
+		a1.adopt(newKeys, newValues, pos);
+		this.shared = newShared;
 	}
 
 	/**

--- a/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/PersistentRoaringBitmap.java
+++ b/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/PersistentRoaringBitmap.java
@@ -1943,9 +1943,10 @@ public class PersistentRoaringBitmap
 			System.arraycopy(this.highLowContainer.values, srcOffset, newValues, size, remainder);
 			System.arraycopy(this.shared, srcOffset, newShared, size, remainder);
 		}
-		this.highLowContainer.keys = newKeys;
-		this.highLowContainer.values = newValues;
-		this.highLowContainer.size = size + remainder;
+		// install through adopt rather than assigning the fields directly: the three arrays above are
+		// freshly allocated and privately owned, so the array-level frozen guard must be cleared with
+		// them - leaving it set would cost a redundant defensive copy on the next structural write
+		this.highLowContainer.adopt(newKeys, newValues, size + remainder);
 		this.shared = newShared;
 	}
 
@@ -2111,7 +2112,7 @@ public class PersistentRoaringBitmap
 	 */
 	@Nonnull
 	@Override
-	public IntIterator getReverseIntIterator() {
+	public PeekableIntIterator getReverseIntIterator() {
 		return new RoaringReverseIntIterator();
 	}
 
@@ -3913,18 +3914,23 @@ public class PersistentRoaringBitmap
 				pos++;
 				j++;
 			} else {
-				// overlapping chunk: clone if the receiver's container is shared, then op in place
-				Container base = values1[i];
-				if (i < this.shared.length && this.shared[i]) {
-					base = base.clone();
-				}
+				// overlapping chunk: the receiver's container is mutated in place, so a co-owned one
+				// has to be cloned first
+				final Container base = values1[i];
+				final boolean sharedBase = i < this.shared.length && this.shared[i];
 				final Container c;
 				if (op == MERGE_XOR) {
-					c = base.ixor(values2[j]);
+					c = (sharedBase ? base.clone() : base).ixor(values2[j]);
 				} else if (op == MERGE_LAZY_OR) {
-					c = base.toBitmapContainer().lazyIOR(values2[j]);
+					// toBitmapContainer() hands back `this` only for a BitmapContainer, since no other shape
+					// can return itself as one; array and run chunks already produce a freshly allocated
+					// bitmap for lazyIOR to consume, so cloning those first would allocate twice
+					final Container target = sharedBase && base instanceof BitmapContainer
+						? base.clone()
+						: base;
+					c = target.toBitmapContainer().lazyIOR(values2[j]);
 				} else {
-					c = base.ior(values2[j]);
+					c = (sharedBase ? base.clone() : base).ior(values2[j]);
 				}
 				if (op != MERGE_XOR || !c.isEmpty()) {
 					newKeys[pos] = k1;
@@ -4141,13 +4147,13 @@ public class PersistentRoaringBitmap
 	}
 
 	/**
-	 * {@link IntIterator} over set values in descending unsigned order.
+	 * {@link PeekableIntIterator} over set values in descending unsigned order.
 	 */
-	private final class RoaringReverseIntIterator implements IntIterator {
+	private final class RoaringReverseIntIterator implements PeekableIntIterator {
 
 		int hs = 0;
 
-		CharIterator iter;
+		PeekableCharIterator iter;
 
 		int pos = PersistentRoaringBitmap.this.highLowContainer.size() - 1;
 
@@ -4157,7 +4163,7 @@ public class PersistentRoaringBitmap
 
 		@Nonnull
 		@Override
-		public IntIterator clone() {
+		public PeekableIntIterator clone() {
 			try {
 				RoaringReverseIntIterator clone = (RoaringReverseIntIterator) super.clone();
 				if (this.iter != null) {
@@ -4182,6 +4188,32 @@ public class PersistentRoaringBitmap
 				nextContainer();
 			}
 			return x;
+		}
+
+		/**
+		 * Descends until the next value is at most `maxval`: first past whole chunks whose key already
+		 * exceeds the bound, then within the chunk that shares the bound's key. A chunk that turns out
+		 * to hold nothing low enough is abandoned for the next one down, whose key is strictly smaller
+		 * and therefore wholly below the bound.
+		 */
+		@Override
+		public void advanceIfNeeded(final int maxval) {
+			while (hasNext() && ((this.hs >>> 16) > (maxval >>> 16))) {
+				--this.pos;
+				nextContainer();
+			}
+			if (hasNext() && ((this.hs >>> 16) == (maxval >>> 16))) {
+				this.iter.advanceIfNeeded(Util.lowbits(maxval));
+				if (!this.iter.hasNext()) {
+					--this.pos;
+					nextContainer();
+				}
+			}
+		}
+
+		@Override
+		public int peekNext() {
+			return (this.iter.peekNext()) | this.hs;
 		}
 
 		private void nextContainer() {

--- a/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/ReverseIntIteratorFlyweight.java
+++ b/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/ReverseIntIteratorFlyweight.java
@@ -22,7 +22,7 @@ import java.util.Objects;
  *
  * @author Borislav Ivanov
  **/
-public class ReverseIntIteratorFlyweight implements IntIterator {
+public class ReverseIntIteratorFlyweight implements PeekableIntIterator {
 
 	/**
 	 * High 16 bits of the current chunk, pre-shifted into the top half and OR-ed onto each container-local char to rebuild the full 32-bit value.
@@ -33,7 +33,7 @@ public class ReverseIntIteratorFlyweight implements IntIterator {
 	 * Reverse char cursor over the current chunk, re-targeted per container shape; `null` before the first {@link #wrap}.
 	 */
 	@Nullable
-	private CharIterator iter;
+	private PeekableCharIterator iter;
 
 	/**
 	 * Cached reverse array-chunk char cursor, re-targeted via `wrap(...)` to avoid per-chunk allocation.
@@ -85,20 +85,25 @@ public class ReverseIntIteratorFlyweight implements IntIterator {
 	/**
 	 * Forks an independent iterator, deep-copying the active reverse char cursor so the fork advances
 	 * without disturbing this one.
+	 *
+	 * A shallow `Object.clone()` will not do here: it would hand the fork the very same cached
+	 * per-shape cursors this instance recycles, and the first chunk boundary either side crosses would
+	 * re-target a cursor the other one is still reading from. The fork therefore starts from a fresh
+	 * instance — with its own cached cursors — onto which only the position state is copied.
 	 */
+	// the cached per-shape cursors must not be aliased into the fork, so this cannot delegate to super
+	@SuppressWarnings("CloneDoesntCallSuperClone")
 	@Nonnull
 	@Override
-	public IntIterator clone() {
-		try {
-			final ReverseIntIteratorFlyweight x = (ReverseIntIteratorFlyweight) super.clone();
-			if (this.iter != null) {
-				x.iter = this.iter.clone();
-			}
-			return x;
-		} catch (CloneNotSupportedException e) {
-			// unreachable: ReverseIntIteratorFlyweight implements Cloneable
-			throw new IllegalStateException(e);
+	public PeekableIntIterator clone() {
+		final ReverseIntIteratorFlyweight x = new ReverseIntIteratorFlyweight();
+		x.roaringBitmap = this.roaringBitmap;
+		x.pos = this.pos;
+		x.hs = this.hs;
+		if (this.iter != null) {
+			x.iter = this.iter.clone();
 		}
+		return x;
 	}
 
 	/**
@@ -115,7 +120,7 @@ public class ReverseIntIteratorFlyweight implements IntIterator {
 	 */
 	@Override
 	public int next() {
-		final CharIterator cursor = Objects.requireNonNull(
+		final PeekableCharIterator cursor = Objects.requireNonNull(
 			this.iter, "ReverseIntIteratorFlyweight has no active cursor (not wrapped or exhausted)");
 		final int x = cursor.nextAsInt() | this.hs;
 		if (!cursor.hasNext()) {
@@ -123,6 +128,40 @@ public class ReverseIntIteratorFlyweight implements IntIterator {
 			nextContainer();
 		}
 		return x;
+	}
+
+	/**
+	 * Descends until the next value is at most `maxval`: first past whole chunks whose key already
+	 * exceeds the bound, then within the chunk that shares the bound's key. A chunk that turns out to
+	 * hold nothing low enough is abandoned for the next one down, whose key is strictly smaller and
+	 * therefore wholly below the bound.
+	 */
+	@Override
+	public void advanceIfNeeded(final int maxval) {
+		while (hasNext() && ((this.hs >>> 16) > (maxval >>> 16))) {
+			--this.pos;
+			nextContainer();
+		}
+		if (hasNext() && ((this.hs >>> 16) == (maxval >>> 16))) {
+			final PeekableCharIterator cursor = Objects.requireNonNull(
+				this.iter, "ReverseIntIteratorFlyweight has no active cursor (not wrapped or exhausted)");
+			cursor.advanceIfNeeded(Util.lowbits(maxval));
+			if (!cursor.hasNext()) {
+				--this.pos;
+				nextContainer();
+			}
+		}
+	}
+
+	/**
+	 * Returns the value {@link #next()} would return — the current chunk's high bits OR-ed onto the
+	 * cursor's upcoming char — without advancing.
+	 */
+	@Override
+	public int peekNext() {
+		final PeekableCharIterator cursor = Objects.requireNonNull(
+			this.iter, "ReverseIntIteratorFlyweight has no active cursor (not wrapped or exhausted)");
+		return cursor.peekNext() | this.hs;
 	}
 
 	/**

--- a/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/RoaringArray.java
+++ b/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/RoaringArray.java
@@ -1033,6 +1033,25 @@ final class RoaringArray implements Cloneable, Externalizable, AppendableStorage
 	}
 
 	/**
+	 * Adopts freshly built backing arrays wholesale, replacing the current contents in a single step.
+	 * Used by the bulk-merge union / xor path in {@link PersistentRoaringBitmap} to install a one-pass
+	 * merge result instead of shifting entries per key (which is quadratic when the operands' keys are
+	 * interleaved). Clears {@link #frozen} because the supplied arrays are privately owned by the
+	 * caller and never aliased by a clone. The caller guarantees the ascending-key ordering invariant
+	 * on `keys[0..size-1]` and that `size <= keys.length == values.length`.
+	 *
+	 * @param keys   chunk-key array taken over as-is
+	 * @param values container array taken over as-is, parallel to `keys`
+	 * @param size   number of live leading entries
+	 */
+	void adopt(@Nonnull final char[] keys, @Nonnull final Container[] values, final int size) {
+		this.keys = keys;
+		this.values = values;
+		this.size = size;
+		this.frozen = false;
+	}
+
+	/**
 	 * Overwrites both the key and the container at slot `i` in place; the caller is responsible for
 	 * preserving the ascending-key invariant.
 	 *

--- a/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/Util.java
+++ b/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/Util.java
@@ -128,13 +128,14 @@ public final class Util {
 	 *
 	 * Complexity: `O(log gap)`, where `gap` is the distance from `pos` to the returned index.
 	 *
-	 * @param array  array sorted in unsigned-ascending order
-	 * @param pos    index the search starts strictly before
-	 * @param length number of leading entries of `array` that are valid
-	 * @param max    maximum (unsigned) value sought
-	 * @return largest index `< pos` with `array[index] <= max`, or `0` if no such value exists
+	 * @param array array sorted in unsigned-ascending order
+	 * @param pos   index the search starts strictly before
+	 * @param max   maximum (unsigned) value sought
+	 * @return largest index `< pos` with `array[index] <= max`. The result saturates at `0` when no
+	 * entry qualifies, so callers that must distinguish "found index 0" from "nothing at or below
+	 * max" have to re-test `array[0]` themselves.
 	 */
-	public static int reverseUntil(@Nonnull final char[] array, final int pos, final int length, final char max) {
+	public static int reverseUntil(@Nonnull final char[] array, final int pos, final char max) {
 		int lower = pos - 1;
 
 		// special handling for a possibly common sequential case

--- a/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/art/AbstractShuttle.java
+++ b/evita_roaring_bitmap/src/main/java/io/evitadb/roaringbitmap/art/AbstractShuttle.java
@@ -124,10 +124,8 @@ public abstract class AbstractShuttle implements Shuttle {
 			if (nextPos != BranchNode.ILLEGAL_IDX) {
 				this.stack[this.depth].position = nextPos;
 				this.depth++;
-				// add a fresh entry on the top of the visiting stack
-				final NodeEntry freshEntry = new NodeEntry();
-				freshEntry.node = currentBranchNode.getChild(nextPos);
-				this.stack[this.depth] = freshEntry;
+				// reuse the stack slot at this depth instead of allocating a fresh entry
+				useEntry(this.depth, currentBranchNode.getChild(nextPos));
 			} else {
 				// current internal node doesn't have anymore unvisited child,move to a top node
 				this.depth--;
@@ -241,10 +239,8 @@ public abstract class AbstractShuttle implements Shuttle {
 			return;
 		}
 		if (node == this.art.getRoot()) {
-			final NodeEntry nodeEntry = new NodeEntry();
-			nodeEntry.node = node;
 			this.depth = 0;
-			this.stack[this.depth] = nodeEntry;
+			useEntry(this.depth, node);
 		}
 		if (node instanceof LeafNode) {
 			// leaf node's corresponding NodeEntry will not have the position member set.
@@ -262,10 +258,8 @@ public abstract class AbstractShuttle implements Shuttle {
 		this.stack[this.depth].position = pos;
 		this.stack[this.depth].visited = true;
 		final Node child = branchNode.getChild(pos);
-		final NodeEntry childNodeEntry = new NodeEntry();
-		childNodeEntry.node = child;
 		this.depth++;
-		this.stack[this.depth] = childNodeEntry;
+		useEntry(this.depth, child);
 		visitToLeaf(child, inRunDirection);
 	}
 
@@ -274,10 +268,8 @@ public abstract class AbstractShuttle implements Shuttle {
 			return;
 		}
 		if (node == this.art.getRoot()) {
-			final NodeEntry nodeEntry = new NodeEntry();
-			nodeEntry.node = node;
 			this.depth = 0;
-			this.stack[this.depth] = nodeEntry;
+			useEntry(this.depth, node);
 		}
 		if (node instanceof LeafNode) {
 			// leaf node's corresponding NodeEntry will not have the position member set.
@@ -330,10 +322,8 @@ public abstract class AbstractShuttle implements Shuttle {
 		this.stack[this.depth].position = pos;
 		this.stack[this.depth].visited = true;
 		final Node child = branchNode.getChild(pos);
-		final NodeEntry childNodeEntry = new NodeEntry();
-		childNodeEntry.node = child;
 		this.depth++;
-		this.stack[this.depth] = childNodeEntry;
+		useEntry(this.depth, child);
 		if (continueAtBoundary) {
 			// once we miss a single match, there's no point comparing parts of the key anymore
 			// we just descend as far in run direction as possible
@@ -350,6 +340,31 @@ public abstract class AbstractShuttle implements Shuttle {
 		if (nextSiblingPos != BranchNode.ILLEGAL_IDX) {
 			this.stack[this.depth - 1].leafNodeNextSiblingKey = parentNode.getChildKey(nextSiblingPos);
 		}
+	}
+
+	/**
+	 * Reuses the {@link NodeEntry} already parked in the stack slot at depth `d` — allocating one only
+	 * the first time a given depth is reached — and resets it to the same defaults a freshly
+	 * constructed {@link NodeEntry} would have. This avoids allocating a `NodeEntry` on every push
+	 * while the shuttle traverses the tree (select / rank / ordered iteration); at most
+	 * {@link #MAX_DEPTH} entries are ever live, so the slots can be recycled safely — the walk only
+	 * ever reads a frame after the push that (re)initialised it here, never the stale contents a pop
+	 * left behind.
+	 *
+	 * @param d    stack depth whose slot is (re)used
+	 * @param node the node the reused frame is positioned on
+	 */
+	private void useEntry(final int d, @Nullable final Node node) {
+		NodeEntry entry = this.stack[d];
+		if (entry == null) {
+			entry = new NodeEntry();
+			this.stack[d] = entry;
+		}
+		entry.node = node;
+		entry.position = BranchNode.ILLEGAL_IDX;
+		entry.visited = false;
+		entry.startFromNextSiblingPosition = false;
+		entry.leafNodeNextSiblingKey = 0;
 	}
 
 	/**

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/ContainerBinaryOpFreshnessTest.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/ContainerBinaryOpFreshnessTest.java
@@ -1,0 +1,150 @@
+package io.evitadb.roaringbitmap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the precondition the copy-on-write bookkeeping in {@link PersistentRoaringBitmap} relies on
+ * when it declines to flag a chunk shared: the out-of-place binary container operators
+ * (`or` / `xor` / `andNot`) hand back a container that shares no mutable state with either operand.
+ *
+ * The static binary operations mark a result chunk owned (not shared) exactly when they produced it
+ * by combining both operands' containers. That is only sound if the combined container is genuinely
+ * private — if any shape pair could return an operand, or a container aliasing an operand's backing
+ * array, the owner would later mutate it in place and silently corrupt the peer.
+ *
+ * Identity is checked first because it is the cheap and obvious way to violate the property, but the
+ * real assertion is behavioural: the result is scribbled over with the in-place mutators and both
+ * operands must come through byte-for-byte unchanged. That catches a result which is a distinct
+ * object yet wraps an operand's `char[]` / `long[]`.
+ *
+ * All nine shape pairs are exercised in both operand orders, since the operators dispatch on the
+ * runtime shape of the argument and several pairs delegate by swapping the receiver.
+ */
+@DisplayName("Out-of-place container or/xor/andNot never alias their operands")
+public class ContainerBinaryOpFreshnessTest {
+
+	/**
+	 * A named container factory, so a failure reports which shape pair broke.
+	 */
+	private record Shape(String name, java.util.function.IntFunction<Container> factory) {
+	}
+
+	/**
+	 * The three container shapes, each built to a caller-chosen offset so two operands can be made to
+	 * overlap partially rather than coincide or stay disjoint.
+	 */
+	private static final List<Shape> SHAPES = List.of(
+		new Shape("array", ContainerBinaryOpFreshnessTest::arrayContainer),
+		new Shape("bitmap", ContainerBinaryOpFreshnessTest::bitmapContainer),
+		new Shape("run", ContainerBinaryOpFreshnessTest::runContainer)
+	);
+
+	/**
+	 * A sparse container that stays below the array/bitmap threshold and does not run-compress.
+	 */
+	private static Container arrayContainer(final int offset) {
+		Container c = new ArrayContainer();
+		for (int i = 0; i < 64; i++) {
+			c = c.add((char) (offset + i * 97));
+		}
+		assertTrue(c instanceof ArrayContainer, "fixture drifted off the array shape");
+		return c;
+	}
+
+	/**
+	 * A container dense enough to be held as a bitmap, laid out with a stride so it never collapses
+	 * into runs.
+	 */
+	private static Container bitmapContainer(final int offset) {
+		final BitmapContainer c = new BitmapContainer();
+		for (int i = 0; i < ArrayContainer.DEFAULT_MAX_SIZE + 512; i++) {
+			c.add((char) (offset + i * 2));
+		}
+		return c;
+	}
+
+	/**
+	 * A single long run, the shape whose operators short-circuit on `isFull()` and delegate through
+	 * `lazyor(...).repairAfterLazy()` — the paths most likely to hand back a non-fresh container.
+	 */
+	private static Container runContainer(final int offset) {
+		return new RunContainer(offset, offset + 20_000);
+	}
+
+	/**
+	 * Reads out a container's values so the operands can be compared before and after the result is
+	 * scribbled over.
+	 */
+	private static int[] contents(final Container container) {
+		final List<Integer> values = new ArrayList<>();
+		final CharIterator it = container.getCharIterator();
+		while (it.hasNext()) {
+			values.add((int) it.next());
+		}
+		final int[] result = new int[values.size()];
+		for (int i = 0; i < result.length; i++) {
+			result[i] = values.get(i);
+		}
+		return result;
+	}
+
+	/**
+	 * Mutates the container as aggressively as an owning bitmap would, preferring the in-place
+	 * operators — those are the ones that write through to a shared backing array. Reassigns as it
+	 * goes, because a mutator is free to return a promoted or demoted replacement.
+	 */
+	private static void scribble(final Container result) {
+		Container c = result;
+		c = c.ior(new RunContainer(1_000, 30_000));
+		c = c.iandNot(new RunContainer(5_000, 6_000));
+		for (int v = 3; v < 1 << 16; v += 1021) {
+			c = c.add((char) v);
+		}
+		for (int v = 7; v < 1 << 16; v += 2039) {
+			c = c.remove((char) v);
+		}
+		c.ixor(new RunContainer(40_000, 41_000));
+	}
+
+	@Test
+	@DisplayName("or/xor/andNot results are private across every shape pair and operand order")
+	public void binaryOperatorsReturnPrivateContainers() {
+		for (final Shape leftShape : SHAPES) {
+			for (final Shape rightShape : SHAPES) {
+				for (int op = 0; op < 3; op++) {
+					final String opName = op == 0 ? "or" : op == 1 ? "xor" : "andNot";
+					final String where = leftShape.name() + "." + opName + "(" + rightShape.name() + ")";
+
+					// partially overlapping operands: neither disjoint (which would make the result a
+					// trivial concatenation) nor identical (which would collapse xor/andNot to empty)
+					final Container left = leftShape.factory().apply(0);
+					final Container right = rightShape.factory().apply(10_000);
+					final int[] leftBefore = contents(left);
+					final int[] rightBefore = contents(right);
+
+					final Container result = op == 0
+						? left.or(right)
+						: op == 1 ? left.xor(right) : left.andNot(right);
+
+					assertNotSame(left, result, where + ": result is the left operand");
+					assertNotSame(right, result, where + ": result is the right operand");
+
+					scribble(result);
+
+					assertArrayEquals(
+						leftBefore, contents(left), where + ": left operand was written through");
+					assertArrayEquals(
+						rightBefore, contents(right), where + ": right operand was written through");
+				}
+			}
+		}
+	}
+}

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/IteratorCloneIndependenceTest.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/IteratorCloneIndependenceTest.java
@@ -1,0 +1,216 @@
+package io.evitadb.roaringbitmap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests asserting that a cloned int iterator is a genuinely independent cursor — for the
+ * reusable {@link IntIteratorFlyweight} / {@link ReverseIntIteratorFlyweight} as well as for the
+ * per-bitmap cursors handed out by {@link PersistentRoaringBitmap#getIntIterator()} and
+ * {@link PersistentRoaringBitmap#getReverseIntIterator()}.
+ *
+ * The flyweights are the interesting case: each caches one reusable per-shape char cursor
+ * ({@link ReverseArrayContainerCharIterator} and friends) as an instance field so that stepping from
+ * chunk to chunk allocates nothing. A shallow `Object.clone()` copies those cursor references, so the
+ * fork and its origin end up writing to the SAME cached cursor as soon as either of them crosses a
+ * chunk boundary and re-targets it. The tests below drive exactly that: fork first, move the fork
+ * across a chunk boundary, then read the origin — whose own position must be untouched.
+ *
+ * Two properties of the fixtures are load-bearing. Every chunk is a small array chunk, because the
+ * collision only bites when both sides are parked on the same cached cursor instance and mixing chunk
+ * shapes would hide it. And each chunk holds a DIFFERENT set of low bits, because equal low bits make
+ * a clobbered cursor coincidentally emit the value the caller expected.
+ */
+@DisplayName("Iterator clone independence")
+public class IteratorCloneIndependenceTest {
+
+	/**
+	 * Builds a bitmap of `chunkCount` small array chunks where chunk `k` holds the three values
+	 * `k * 5 + 1 .. k * 5 + 3` — distinct low bits per chunk, so a cursor re-seated onto the wrong
+	 * chunk is immediately visible in the emitted value.
+	 */
+	private static PersistentRoaringBitmap arrayChunkedBitmap(final int chunkCount) {
+		final PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+		for (int chunk = 0; chunk < chunkCount; chunk++) {
+			for (int offset = 1; offset <= 3; offset++) {
+				bitmap.add((chunk << 16) + chunk * 5 + offset);
+			}
+		}
+		return bitmap;
+	}
+
+	/**
+	 * Value `offset` of chunk `chunk` in the fixture built by {@link #arrayChunkedBitmap(int)}.
+	 */
+	private static int value(final int chunk, final int offset) {
+		return (chunk << 16) + chunk * 5 + offset;
+	}
+
+	/**
+	 * Reverse flyweight: the fork drains the top chunk, steps down and re-targets the cached array
+	 * cursor. The origin is still parked on the top chunk and must keep emitting the top chunk's tail.
+	 */
+	@Test
+	public void reverseFlyweightCloneCrossingChunkLeavesOriginIntact() {
+		final PersistentRoaringBitmap bitmap = arrayChunkedBitmap(3);
+		final ReverseIntIteratorFlyweight origin = new ReverseIntIteratorFlyweight(bitmap);
+
+		assertEquals(value(2, 3), origin.next());
+
+		final PeekableIntIterator fork = origin.clone();
+		// drain the rest of the top chunk on the fork, forcing it down into chunk 1
+		assertEquals(value(2, 2), fork.next());
+		assertEquals(value(2, 1), fork.next());
+		assertEquals(value(1, 3), fork.next());
+
+		assertTrue(origin.hasNext(), "origin exhausted by the fork's descent");
+		assertEquals(value(2, 2), origin.peekNext(), "fork's descent moved the origin's cursor");
+		assertEquals(value(2, 2), origin.next(), "fork's descent moved the origin's cursor");
+		assertEquals(value(2, 1), origin.next(), "fork's descent moved the origin's cursor");
+	}
+
+	/**
+	 * Reverse flyweight, `advanceIfNeeded` entry point: seeking the fork below the top chunk crosses a
+	 * boundary through the same cached-cursor re-target as `next()` does.
+	 */
+	@Test
+	public void reverseFlyweightCloneAdvanceIfNeededLeavesOriginIntact() {
+		final PersistentRoaringBitmap bitmap = arrayChunkedBitmap(3);
+		final ReverseIntIteratorFlyweight origin = new ReverseIntIteratorFlyweight(bitmap);
+
+		final PeekableIntIterator fork = origin.clone();
+		fork.advanceIfNeeded(value(1, 2));
+		assertEquals(value(1, 2), fork.next());
+
+		assertTrue(origin.hasNext(), "origin exhausted by the fork's seek");
+		assertEquals(value(2, 3), origin.peekNext(), "fork's seek moved the origin's cursor");
+		assertEquals(value(2, 3), origin.next(), "fork's seek moved the origin's cursor");
+	}
+
+	/**
+	 * Forward flyweight: the same cached-cursor reuse, walking upward instead.
+	 */
+	@Test
+	public void forwardFlyweightCloneCrossingChunkLeavesOriginIntact() {
+		final PersistentRoaringBitmap bitmap = arrayChunkedBitmap(3);
+		final IntIteratorFlyweight origin = new IntIteratorFlyweight(bitmap);
+
+		assertEquals(value(0, 1), origin.next());
+
+		final PeekableIntIterator fork = origin.clone();
+		// drain the rest of chunk 0 on the fork, forcing it up into chunk 1
+		assertEquals(value(0, 2), fork.next());
+		assertEquals(value(0, 3), fork.next());
+		assertEquals(value(1, 1), fork.next());
+
+		assertTrue(origin.hasNext(), "origin exhausted by the fork's advance");
+		assertEquals(value(0, 2), origin.peekNext(), "fork's advance moved the origin's cursor");
+		assertEquals(value(0, 2), origin.next(), "fork's advance moved the origin's cursor");
+		assertEquals(value(0, 3), origin.next(), "fork's advance moved the origin's cursor");
+	}
+
+	/**
+	 * Forward flyweight, `advanceIfNeeded` entry point.
+	 */
+	@Test
+	public void forwardFlyweightCloneAdvanceIfNeededLeavesOriginIntact() {
+		final PersistentRoaringBitmap bitmap = arrayChunkedBitmap(3);
+		final IntIteratorFlyweight origin = new IntIteratorFlyweight(bitmap);
+
+		final PeekableIntIterator fork = origin.clone();
+		fork.advanceIfNeeded(value(1, 2));
+		assertEquals(value(1, 2), fork.next());
+
+		assertTrue(origin.hasNext(), "origin exhausted by the fork's seek");
+		assertEquals(value(0, 1), origin.peekNext(), "fork's seek moved the origin's cursor");
+		assertEquals(value(0, 1), origin.next(), "fork's seek moved the origin's cursor");
+	}
+
+	/**
+	 * The origin must equally be free to move without disturbing an already-forked cursor once BOTH
+	 * sides have crossed a boundary — at that point a shallow clone leaves them on one cursor again.
+	 */
+	@Test
+	public void reverseFlyweightBothSidesCrossingStayIndependent() {
+		final PersistentRoaringBitmap bitmap = arrayChunkedBitmap(4);
+		final ReverseIntIteratorFlyweight origin = new ReverseIntIteratorFlyweight(bitmap);
+
+		final PeekableIntIterator fork = origin.clone();
+		// fork descends one chunk
+		assertEquals(value(3, 3), fork.next());
+		assertEquals(value(3, 2), fork.next());
+		assertEquals(value(3, 1), fork.next());
+		assertEquals(value(2, 3), fork.peekNext());
+
+		// origin descends one chunk too
+		assertEquals(value(3, 3), origin.next());
+		assertEquals(value(3, 2), origin.next());
+		assertEquals(value(3, 1), origin.next());
+		assertEquals(value(2, 3), origin.next());
+
+		assertEquals(value(2, 3), fork.next(), "origin's descent moved the fork's cursor");
+		assertEquals(value(2, 2), fork.next(), "origin's descent moved the fork's cursor");
+	}
+
+	/**
+	 * The per-bitmap reverse cursor allocates a fresh char iterator per chunk rather than recycling
+	 * cached ones, so a shallow clone is enough — but the independence contract is the same and must
+	 * hold across a chunk boundary and after a partial seek.
+	 */
+	@Test
+	public void bitmapReverseIteratorCloneIsIndependent() {
+		final PersistentRoaringBitmap bitmap = arrayChunkedBitmap(3);
+		final PeekableIntIterator origin = bitmap.getReverseIntIterator();
+
+		assertEquals(value(2, 3), origin.next());
+
+		final PeekableIntIterator fork = origin.clone();
+		assertEquals(value(2, 2), fork.next());
+		assertEquals(value(2, 1), fork.next());
+		assertEquals(value(1, 3), fork.next());
+
+		assertTrue(origin.hasNext(), "origin exhausted by the fork's descent");
+		assertEquals(value(2, 2), origin.peekNext(), "fork's descent moved the origin's cursor");
+		assertEquals(value(2, 2), origin.next(), "fork's descent moved the origin's cursor");
+		assertEquals(value(2, 1), origin.next(), "fork's descent moved the origin's cursor");
+
+		// forking after a partial seek must copy the sought-to position, not reset or share it
+		final PeekableIntIterator sought = bitmap.getReverseIntIterator();
+		sought.advanceIfNeeded(value(1, 2));
+		final PeekableIntIterator soughtFork = sought.clone();
+		assertEquals(value(1, 2), soughtFork.next());
+		assertEquals(value(1, 1), soughtFork.next());
+		assertEquals(value(1, 2), sought.next(), "the fork consumed the origin's sought-to value");
+	}
+
+	/**
+	 * Forward counterpart of {@link #bitmapReverseIteratorCloneIsIndependent()}.
+	 */
+	@Test
+	public void bitmapForwardIteratorCloneIsIndependent() {
+		final PersistentRoaringBitmap bitmap = arrayChunkedBitmap(3);
+		final PeekableIntIterator origin = bitmap.getIntIterator();
+
+		assertEquals(value(0, 1), origin.next());
+
+		final PeekableIntIterator fork = origin.clone();
+		assertEquals(value(0, 2), fork.next());
+		assertEquals(value(0, 3), fork.next());
+		assertEquals(value(1, 1), fork.next());
+
+		assertTrue(origin.hasNext(), "origin exhausted by the fork's advance");
+		assertEquals(value(0, 2), origin.peekNext(), "fork's advance moved the origin's cursor");
+		assertEquals(value(0, 2), origin.next(), "fork's advance moved the origin's cursor");
+		assertEquals(value(0, 3), origin.next(), "fork's advance moved the origin's cursor");
+
+		final PeekableIntIterator sought = bitmap.getIntIterator();
+		sought.advanceIfNeeded(value(1, 2));
+		final PeekableIntIterator soughtFork = sought.clone();
+		assertEquals(value(1, 2), soughtFork.next());
+		assertEquals(value(1, 3), soughtFork.next());
+		assertEquals(value(1, 2), sought.next(), "the fork consumed the origin's sought-to value");
+	}
+}

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/MergeBulkCopyOnWriteTest.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/MergeBulkCopyOnWriteTest.java
@@ -1,0 +1,360 @@
+package io.evitadb.roaringbitmap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Regression tests for the bulk-merge path added when porting upstream RoaringBitmap PR #840
+ * ("Avoid O(N^2) operations in some cases") onto the copy-on-write {@link PersistentRoaringBitmap}.
+ *
+ * The in-place {@link PersistentRoaringBitmap#or}, {@link PersistentRoaringBitmap#xor} and
+ * {@link PersistentRoaringBitmap#naivelazyor} switch from a per-key insert/remove loop to a single
+ * suffix rebuild ({@code mergeBulk}) the moment the receiver's structure must change. That rebuild
+ * is the copy-on-write landmine: it must borrow source-only containers by structural sharing (never
+ * corrupting the source), clone a shared receiver container before an in-place overlap op (never
+ * corrupting a cloned peer), and rebuild the parallel {@code shared[]} flag array in lockstep (never
+ * indexing out of bounds). These tests force the mid-stream divergence together with a {@code clone()}
+ * peer — the combination the pre-existing sharing tests do not exercise, because they only cover
+ * disjoint tail-append and full-overlap sharing through the static operators.
+ */
+@DisplayName("mergeBulk (PR #840) copy-on-write correctness")
+public class MergeBulkCopyOnWriteTest {
+
+	/**
+	 * In-place OR with interleaved keys, entered while the receiver is a frozen, fully-shared clone
+	 * peer. The very first comparison is a source-only insert at position 0 (`A`'s smallest key is
+	 * greater than `B`'s), so {@code mergeBulk} runs against a still-frozen receiver — the hardest
+	 * copy-on-write case. Covers source-only borrow, overlap clone-before-op and receiver-only carry
+	 * in one pass.
+	 */
+	@Test
+	public void orInterleavedFrozenReceiverPreservesPeerAndSource() {
+		// keys interleave and A's first key (10) > B's first key (5) -> mergeBulk fires at index 0
+		final int[] aValues = values(new int[]{10, 20}, 3);          // chunks 10, 20
+		final int[] bValues = concat(values(new int[]{5, 15, 25}, 3), // disjoint chunks 5, 15, 25
+			values(new int[]{10}, 7));                                // overlapping chunk 10, other lows
+		final PersistentRoaringBitmap a = bitmapOf(aValues);
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+
+		final PersistentRoaringBitmap peer = a.clone();               // a becomes frozen + all-shared
+		final int[] peerBefore = peer.toArray();
+		final int[] bBefore = b.toArray();
+
+		a.or(b);
+
+		assertArrayEquals(union(aValues, bValues), a.toArray(), "in-place or produced a wrong result");
+		assertArrayEquals(peerBefore, peer.toArray(), "clone peer corrupted by in-place or");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by in-place or");
+	}
+
+	/**
+	 * In-place XOR with interleaved keys and a shared clone peer, where the overlapping chunk holds a
+	 * different value in each operand so the symmetric difference keeps it.
+	 */
+	@Test
+	public void xorInterleavedPreservesPeerAndSource() {
+		final int[] aValues = concat(values(new int[]{0, 10, 20}, 3), values(new int[]{10}, 50));
+		final int[] bValues = values(new int[]{5, 10, 15, 25}, 3);
+		final PersistentRoaringBitmap a = bitmapOf(aValues);
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+
+		final PersistentRoaringBitmap peer = a.clone();
+		final int[] peerBefore = peer.toArray();
+		final int[] bBefore = b.toArray();
+
+		a.xor(b);
+
+		assertArrayEquals(symmetricDifference(aValues, bValues), a.toArray(), "in-place xor wrong result");
+		assertArrayEquals(peerBefore, peer.toArray(), "clone peer corrupted by in-place xor");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by in-place xor");
+	}
+
+	/**
+	 * In-place XOR where an overlapping chunk holds the identical container in both operands, so the
+	 * overlap cancels to an empty container. This is the {@code mergeBulk} cancelled-pair entry point
+	 * (`dst = pos1`, `left = pos1 + 1`) that must drop the emptied chunk while keeping both peers
+	 * intact.
+	 */
+	@Test
+	public void xorCancelledPairDropsEmptiedChunkAndPreservesPeers() {
+		// chunk 10 identical in both -> ixor empties it; it must vanish from the result
+		final int[] aValues = values(new int[]{10, 20, 30}, 1);
+		final int[] bValues = values(new int[]{10, 25}, 1);
+		final PersistentRoaringBitmap a = bitmapOf(aValues);
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+
+		final PersistentRoaringBitmap peer = a.clone();
+		final int[] peerBefore = peer.toArray();
+		final int[] bBefore = b.toArray();
+
+		a.xor(b);
+
+		final int[] expected = symmetricDifference(aValues, bValues);
+		assertArrayEquals(expected, a.toArray(), "cancelled-pair xor produced a wrong result");
+		// the identical chunk-10 value must not survive the symmetric difference
+		assertFalse(a.contains(10 << 16 | 0), "emptied chunk was not dropped");
+		assertArrayEquals(peerBefore, peer.toArray(), "clone peer corrupted by cancelled-pair xor");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by cancelled-pair xor");
+	}
+
+	/**
+	 * In-place naive lazy OR (promotes overlaps to bitmap containers, exercising the
+	 * {@code MERGE_LAZY_OR} branch), followed by {@code repairAfterLazy()}, with interleaved keys and a
+	 * shared clone peer.
+	 */
+	@Test
+	public void naiveLazyOrInterleavedPreservesPeerAndSource() {
+		final int[] aValues = concat(values(new int[]{10, 20}, 5), values(new int[]{10}, 40));
+		final int[] bValues = values(new int[]{5, 10, 15, 25}, 5);
+		final PersistentRoaringBitmap a = bitmapOf(aValues);
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+
+		final PersistentRoaringBitmap peer = a.clone();
+		final int[] peerBefore = peer.toArray();
+		final int[] bBefore = b.toArray();
+
+		a.naivelazyor(b);
+		a.repairAfterLazy();
+
+		assertArrayEquals(union(aValues, bValues), a.toArray(), "in-place naivelazyor wrong result");
+		assertArrayEquals(peerBefore, peer.toArray(), "clone peer corrupted by in-place naivelazyor");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by in-place naivelazyor");
+	}
+
+	/**
+	 * The untouched instance {@link PersistentRoaringBitmap#lazyor} (upstream PR #840 deliberately left
+	 * it on the per-key path) must keep producing correct unions with interleaved keys and preserve a
+	 * shared clone peer.
+	 */
+	@Test
+	public void lazyOrInterleavedStillCorrectAndPreservesPeers() {
+		final int[] aValues = values(new int[]{10, 20}, 4);
+		final int[] bValues = values(new int[]{5, 15, 25}, 4);
+		final PersistentRoaringBitmap a = bitmapOf(aValues);
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+
+		final PersistentRoaringBitmap peer = a.clone();
+		final int[] peerBefore = peer.toArray();
+		final int[] bBefore = b.toArray();
+
+		a.lazyor(b);
+		a.repairAfterLazy();
+
+		assertArrayEquals(union(aValues, bValues), a.toArray(), "in-place lazyor wrong result");
+		assertArrayEquals(peerBefore, peer.toArray(), "clone peer corrupted by in-place lazyor");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by in-place lazyor");
+	}
+
+	/**
+	 * Large fully-interleaved OR: `A` on even chunks, `B` on odd chunks, thousands of keys. This is the
+	 * O(N) path {@code mergeBulk} exists to provide and where an undersized rebuilt {@code shared[]}
+	 * would throw {@link ArrayIndexOutOfBoundsException}. Runs against a frozen clone peer to force the
+	 * shared-flag rebuild across the whole suffix.
+	 */
+	@Test
+	public void largeInterleavedOrIsCorrectAndDoesNotOverflowSharedFlags() {
+		final int chunks = 2000;
+		final int[] evenChunks = new int[chunks];
+		final int[] oddChunks = new int[chunks];
+		for (int i = 0; i < chunks; i++) {
+			evenChunks[i] = 2 * i;
+			oddChunks[i] = 2 * i + 1;
+		}
+		final int[] aValues = values(evenChunks, 1);
+		final int[] bValues = values(oddChunks, 1);
+		final PersistentRoaringBitmap a = bitmapOf(aValues);
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+
+		final PersistentRoaringBitmap peer = a.clone();
+		final int[] peerBefore = peer.toArray();
+		final int[] bBefore = b.toArray();
+
+		a.or(b);
+
+		assertArrayEquals(union(aValues, bValues), a.toArray(), "large interleaved or wrong result");
+		assertArrayEquals(peerBefore, peer.toArray(), "clone peer corrupted by large interleaved or");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by large interleaved or");
+	}
+
+	/**
+	 * In-place OR entered on an _owned_ (never-cloned) receiver whose interleaved keys force the
+	 * source-only branch to invoke {@code mergeBulk}, which borrows a source-only chunk from `b` by
+	 * structural sharing. {@code mergeBulk} must raise the shared flag on _both_ operands for
+	 * that borrowed chunk, so a later write to either side clones on demand and leaves the other intact.
+	 * The source `b` is mutated first — while `a` still aliases the borrowed container — so the check
+	 * fails if {@code mergeBulk} forgot to flag the borrowed chunk shared on the source side.
+	 */
+	@Test
+	public void orBorrowedChunkIsolatesBothOperandsUnderLaterMutation() {
+		// a's first key (10) > b's first key (5) -> or() takes the source-only branch into mergeBulk;
+		// chunk 5 (and 25) exist only in b and are borrowed into a by structural sharing.
+		final int[] aValues = values(new int[]{10, 20}, 3);
+		final int[] bValues = values(new int[]{5, 10, 25}, 3);
+		final PersistentRoaringBitmap a = bitmapOf(aValues);   // owned: never cloned
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+		final int[] bBefore = b.toArray();
+
+		a.or(b);
+
+		assertArrayEquals(union(aValues, bValues), a.toArray(), "owned-receiver or produced a wrong result");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by owned-receiver or");
+
+		final int[] aAfterOp = a.toArray();
+		// mutate the SOURCE inside the borrowed chunk 5 while a still aliases it: a must stay intact
+		b.add((5 << 16) | 888);
+		assertArrayEquals(aAfterOp, a.toArray(), "receiver corrupted by mutating source in a borrowed chunk");
+
+		final int[] bAfterSourceMutation = b.toArray();
+		// mutate the RECEIVER inside the same chunk: the source must stay intact
+		a.add((5 << 16) | 999);
+		assertArrayEquals(bAfterSourceMutation, b.toArray(), "source corrupted by mutating receiver in a borrowed chunk");
+	}
+
+	/**
+	 * In-place XOR counterpart of {@link #orBorrowedChunkIsolatesBothOperandsUnderLaterMutation()}: an
+	 * owned receiver with interleaved keys enters {@code mergeBulk} through the source-only branch, the
+	 * overlapping chunk carries distinct values so its symmetric difference survives, and a source-only
+	 * chunk is borrowed. Mutating the source first, then the receiver, must leave the other side intact.
+	 */
+	@Test
+	public void xorBorrowedChunkIsolatesBothOperandsUnderLaterMutation() {
+		final int[] aValues = values(new int[]{10, 20}, 3);
+		final int[] bValues = concat(values(new int[]{5, 25}, 3), values(new int[]{10}, 7));
+		final PersistentRoaringBitmap a = bitmapOf(aValues);   // owned: never cloned
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+		final int[] bBefore = b.toArray();
+
+		a.xor(b);
+
+		assertArrayEquals(symmetricDifference(aValues, bValues), a.toArray(), "owned-receiver xor wrong result");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by owned-receiver xor");
+
+		final int[] aAfterOp = a.toArray();
+		b.add((5 << 16) | 888);
+		assertArrayEquals(aAfterOp, a.toArray(), "receiver corrupted by mutating source in a borrowed chunk");
+
+		final int[] bAfterSourceMutation = b.toArray();
+		a.add((5 << 16) | 999);
+		assertArrayEquals(bAfterSourceMutation, b.toArray(), "source corrupted by mutating receiver in a borrowed chunk");
+	}
+
+	/**
+	 * In-place naive lazy OR on an owned receiver whose interleaved keys enter {@code mergeBulk} through
+	 * the source-only branch, promoting the overlapping chunk to a bitmap accumulator and borrowing a
+	 * source-only chunk. After the mandatory {@link PersistentRoaringBitmap#repairAfterLazy()} the union
+	 * must be correct, and mutating either operand in the borrowed chunk must leave the other intact.
+	 */
+	@Test
+	public void naiveLazyOrBorrowedChunkIsolatesBothOperandsUnderLaterMutation() {
+		final int[] aValues = concat(values(new int[]{10, 20}, 5), values(new int[]{10}, 40));
+		final int[] bValues = values(new int[]{5, 10, 25}, 5);
+		final PersistentRoaringBitmap a = bitmapOf(aValues);   // owned: never cloned
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+		final int[] bBefore = b.toArray();
+
+		a.naivelazyor(b);
+		a.repairAfterLazy();
+
+		assertArrayEquals(union(aValues, bValues), a.toArray(), "owned-receiver naivelazyor wrong result");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by owned-receiver naivelazyor");
+
+		final int[] aAfterOp = a.toArray();
+		b.add((5 << 16) | 888);
+		assertArrayEquals(aAfterOp, a.toArray(), "receiver corrupted by mutating source in a borrowed chunk");
+
+		final int[] bAfterSourceMutation = b.toArray();
+		a.add((5 << 16) | 999);
+		assertArrayEquals(bAfterSourceMutation, b.toArray(), "source corrupted by mutating receiver in a borrowed chunk");
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Helpers: bitmap construction and independent set-algebra oracle
+	// ---------------------------------------------------------------------------------------------
+
+	/**
+	 * Builds a bitmap from an explicit list of values.
+	 */
+	private static PersistentRoaringBitmap bitmapOf(final int[] values) {
+		final PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+		for (final int value : values) {
+			bitmap.add(value);
+		}
+		return bitmap;
+	}
+
+	/**
+	 * Produces `count` values inside each of the given high-16-bit chunk keys, so each chunk becomes a
+	 * distinct container.
+	 *
+	 * @param chunks high-16-bit chunk keys to populate
+	 * @param count  number of consecutive low values written into every chunk
+	 * @return the flattened value array
+	 */
+	private static int[] values(final int[] chunks, final int count) {
+		final int[] out = new int[chunks.length * count];
+		int pos = 0;
+		for (final int chunk : chunks) {
+			for (int low = 0; low < count; low++) {
+				out[pos++] = (chunk << 16) | low;
+			}
+		}
+		return out;
+	}
+
+	/**
+	 * Concatenates two value arrays.
+	 */
+	private static int[] concat(final int[] first, final int[] second) {
+		final int[] out = Arrays.copyOf(first, first.length + second.length);
+		System.arraycopy(second, 0, out, first.length, second.length);
+		return out;
+	}
+
+	/**
+	 * Independent union oracle: sorted distinct union of the two value sets.
+	 */
+	private static int[] union(final int[] a, final int[] b) {
+		final TreeSet<Integer> set = new TreeSet<>(Integer::compareUnsigned);
+		for (final int value : a) {
+			set.add(value);
+		}
+		for (final int value : b) {
+			set.add(value);
+		}
+		return toIntArray(set);
+	}
+
+	/**
+	 * Independent symmetric-difference oracle: values present in exactly one of the two sets.
+	 */
+	private static int[] symmetricDifference(final int[] a, final int[] b) {
+		final TreeSet<Integer> set = new TreeSet<>(Integer::compareUnsigned);
+		for (final int value : a) {
+			set.add(value);
+		}
+		for (final int value : b) {
+			if (!set.remove(value)) {
+				set.add(value);
+			}
+		}
+		return toIntArray(set);
+	}
+
+	/**
+	 * Converts a sorted integer set to a primitive array preserving order.
+	 */
+	private static int[] toIntArray(final TreeSet<Integer> set) {
+		final int[] out = new int[set.size()];
+		int pos = 0;
+		for (final int value : set) {
+			out[pos++] = value;
+		}
+		return out;
+	}
+}

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/MergeBulkCopyOnWriteTest.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/MergeBulkCopyOnWriteTest.java
@@ -8,6 +8,7 @@ import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Regression tests for the bulk-merge path added when porting upstream RoaringBitmap PR #840
@@ -271,6 +272,114 @@ public class MergeBulkCopyOnWriteTest {
 		final int[] bAfterSourceMutation = b.toArray();
 		a.add((5 << 16) | 999);
 		assertArrayEquals(bAfterSourceMutation, b.toArray(), "source corrupted by mutating receiver in a borrowed chunk");
+	}
+
+	/**
+	 * Enters `mergeBulk` with a non-zero `dst` that sits past a container the main loop already
+	 * mutated **in place**, rather than past receiver-only chunks it merely skipped.
+	 *
+	 * The other cases reach the bulk path either at `dst == 0` or with a prefix of untouched
+	 * receiver-only chunks. Here chunk 5 overlaps, so the main loop runs a real in-place op and
+	 * advances both cursors; only then does source-only key 10 trigger the bulk rebuild, which must
+	 * copy that freshly-owned prefix container across verbatim and leave its `shared` flag clear.
+	 */
+	@Test
+	public void orAfterMutatedPrefixPreservesPeerAndSource() {
+		// chunk 5 overlaps (mutated in place, dst -> 1), then source-only chunk 10 fires mergeBulk
+		final int[] aValues = values(new int[]{5, 20}, 3);
+		final int[] bValues = concat(values(new int[]{5}, 7), values(new int[]{10, 15}, 3));
+		final PersistentRoaringBitmap a = bitmapOf(aValues);
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+
+		final PersistentRoaringBitmap peer = a.clone();
+		final int[] peerBefore = peer.toArray();
+		final int[] bBefore = b.toArray();
+
+		a.or(b);
+
+		assertArrayEquals(union(aValues, bValues), a.toArray(), "or past a mutated prefix wrong result");
+		assertArrayEquals(peerBefore, peer.toArray(), "clone peer corrupted by or past a mutated prefix");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by or past a mutated prefix");
+	}
+
+	/**
+	 * The mutated-prefix entry for `xor`. Chunk 5's overlap must stay non-empty so the main loop
+	 * advances normally instead of taking the cancelled-pair branch.
+	 */
+	@Test
+	public void xorAfterMutatedPrefixPreservesPeerAndSource() {
+		final int[] aValues = values(new int[]{5, 20}, 3);
+		final int[] bValues = concat(values(new int[]{5}, 7), values(new int[]{10, 15}, 3));
+		final PersistentRoaringBitmap a = bitmapOf(aValues);
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+
+		final PersistentRoaringBitmap peer = a.clone();
+		final int[] peerBefore = peer.toArray();
+		final int[] bBefore = b.toArray();
+
+		a.xor(b);
+
+		assertArrayEquals(
+			symmetricDifference(aValues, bValues), a.toArray(), "xor past a mutated prefix wrong result");
+		assertArrayEquals(peerBefore, peer.toArray(), "clone peer corrupted by xor past a mutated prefix");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by xor past a mutated prefix");
+	}
+
+	/**
+	 * The mutated-prefix entry for `naivelazyor`, which reaches the bulk path through the
+	 * `toBitmapContainer().lazyIOR(...)` overlap branch rather than `ior`.
+	 */
+	@Test
+	public void naiveLazyOrAfterMutatedPrefixPreservesPeerAndSource() {
+		final int[] aValues = values(new int[]{5, 20}, 3);
+		final int[] bValues = concat(values(new int[]{5}, 7), values(new int[]{10, 15}, 3));
+		final PersistentRoaringBitmap a = bitmapOf(aValues);
+		final PersistentRoaringBitmap b = bitmapOf(bValues);
+
+		final PersistentRoaringBitmap peer = a.clone();
+		final int[] peerBefore = peer.toArray();
+		final int[] bBefore = b.toArray();
+
+		a.naivelazyor(b);
+		a.repairAfterLazy();
+
+		assertArrayEquals(
+			union(aValues, bValues), a.toArray(), "naivelazyor past a mutated prefix wrong result");
+		assertArrayEquals(
+			peerBefore, peer.toArray(), "clone peer corrupted by naivelazyor past a mutated prefix");
+		assertArrayEquals(
+			bBefore, b.toArray(), "source operand corrupted by naivelazyor past a mutated prefix");
+	}
+
+	/**
+	 * Cancelled-pair `xor` where the operands hold one identical chunk and nothing else, so the bulk
+	 * rebuild is asked to produce a result of size zero.
+	 *
+	 * This is the degenerate end of the cancelled-pair path: `dst`, `left` and `right` all leave the
+	 * merge with nothing to copy, so the rebuilt arrays must be adopted at length zero — and the
+	 * co-owned peer must still hold the original values.
+	 */
+	@Test
+	public void xorCancellingEveryChunkYieldsEmptyBitmapAndPreservesPeer() {
+		final int[] sharedValues = values(new int[]{7}, 3);
+		final PersistentRoaringBitmap a = bitmapOf(sharedValues);
+		final PersistentRoaringBitmap b = bitmapOf(sharedValues);
+
+		final PersistentRoaringBitmap peer = a.clone();
+		final int[] peerBefore = peer.toArray();
+		final int[] bBefore = b.toArray();
+
+		a.xor(b);
+
+		assertTrue(a.isEmpty(), "xor of two identical single-chunk bitmaps must be empty");
+		assertArrayEquals(new int[0], a.toArray(), "fully cancelled xor must expose no values");
+		assertArrayEquals(peerBefore, peer.toArray(), "clone peer corrupted by a fully cancelled xor");
+		assertArrayEquals(bBefore, b.toArray(), "source operand corrupted by a fully cancelled xor");
+
+		// the emptied receiver must still be a usable bitmap rather than a corpse of the merge
+		a.add((7 << 16) | 42);
+		assertArrayEquals(new int[]{(7 << 16) | 42}, a.toArray(), "emptied receiver is no longer usable");
+		assertArrayEquals(peerBefore, peer.toArray(), "clone peer corrupted by reusing the emptied receiver");
 	}
 
 	// ---------------------------------------------------------------------------------------------

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/ReverseAdvanceIfNeededContractTest.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/ReverseAdvanceIfNeededContractTest.java
@@ -1,0 +1,171 @@
+package io.evitadb.roaringbitmap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Post-condition tests for {@link PeekableCharIterator#advanceIfNeeded(char)} on the three _reverse_
+ * container cursors, and for the reverse seek they back.
+ *
+ * The interface contract is direction-aware: a reverse iterator "advances while the next value is
+ * larger than `thresholdVal`". So after `advanceIfNeeded(m)` exactly one of two things must hold —
+ * the cursor is exhausted, or `peekNext() <= m`. Nothing may be left sitting _above_ the bound.
+ *
+ * The interesting input is a threshold below the container's smallest value, because there the
+ * correct answer is "exhausted" rather than "repositioned". The upstream test suite never probes it:
+ * it only advances to values that are actually present in the bitmap, so a cursor that clamps at the
+ * first slot instead of exhausting still passes every upstream assertion. The three shapes did not
+ * agree on that edge — which is why this is asserted per shape rather than once.
+ *
+ * The last test pins the user-visible consequence, since
+ * {@link PersistentLongRoaringBitmap#getReverseLongIterator()} forwards its seek straight down to
+ * these cursors.
+ */
+@DisplayName("Reverse advanceIfNeeded post-condition")
+public class ReverseAdvanceIfNeededContractTest {
+
+	/**
+	 * Asserts the direction-aware post-condition: after seeking to `maxval` the cursor is either
+	 * exhausted or positioned at a value that does not exceed `maxval`.
+	 */
+	private static void assertAtOrBelow(final PeekableCharIterator iterator, final char maxval) {
+		if (iterator.hasNext()) {
+			final char peeked = iterator.peekNext();
+			assertTrue(
+				peeked <= maxval,
+				"reverse cursor left at " + (int) peeked + ", above the requested bound " + (int) maxval);
+		}
+	}
+
+	/**
+	 * Builds a single-container bitmap and hands back that container, so each test can pin one shape.
+	 */
+	private static Container singleContainerOf(final PersistentRoaringBitmap bitmap) {
+		assertEquals(1, bitmap.highLowContainer.size(), "test fixture must hold exactly one container");
+		return bitmap.highLowContainer.getContainerAtIndex(0);
+	}
+
+	@Test
+	@DisplayName("Array container: seeking below the smallest value exhausts the cursor")
+	public void arrayContainerSeekBelowMinimumExhausts() {
+		// two values only - comfortably under DEFAULT_MAX_SIZE, so the container stays an array
+		final PersistentRoaringBitmap bitmap = PersistentRoaringBitmap.bitmapOf(1000, 2000);
+		final Container container = singleContainerOf(bitmap);
+		assertTrue(container instanceof ArrayContainer, "fixture must produce an array container");
+
+		final PeekableCharIterator iterator = container.getReverseCharIterator();
+		iterator.advanceIfNeeded((char) 500);
+
+		assertAtOrBelow(iterator, (char) 500);
+		assertFalse(iterator.hasNext(), "no value is at or below 500, so the cursor must be exhausted");
+	}
+
+	@Test
+	@DisplayName("Bitmap container: seeking below the smallest value exhausts the cursor")
+	public void bitmapContainerSeekBelowMinimumExhausts() {
+		// more than DEFAULT_MAX_SIZE values, none below 5000, forces a bitmap container
+		final PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+		for (int value = 5000; value < 5000 + ArrayContainer.DEFAULT_MAX_SIZE + 1; value++) {
+			bitmap.add(value);
+		}
+		final Container container = singleContainerOf(bitmap);
+		assertTrue(container instanceof BitmapContainer, "fixture must produce a bitmap container");
+
+		final PeekableCharIterator iterator = container.getReverseCharIterator();
+		iterator.advanceIfNeeded((char) 4000);
+
+		assertAtOrBelow(iterator, (char) 4000);
+		assertFalse(iterator.hasNext(), "no value is at or below 4000, so the cursor must be exhausted");
+	}
+
+	@Test
+	@DisplayName("Run container: seeking below the smallest value exhausts the cursor")
+	public void runContainerSeekBelowMinimumExhausts() {
+		// one dense run, then runOptimize collapses it into a run container
+		final PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+		bitmap.add(5000L, 9000L);
+		assertTrue(bitmap.runOptimize(), "fixture must collapse into a run container");
+		final Container container = singleContainerOf(bitmap);
+		assertTrue(container instanceof RunContainer, "fixture must produce a run container");
+
+		final PeekableCharIterator iterator = container.getReverseCharIterator();
+		iterator.advanceIfNeeded((char) 4000);
+
+		assertAtOrBelow(iterator, (char) 4000);
+		assertFalse(iterator.hasNext(), "no value is at or below 4000, so the cursor must be exhausted");
+	}
+
+	@Test
+	@DisplayName("Every shape holds the post-condition across a sweep of thresholds")
+	public void allShapesHoldPostConditionAcrossThresholds() {
+		final PersistentRoaringBitmap arrayBacked = PersistentRoaringBitmap.bitmapOf(1000, 2000, 3000);
+
+		final PersistentRoaringBitmap bitmapBacked = new PersistentRoaringBitmap();
+		for (int value = 5000; value < 5000 + ArrayContainer.DEFAULT_MAX_SIZE + 1; value++) {
+			bitmapBacked.add(value);
+		}
+
+		final PersistentRoaringBitmap runBacked = new PersistentRoaringBitmap();
+		runBacked.add(5000L, 9000L);
+		runBacked.runOptimize();
+
+		final PersistentRoaringBitmap[] fixtures = {arrayBacked, bitmapBacked, runBacked};
+		for (int fixture = 0; fixture < fixtures.length; fixture++) {
+			final Container container = singleContainerOf(fixtures[fixture]);
+			// sweep thresholds below, inside and above the populated span
+			for (int threshold = 0; threshold <= 10000; threshold += 250) {
+				final PeekableCharIterator iterator = container.getReverseCharIterator();
+				iterator.advanceIfNeeded((char) threshold);
+				assertAtOrBelow(iterator, (char) threshold);
+			}
+		}
+	}
+
+	@Test
+	@DisplayName("Reverse int seek crosses into the next chunk when the current one holds nothing low enough")
+	public void reverseIntSeekCrossesChunkWhenNoValueQualifies() {
+		// chunk 0 holds the only value that satisfies the seek, while chunk 1 holds an array container
+		// whose values all sit above the requested bound
+		final PersistentRoaringBitmap bitmap =
+			PersistentRoaringBitmap.bitmapOf(500, 65536 + 1000, 65536 + 2000);
+
+		final PeekableIntIterator iterator = bitmap.getReverseIntIterator();
+		assertEquals(65536 + 2000, iterator.peekNext());
+
+		iterator.advanceIfNeeded(65536 + 700);
+
+		assertTrue(iterator.hasNext(), "value 500 is at or below the bound, so iteration must continue");
+		assertEquals(500, iterator.peekNext());
+
+		// the reusable flyweight walks the same chunks and must agree
+		final ReverseIntIteratorFlyweight flyweight = new ReverseIntIteratorFlyweight(bitmap);
+		flyweight.advanceIfNeeded(65536 + 700);
+		assertTrue(flyweight.hasNext(), "the flyweight must descend past the exhausted chunk too");
+		assertEquals(500, flyweight.peekNext());
+	}
+
+	@Test
+	@DisplayName("Reverse long seek crosses into the next chunk when the current one holds nothing low enough")
+	public void reverseLongSeekCrossesChunkWhenNoValueQualifies() {
+		final PersistentLongRoaringBitmap bitmap = new PersistentLongRoaringBitmap();
+		// chunk 0 holds the only value that satisfies the seek...
+		bitmap.addLong(500L);
+		// ...while chunk 1 holds an array container whose values all sit above the requested bound
+		bitmap.addLong(65536L + 1000L);
+		bitmap.addLong(65536L + 2000L);
+
+		final PeekableLongIterator iterator = bitmap.getReverseLongIterator();
+		assertEquals(65536L + 2000L, iterator.peekNext());
+
+		// the bound falls inside chunk 1's key range but below every value stored there, so the seek
+		// has to abandon that chunk and descend into chunk 0
+		iterator.advanceIfNeeded(65536L + 700L);
+
+		assertTrue(iterator.hasNext(), "value 500 is at or below the bound, so iteration must continue");
+		assertEquals(500L, iterator.peekNext());
+	}
+}

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/ReverseIntIteratorUnsignedContractTest.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/ReverseIntIteratorUnsignedContractTest.java
@@ -1,0 +1,215 @@
+package io.evitadb.roaringbitmap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Contract tests for `advanceIfNeeded` on the reverse int iterators, with the emphasis on UNSIGNED
+ * ordering across the `0x8000` chunk-key boundary.
+ *
+ * The post-condition after `advanceIfNeeded(maxval)` is: either the iterator is exhausted, or
+ * `peekNext()` compares less than or equal to `maxval` as an unsigned 32-bit value. The chunk-skipping
+ * loop compares chunk keys via `hs >>> 16`; had it used the arithmetic shift instead, a bitmap holding
+ * a value in chunk `0x8000` and a probe in chunk `0x7FFF` would leave the cursor parked ABOVE the
+ * bound, because signed comparison ranks `0x8000` below `0x7FFF`. The first test pins exactly that.
+ */
+@DisplayName("Reverse int iterator advanceIfNeeded unsigned contract")
+public class ReverseIntIteratorUnsignedContractTest {
+
+	/**
+	 * Chunk keys spanning both halves of the unsigned range, including the two straddling the signed
+	 * wrap.
+	 */
+	private static final int[] CHUNK_KEYS = {0x0000, 0x0001, 0x7FFE, 0x7FFF, 0x8000, 0x8001, 0xFFFF};
+
+	/**
+	 * Builds a bitmap holding values in every {@link #CHUNK_KEYS} chunk, cycling the container shape so
+	 * array, bitmap and run chunks all sit on both sides of the signed wrap.
+	 */
+	private static PersistentRoaringBitmap mixedShapeBitmap() {
+		final PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+		for (int index = 0; index < CHUNK_KEYS.length; index++) {
+			final long base = (long) CHUNK_KEYS[index] << 16;
+			if (index % 3 == 0) {
+				// sparse -> array chunk
+				bitmap.add((int) (base + 5));
+				bitmap.add((int) (base + 1000));
+				bitmap.add((int) (base + 60000));
+			} else if (index % 3 == 1) {
+				// dense scatter -> bitmap chunk
+				for (int offset = 0; offset < 2 * ArrayContainer.DEFAULT_MAX_SIZE; offset++) {
+					bitmap.add((int) (base + offset * 3L));
+				}
+			} else {
+				// contiguous -> run chunk after runOptimize
+				bitmap.add(base + 2000L, base + 12000L);
+			}
+		}
+		bitmap.runOptimize();
+		return bitmap;
+	}
+
+	/**
+	 * Asserts the post-condition, and additionally that exhaustion is only ever reported when the
+	 * bitmap genuinely holds nothing at or below the bound.
+	 */
+	private static void assertPostCondition(
+		final PeekableIntIterator iterator, final int maxval, final int[] allValuesAscending,
+		final String where
+	) {
+		final boolean somethingQualifies =
+			allValuesAscending.length > 0 && Integer.compareUnsigned(allValuesAscending[0], maxval) <= 0;
+		if (!iterator.hasNext()) {
+			assertFalse(
+				somethingQualifies,
+				where + ": iterator exhausted although " + Integer.toUnsignedString(allValuesAscending[0])
+					+ " is at or below " + Integer.toUnsignedString(maxval));
+			return;
+		}
+		final int peeked = iterator.peekNext();
+		assertTrue(
+			Integer.compareUnsigned(peeked, maxval) <= 0,
+			where + ": peekNext " + Integer.toUnsignedString(peeked) + " exceeds bound "
+				+ Integer.toUnsignedString(maxval));
+	}
+
+	/**
+	 * The discriminating case for unsigned chunk-key comparison: the only value above the bound lives
+	 * in chunk `0x8000`, whose key ranks BELOW the probe's chunk `0x7FFF` under signed comparison.
+	 */
+	@Test
+	@DisplayName("A chunk above the signed wrap is skipped for a probe below it")
+	public void chunkAboveSignedWrapIsSkipped() {
+		final PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+		bitmap.add(5);
+		bitmap.add(0x80000005);
+
+		final PeekableIntIterator iterator = bitmap.getReverseIntIterator();
+		assertEquals(0x80000005, iterator.peekNext(), "reverse iteration must start at the unsigned maximum");
+
+		iterator.advanceIfNeeded(0x7FFF0000);
+
+		assertTrue(iterator.hasNext(), "value 5 is at or below the bound, so iteration must continue");
+		assertEquals(5, iterator.peekNext());
+
+		final ReverseIntIteratorFlyweight flyweight = new ReverseIntIteratorFlyweight(bitmap);
+		flyweight.advanceIfNeeded(0x7FFF0000);
+		assertTrue(flyweight.hasNext(), "the flyweight must skip the chunk above the signed wrap too");
+		assertEquals(5, flyweight.peekNext());
+	}
+
+	/**
+	 * A probe at the unsigned maximum must not move a cursor that already sits below it, and a probe
+	 * below every stored value must exhaust the cursor rather than park it on a too-large value.
+	 */
+	@Test
+	@DisplayName("Probes at the extremes of the unsigned range behave")
+	public void probesAtUnsignedExtremes() {
+		final PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+		bitmap.add(0x80000000);
+		bitmap.add(0xFFFFFFFF);
+
+		final PeekableIntIterator top = bitmap.getReverseIntIterator();
+		top.advanceIfNeeded(0xFFFFFFFF);
+		assertTrue(top.hasNext());
+		assertEquals(0xFFFFFFFF, top.peekNext(), "a bound at the unsigned maximum must not move the cursor");
+
+		final PeekableIntIterator below = bitmap.getReverseIntIterator();
+		below.advanceIfNeeded(0x7FFFFFFF);
+		assertFalse(below.hasNext(), "every stored value is above the bound, so the cursor must exhaust");
+
+		final ReverseIntIteratorFlyweight flyweight = new ReverseIntIteratorFlyweight(bitmap);
+		flyweight.advanceIfNeeded(0x7FFFFFFF);
+		assertFalse(flyweight.hasNext(), "the flyweight must exhaust as well");
+	}
+
+	/**
+	 * An empty bitmap yields an already-exhausted reverse cursor that survives any probe.
+	 */
+	@Test
+	@DisplayName("An empty bitmap tolerates any probe")
+	public void emptyBitmapToleratesAnyProbe() {
+		final PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+		for (final int probe : new int[]{0, 1, 0x7FFFFFFF, 0x80000000, 0xFFFFFFFF}) {
+			final PeekableIntIterator iterator = bitmap.getReverseIntIterator();
+			iterator.advanceIfNeeded(probe);
+			assertFalse(iterator.hasNext(), "empty bitmap must stay exhausted");
+
+			final ReverseIntIteratorFlyweight flyweight = new ReverseIntIteratorFlyweight(bitmap);
+			flyweight.advanceIfNeeded(probe);
+			assertFalse(flyweight.hasNext(), "empty bitmap must stay exhausted for the flyweight too");
+		}
+	}
+
+	/**
+	 * Sweeps deterministic probes at, just below and just above every chunk boundary of a bitmap whose
+	 * chunks mix all three container shapes on both sides of the signed wrap.
+	 */
+	@Test
+	@DisplayName("Every chunk boundary holds the post-condition for both reverse cursors")
+	public void chunkBoundarySweepHoldsPostCondition() {
+		final PersistentRoaringBitmap bitmap = mixedShapeBitmap();
+		final int[] values = bitmap.toArray();
+
+		for (final int key : CHUNK_KEYS) {
+			final long base = (long) key << 16;
+			for (final long delta : new long[]{-1L, 0L, 1L, 4999L, 60000L, 65535L}) {
+				final long candidate = base + delta;
+				if (candidate < 0 || candidate > 0xFFFFFFFFL) {
+					continue;
+				}
+				final int probe = (int) candidate;
+				final String where = "key=" + Integer.toHexString(key) + " probe="
+					+ Integer.toUnsignedString(probe);
+
+				final PeekableIntIterator iterator = bitmap.getReverseIntIterator();
+				iterator.advanceIfNeeded(probe);
+				assertPostCondition(iterator, probe, values, where);
+
+				final ReverseIntIteratorFlyweight flyweight = new ReverseIntIteratorFlyweight(bitmap);
+				flyweight.advanceIfNeeded(probe);
+				assertPostCondition(flyweight, probe, values, where + " (flyweight)");
+			}
+		}
+	}
+
+	/**
+	 * Randomized sweep over the whole unsigned range, including a strictly descending probe sequence on
+	 * one cursor (the monotonic usage the contract is written for) as well as fresh-cursor probes.
+	 */
+	@Test
+	@DisplayName("Randomized probes hold the post-condition, including a descending probe sequence")
+	public void randomizedProbesHoldPostCondition() {
+		final PersistentRoaringBitmap bitmap = mixedShapeBitmap();
+		final int[] values = bitmap.toArray();
+
+		for (int seed = 0; seed < 25; seed++) {
+			final Random random = new Random(seed);
+
+			for (int attempt = 0; attempt < 200; attempt++) {
+				final int probe = random.nextInt();
+				final PeekableIntIterator iterator = bitmap.getReverseIntIterator();
+				iterator.advanceIfNeeded(probe);
+				assertPostCondition(iterator, probe, values, "seed " + seed + " fresh probe");
+			}
+
+			// one cursor, strictly descending probes -- the monotonic idiom advanceIfNeeded is built for
+			final PeekableIntIterator descending = bitmap.getReverseIntIterator();
+			long probe = 0xFFFFFFFFL;
+			while (probe >= 0) {
+				descending.advanceIfNeeded((int) probe);
+				assertPostCondition(descending, (int) probe, values, "seed " + seed + " descending probe");
+				if (!descending.hasNext()) {
+					break;
+				}
+				probe -= 1 + random.nextInt(1 << 24);
+			}
+		}
+	}
+}

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/SharedContainerLockstepFuzzTest.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/SharedContainerLockstepFuzzTest.java
@@ -172,7 +172,7 @@ public class SharedContainerLockstepFuzzTest {
 	private static void step(final Random random, final List<Tracked> pool) {
 		final Tracked target = pool.get(random.nextInt(pool.size()));
 		final Tracked other = pool.get(random.nextInt(pool.size()));
-		switch (random.nextInt(14)) {
+		switch (random.nextInt(16)) {
 			case 0: {
 				if (target == other) {
 					break;
@@ -283,6 +283,30 @@ public class SharedContainerLockstepFuzzTest {
 				if (random.nextBoolean()) {
 					target.bitmap.trim();
 				}
+				break;
+			}
+			case 13: {
+				if (target == other) {
+					break;
+				}
+				final TreeSet<Integer> symmetric = new TreeSet<>(target.model);
+				for (final Integer value : other.model) {
+					if (!symmetric.add(value)) {
+						symmetric.remove(value);
+					}
+				}
+				pool.add(
+					new Tracked(PersistentRoaringBitmap.xor(target.bitmap, other.bitmap), symmetric));
+				break;
+			}
+			case 14: {
+				if (target == other) {
+					break;
+				}
+				final TreeSet<Integer> difference = new TreeSet<>(target.model);
+				difference.removeAll(other.model);
+				pool.add(
+					new Tracked(PersistentRoaringBitmap.andNot(target.bitmap, other.bitmap), difference));
 				break;
 			}
 			default: {

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/SharedContainerLockstepFuzzTest.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/SharedContainerLockstepFuzzTest.java
@@ -1,0 +1,394 @@
+package io.evitadb.roaringbitmap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Randomized stress test for the two copy-on-write bookkeeping invariants of
+ * {@link PersistentRoaringBitmap}.
+ *
+ * LOCKSTEP — the parallel `shared[]` flag array must always be long enough to describe every live
+ * slot of `highLowContainer`, so that no raw `shared[i]` index can run off the end. Every path that
+ * grows, shrinks or rebuilds the container array has to keep the two in step; historically that is
+ * where this class has broken.
+ *
+ * ALIASING — whenever two distinct bitmaps hold the very same {@link Container} instance, BOTH must
+ * have that slot flagged shared. A single unflagged slot over an aliased container is the precise
+ * precondition for silent cross-bitmap corruption: the unflagged owner believes it may mutate in
+ * place, and the peer sees the write. Checking the alias graph directly catches the desync at the
+ * moment it is created, rather than waiting for a later mutation to expose it.
+ *
+ * The fuzz drives a pool of bitmaps through the in-place operators (whose bulk-merge rebuild is the
+ * riskiest path), the structural mutators and the static/cloning producers, re-checking both
+ * invariants plus every bitmap's contents against a reference model after every single step.
+ */
+@DisplayName("Copy-on-write shared[] lockstep and aliasing invariants")
+public class SharedContainerLockstepFuzzTest {
+
+	/**
+	 * A bitmap paired with the reference model of the values it is supposed to hold.
+	 */
+	private static final class Tracked {
+		@SuppressWarnings("checkstyle:VisibilityModifier")
+		private final PersistentRoaringBitmap bitmap;
+		@SuppressWarnings("checkstyle:VisibilityModifier")
+		private final TreeSet<Integer> model;
+
+		private Tracked(final PersistentRoaringBitmap bitmap, final TreeSet<Integer> model) {
+			this.bitmap = bitmap;
+			this.model = model;
+		}
+	}
+
+	/**
+	 * Chunk keys the fuzz draws from — deliberately few and interleavable, so that in-place operators
+	 * hit the bulk-merge rebuild rather than the plain tail-append.
+	 */
+	private static final int[] CHUNK_KEYS = {0, 1, 2, 3, 5, 8, 13, 400};
+
+	/**
+	 * Asserts that `shared[]` covers every live slot of the container array.
+	 */
+	private static void assertLockstep(final PersistentRoaringBitmap bitmap, final String where) {
+		assertTrue(
+			bitmap.shared.length >= bitmap.highLowContainer.size(),
+			() -> where + ": shared[] holds " + bitmap.shared.length + " flags for "
+				+ bitmap.highLowContainer.size() + " containers");
+	}
+
+	/**
+	 * Asserts that no two bitmaps in the pool alias a container without both flagging it shared.
+	 */
+	private static void assertNoUnflaggedAliasing(final List<Tracked> pool, final String where) {
+		for (int x = 0; x < pool.size(); x++) {
+			final PersistentRoaringBitmap left = pool.get(x).bitmap;
+			for (int y = x + 1; y < pool.size(); y++) {
+				final PersistentRoaringBitmap right = pool.get(y).bitmap;
+				for (int i = 0; i < left.highLowContainer.size(); i++) {
+					final Container container = left.getContainerAtIndex(i);
+					for (int j = 0; j < right.highLowContainer.size(); j++) {
+						if (right.getContainerAtIndex(j) == container) {
+							assertTrue(
+								left.isShared(i) && right.isShared(j),
+								where + ": bitmap " + x + " slot " + i + " and bitmap " + y
+									+ " slot " + j + " alias one container but are flagged "
+									+ left.isShared(i) + "/" + right.isShared(j));
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Asserts every tracked bitmap still holds exactly the values its model records.
+	 */
+	private static void assertContents(final List<Tracked> pool, final String where) {
+		for (int index = 0; index < pool.size(); index++) {
+			final Tracked tracked = pool.get(index);
+			final int[] expected = new int[tracked.model.size()];
+			int cursor = 0;
+			for (final Integer value : tracked.model) {
+				expected[cursor++] = value;
+			}
+			final int position = index;
+			assertArrayEquals(
+				expected, tracked.bitmap.toArray(), where + ": bitmap " + position + " content drifted");
+		}
+	}
+
+	/**
+	 * Runs all invariant checks after a step.
+	 */
+	private static void assertAllInvariants(final List<Tracked> pool, final String where) {
+		for (final Tracked tracked : pool) {
+			assertLockstep(tracked.bitmap, where);
+		}
+		assertNoUnflaggedAliasing(pool, where);
+		assertContents(pool, where);
+	}
+
+	/**
+	 * Draws a random value inside one of the {@link #CHUNK_KEYS} chunks.
+	 */
+	private static int randomValue(final Random random) {
+		final int key = CHUNK_KEYS[random.nextInt(CHUNK_KEYS.length)];
+		return (key << 16) + random.nextInt(1 << 16);
+	}
+
+	/**
+	 * Builds a random bitmap together with its model. Container shapes vary: sparse chunks stay array
+	 * chunks, dense ones become bitmap chunks, and one chunk is written as a full run.
+	 */
+	private static Tracked randomBitmap(final Random random) {
+		final PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+		final TreeSet<Integer> model = new TreeSet<>();
+		final int chunks = 1 + random.nextInt(5);
+		for (int chunk = 0; chunk < chunks; chunk++) {
+			final int key = CHUNK_KEYS[random.nextInt(CHUNK_KEYS.length)];
+			final int shape = random.nextInt(3);
+			if (shape == 0) {
+				final int count = 1 + random.nextInt(8);
+				for (int i = 0; i < count; i++) {
+					final int value = (key << 16) + random.nextInt(1 << 16);
+					bitmap.add(value);
+					model.add(value);
+				}
+			} else if (shape == 1) {
+				final int start = random.nextInt(1 << 15);
+				final int count = ArrayContainer.DEFAULT_MAX_SIZE + 1 + random.nextInt(64);
+				for (int i = 0; i < count; i++) {
+					final int value = (key << 16) + start + i;
+					bitmap.add(value);
+					model.add(value);
+				}
+			} else {
+				final int start = random.nextInt(1 << 15);
+				final int length = 1 + random.nextInt(4096);
+				for (int i = 0; i < length; i++) {
+					model.add((key << 16) + start + i);
+				}
+				bitmap.add((long) (key << 16) + start, (long) (key << 16) + start + length);
+			}
+		}
+		if (random.nextBoolean()) {
+			bitmap.runOptimize();
+		}
+		return new Tracked(bitmap, model);
+	}
+
+	/**
+	 * Applies one random operation to the pool, mutating both the bitmaps and their models in step.
+	 */
+	private static void step(final Random random, final List<Tracked> pool) {
+		final Tracked target = pool.get(random.nextInt(pool.size()));
+		final Tracked other = pool.get(random.nextInt(pool.size()));
+		switch (random.nextInt(14)) {
+			case 0: {
+				if (target == other) {
+					break;
+				}
+				target.bitmap.or(other.bitmap);
+				target.model.addAll(other.model);
+				break;
+			}
+			case 1: {
+				if (target == other) {
+					break;
+				}
+				final TreeSet<Integer> symmetric = new TreeSet<>(target.model);
+				for (final Integer value : other.model) {
+					if (!symmetric.add(value)) {
+						symmetric.remove(value);
+					}
+				}
+				target.bitmap.xor(other.bitmap);
+				target.model.clear();
+				target.model.addAll(symmetric);
+				break;
+			}
+			case 2: {
+				if (target == other) {
+					break;
+				}
+				target.bitmap.and(other.bitmap);
+				target.model.retainAll(other.model);
+				break;
+			}
+			case 3: {
+				if (target == other) {
+					break;
+				}
+				target.bitmap.andNot(other.bitmap);
+				target.model.removeAll(other.model);
+				break;
+			}
+			case 4: {
+				if (target == other) {
+					break;
+				}
+				target.bitmap.naivelazyor(other.bitmap);
+				target.bitmap.repairAfterLazy();
+				target.model.addAll(other.model);
+				break;
+			}
+			case 5: {
+				if (target == other) {
+					break;
+				}
+				target.bitmap.lazyor(other.bitmap);
+				target.bitmap.repairAfterLazy();
+				target.model.addAll(other.model);
+				break;
+			}
+			case 6: {
+				final int value = randomValue(random);
+				target.bitmap.add(value);
+				target.model.add(value);
+				break;
+			}
+			case 7: {
+				final int value = target.model.isEmpty() || random.nextBoolean()
+					? randomValue(random)
+					: target.model.first();
+				target.bitmap.remove(value);
+				target.model.remove(value);
+				break;
+			}
+			case 8: {
+				final int value = randomValue(random);
+				target.bitmap.flip(value);
+				if (!target.model.remove(value)) {
+					target.model.add(value);
+				}
+				break;
+			}
+			case 9: {
+				final long start = randomValue(random) & 0xFFFFFFFFL;
+				final long end = Math.min(start + 1 + random.nextInt(1 << 17), 1L << 32);
+				target.bitmap.remove(start, end);
+				final Iterator<Integer> iterator = target.model.iterator();
+				while (iterator.hasNext()) {
+					final long value = iterator.next() & 0xFFFFFFFFL;
+					if (value >= start && value < end) {
+						iterator.remove();
+					}
+				}
+				break;
+			}
+			case 10: {
+				final long start = randomValue(random) & 0xFFFFFFFFL;
+				final long end = Math.min(start + 1 + random.nextInt(1 << 13), 1L << 32);
+				target.bitmap.add(start, end);
+				for (long value = start; value < end; value++) {
+					target.model.add((int) value);
+				}
+				break;
+			}
+			case 11: {
+				pool.add(new Tracked(target.bitmap.clone(), new TreeSet<>(target.model)));
+				break;
+			}
+			case 12: {
+				target.bitmap.runOptimize();
+				if (random.nextBoolean()) {
+					target.bitmap.trim();
+				}
+				break;
+			}
+			default: {
+				if (target == other) {
+					break;
+				}
+				final TreeSet<Integer> union = new TreeSet<>(target.model);
+				union.addAll(other.model);
+				pool.add(new Tracked(PersistentRoaringBitmap.or(target.bitmap, other.bitmap), union));
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Drives the pool through many random steps, re-checking the lockstep, aliasing and content
+	 * invariants after each one. Seeds are fixed so a failure is reproducible.
+	 */
+	@Test
+	@DisplayName("Random operator sequences keep shared[] in lockstep and never alias unflagged")
+	public void randomOperatorSequencesPreserveCopyOnWriteInvariants() {
+		for (int seed = 0; seed < 40; seed++) {
+			final Random random = new Random(seed);
+			final List<Tracked> pool = new ArrayList<>();
+			for (int i = 0; i < 3; i++) {
+				pool.add(randomBitmap(random));
+			}
+			assertAllInvariants(pool, "seed " + seed + " setup");
+
+			for (int iteration = 0; iteration < 60; iteration++) {
+				step(random, pool);
+				assertAllInvariants(pool, "seed " + seed + " step " + iteration);
+				// keep the pairwise alias scan affordable
+				while (pool.size() > 6) {
+					pool.remove(pool.size() - 1);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Narrower, fully deterministic probe of the bulk-merge entry point: every combination of operand
+	 * chunk-key layouts up to five chunks, each run against a freshly cloned peer so the receiver is
+	 * frozen and fully shared when the merge fires.
+	 */
+	@Test
+	@DisplayName("Every small key layout survives or/xor/naivelazyor against a cloned peer")
+	public void exhaustiveSmallKeyLayoutsPreserveInvariants() {
+		for (int leftMask = 0; leftMask < 32; leftMask++) {
+			for (int rightMask = 0; rightMask < 32; rightMask++) {
+				for (int op = 0; op < 3; op++) {
+					final Tracked left = fromKeyMask(leftMask);
+					final Tracked right = fromKeyMask(rightMask);
+					final PersistentRoaringBitmap peer = left.bitmap.clone();
+					final TreeSet<Integer> peerModel = new TreeSet<>(left.model);
+					final TreeSet<Integer> rightModel = new TreeSet<>(right.model);
+
+					if (op == 0) {
+						left.bitmap.or(right.bitmap);
+						left.model.addAll(right.model);
+					} else if (op == 1) {
+						final TreeSet<Integer> symmetric = new TreeSet<>(left.model);
+						for (final Integer value : right.model) {
+							if (!symmetric.add(value)) {
+								symmetric.remove(value);
+							}
+						}
+						left.bitmap.xor(right.bitmap);
+						left.model.clear();
+						left.model.addAll(symmetric);
+					} else {
+						left.bitmap.naivelazyor(right.bitmap);
+						left.bitmap.repairAfterLazy();
+						left.model.addAll(right.model);
+					}
+
+					final List<Tracked> pool = new ArrayList<>();
+					pool.add(left);
+					pool.add(right);
+					pool.add(new Tracked(peer, peerModel));
+					final String where =
+						"left=" + leftMask + " right=" + rightMask + " op=" + op;
+					assertAllInvariants(pool, where);
+					assertArrayEquals(
+						rightModel.stream().mapToInt(Integer::intValue).toArray(),
+						right.bitmap.toArray(), where + ": source operand corrupted");
+				}
+			}
+		}
+	}
+
+	/**
+	 * Builds a bitmap holding chunks `0 .. 4` selected by the bits of `mask`, three values per chunk.
+	 */
+	private static Tracked fromKeyMask(final int mask) {
+		final PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+		final TreeSet<Integer> model = new TreeSet<>();
+		for (int key = 0; key < 5; key++) {
+			if ((mask & (1 << key)) != 0) {
+				for (int offset = 1; offset <= 3; offset++) {
+					final int value = (key << 16) + offset * 7;
+					bitmap.add(value);
+					model.add(value);
+				}
+			}
+		}
+		return new Tracked(bitmap, model);
+	}
+}

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/SharedFlagPrecisionTest.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/SharedFlagPrecisionTest.java
@@ -1,0 +1,231 @@
+package io.evitadb.roaringbitmap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins how precisely the static binary operations of {@link PersistentRoaringBitmap} raise
+ * copy-on-write flags, which is deliberately different on the two sides of the operation.
+ *
+ * A `shared` flag is a promise to clone before the next in-place write. Raising it on a chunk nobody
+ * co-owns is safe but not free: the clone still happens, and for a bitmap chunk that is an 8 KiB copy
+ * bought for nothing.
+ *
+ * **The result** is a brand-new bitmap, reachable only by the caller until it is published, so its
+ * flags are tracked per slot: a chunk lent from one operand is flagged, a chunk recombined from both
+ * into a private container ({@link ContainerBinaryOpFreshnessTest} pins that privateness) is not.
+ *
+ * **The operands** are marked wholesale instead, and that is on purpose rather than an oversight — see
+ * `markAllShared`. A live bitmap can be an operand of two concurrent queries, and the flag array is
+ * written unsynchronised; a full fill converges on the conservative value under a lost update, while
+ * sparse writes would leave behind the unsafe one. The operand-side tests below therefore assert the
+ * *conservative* behaviour deliberately, and tightening it is not a free optimisation.
+ */
+@DisplayName("Static or/xor/andNot flag result chunks precisely and operands conservatively")
+public class SharedFlagPrecisionTest {
+
+	/**
+	 * Fills the given chunk densely enough that it is held as a {@link BitmapContainer}. That matters
+	 * for the clone census: a bitmap container absorbs {@link Container#add(char)} in place and returns
+	 * itself, so any change of container identity across a write is a copy-on-write clone and nothing
+	 * else.
+	 */
+	private static void fillDenseChunk(
+		final PersistentRoaringBitmap bitmap, final int chunkKey, final int offset
+	) {
+		final int base = chunkKey << 16;
+		for (int i = 0; i < ArrayContainer.DEFAULT_MAX_SIZE + 256; i++) {
+			bitmap.add(base + offset + i * 3);
+		}
+	}
+
+	/**
+	 * Builds a bitmap holding one dense chunk per requested key.
+	 */
+	private static PersistentRoaringBitmap denseChunks(final int offset, final int... chunkKeys) {
+		final PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+		for (final int key : chunkKeys) {
+			fillDenseChunk(bitmap, key, offset);
+		}
+		for (int i = 0; i < bitmap.highLowContainer.size(); i++) {
+			assertTrue(
+				bitmap.getContainerAtIndex(i) instanceof BitmapContainer,
+				"fixture drifted off the bitmap-container shape at slot " + i);
+		}
+		return bitmap;
+	}
+
+	/**
+	 * Snapshots container identities so a later write pass can be audited for clones.
+	 */
+	private static Container[] identities(final PersistentRoaringBitmap bitmap) {
+		final Container[] snapshot = new Container[bitmap.highLowContainer.size()];
+		for (int i = 0; i < snapshot.length; i++) {
+			snapshot[i] = bitmap.getContainerAtIndex(i);
+		}
+		return snapshot;
+	}
+
+	/**
+	 * Writes one fresh value into every chunk and reports which slots had their container replaced,
+	 * i.e. where the write pass had to pay for a copy-on-write clone.
+	 */
+	private static boolean[] clonesOnWritePass(final PersistentRoaringBitmap bitmap) {
+		final Container[] before = identities(bitmap);
+		for (int i = 0; i < before.length; i++) {
+			// a value guaranteed absent from the fixtures, which stride by 3 from a small offset
+			bitmap.add((bitmap.getKeyAtIndex(i) << 16) + 0xFFFF);
+		}
+		final Container[] after = identities(bitmap);
+		final boolean[] cloned = new boolean[before.length];
+		for (int i = 0; i < before.length; i++) {
+			cloned[i] = before[i] != after[i];
+		}
+		return cloned;
+	}
+
+	/**
+	 * Asserts every live slot of the bitmap carries the expected flag.
+	 */
+	private static void assertAllFlags(
+		final PersistentRoaringBitmap bitmap, final boolean expected, final String where
+	) {
+		for (int i = 0; i < bitmap.highLowContainer.size(); i++) {
+			final int slot = i;
+			assertEquals(
+				expected, bitmap.isShared(i),
+				() -> where + ": slot " + slot + " (chunk " + (int) bitmap.getKeyAtIndex(slot) + ")");
+		}
+	}
+
+	@Test
+	@DisplayName("or over fully overlapping chunks aliases nothing, so the result flags nothing")
+	public void orOverFullyOverlappingChunksFlagsNothingInTheResult() {
+		final PersistentRoaringBitmap left = denseChunks(1, 0, 1, 2);
+		final PersistentRoaringBitmap right = denseChunks(2, 0, 1, 2);
+
+		final PersistentRoaringBitmap result = PersistentRoaringBitmap.or(left, right);
+
+		// every result chunk was recombined from both operands, so all three containers are private
+		assertAllFlags(result, false, "or result");
+		// the operands are still marked wholesale - deliberately conservative, see the class comment
+		assertAllFlags(left, true, "or left operand");
+		assertAllFlags(right, true, "or right operand");
+	}
+
+	@Test
+	@DisplayName("or flags exactly the result chunks carried over from a single operand")
+	public void orFlagsOnlyCarriedOverChunks() {
+		final PersistentRoaringBitmap left = denseChunks(1, 0, 1);
+		final PersistentRoaringBitmap right = denseChunks(2, 1, 2);
+
+		final PersistentRoaringBitmap result = PersistentRoaringBitmap.or(left, right);
+
+		assertEquals(3, result.highLowContainer.size());
+		// chunk 0 comes from `left` alone and chunk 2 from `right` alone: both are aliased. Chunk 1 is
+		// present on both sides and is therefore a freshly combined, privately owned container.
+		assertTrue(result.isShared(0), "chunk 0 is aliased from the left operand");
+		assertFalse(result.isShared(1), "chunk 1 was recombined and is private");
+		assertTrue(result.isShared(2), "chunk 2 is aliased from the right operand");
+
+		assertSame(left.getContainerAtIndex(0), result.getContainerAtIndex(0));
+		assertNotSame(left.getContainerAtIndex(1), result.getContainerAtIndex(1));
+		assertNotSame(right.getContainerAtIndex(0), result.getContainerAtIndex(1));
+		assertSame(right.getContainerAtIndex(1), result.getContainerAtIndex(2));
+	}
+
+	@Test
+	@DisplayName("xor flags exactly the result chunks carried over from a single operand")
+	public void xorFlagsOnlyCarriedOverChunks() {
+		final PersistentRoaringBitmap left = denseChunks(1, 0, 1);
+		final PersistentRoaringBitmap right = denseChunks(2, 1, 2);
+
+		final PersistentRoaringBitmap result = PersistentRoaringBitmap.xor(left, right);
+
+		assertEquals(3, result.highLowContainer.size());
+		assertTrue(result.isShared(0), "chunk 0 is aliased from the left operand");
+		assertFalse(result.isShared(1), "chunk 1 was recombined and is private");
+		assertTrue(result.isShared(2), "chunk 2 is aliased from the right operand");
+	}
+
+	@Test
+	@DisplayName("andNot flags only the left-only result chunks and never touches the subtrahend")
+	public void andNotFlagsOnlyLeftOnlyChunks() {
+		final PersistentRoaringBitmap left = denseChunks(1, 0, 1, 2);
+		final PersistentRoaringBitmap right = denseChunks(2, 1);
+
+		final PersistentRoaringBitmap result = PersistentRoaringBitmap.andNot(left, right);
+
+		assertEquals(3, result.highLowContainer.size());
+		assertTrue(result.isShared(0), "chunk 0 has no counterpart and is aliased");
+		assertFalse(result.isShared(1), "chunk 1 was recombined and is private");
+		assertTrue(result.isShared(2), "chunk 2 has no counterpart and is aliased");
+
+		// andNot never carries a container out of its subtrahend, so it is not marked at all
+		assertAllFlags(right, false, "andNot right operand");
+	}
+
+	@Test
+	@DisplayName("writing to a merged result clones only the chunks it really borrowed")
+	public void writingToAMergedResultClonesOnlyBorrowedChunks() {
+		// chunks 0 and 3 exist on one side only and are borrowed; chunks 1 and 2 exist on both and are
+		// recombined into containers the result owns outright
+		final PersistentRoaringBitmap left = denseChunks(1, 0, 1, 2);
+		final PersistentRoaringBitmap right = denseChunks(2, 1, 2, 3);
+
+		final PersistentRoaringBitmap result = PersistentRoaringBitmap.or(left, right);
+		assertEquals(4, result.highLowContainer.size());
+
+		final boolean[] cloned = clonesOnWritePass(result);
+		assertArrayEquals(
+			new boolean[]{true, false, false, true}, cloned,
+			"a write into the merged result should clone the two borrowed chunks and no others");
+
+		// and the operands the borrowed chunks came from must be untouched by that write
+		assertArrayEquals(
+			denseChunks(1, 0, 1, 2).toArray(), left.toArray(), "left operand was written through");
+		assertArrayEquals(
+			denseChunks(2, 1, 2, 3).toArray(), right.toArray(), "right operand was written through");
+	}
+
+	@Test
+	@DisplayName("re-encoding a chunk hands its slot a private container, so the flag must drop")
+	public void reEncodingClearsTheSharedFlag() {
+		// a run-shaped chunk plus a chunk that stays a bitmap, so both branches of runOptimize appear
+		final PersistentRoaringBitmap source = new PersistentRoaringBitmap();
+		source.add(0L, 40_000L);
+		fillDenseChunk(source, 1, 1);
+
+		final PersistentRoaringBitmap peer = source.clone();
+		assertAllFlags(peer, true, "a fresh clone co-owns every chunk");
+
+		peer.removeRunCompression();
+		for (int i = 0; i < peer.highLowContainer.size(); i++) {
+			// a chunk that was actually re-encoded holds a container built for this bitmap alone
+			final boolean reEncoded = peer.getContainerAtIndex(i) != source.getContainerAtIndex(i);
+			assertEquals(
+				!reEncoded, peer.isShared(i),
+				"slot " + i + " was re-encoded=" + reEncoded + " but is flagged " + peer.isShared(i));
+		}
+
+		final PersistentRoaringBitmap second = source.clone();
+		second.runOptimize();
+		for (int i = 0; i < second.highLowContainer.size(); i++) {
+			final boolean reEncoded = second.getContainerAtIndex(i) != source.getContainerAtIndex(i);
+			assertEquals(
+				!reEncoded, second.isShared(i),
+				"slot " + i + " was re-encoded=" + reEncoded + " but is flagged " + second.isShared(i));
+		}
+
+		// the bitmap the re-encoding forked away from must be untouched
+		assertArrayEquals(source.toArray(), peer.toArray(), "removeRunCompression changed contents");
+		assertArrayEquals(source.toArray(), second.toArray(), "runOptimize changed contents");
+	}
+}

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/TestIntIteratorFlyweight.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/TestIntIteratorFlyweight.java
@@ -101,6 +101,19 @@ public class TestIntIteratorFlyweight {
 		ReverseIntIteratorFlyweight reverseIter = new ReverseIntIteratorFlyweight();
 		reverseIter.wrap(bitmap);
 
+		ReverseIntIteratorFlyweight reverseIter2 = new ReverseIntIteratorFlyweight(bitmap);
+		PeekableIntIterator rj = bitmap.getReverseIntIterator();
+		for (int k = data.length - 1; k >= 0; k -= 3) {
+			reverseIter2.advanceIfNeeded(data[k]);
+			reverseIter2.advanceIfNeeded(data[k]);
+			rj.advanceIfNeeded(data[k]);
+			rj.advanceIfNeeded(data[k]);
+			assertEquals(data[k], rj.peekNext());
+			assertEquals(data[k], reverseIter2.peekNext());
+		}
+		new ReverseIntIteratorFlyweight(bitmap).advanceIfNeeded(-1);
+		bitmap.getReverseIntIterator().advanceIfNeeded(-1); // should not crash
+
 		final List<Integer> intIteratorCopy = asList(iter);
 		final List<Integer> reverseIntIteratorCopy = asList(reverseIter);
 
@@ -141,6 +154,19 @@ public class TestIntIteratorFlyweight {
 		}
 
 		ReverseIntIteratorFlyweight reverseIter = new ReverseIntIteratorFlyweight(bitmap);
+		assertEquals(data[data.length - 1], reverseIter.peekNext());
+		assertEquals(data[data.length - 1], reverseIter.peekNext());
+
+		ReverseIntIteratorFlyweight reverseIter2 = new ReverseIntIteratorFlyweight(bitmap);
+		PeekableIntIterator rj = bitmap.getReverseIntIterator();
+		for (int k = data.length - 1; k >= 0; k -= 3) {
+			reverseIter2.advanceIfNeeded(data[k]);
+			reverseIter2.advanceIfNeeded(data[k]);
+			rj.advanceIfNeeded(data[k]);
+			rj.advanceIfNeeded(data[k]);
+			assertEquals(data[k], rj.peekNext());
+			assertEquals(data[k], reverseIter2.peekNext());
+		}
 
 		final List<Integer> intIteratorCopy = asList(iter);
 		final List<Integer> reverseIntIteratorCopy = asList(reverseIter);

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/TestIterators.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/TestIterators.java
@@ -168,6 +168,31 @@ public class TestIterators {
 		}
 
 		@Test
+		@DisplayName("advanceIfNeeded positions the reverse iterator on each value")
+		public void testSkipsReverse() {
+			final Random source = new Random(0xcb000a2b9b5bdfb6L);
+			final int[] data = takeSortedAndDistinct(source, 45000, Integer::compareUnsigned);
+			PersistentRoaringBitmap bitmap = PersistentRoaringBitmap.bitmapOf(data);
+			PeekableIntIterator pii = bitmap.getReverseIntIterator();
+			for (int i = data.length - 1; i >= 0; --i) {
+				pii.advanceIfNeeded(data[i]);
+				assertEquals(data[i], pii.peekNext());
+			}
+			pii = bitmap.getReverseIntIterator();
+			for (int i = data.length - 1; i >= 0; --i) {
+				pii.advanceIfNeeded(data[i]);
+				assertEquals(data[i], pii.next());
+			}
+			pii = bitmap.getReverseIntIterator();
+			for (int i = data.length - 2; i >= 0; --i) {
+				pii.advanceIfNeeded(data[i + 1]);
+				pii.next();
+				assertEquals(data[i], pii.peekNext());
+			}
+			bitmap.getReverseIntIterator().advanceIfNeeded(-1); // should not crash
+		}
+
+		@Test
 		@DisplayName("advanceIfNeeded positions the signed iterator and never moves backward")
 		public void testSkipsSignedIterator() {
 			final Random source = new Random(0xcb000a2b9b5bdfb6L);
@@ -214,6 +239,46 @@ public class TestIterators {
 		}
 
 		@Test
+		@DisplayName("advanceIfNeeded lands on each value of a dense bitmap in reverse")
+		public void testSkipsDenseReverse() {
+			PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+			int N = 100000;
+			for (int i = 0; i < N; ++i) {
+				bitmap.add(2 * i);
+			}
+			for (int i = N - 1; i >= 0; --i) {
+				PeekableIntIterator pii = bitmap.getReverseIntIterator();
+				pii.advanceIfNeeded(2 * i);
+				assertEquals(2 * i, pii.peekNext());
+				assertEquals(2 * i, pii.next());
+			}
+		}
+
+		@Test
+		@DisplayName("advanceIfNeeded lands on each value in reverse across several containers")
+		public void testSkipsMultipleContainersReverse() {
+			PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+			int n = 1000;
+			int numHighPoints = 10;
+			for (int h = 0; h < numHighPoints; ++h) {
+				int base = h << 16;
+				for (int i = 0; i < n; ++i) {
+					bitmap.add(2 * i + base);
+				}
+			}
+			for (int h = 0; h < numHighPoints; ++h) {
+				int base = h << 16;
+				for (int i = n - 1; i >= 0; --i) {
+					PeekableIntIterator pii = bitmap.getReverseIntIterator();
+					int expected = 2 * i + base;
+					pii.advanceIfNeeded(expected);
+					assertEquals(expected, pii.peekNext());
+					assertEquals(expected, pii.next());
+				}
+			}
+		}
+
+		@Test
 		@DisplayName("advanceIfNeeded lands on each value across a run container")
 		public void testSkipsRun() {
 			PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
@@ -224,6 +289,20 @@ public class TestIterators {
 				pii.advanceIfNeeded(i);
 				assertEquals(pii.peekNext(), i);
 				assertEquals(pii.next(), i);
+			}
+		}
+
+		@Test
+		@DisplayName("advanceIfNeeded lands on each value of a run container in reverse")
+		public void testSkipsRunReverse() {
+			PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+			bitmap.add(4L, 100000L);
+			bitmap.runOptimize();
+			for (int i = 99999; i >= 4; --i) {
+				PeekableIntIterator pii = bitmap.getReverseIntIterator();
+				pii.advanceIfNeeded(i);
+				assertEquals(i, pii.peekNext());
+				assertEquals(i, pii.next());
 			}
 		}
 
@@ -246,6 +325,14 @@ public class TestIterators {
 		public void testEmptySkips() {
 			PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
 			PeekableIntIterator it = bitmap.getIntIterator();
+			it.advanceIfNeeded(0);
+		}
+
+		@Test
+		@DisplayName("advanceIfNeeded on an empty bitmap does not fail in reverse")
+		public void testEmptySkipsReverse() {
+			PersistentRoaringBitmap bitmap = new PersistentRoaringBitmap();
+			PeekableIntIterator it = bitmap.getReverseIntIterator();
 			it.advanceIfNeeded(0);
 		}
 
@@ -277,6 +364,36 @@ public class TestIterators {
 			bitIt.advanceIfNeeded(4000000);
 			assertEquals(4000000, bitIt.peekNext());
 			assertEquals(4000000, bitIt.next());
+		}
+
+		@Test
+		@DisplayName("advanceIfNeeded into a gap lands on the previous present value in reverse")
+		public void testSkipIntoGapsReverse() {
+			PersistentRoaringBitmap bitset = new PersistentRoaringBitmap();
+
+			bitset.add(2000000L, 2200000L);
+			bitset.add(4000000L, 4300000L);
+
+			PeekableIntIterator bitIt = bitset.getReverseIntIterator();
+
+			assertEquals(4299999, bitIt.peekNext());
+			assertEquals(4299999, bitIt.next());
+
+			assertTrue(bitset.contains(4100000));
+			bitIt.advanceIfNeeded(4100000);
+			assertEquals(4100000, bitIt.peekNext());
+			assertEquals(4100000, bitIt.next());
+
+			// advancing reverse to a value in the gap should land on the last value of the first range
+			assertFalse(bitset.contains(2300000));
+			bitIt.advanceIfNeeded(2300000);
+
+			assertEquals(2199999, bitIt.peekNext());
+
+			assertTrue(bitset.contains(2199999));
+			bitIt.advanceIfNeeded(2199999);
+			assertEquals(2199999, bitIt.peekNext());
+			assertEquals(2199999, bitIt.next());
 		}
 
 		@Test

--- a/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/TestUtil.java
+++ b/evita_roaring_bitmap/src/test/java/io/evitadb/roaringbitmap/TestUtil.java
@@ -150,13 +150,14 @@ public class TestUtil {
 	@Test
 	public void testReverseUntil() {
 		char[] data = fromShorts(new short[]{1, 3, 16, 18, 21, 29, 30, -342});
-		assertEquals(0, Util.reverseUntil(data, data.length, data.length, (char) 0));
-		assertEquals(1, Util.reverseUntil(data, data.length, data.length, (char) 3));
-		assertEquals(4, Util.reverseUntil(data, data.length, data.length, (char) 28));
-		assertEquals(5, Util.reverseUntil(data, data.length, data.length, (char) 29));
-		assertEquals(6, Util.reverseUntil(data, data.length, data.length, (char) 30));
-		assertEquals(6, Util.reverseUntil(data, data.length, data.length, (char) 31));
-		assertEquals(7, Util.reverseUntil(data, data.length, data.length, (char) -342));
+		// data[0] is 1, so the (char) 0 probe has no answer and the result saturates at 0
+		assertEquals(0, Util.reverseUntil(data, data.length, (char) 0));
+		assertEquals(1, Util.reverseUntil(data, data.length, (char) 3));
+		assertEquals(4, Util.reverseUntil(data, data.length, (char) 28));
+		assertEquals(5, Util.reverseUntil(data, data.length, (char) 29));
+		assertEquals(6, Util.reverseUntil(data, data.length, (char) 30));
+		assertEquals(6, Util.reverseUntil(data, data.length, (char) 31));
+		assertEquals(7, Util.reverseUntil(data, data.length, (char) -342));
 	}
 
 	@Test


### PR DESCRIPTION
Replays upstream RoaringBitmap `master` onto the vendored `evita_roaring_bitmap`
subset, advancing the sync ledger from `2863e96d` to `ba92f497`, upstream
`master`'s tip. Effective coverage is **v1.6.15**, the newest release — tag
`1.6.15` points at `ef131a71` (#840, incorporated), and `ba92f497` merely bumps
`gradle.properties` to the next development version `1.6.16`, which has not been
released. Three upstream changes were incorporated; two more were already
satisfied by pre-existing evita divergences. Porting the third surfaced a
correctness bug that evita ships today.

## Incorporated

- **[#840](https://github.com/RoaringBitmap/RoaringBitmap/pull/840) — Avoid O(N²) operations in some cases.**
  The in-place `or`/`xor`/`naivelazyor` did a per-key `insertNewKeyValueAt`/`removeAtIndex`
  shift that is O(N²) when the two operands' keys interleave. At the first
  structural divergence they now collapse the remaining suffix into a single-pass
  `mergeBulk`.

  Ported **adapted to the copy-on-write model**: `mergeBulk` lives on
  `PersistentRoaringBitmap` (not `RoaringArray`, as upstream) because the parallel
  `shared[]` flag array lives there and the merge needs both operands' flags. It
  borrows source-only chunks by structural sharing (not upstream's clone), clones a
  shared receiver container before the in-place overlap op, and rebuilds `shared[]`
  in lockstep. Added `RoaringArray.adopt(...)` to install the rebuilt arrays.
  Instance `lazyor` is left on the per-key path, matching upstream (PR #840 did not
  touch it).

- **[#831](https://github.com/RoaringBitmap/RoaringBitmap/pull/831) — Reuse ART shuttle stack entries.**
  ART traversal (`select` / `rankLong` / ordered iteration, used by
  `PersistentLongRoaringBitmap`) allocated a `NodeEntry` per node visited. Added a
  `useEntry(depth, node)` slot-reuse helper (resets exactly the five `NodeEntry`
  fields a fresh one would have) replacing the 5 `new NodeEntry()` push sites.
  Behaviour unchanged; upstream reports −36…−65 % traversal allocation.

- **[#837](https://github.com/RoaringBitmap/RoaringBitmap/pull/837) — Reverse iterators become peekable.**
  `RoaringReverseIntIterator` and `ReverseIntIteratorFlyweight` gain
  `advanceIfNeeded(int)` / `peekNext()`, `ImmutableBitmapDataProvider.getReverseIntIterator()`
  narrows to `PeekableIntIterator`, and `Util.reverseUntil` drops its unused
  `length` parameter. The narrowing is source-compatible — every caller either
  assigns to `IntIterator` or consumes the iterator directly. Upstream's
  `ArrayContainer`/`BitmapContainer` signature hunks were already satisfied here:
  all three reverse char cursors already implement `PeekableCharIterator`.

## Bug found while porting #837

`PeekableCharIterator.advanceIfNeeded` is direction-aware — after the call a reverse
cursor must be **either exhausted or positioned at a value ≤ the bound**. The three
reverse cursors disagreed on the case where a container holds no value at or below
the bound:

| cursor | behaviour |
|---|---|
| `ReverseBitmapContainerCharIterator` | correct (already an evita divergence — upstream neither exhausts nor reads `bitmap[0]`) |
| `ReverseRunContainerCharIterator` | correct |
| `ReverseArrayContainerCharIterator` | **wrong** — parked at index 0, above the bound |

`Util.reverseUntil` saturates at index `0` instead of reporting "no match", so the
array cursor was left with `hasNext() == true` and `peekNext()` **greater than the
requested bound**.

This is **not** merely latent in the newly-ported API.
`PersistentLongRoaringBitmap.getReverseLongIterator()` has always returned a
`PeekableLongIterator` and forwards its seek straight down to these cursors, so a
reverse seek that had to cross out of an array-backed chunk already returned a wrong
value. Reduced repro, red before this PR:

```java
PersistentLongRoaringBitmap b = new PersistentLongRoaringBitmap();
b.addLong(500L);            // chunk 0 — the only value at or below the bound
b.addLong(65536L + 1000L);  // chunk 1 — an array container, all values above it
b.addLong(65536L + 2000L);

PeekableLongIterator it = b.getReverseLongIterator();
it.advanceIfNeeded(65536L + 700L);
it.peekNext();              // was 66536, must be 500
```

Fixed in `ReverseArrayContainerCharIterator.advanceIfNeeded` by re-testing
`content[0]` and exhausting, rather than in `Util.reverseUntil` — the saturating
return is what upstream's own `TestUtil.testReverseUntil` asserts.

Deliberately **not** changed: `advanceIfNeeded` (both directions, every shape)
assumes a monotonic probe sequence, so probing backwards can re-emit consumed
values. That is upstream's documented intersection idiom, shared by the forward
cursors, and no caller violates it. Recorded in the ledger instead.

## Already satisfied (no-op)

- **#833** (static `orNot` must not mutate its input): our static `orNot` already
  clones before the in-place `ior` — a stronger COW guarantee that subsumes the fix.
- **#836** (`ReverseIntIteratorFlyweight` short overflow): our `pos` is already an
  `int`, and the `>Short.MAX_VALUE` regression already ships.

The remaining upstream commits in range are build/release/README (N/A). See
`evita_roaring_bitmap/UPSTREAM_SYNC.md` → *Review 2* for the per-commit ledger, the
recorded `mergeBulk`-on-`PersistentRoaringBitmap` divergence, and the reverse-cursor
divergence.

## Testing

- Full module suite green: **17908 tests, 0 failures** (`mvn -o test`, standalone).
- `ReverseAdvanceIfNeededContractTest` (new) asserts the reverse post-condition per
  container shape, sweeps thresholds below/inside/above each populated span, and pins
  both the 32-bit and 64-bit cross-chunk seeks. This is the test that would have
  caught the upstream bitmap-container bug we had already diverged on.
- `MergeBulkCopyOnWriteTest` (from the #840 port) targets the COW landmine the ported
  upstream tests can't reach: interleaved keys forcing a mid-stream `mergeBulk`
  against a `clone()` peer (incl. a frozen receiver at entry), the xor cancelled-pair
  container drop, a 2000-key `shared[]`-overflow guard, and bidirectional isolation.
- Upstream's own #837 tests ported into `TestIterators`, `TestIntIteratorFlyweight`
  and `TestUtil`.

## Second defect found while auditing the result: flyweight `clone()` is not independent

`IntIteratorFlyweight` and `ReverseIntIteratorFlyweight` cache one reusable char cursor per container
shape so that chunk stepping allocates nothing. `clone()` delegated to `Object.clone()` — a shallow
copy — so a fork and its origin held the **same three cursor objects**. The explicit
`x.iter = this.iter.clone()` repairs only the *active* cursor, so the pair stays independent exactly
until one side crosses a chunk boundary and re-wraps a cursor the other is still reading through. The
victim then emits a value assembled from one chunk's low bits and another chunk's high bits.

Also upstream, also long-standing, also reproducible through public API on released 1.6.15:

```java
RoaringBitmap b = RoaringBitmap.bitmapOf(10, 20, 30, 65536 + 40, 65536 + 50, 65536 + 60);
IntIteratorFlyweight origin = new IntIteratorFlyweight(b);
PeekableIntIterator fork = origin.clone();
fork.next(); fork.next(); fork.next();   // fork crosses into chunk 1
origin.next();                            // was 40 (!), must be 10 — and b.contains(40) is false
```

Fixed in both by building the fork from the no-arg constructor and copying only position state. The
per-bitmap `RoaringIntIterator` / `RoaringReverseIntIterator` are **not** affected (they allocate a
fresh cursor per chunk) but are covered by the same test so the two families cannot drift apart.

## Review feedback addressed

- **MINOR — `mergeBulk` coverage gap for entry with `dst > 0` past an in-place-mutated prefix.**
  Added for all three ops (`or` / `xor` / `naivelazyor`), using the exact suggested shape (`a` chunks
  `{5, 20}`, `b` chunks `{5, 10, 15}`). Verified by temporary instrumentation that they genuinely
  reach `mergeBulk` with `dst=1` rather than merely passing.
- **Not blocking — xor reducing the whole result to empty via `mergeBulk`.** Added; instrumentation
  confirms it enters at `dst=0, left=1, right=1`, and it further asserts the emptied receiver is
  still usable and its co-owned peer intact.
- **NIT — redundant `clone()` in the `MERGE_LAZY_OR` overlap.** Accepted. The guard is
  type-guaranteed rather than incidental: `toBitmapContainer()` returns `BitmapContainer`, so only a
  `BitmapContainer` can return `this`; array and run chunks always allocate fresh. Verified against
  all three implementations.

## Additional hardening

- `orNot` now installs its rebuilt arrays through `RoaringArray.adopt` instead of assigning the
  fields directly, so the array-level `frozen` guard is cleared with them (previously stale, costing
  a redundant defensive copy — safe, but it made `orNot` the one rebuild path bypassing the sink).
- `SharedContainerLockstepFuzzTest` — seeded (`seed = 0..39`, no entropy) fuzz over the in-place
  operators asserting `shared[]`/container lockstep *and* the cross-bitmap alias graph directly:
  whenever two bitmaps hold the same `Container` instance, both must flag that slot shared. A census
  confirmed the check is not vacuous — 5120 aliased pairs observed, all correctly double-flagged,
  across 2334 `mergeBulk` rebuilds.
- `ReverseIntIteratorUnsignedContractTest` — seeded; pins unsigned chunk-key ordering across the
  signed wrap. Note only the `0x8000`-vs-`0x7FFF` pairing discriminates `>>>` from `>>`.

## Follow-up: copy-on-write flags tracked per slot on static operation results

An allocation pass over `PersistentRoaringBitmap` after the sync. A `shared` flag
is a promise to clone the container before the next in-place write, so raising it
on a chunk nobody co-owns still costs the clone — 8 KiB for a bitmap chunk — and
buys nothing. The static binary operations raised it wholesale on both sides:
`markAllShared` on each operand plus an all-`true` result array. `and` and
`fromBitmap` already built precise arrays, and these three methods' own JavaDoc
already described the precise semantics; only the code was coarser.

**The result side is now per slot.** A chunk present in both operands is
recombined into a private container and left unflagged; a chunk lent from one
operand is flagged. `newAllSharedResult` is gone. Safe unconditionally — the
result is reachable only by the caller until published.

**The operand side is deliberately left wholesale**, and the reason is now on
`markAllShared` so it is not "optimised" later. `TransactionalBitmap` is
`@ThreadSafe` and hands the same live bitmap to every concurrent read-only query
thread, while `shared[]` is written without synchronisation. A full fill is
idempotent — an update lost to a racing `ensureSharedCapacity` reallocation is
re-established by the next caller, converging on the conservative value. Sparse
writes have no such convergence, and what a lost sparse write leaves behind is
the *unsafe* value: an unflagged slot over a container the result aliases.
Narrowing this side measures at −32 % allocation and is worth revisiting, but
only behind a hard `shared.length >= size` invariant and a decision on publishing
those writes; both are recorded in the ledger.

`runOptimize` / `removeRunCompression` additionally clear the flag of any slot
whose container they re-encoded — the replacement was allocated for this bitmap
alone.

Measured A/B over two builds using thread-allocation counters, 64-chunk operands:

| shape | allocation | best-of-9 wall clock |
|---|---|---|
| `or(a, b)` then writes into the result | 217,095,792 → 164,417,392 bytes/cycle (**−24.3 %**) | 12.2 → 10.3 ms |
| diff-layer `andNot(or(baseline, insertions), removals)` then writes into the deltas | unchanged | unchanged |

Allocation is bit-for-bit reproducible across runs, so it is a count rather than
a sample. The second row is the honest counterpart of the first: that shape's
cost sits entirely in the operand flags this change does not touch.

### Testing

- `ContainerBinaryOpFreshnessTest` (new) pins the precondition the whole change
  rests on — out-of-place container `or`/`xor`/`andNot` never return an operand
  nor anything aliasing one — across all nine shape pairs in both operand orders.
  It checks identity and then scribbles over the result with the in-place
  mutators, so a distinct object wrapping an operand's backing array is caught
  too.
- `SharedFlagPrecisionTest` (new) pins the result-side precision, the deliberately
  conservative operand marking, and the re-encoding flag drop; the clone census
  asserts a write into a merged result clones the borrowed chunks and no others.
- `SharedContainerLockstepFuzzTest` now drives the static `xor` and `andNot`
  producers, so its alias-graph invariant covers them. Deliberately dropping a
  lent chunk's flag makes it fail at seed 0, step 26.
- Full module suite **17915 tests, 0 failures**, plus 327 engine-level bitmap and
  transactional-layer tests.

**Not applicable upstream.** `shared[]` has no upstream counterpart, and upstream
results are freely mutable by contract — which is exactly why upstream clones
carried-over chunks (`appendCopy`) instead of sharing them. Nothing to contribute
there.

Ref: #1252

