### PR TITLE
perf: collapse write-path device syncs (WAL group commit + checkpoint interval)

### DIFF
--- a/documentation/user/en/operate/configure.md
+++ b/documentation/user/en/operate/configure.md
@@ -82,7 +82,8 @@ transaction:                                      # [see Transaction configurati
   walFileSizeBytes: 16MB
   walFileCountKept: 8
   waitForTransactionAcceptanceInMillis: 20s
-  flushFrequencyInMillis: 1s
+  flushFrequencyInMillis: 10s
+  checkpointIntervalInMillis: 1s
   conflictPolicy: ENTITY
 
 cache:                                            # [see Cache configuration](#cache-configuration)
@@ -595,9 +596,23 @@ This section contains configuration options for the storage layer of the databas
         <p>**Default:** `true`</p>
         <p>It determines whether CRC32C checksums are calculated for written records in a key/value store, and also whether 
         the CRC32C checksum is checked when a record is read.</p>
+        <p>This setting also selects **how the write-ahead log survives a crash**, which makes switching it off far more
+        expensive than the checksum computation it saves. A crash can leave a record with a *hole* - bytes missing in its
+        middle while later bytes reached the device - and surviving that requires either detecting the hole or
+        guaranteeing it cannot occur:</p>
+        <ul>
+            <li>**`true`** - the WAL's cumulative CRC32C chain detects the hole and recovery truncates to the last intact
+                transaction. The log can therefore be written at **one device sync per batch of transactions**, which is
+                what allows commit throughput to scale with the number of concurrent writers.</li>
+            <li>**`false`** - nothing can tell a hole from valid data, because the file length is unchanged and the record
+                still parses, so the damage would be replayed as genuine history. The WAL is therefore opened with
+                `DSYNC`, which syncs **every individual write** and so guarantees a crash can only ever leave a clean
+                prefix. This is correct, but costs roughly one device sync per write instead of per batch.</li>
+        </ul>
         <Note type="warning">
-            It is strongly recommended that this setting be set to `true`, as it will report potentially corrupt records as 
-            early as possible.
+            It is strongly recommended that this setting be set to `true`. Besides reporting potentially corrupt records as
+            early as possible, it is what allows the write-ahead log to batch its device syncs - so turning it off costs
+            considerably more write throughput than the checksum computation itself ever did.
         </Note>
     </dd>
     <dt>compress</dt>
@@ -799,11 +814,31 @@ This section contains configuration options for the storage layer of the databas
     </dd>
     <dt>flushFrequencyInMillis</dt>
     <dd>
-        <p>**Default:** `1s`</p>
+        <p>**Default:** `10s`</p>
         <p>The frequency of flushing the transactional data to the disk when they are sequentially processed.
             If database process the (small) transaction very quickly, it may decide to process next transaction before
             flushing changes to the disk. If the client waits for `WAIT_FOR_CHANGES_VISIBLE` he may wait entire
             `flushFrequencyInMillis` milliseconds before he gets the response.</p>
+    </dd>
+    <dt>checkpointIntervalInMillis</dt>
+    <dd>
+        <p>**Default:** `1s`</p>
+        <p>How often the data files are made durable (fsync) and the bootstrap record pointing at them is written.
+            Transaction processing always writes its bytes out, but between checkpoints they only reach the operating
+            system page cache - the device flush is what this interval bounds. Set to `0` to checkpoint at the end of
+            every transaction processing round.</p>
+        <p>This is deliberately a different cadence from `flushFrequencyInMillis`: that one bounds when changes become
+            **visible**, this one bounds when they become **durable on the data files**. Durability of an acknowledged
+            commit does not depend on it - the write-ahead log is the source of truth for that, and anything written
+            after the last checkpoint is replayed from the WAL on restart. What the interval trades is WAL retention
+            and restart replay time (both bounded by the interval) for write throughput.</p>
+        <p>The gain is largest on lightly loaded systems. A checkpoint costs a fixed number of device flushes
+            regardless of how many transactions it covers, so when few transactions are in flight that cost is divided
+            among few of them: measured at roughly 57% of a processing round with two concurrent writers, and
+            negligible with sixty-four. Raising the interval mostly helps the former case; the latter is already
+            dominated by other work.</p>
+        <p>The setting has no effect when `storage.syncWrites` is `false`, since there is then no device flush to
+            defer in the first place.</p>
     </dd>
     <dt>conflictPolicy</dt>
     <dd>

--- a/documentation/user/en/operate/reference/jfr-events.md
+++ b/documentation/user/en/operate/reference/jfr-events.md
@@ -95,6 +95,8 @@
 #### Storage
 
 <dl>
+  <dt><SourceClass>evita_engine/src/main/java/io/evitadb/core/metric/event/storage/CatalogCheckpointEvent.java</SourceClass> Catalog checkpointed</dt>
+  <dd>Event that is fired when the catalog data files are made durable and a bootstrap record is written.</dd>
   <dt><SourceClass>evita_engine/src/main/java/io/evitadb/core/metric/event/storage/CatalogStatisticsEvent.java</SourceClass> Catalog flushed</dt>
   <dd>Event that is fired when a new catalog version is flushed.</dd>
   <dt><SourceClass>evita_engine/src/main/java/io/evitadb/core/metric/event/storage/DataFileCompactEvent.java</SourceClass> OffsetIndex compaction</dt>

--- a/documentation/user/en/operate/reference/metrics.md
+++ b/documentation/user/en/operate/reference/metrics.md
@@ -321,6 +321,16 @@ duration of the probe.</dd>
 #### Storage
 
 <dl>
+  <dt><code>io_evitadb_storage_catalog_checkpoint_cadence_milliseconds</code> (GAUGE)</dt>
+  <dd><strong>Checkpoint cadence in milliseconds</strong>: The time elapsed since the previous completed checkpoint. Compare against the configured checkpoint interval - sustained higher values mean checkpointing is not keeping up with the write rate.</dd>
+  <dt><code>io_evitadb_storage_catalog_checkpoint_fence_depth_milliseconds</code> (GAUGE)</dt>
+  <dd><strong>Fence depth in milliseconds</strong>: How long the oldest change covered by this checkpoint waited to become durable. Bounds both the write-ahead log retention and the amount of replay a restart has to perform. Zero when the round checkpointed without deferring.</dd>
+  <dt><code>io_evitadb_storage_catalog_checkpoint_files_forced</code> (GAUGE)</dt>
+  <dd><strong>Number of files forced</strong>: The number of data files that were forced to the physical device by this checkpoint.</dd>
+  <dt><code>io_evitadb_storage_catalog_checkpoint_force_duration_milliseconds</code> (GAUGE)</dt>
+  <dd><strong>Device force duration in milliseconds</strong>: The time spent forcing the data files to the physical device. This is the cost the checkpoint interval exists to amortise - it is paid once per checkpoint instead of once per trunk round.</dd>
+  <dt><code>io_evitadb_storage_catalog_checkpoint_total</code> (COUNTER)</dt>
+  <dd>Catalog checkpoints.</dd>
   <dt><code>io_evitadb_storage_catalog_statistics_entity_collections</code> (GAUGE)</dt>
   <dd><strong>Entity collection count</strong>: The number of active entity collections (entity types) in the catalog.</dd>
   <dt><code>io_evitadb_storage_catalog_statistics_occupied_disk_space_bytes</code> (GAUGE)</dt>

--- a/evita_api/src/main/java/io/evitadb/api/CommitProgress.java
+++ b/evita_api/src/main/java/io/evitadb/api/CommitProgress.java
@@ -173,8 +173,9 @@ public interface CommitProgress {
 	 *
 	 * **Performance Note**
 	 *
-	 * evitaDB may batch fsync operations from multiple transactions to amortize disk I/O cost. This stage may complete
-	 * faster than expected if batched with other concurrent commits.
+	 * Every transaction is made durable by its own `force` on the shared WAL file, and appends are serialized, so this
+	 * stage costs one device sync per transaction and concurrent commits queue behind one another. fsync operations are
+	 * **not** currently batched across transactions.
 	 *
 	 * **Equivalent to**
 	 *

--- a/evita_api/src/main/java/io/evitadb/api/TransactionContract.java
+++ b/evita_api/src/main/java/io/evitadb/api/TransactionContract.java
@@ -236,8 +236,8 @@ public interface TransactionContract extends AutoCloseable {
 		 * **Performance**
 		 *
 		 * Slower than {@link #WAIT_FOR_CONFLICT_RESOLUTION} due to fsync overhead, but faster than
-		 * {@link #WAIT_FOR_CHANGES_VISIBLE}. evitaDB may batch fsync operations from multiple transactions to amortize
-		 * cost, so latency may vary depending on concurrent commit activity.
+		 * {@link #WAIT_FOR_CHANGES_VISIBLE}. Each transaction pays its own device sync and WAL appends are serialized,
+		 * so latency grows with concurrent commit activity; fsync operations are **not** batched across transactions.
 		 *
 		 * **Use Cases**
 		 *

--- a/evita_api/src/main/java/io/evitadb/api/configuration/StorageOptions.java
+++ b/evita_api/src/main/java/io/evitadb/api/configuration/StorageOptions.java
@@ -68,6 +68,20 @@ import static java.util.Optional.ofNullable;
  *                                           the original size will be saved in compressed form. The default is false.
  * @param computeCRC32C                      Determines whether CRC32C checksums will be computed for written
  *                                           records and also whether the CRC32C checksum will be checked on record read.
+ *                                           **This setting also selects how the write-ahead log survives a crash, which
+ *                                           makes it considerably more expensive to switch off than the checksum
+ *                                           computation it saves.** A crash can leave a record with a *hole* - bytes
+ *                                           missing in its middle while later bytes reached the device - and surviving
+ *                                           that needs either the ability to detect it or a guarantee it cannot happen.
+ *                                           With checksums on, the WAL's cumulative CRC32C chain detects a hole and
+ *                                           recovery truncates to the last intact transaction, so the log can be written
+ *                                           at one device sync per batch of transactions. With checksums off there is
+ *                                           nothing that can tell a hole from valid data - the file length is unchanged,
+ *                                           so the record still parses - and the damage would be replayed as real
+ *                                           history; the WAL is therefore opened with `DSYNC` instead, which syncs every
+ *                                           individual write so a crash can only ever leave a clean prefix. That trades
+ *                                           one device sync per batch for one per write, which costs far more write
+ *                                           throughput than the checksums do CPU.
  * @param minimalActiveRecordShare           Minimal share of active records in the file. If the share is lower, the file will
  *                                           be compacted.
  * @param fileSizeCompactionThresholdBytes   Minimal file size threshold for compaction. If the file size is lower,

--- a/evita_api/src/main/java/io/evitadb/api/configuration/TransactionOptions.java
+++ b/evita_api/src/main/java/io/evitadb/api/configuration/TransactionOptions.java
@@ -64,6 +64,23 @@ import java.util.Optional;
  *                                              changes to the disk. If the client waits for `CommitBehavior.WAIT_FOR_CHANGES_VISIBLE`
  *                                              he may wait entire `flushFrequencyInMillis` milliseconds before he gets
  *                                              the response.
+ * @param checkpointIntervalInMillis            How often the data files are made durable (fsync) and the bootstrap
+ *                                              record pointing at them is written. Trunk incorporation always writes
+ *                                              its bytes out, but between checkpoints they only reach the operating
+ *                                              system page cache - the device flush is what this interval bounds.
+ *                                              Set to `0` to checkpoint at the end of every trunk round. The
+ *                                              interval is **ignored entirely when `syncWrites` is off** in
+ *                                              `StorageOptions`: with no device flush being issued there is nothing
+ *                                              to defer, so the two settings stay orthogonal instead of one
+ *                                              silently re-enabling the other.
+ *                                              This is deliberately a different cadence from
+ *                                              `flushFrequencyInMillis`: that one bounds when changes become
+ *                                              **visible**, this one bounds when they become **durable on the data
+ *                                              files**. Durability of an acknowledged commit does not depend on it -
+ *                                              the write-ahead log is the source of truth for that, and anything
+ *                                              written after the last checkpoint is replayed from the WAL on restart.
+ *                                              The interval therefore trades WAL retention and restart replay time
+ *                                              for write throughput.
  * @param conflictRingBufferSize                Size of the array inside transaction conflict keys ring buffer.
  *                                              The larger the size, the more conflict keys the ring buffer can keep
  *                                              in volatile memory. Amount of necessary conflict keys is dependent on
@@ -84,6 +101,7 @@ public record TransactionOptions(
 	int walFileCountKept,
 	long waitForTransactionAcceptanceInMillis,
 	long flushFrequencyInMillis,
+	long checkpointIntervalInMillis,
 	int conflictRingBufferSize,
 	@Nonnull ConflictResolution conflictPolicy
 ) {
@@ -93,12 +111,52 @@ public record TransactionOptions(
 	public static final int DEFAULT_WAL_SIZE_BYTES = 16_777_216;
 	public static final int DEFAULT_WAL_FILE_COUNT_KEPT = 8;
 	public static final int DEFAULT_WAIT_FOR_TRANSACTION_ACCEPTANCE = 20_000;
-	public static final int DEFAULT_FLUSH_FREQUENCY = 1_000;
+	/**
+	 * Relaxed from `1_000` when the budget started being honoured at all.
+	 *
+	 * The value was previously handed to trunk incorporation in nanoseconds while being compared in milliseconds,
+	 * which inflated it to roughly 11.6 days - so in practice a round always drained the entire WAL backlog present
+	 * when it opened, and this knob never bounded anything. Restoring the unit at `1_000` would have taken the engine
+	 * from an effectively unbounded batching window straight to a one-second one, cutting rounds far more aggressively
+	 * than any behaviour that has ever been exercised in production.
+	 *
+	 * Measured commit throughput is flat across `1_000`..`60_000` at 4 and 16 concurrent writers, because at those
+	 * rates trunk incorporation keeps up and no backlog forms for the budget to cut. The value therefore only starts
+	 * to matter in a sustained-backlog regime that the benchmark could not reproduce, and is chosen to hedge that
+	 * regime: an order of magnitude more batching headroom than the nominal old value, while still bounding how long
+	 * a client awaiting {@link io.evitadb.api.TransactionContract.CommitBehavior#WAIT_FOR_CHANGES_VISIBLE} can be kept
+	 * behind other writers' work.
+	 */
+	public static final int DEFAULT_FLUSH_FREQUENCY = 10_000;
+	/**
+	 * Bounds how long the data files may sit in the operating system page cache before they are forced to the device
+	 * and a bootstrap record is written to point at them.
+	 *
+	 * Before this interval existed, every trunk round paid the full device bill: `N_changed + 2` fsyncs, measured at
+	 * roughly 15.5 ms on a LUKS+xfs SSD. That bill is **fixed per round**, so its per-transaction share is
+	 * `15.5 / k`, where `k` is the number of transactions the round collapses. Under
+	 * {@link io.evitadb.api.TransactionContract.CommitBehavior#WAIT_FOR_CHANGES_VISIBLE} a client blocks until its own
+	 * change is visible and therefore cannot join a later batch, which caps `k` at the number of concurrent writers -
+	 * the fsync share is consequently **largest when the system is least busy**. Measured share of the round: 57 % at
+	 * 2 writers, 47 % at 8, 24 % at 16 and nothing at 64, where trunk incorporation's own merge work dominates.
+	 *
+	 * One second is the same order as the visibility cadence other engines expose, and two orders below their
+	 * checkpoint cadences (WiredTiger 60 s, PostgreSQL 5 min), so it is a deliberately conservative starting point:
+	 * it collects most of the win while keeping WAL retention and restart replay to about a second of writes.
+	 */
+	public static final int DEFAULT_CHECKPOINT_INTERVAL = 1_000;
 	public static final int DEFAULT_CONFLICT_RING_BUFFER_SIZE = 65_536;
 	public static final ConflictResolution DEFAULT_CONFLICT_RESOLUTION = new ConflictResolution(ConflictPolicy.ENTITY);
 
 	/**
 	 * Builder method is planned to be used only in tests.
+	 *
+	 * Checkpointing is pinned to every round here rather than to {@link #DEFAULT_CHECKPOINT_INTERVAL}. Deferred
+	 * checkpointing is time-dependent by construction, and a test that commits and then inspects the catalog on disk
+	 * would otherwise be asserting against a checkpoint that has not fired yet. The deferred path is covered by tests
+	 * that configure the interval explicitly. This value is in the same spirit as the other deviations here (a 1 MB
+	 * transaction buffer against 16 MB, one WAL file against eight): the method exists to make tests fast and
+	 * deterministic, not to mirror production.
 	 */
 	public static TransactionOptions temporary() {
 		return new TransactionOptions(
@@ -109,6 +167,7 @@ public record TransactionOptions(
 			1,
 			100,
 			100,
+			0,
 			256,
 			DEFAULT_CONFLICT_RESOLUTION
 		);
@@ -137,6 +196,7 @@ public record TransactionOptions(
 			DEFAULT_WAL_FILE_COUNT_KEPT,
 			DEFAULT_WAIT_FOR_TRANSACTION_ACCEPTANCE,
 			DEFAULT_FLUSH_FREQUENCY,
+			DEFAULT_CHECKPOINT_INTERVAL,
 			DEFAULT_CONFLICT_RING_BUFFER_SIZE,
 			DEFAULT_CONFLICT_RESOLUTION
 		);
@@ -150,6 +210,7 @@ public record TransactionOptions(
 		int walFileCountKept,
 		long waitForTransactionAcceptanceInMillis,
 		long flushFrequencyInMillis,
+		long checkpointIntervalInMillis,
 		int conflictRingBufferSize,
 		@Nullable ConflictResolution conflictPolicy
 	) {
@@ -160,6 +221,7 @@ public record TransactionOptions(
 		this.walFileCountKept = walFileCountKept;
 		this.waitForTransactionAcceptanceInMillis = waitForTransactionAcceptanceInMillis;
 		this.flushFrequencyInMillis = flushFrequencyInMillis;
+		this.checkpointIntervalInMillis = checkpointIntervalInMillis;
 		this.conflictRingBufferSize = conflictRingBufferSize;
 		// ConflictResolution is immutable, no defensive copy required; null falls back to the default
 		this.conflictPolicy = Optional.ofNullable(conflictPolicy).orElse(DEFAULT_CONFLICT_RESOLUTION);
@@ -177,6 +239,7 @@ public record TransactionOptions(
 		private int walFileCountKept = DEFAULT_WAL_FILE_COUNT_KEPT;
 		private long waitForTransactionAcceptance = DEFAULT_WAIT_FOR_TRANSACTION_ACCEPTANCE;
 		private long flushFrequency = DEFAULT_FLUSH_FREQUENCY;
+		private long checkpointInterval = DEFAULT_CHECKPOINT_INTERVAL;
 		private int conflictRingBufferSize = DEFAULT_CONFLICT_RING_BUFFER_SIZE;
 		private ConflictResolution conflictPolicy = DEFAULT_CONFLICT_RESOLUTION;
 
@@ -191,6 +254,7 @@ public record TransactionOptions(
 			this.walFileCountKept = transactionOptions.walFileCountKept;
 			this.waitForTransactionAcceptance = transactionOptions.waitForTransactionAcceptanceInMillis;
 			this.flushFrequency = transactionOptions.flushFrequencyInMillis;
+			this.checkpointInterval = transactionOptions.checkpointIntervalInMillis;
 			this.conflictRingBufferSize = transactionOptions.conflictRingBufferSize;
 			this.conflictPolicy = transactionOptions.conflictPolicy;
 		}
@@ -234,6 +298,17 @@ public record TransactionOptions(
 		@Nonnull
 		public TransactionOptions.Builder flushFrequencyInMillis(long flushFrequency) {
 			this.flushFrequency = flushFrequency;
+			return this;
+		}
+
+		/**
+		 * Sets how often the data files are forced to the device and a bootstrap record is written to point at them.
+		 *
+		 * @param checkpointInterval interval in milliseconds, `0` to checkpoint at the end of every trunk round
+		 */
+		@Nonnull
+		public TransactionOptions.Builder checkpointIntervalInMillis(long checkpointInterval) {
+			this.checkpointInterval = checkpointInterval;
 			return this;
 		}
 
@@ -292,6 +367,7 @@ public record TransactionOptions(
 				this.walFileCountKept,
 				this.waitForTransactionAcceptance,
 				this.flushFrequency,
+				this.checkpointInterval,
 				this.conflictRingBufferSize,
 				this.conflictPolicy
 			);

--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -699,12 +699,9 @@ public final class Catalog
 		this.schema = new TransactionalReference<>(new CatalogSchemaDecorator(catalogSchema));
 		this.catalogIndex = this.persistenceService.readCatalogIndex(this, Scope.LIVE)
 			.orElseGet(() -> new CatalogIndex(Scope.LIVE));
-		final CatalogIndex loadedArchiveCatalogIndex = this.persistenceService.readCatalogIndex(this, Scope.ARCHIVED)
+		this.persistenceService.readCatalogIndex(this, Scope.ARCHIVED)
 			.filter(it -> !it.isEmpty())
-			.orElse(null);
-		if (loadedArchiveCatalogIndex != null) {
-			this.archiveCatalogIndex.set(loadedArchiveCatalogIndex);
-		}
+			.ifPresent(this.archiveCatalogIndex::set);
 		this.cacheSupervisor = cacheSupervisor;
 		this.trafficRecordingEngine = new TrafficRecordingEngine(
 			catalogSchema.getName(),
@@ -1881,10 +1878,14 @@ public final class Catalog
 	}
 
 	/**
-	 * Returns the newest catalog version that has actually reached disk, which may lag {@link #getVersion()} while a
-	 * commit is in flight. Tells apart a failure that struck before its version was durable from one that struck after.
+	 * Returns the newest catalog version that has actually been checkpointed to disk. Tells apart a failure that
+	 * struck before its version was durable from one that struck after.
 	 *
-	 * @return the last catalog version present in persistent storage
+	 * This lags {@link #getVersion()} by an entire checkpoint interval when one is configured - not merely for the
+	 * duration of a commit in flight. Everything above it is recovered by replaying the write-ahead log, so the gap
+	 * is bounded but is measured in seconds rather than milliseconds.
+	 *
+	 * @return the last catalog version whose checkpoint completed
 	 */
 	public long getLastPersistedCatalogVersion() {
 		return this.persistenceService.getLastCatalogVersion();
@@ -1896,7 +1897,9 @@ public final class Catalog
 	 */
 	public void flush(long catalogVersion, @Nonnull TransactionMutation lastProcessedTransaction) {
 		Assert.isPremiseValid(getCatalogState() == CatalogState.ALIVE, "Catalog is not in ALIVE state!");
-		boolean changeOccurred = this.persistenceService.getLastCatalogVersion() != catalogVersion ||
+		// the last APPLIED version, not the last checkpointed one: with a checkpoint interval configured the latter
+		// lags by up to that interval, which would make every round in between look like a change
+		boolean changeOccurred = this.persistenceService.getLastAppliedCatalogVersion() != catalogVersion ||
 			getInternalSchema().version() != this.lastPersistedSchemaVersion;
 		final List<EntityCollectionHeader> entityHeaders = new ArrayList<>(this.entityCollections.size());
 		for (EntityCollection entityCollection : this.entityCollections.values()) {
@@ -1945,15 +1948,28 @@ public final class Catalog
 	 * Appends the given transaction mutation to the write-ahead log (WAL) and appends its mutation chain taken from
 	 * offHeapWithFileBackupReference. After that it discards the specified off-heap data with file backup reference.
 	 *
+	 * The append is left merely **written** rather than durable - the caller must pair it with {@link #syncWal()}
+	 * before the transaction may be acknowledged or checkpointed. That is what allows one device sync to cover
+	 * a whole batch of transactions instead of one each.
+	 *
 	 * @param transactionMutation The transaction mutation to append to the WAL.
 	 * @param walReference        The off-heap data with file backup reference to discard.
 	 * @return the number of Bytes written
 	 */
-	public long appendWalAndDiscard(
+	public long appendWalAndDiscardDeferringSync(
 		@Nonnull TransactionMutation transactionMutation,
 		@Nonnull LogRecordReference walReference
 	) {
-		return this.persistenceService.appendWalAndDiscard(getVersion(), transactionMutation, walReference);
+		return this.persistenceService.appendWalAndDiscardDeferringSync(
+			getVersion(), transactionMutation, walReference
+		);
+	}
+
+	/**
+	 * Makes everything appended to this catalog's WAL so far durable.
+	 */
+	public void syncWal() {
+		this.persistenceService.syncWal();
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/metric/event/storage/CatalogCheckpointEvent.java
+++ b/evita_engine/src/main/java/io/evitadb/core/metric/event/storage/CatalogCheckpointEvent.java
@@ -1,0 +1,109 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.core.metric.event.storage;
+
+import io.evitadb.api.configuration.metric.MetricType;
+import io.evitadb.api.observability.annotation.ExportInvocationMetric;
+import io.evitadb.api.observability.annotation.ExportMetric;
+import jdk.jfr.Description;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Event fired when a catalog checkpoint completes - that is, when the data files written since the previous
+ * checkpoint have been forced to the physical device and the bootstrap record pointing at them has been written.
+ *
+ * Emitted at the point the device acknowledges, not at the end of the trunk round that queued the work, because the
+ * whole purpose of the checkpoint interval is that those two moments are no longer the same.
+ *
+ * Read the two gauges together - they answer different questions:
+ *
+ * - **Cadence** says whether checkpoints are happening as often as configured. Sustained values far above
+ *   the configured interval mean checkpointing cannot keep up with the write rate.
+ * - **Fence depth** says how far behind durability is running, and therefore bounds both how much write-ahead log
+ *   must be retained and how much of it a restart has to replay. On a quiet catalog it should show roughly one
+ *   interval and then stay flat.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Name(AbstractStorageEvent.PACKAGE_NAME + ".CatalogCheckpoint")
+@Description("Event that is fired when the catalog data files are made durable and a bootstrap record is written.")
+@Label("Catalog checkpointed")
+@ExportInvocationMetric(label = "Catalog checkpoints.")
+@Getter
+public class CatalogCheckpointEvent extends AbstractStorageEvent {
+
+	@Label("Device force duration in milliseconds")
+	@Description("The time spent forcing the data files to the physical device. This is the cost the checkpoint interval exists to amortise - it is paid once per checkpoint instead of once per trunk round.")
+	@ExportMetric(metricType = MetricType.GAUGE)
+	private long forceDurationMilliseconds;
+
+	@Label("Checkpoint cadence in milliseconds")
+	@Description("The time elapsed since the previous completed checkpoint. Compare against the configured checkpoint interval - sustained higher values mean checkpointing is not keeping up with the write rate.")
+	@ExportMetric(metricType = MetricType.GAUGE)
+	private long cadenceMilliseconds;
+
+	@Label("Fence depth in milliseconds")
+	@Description("How long the oldest change covered by this checkpoint waited to become durable. Bounds both the write-ahead log retention and the amount of replay a restart has to perform. Zero when the round checkpointed without deferring.")
+	@ExportMetric(metricType = MetricType.GAUGE)
+	private long fenceDepthMilliseconds;
+
+	@Label("Number of files forced")
+	@Description("The number of data files that were forced to the physical device by this checkpoint.")
+	@ExportMetric(metricType = MetricType.GAUGE)
+	private int filesForced;
+
+	public CatalogCheckpointEvent(@Nonnull String catalogName) {
+		super(catalogName);
+		this.begin();
+	}
+
+	/**
+	 * Finish the event.
+	 *
+	 * @param cadenceMilliseconds       time elapsed since the previous completed checkpoint
+	 * @param fenceDepthMilliseconds    how long the oldest change covered by this checkpoint waited for the device
+	 * @param filesForced               number of data files forced to the device
+	 * @param forceDurationMilliseconds time spent forcing those files
+	 * @return this event
+	 */
+	@Nonnull
+	public CatalogCheckpointEvent finish(
+		long cadenceMilliseconds,
+		long fenceDepthMilliseconds,
+		int filesForced,
+		long forceDurationMilliseconds
+	) {
+		this.cadenceMilliseconds = cadenceMilliseconds;
+		this.fenceDepthMilliseconds = fenceDepthMilliseconds;
+		this.filesForced = filesForced;
+		this.forceDurationMilliseconds = forceDurationMilliseconds;
+		this.end();
+		return this;
+	}
+
+}

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/TransactionManager.java
@@ -191,8 +191,23 @@ public class TransactionManager implements Closeable {
 	/**
 	 * Contains the last catalog version appended successfully to the WAL (i.e. {@link #lastAssignedCatalogVersion} that
 	 * finally arrived to WAL file).
+	 *
+	 * "Written" means the bytes were handed to the WAL, **not** that they reached the device - see
+	 * {@link #lastDurableCatalogVersion} for that. The append sequence check and every rollback /
+	 * diagnostic path want this counter, because they reason about what the WAL file already contains.
 	 */
 	private final AtomicLong lastWrittenCatalogVersion;
+	/**
+	 * Contains the last catalog version whose WAL bytes are durable on the device.
+	 *
+	 * Trails {@link #lastWrittenCatalogVersion} by however many transactions the appender managed to write
+	 * while a force was in flight. Anything that would make a transaction irreversible to the outside world
+	 * must be gated on this counter rather than on `lastWritten`: acknowledging the client, and - more
+	 * subtly - letting trunk incorporation checkpoint the version into the data files, because a bootstrap
+	 * record pointing past the durable end of the WAL would come back after a crash as a catalog whose WAL
+	 * is missing its own head.
+	 */
+	private final AtomicLong lastDurableCatalogVersion;
 	/**
 	 * Contains the ID of the last finalized transaction. This is used to skip already processed transaction.
 	 */
@@ -230,6 +245,12 @@ public class TransactionManager implements Closeable {
 	private final ReentrantLock conflictResolutionLock = new ReentrantLock(true);
 	/**
 	 * Lock used for appending to WAL.
+	 *
+	 * Do not read its fair-lock shape as evidence that appends contend: they cannot. The appending stage is
+	 * a `Flow` subscriber that requests one task at a time and `SubmissionPublisher` delivers to a
+	 * subscriber serially, so there is only ever one thread appending. What this lock still buys is the
+	 * acceptance-timeout gate in {@link #appendWalAndDiscard} - a transaction that has already spent its
+	 * budget queuing gives up here instead of joining the back of the line.
 	 */
 	private final ReentrantLock walAppendingLock = new ReentrantLock(true);
 	/**
@@ -396,6 +417,8 @@ public class TransactionManager implements Closeable {
 		this.lastCatalogSchemaVersion = new AtomicInteger(catalog.getSchema().version());
 		this.accumulatedCatalogSchemaVersionDelta = new AtomicInteger(0);
 		this.lastWrittenCatalogVersion = new AtomicLong(bootstrapAssignedVersion);
+		// whatever the WAL already contains at bootstrap is durable by definition - it survived a restart
+		this.lastDurableCatalogVersion = new AtomicLong(bootstrapAssignedVersion);
 		// this is the catalog version really used (propagated in indexes) - WAL replay will advance
 		// this to match lastWritten before any new transactions can be accepted
 		this.lastFinalizedCatalogVersion = new AtomicLong(catalog.getVersion());
@@ -719,6 +742,9 @@ public class TransactionManager implements Closeable {
 		);
 		if (theLastWrittenCatalogVersion < catalogVersion) {
 			updateLastWrittenCatalogVersion(catalogVersion);
+			// an externally advanced version (e.g. a catalog rename) is already persisted by whoever
+			// advanced it - there is no pending force to wait for, so durability tracks it immediately
+			updateLastDurableCatalogVersion(catalogVersion);
 		}
 		final long theLastFinalizedCatalogVersion = getLastFinalizedCatalogVersion();
 		Assert.isPremiseValid(
@@ -760,6 +786,47 @@ public class TransactionManager implements Closeable {
 		} finally {
 			this.conflictRingBuffer.setEffectiveLastCatalogVersion(catalogVersion);
 		}
+	}
+
+	/**
+	 * Returns the last catalog version whose WAL bytes are durable on the device.
+	 *
+	 * @return the last durable catalog version
+	 */
+	public long getLastDurableCatalogVersion() {
+		return this.lastDurableCatalogVersion.get();
+	}
+
+	/**
+	 * Publishes the fact that every catalog version up to (and including) the given one is durable.
+	 *
+	 * Monotonic by construction: the value must have been sampled before the force that covered it, and
+	 * forces are issued in append order, so a later call can never carry a lower version. It is asserted
+	 * rather than silently clamped, because a regression here would mean the durability handshake itself
+	 * is broken and the difference is not something to paper over.
+	 *
+	 * @param catalogVersion the last catalog version made durable
+	 */
+	public void updateLastDurableCatalogVersion(long catalogVersion) {
+		final long previous = this.lastDurableCatalogVersion.getAndSet(catalogVersion);
+		Assert.isPremiseValid(
+			previous <= catalogVersion,
+			"Durable catalog version must never go backwards! " +
+				"Was " + previous + ", got " + catalogVersion + "."
+		);
+		Assert.isPremiseValid(
+			catalogVersion <= getLastWrittenCatalogVersion(),
+			"Durable catalog version must never outrun the written one! " +
+				"Written " + getLastWrittenCatalogVersion() + ", got " + catalogVersion + "."
+		);
+	}
+
+	/**
+	 * Makes every WAL append issued so far durable. Callers must sample the version they intend to declare
+	 * durable **before** calling this - see {@link Catalog#syncWal()}.
+	 */
+	public void syncWal() {
+		getLivingCatalog().syncWal();
 	}
 
 	/**
@@ -1218,6 +1285,11 @@ public class TransactionManager implements Closeable {
 	/**
 	 * This method writes the contents to the WAL and discards the contents of the isolated WAL.
 	 *
+	 * The append is left **written but not durable** - the caller owns the durability handshake and must
+	 * pair it with {@link #syncWal()} plus {@link #updateLastDurableCatalogVersion(long)} before the
+	 * transaction is acknowledged or handed to trunk incorporation. That is what lets a single device sync
+	 * cover a whole batch of transactions rather than one each.
+	 *
 	 * @param transactionMutation the leading transaction mutation to write to the WAL
 	 * @param walReference        the reference to the WAL file
 	 * @return the length of the written WAL contents
@@ -1242,7 +1314,7 @@ public class TransactionManager implements Closeable {
 						"Expected version " + (theLastWrittenCatalogVersion + 1) + ", got " + transactionMutation.getVersion() + "."
 				);
 				return getLivingCatalog()
-					.appendWalAndDiscard(
+					.appendWalAndDiscardDeferringSync(
 						transactionMutation,
 						walReference
 					);
@@ -1323,9 +1395,18 @@ public class TransactionManager implements Closeable {
 					// if the transaction failed we need to replay it again
 					final long readFromVersion = Math.max(lastFinalizedVersion + 1, 2);
 					if (alive) {
-						committedMutationStream = latestCatalog.getCommittedLiveMutationStream(readFromVersion, this.lastWrittenCatalogVersion.get());
+						// bounded by the DURABLE version, not the written one: a greedy round drains as far as
+						// this bound allows and then checkpoints what it incorporated into the data files. Were
+						// the bound `lastWritten`, a round could checkpoint a version whose WAL bytes are still
+						// only in the page cache, and a crash in that window would leave a catalog claiming a
+						// version its own WAL no longer reaches
+						committedMutationStream = latestCatalog.getCommittedLiveMutationStream(
+							readFromVersion, getLastDurableCatalogVersion()
+						);
 					} else {
-						committedMutationStream = latestCatalog.getCommittedMutationStream(readFromVersion);
+						committedMutationStream = latestCatalog.getCommittedMutationStream(
+							readFromVersion
+						);
 					}
 					final Iterator<CatalogBoundMutation> mutationIterator = committedMutationStream.iterator();
 					if (!mutationIterator.hasNext()) {
@@ -1343,7 +1424,8 @@ public class TransactionManager implements Closeable {
 							"WAL mutation stream of catalog `" + getCatalogName() + "` went dry at finalized " +
 								"version " + lastFinalizedVersion + " without reaching requested version " +
 								nextCatalogVersion + " (last written version " +
-								this.lastWrittenCatalogVersion.get() + "). A committed transaction was not " +
+								this.lastWrittenCatalogVersion.get() + ", last durable version " +
+								this.lastDurableCatalogVersion.get() + "). A committed transaction was not " +
 								"readable - refusing to report it as already processed.",
 							"Write-ahead log mutation stream ended before reaching a committed transaction."
 						);
@@ -1676,7 +1758,9 @@ public class TransactionManager implements Closeable {
 	private long drainWal() {
 		try {
 			this.processTransactions(
-				this.lastWrittenCatalogVersion.get(),
+				// the drainer may only chase versions that are already durable - same reasoning as the
+				// round bound inside `processTransactions`
+				getLastDurableCatalogVersion(),
 				this.configuration.transaction().flushFrequencyInMillis(),
 				true,
 				false, // we should not wait for the lock here - if its already running it will process the transactions

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/stage/ConflictResolutionAndWalAppendingTransactionStage.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/stage/ConflictResolutionAndWalAppendingTransactionStage.java
@@ -27,6 +27,7 @@ import io.evitadb.api.CommitProgress.CommitVersions;
 import io.evitadb.api.CommitProgressRecord;
 import io.evitadb.api.TransactionContract.CommitBehavior;
 import io.evitadb.api.exception.ConflictingCatalogMutationException;
+import io.evitadb.api.exception.TransactionException;
 import io.evitadb.api.requestResponse.mutation.conflict.ConflictKey;
 import io.evitadb.api.requestResponse.mutation.infrastructure.TransactionMutation;
 import io.evitadb.core.catalog.Catalog;
@@ -46,12 +47,15 @@ import lombok.extern.slf4j.Slf4j;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.time.OffsetDateTime;
+import java.util.ArrayDeque;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.SubmissionPublisher;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 
 /**
@@ -61,6 +65,15 @@ import java.util.function.BiConsumer;
  *
  * It processes {@link ConflictResolutionAndWalAppendingTransactionTask} objects and produces {@link TrunkIncorporationTransactionTask}
  * objects.
+ *
+ * Tasks are still delivered to this stage strictly one at a time, but the stage no longer waits for the
+ * WAL to reach the device before taking the next one. An append leaves the transaction merely written and
+ * parks it on an internal queue; a separate sync task forces the WAL and only then notifies the client and
+ * hands the transaction to trunk incorporation. Everything appended while a force is in flight is carried
+ * by that force's successor, so one device sync serves a whole batch instead of one transaction - which is
+ * what lifts sustained commit throughput off the per-transaction fsync ceiling. The trade is the usual one
+ * for group commit: under load a transaction can wait for the tail of an in-flight force plus the next one,
+ * so WAL-persistence latency at the high percentiles rises while throughput does.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
@@ -74,6 +87,44 @@ public final class ConflictResolutionAndWalAppendingTransactionStage
 	 * Publisher that emits {@link TrunkIncorporationTransactionTask} objects to be processed by the next stage.
 	 */
 	private final SubmissionPublisher<TrunkIncorporationTransactionTask> publisher;
+	/**
+	 * Executor the WAL syncing task is dispatched to. It is the same pool the publisher hands tasks to the
+	 * next stage on - the sync task occupies a thread only while a force is actually in flight and
+	 * re-dispatches itself instead of parking, so it costs no permanently blocked thread.
+	 */
+	private final Executor executor;
+	/**
+	 * Transactions whose bytes are in the WAL but which no force has covered yet, in append order.
+	 *
+	 * This queue *is* the group commit: the appending thread pushes onto it and returns immediately, so
+	 * everything that accumulates while a force is in flight gets carried to the device by the next single
+	 * force instead of paying for one each.
+	 */
+	private final ArrayDeque<PendingDurability> pendingDurability = new ArrayDeque<>(64);
+	/**
+	 * Guards {@link #pendingDurability}, which is touched by the appending thread and the syncing task - the
+	 * appender keeps adding at the tail while the syncer drains the head, which is precisely what lets one device
+	 * force cover a whole batch.
+	 *
+	 * It is not enough to make the deque itself thread-safe: {@link #releaseDurableTransactions} peeks the head and
+	 * then removes it, and those two steps must be **atomic** against each other. Swapping in a concurrent
+	 * collection would keep each individual operation safe while silently relying on an invariant enforced
+	 * elsewhere - that {@link #syncInFlight} admits only one syncer at a time.
+	 */
+	private final ReentrantLock pendingDurabilityLock = new ReentrantLock();
+	/**
+	 * TRUE while a sync task is dispatched or running, so appends do not pile up redundant sync tasks.
+	 */
+	private final AtomicBoolean syncInFlight = new AtomicBoolean();
+	/**
+	 * Set to the failure that broke the WAL durability handshake, which permanently fail-stops this stage.
+	 *
+	 * A force that fails means the device is not accepting the log any more; every transaction appended
+	 * after that point could never be made durable, so accepting more of them would hand out commit
+	 * acknowledgements that can never be honoured. Deliberately one-way - recovering the WAL is a restart
+	 * concern, not something a commit path should attempt.
+	 */
+	private volatile Throwable walDurabilityFailure;
 
 	public ConflictResolutionAndWalAppendingTransactionStage(
 		@Nonnull Executor executor,
@@ -82,6 +133,7 @@ public final class ConflictResolutionAndWalAppendingTransactionStage
 		@Nonnull BiConsumer<TransactionTask, Throwable> onException
 	) {
 		super(transactionManager, onException);
+		this.executor = executor;
 		this.publisher = new SubmissionPublisher<>(executor, maxBufferCapacity);
 	}
 
@@ -105,6 +157,16 @@ public final class ConflictResolutionAndWalAppendingTransactionStage
 			task.commitProgress() != null,
 			"Future is unexpectedly null in the first stage!"
 		);
+
+		// refuse up front once the WAL has stopped being able to accept durable writes - see the field
+		final Throwable durabilityFailure = this.walDurabilityFailure;
+		if (durabilityFailure != null) {
+			throw new TransactionException(
+				"Write-ahead log of catalog `" + task.catalogName() + "` can no longer be made durable - " +
+					"refusing to accept further transactions.",
+				durabilityFailure
+			);
+		}
 
 		final long expectedCatalogVersion = this.transactionManager.getLastAssignedCatalogVersion() + 1L;
 		// track how many catalog versions / schema deltas must be rolled back if something throws below
@@ -130,28 +192,15 @@ public final class ConflictResolutionAndWalAppendingTransactionStage
 			// and the version cannot be reclaimed without corrupting the mutation stream
 			droppedCatalogVersions = 0;
 			droppedCatalogSchemaVersionDelta = 0;
-			// notify client at this moment that the transaction is safely written to the WAL
-			// the push to next stage might fail, but the WAL is already written
-			task.commitProgress()
-				.complete(
-					CommitBehavior.WAIT_FOR_WAL_PERSISTENCE,
-					commitVersions,
-					this.transactionManager.getRequestExecutor()
-				);
+			// the bytes are in the WAL, so the reserved version is spoken for and the append-ordering
+			// check for the next transaction must already see it
 			this.transactionManager.updateLastWrittenCatalogVersion(commitVersions.catalogVersion());
-			// emit the event
-			walAppendEvent.finish(task.mutationCount() + 1, writtenLength).commit();
-			// and continue with trunk incorporation
-			push(
-				task,
-				new TrunkIncorporationTransactionTask(
-					task.catalogName(),
-					commitVersions.catalogVersion(),
-					commitVersions.catalogSchemaVersion(),
-					task.transactionId(),
-					task.commitProgress()
-				),
-				this.publisher
+			// the client is deliberately NOT notified here, nor is the task pushed onward:
+			// WAIT_FOR_WAL_PERSISTENCE promises the change survives a crash and nothing has reached the
+			// device yet. Both happen once a force covers this transaction, which also keeps trunk
+			// incorporation from ever checkpointing a version the WAL does not durably hold
+			enqueueForDurability(
+				new PendingDurability(task, commitVersions, walAppendEvent, writtenLength)
 			);
 		} catch (RuntimeException ex) {
 			// count only genuine conflict-induced rollbacks - not WAL mismatches or other runtime failures -
@@ -169,6 +218,214 @@ public final class ConflictResolutionAndWalAppendingTransactionStage
 			);
 			// rethrow the exception to be handled by the exception handler
 			throw ex;
+		}
+	}
+
+	/**
+	 * Records a written-but-not-yet-durable transaction and makes sure a sync task is on its way.
+	 *
+	 * @param pending the transaction awaiting a force
+	 */
+	private void enqueueForDurability(@Nonnull PendingDurability pending) {
+		this.pendingDurabilityLock.lock();
+		try {
+			this.pendingDurability.addLast(pending);
+		} finally {
+			this.pendingDurabilityLock.unlock();
+		}
+		scheduleSync();
+	}
+
+	/**
+	 * Dispatches the sync task unless one is already dispatched or running - in which case that one will
+	 * pick up whatever was just enqueued, because it re-reads the queue after every force.
+	 */
+	private void scheduleSync() {
+		if (this.syncInFlight.compareAndSet(false, true)) {
+			try {
+				this.executor.execute(this::syncPendingTransactions);
+			} catch (RuntimeException ex) {
+				// the task never started, so nothing else will ever clear the flag
+				this.syncInFlight.set(false);
+				failPendingDurability(ex);
+			}
+		}
+	}
+
+	/**
+	 * Forces the WAL and releases everything the force covered, repeating while transactions keep arriving.
+	 *
+	 * Each pass samples the queue's tail **before** forcing and credits only up to that version;
+	 * transactions appended while the force is in flight are covered by the next pass. Sampling after the
+	 * force would acknowledge transactions the device was never asked about.
+	 */
+	private void syncPendingTransactions() {
+		try {
+			while (true) {
+				final long durableUpTo;
+				this.pendingDurabilityLock.lock();
+				try {
+					final PendingDurability last = this.pendingDurability.peekLast();
+					if (last == null) {
+						break;
+					}
+					durableUpTo = last.commitVersions().catalogVersion();
+				} finally {
+					this.pendingDurabilityLock.unlock();
+				}
+				if (!forceAndRelease(durableUpTo)) {
+					// the WAL is gone - `failPendingDurability` has already emptied the queue
+					return;
+				}
+			}
+		} finally {
+			this.syncInFlight.set(false);
+			// Hand the work on if anything is still queued. Two distinct cases reach this, and both need it:
+			//
+			// 1. An append landed between the last queue read and the flag clearing above. That appender saw the
+			//    flag still set and skipped scheduling, so nobody else will.
+			// 2. Something escaped the loop. The flag has just been cleared, but the queue was NOT emptied - unlike
+			//    the fail-stop exit, where `failPendingDurability` empties it first. Leaving it here would strand
+			//    written-but-unforced transactions until some later append happened to re-arm the syncer, and if no
+			//    further write ever arrives their clients wait on durability forever.
+			//
+			// Deliberately inside the `finally` for case 2: a statement after the try block would be skipped by the
+			// very exception that makes the re-dispatch necessary. Re-dispatching cannot spin - each pass of
+			// `releaseDurableTransactions` removes its entry before doing anything that can throw, so progress is
+			// made even when the failure repeats.
+			if (hasPendingDurability()) {
+				scheduleSync();
+			}
+		}
+	}
+
+	/**
+	 * Forces the WAL, publishes the new durable version and releases every transaction it covered.
+	 *
+	 * @param durableUpTo the catalog version sampled before the force
+	 * @return FALSE when the force failed and this stage has fail-stopped
+	 */
+	private boolean forceAndRelease(long durableUpTo) {
+		try {
+			this.transactionManager.syncWal();
+			// published before the tasks are pushed onward, so trunk incorporation's round bound already
+			// includes everything it is about to be handed
+			this.transactionManager.updateLastDurableCatalogVersion(durableUpTo);
+		} catch (RuntimeException ex) {
+			failPendingDurability(ex);
+			return false;
+		}
+		releaseDurableTransactions(durableUpTo);
+		return true;
+	}
+
+	/**
+	 * Notifies clients and hands to trunk incorporation every transaction now known to be durable, in
+	 * append order.
+	 *
+	 * A failure while releasing one transaction must not strand the rest, so each is released under its own
+	 * guard - the WAL itself is fine at this point, the transaction is durable, and the only thing that can
+	 * throw here is downstream bookkeeping.
+	 *
+	 * @param durableUpTo the highest catalog version the completed force covered
+	 */
+	private void releaseDurableTransactions(long durableUpTo) {
+		while (true) {
+			final PendingDurability pending;
+			this.pendingDurabilityLock.lock();
+			try {
+				final PendingDurability head = this.pendingDurability.peekFirst();
+				if (head == null || head.commitVersions().catalogVersion() > durableUpTo) {
+					break;
+				}
+				pending = this.pendingDurability.removeFirst();
+			} finally {
+				this.pendingDurabilityLock.unlock();
+			}
+			try {
+				// notify the client - at this point the transaction genuinely survives a crash
+				pending.task().commitProgress()
+					.complete(
+						CommitBehavior.WAIT_FOR_WAL_PERSISTENCE,
+						pending.commitVersions(),
+						this.transactionManager.getRequestExecutor()
+					);
+				// the event now spans the append *and* the wait for the force that covered it, which is
+				// what "appended to WAL" costs a transaction from the commit path's point of view
+				pending.walAppendEvent()
+					.finish(pending.task().mutationCount() + 1, pending.writtenLength())
+					.commit();
+				// and continue with trunk incorporation
+				push(
+					pending.task(),
+					new TrunkIncorporationTransactionTask(
+						pending.task().catalogName(),
+						pending.commitVersions().catalogVersion(),
+						pending.commitVersions().catalogSchemaVersion(),
+						pending.task().transactionId(),
+						pending.task().commitProgress()
+					),
+					this.publisher
+				);
+			} catch (RuntimeException ex) {
+				handleException(pending.task(), ex);
+			}
+		}
+	}
+
+	/**
+	 * Fail-stops the stage after the WAL could not be made durable and fails every transaction that was
+	 * waiting on that force.
+	 *
+	 * No attempt is made to roll the catalog versions back. Their bytes are in the WAL file already, the
+	 * device has stopped accepting writes, and recovery truncates the unreadable tail on restart - trying
+	 * to unwind counters in that state would add a second, less predictable failure on top of the first.
+	 *
+	 * @param cause the failure that broke the durability handshake
+	 */
+	private void failPendingDurability(@Nonnull Throwable cause) {
+		if (this.walDurabilityFailure == null) {
+			this.walDurabilityFailure = cause;
+		}
+		while (true) {
+			final PendingDurability pending;
+			this.pendingDurabilityLock.lock();
+			try {
+				pending = this.pendingDurability.pollFirst();
+			} finally {
+				this.pendingDurabilityLock.unlock();
+			}
+			if (pending == null) {
+				break;
+			}
+			log.error(
+				"Transaction {} (catalogVersion={}) on catalog `{}` was written to the WAL but could not be " +
+					"made durable - failing it. No further transaction will be accepted by this catalog.",
+				pending.task().transactionId(),
+				pending.commitVersions().catalogVersion(),
+				pending.task().catalogName(),
+				cause
+			);
+			try {
+				pending.task().commitProgress().completeExceptionally(cause);
+			} catch (RuntimeException ex) {
+				log.error(
+					"Failed to notify transaction {} on catalog `{}` about the WAL durability failure.",
+					pending.task().transactionId(), pending.task().catalogName(), ex
+				);
+			}
+		}
+	}
+
+	/**
+	 * @return TRUE when at least one transaction is still awaiting a force
+	 */
+	private boolean hasPendingDurability() {
+		this.pendingDurabilityLock.lock();
+		try {
+			return !this.pendingDurability.isEmpty();
+		} finally {
+			this.pendingDurabilityLock.unlock();
 		}
 	}
 
@@ -436,6 +693,23 @@ public final class ConflictResolutionAndWalAppendingTransactionStage
 			);
 			throw ex;
 		}
+	}
+
+	/**
+	 * A transaction whose bytes are in the WAL but which no force has covered yet.
+	 *
+	 * @param task            the originating task - the client is notified and the trunk task built from it
+	 *                        once the transaction turns durable
+	 * @param commitVersions  the versions assigned to the transaction
+	 * @param walAppendEvent  the metric event opened before the append, finished when the force lands
+	 * @param writtenLength   number of bytes the append wrote
+	 */
+	private record PendingDurability(
+		@Nonnull ConflictResolutionAndWalAppendingTransactionTask task,
+		@Nonnull CommitVersions commitVersions,
+		@Nonnull TransactionAppendedToWalEvent walAppendEvent,
+		long writtenLength
+	) {
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/stage/TrunkIncorporationTransactionStage.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/stage/TrunkIncorporationTransactionStage.java
@@ -59,11 +59,15 @@ import java.util.function.BiConsumer;
 public final class TrunkIncorporationTransactionStage
 	extends AbstractTransactionStage<TrunkIncorporationTransactionTask> {
 	/**
-	 * The timeout in nanoseconds determining the maximum time the task is allowed to consume multiple transaction.
+	 * The timeout in **milliseconds** determining the maximum time the task is allowed to consume multiple transaction.
 	 * It might be exceeded if the single transaction processing takes too long, but if the single transaction is very
 	 * fast it tries to process next one until the timeout is exceeded.
+	 *
+	 * The unit has to stay milliseconds, because this value is handed to
+	 * {@link TransactionManager#processTransactions(long, long, boolean, boolean, java.util.function.LongConsumer)}
+	 * as its `timeoutMs` argument, and is ultimately compared against a `System.currentTimeMillis()` delta.
 	 */
-	private final long timeout;
+	private final long timeoutInMillis;
 
 	public TrunkIncorporationTransactionStage(
 		@Nonnull TransactionManager transactionManager,
@@ -71,7 +75,7 @@ public final class TrunkIncorporationTransactionStage
 		@Nonnull BiConsumer<TransactionTask, Throwable> onException
 	) {
 		super(transactionManager, onException);
-		this.timeout = timeoutInMillis * 1_000_000;
+		this.timeoutInMillis = timeoutInMillis;
 	}
 
 	@Override
@@ -99,7 +103,7 @@ public final class TrunkIncorporationTransactionStage
 			final TransactionIncorporatedToTrunkEvent event = new TransactionIncorporatedToTrunkEvent(this.transactionManager.getCatalogName());
 			this.transactionManager.processTransactions(
 					task.catalogVersion(),
-					this.timeout,
+					this.timeoutInMillis,
 					true,
 					true, // we want to wait for lock so that we can complete the commit progress record
 					Functions.noOpLongConsumer()

--- a/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/CatalogPersistenceService.java
+++ b/evita_engine/src/main/java/io/evitadb/spi/store/catalog/persistence/CatalogPersistenceService.java
@@ -82,7 +82,8 @@ import java.util.stream.Stream;
  * - Reading and writing the {@link io.evitadb.spi.store.catalog.header.model.CatalogHeader} (the root metadata record)
  * - Managing the catalog-level offset-index file (via {@link #getStoragePartPersistenceService(long)})
  * - Creating and providing access to per-collection {@link EntityCollectionPersistenceService} instances
- * - Appending to and reading from the Write-Ahead-Log (WAL) via {@link #appendWalAndDiscard} and the mutation streams
+ * - Appending to and reading from the Write-Ahead-Log (WAL) via {@link #appendWalAndDiscardDeferringSync} and the
+ *   mutation streams
  * - Creating backups, restoring from backups, and duplicating catalogs
  * - Reporting catalog version history and point-in-time queries
  *
@@ -253,11 +254,29 @@ public non-sealed interface CatalogPersistenceService<S extends LogRecordReferen
 	<W extends StorageDescriptor> CatalogStoragePartPersistenceService<S, T, W> getStoragePartPersistenceService(long catalogVersion);
 
 	/**
-	 * Returns the last catalog version that was written to the persistent storage.
+	 * Returns the last catalog version that was **checkpointed** to the persistent storage.
 	 *
-	 * @return the last catalog version that was written to the persistent storage
+	 * With a checkpoint interval configured this may lag {@link #getLastAppliedCatalogVersion()} - which answers the
+	 * different question of what has been *written* - by up to that interval. That is the intended meaning: the
+	 * answer this method gives is used to tell a failure that struck before durability from one that struck after,
+	 * and a version that has not been checkpointed genuinely is not on disk - a restart resumes below it and replays
+	 * the rest from the write-ahead log.
+	 *
+	 * @return the last catalog version whose checkpoint completed
 	 */
 	long getLastCatalogVersion();
+
+	/**
+	 * Returns the last catalog version whose header was written, whether or not it has been checkpointed.
+	 *
+	 * Answers "has anything been stored since?", which is a different question from
+	 * {@link #getLastCatalogVersion()}'s "what is safely on the device?". Callers deciding whether a round has
+	 * anything to write want this one, otherwise every round between two checkpoints looks like a change.
+	 *
+	 * @return the last catalog version handed to
+	 *         {@link #storeHeader(UUID, CatalogState, long, int, TransactionMutation, List, DataStoreMemoryBuffer)}
+	 */
+	long getLastAppliedCatalogVersion();
 
 	/**
 	 * Returns {@link CatalogHeader} that is used for this service. The header is initialized in the instance constructor
@@ -397,16 +416,32 @@ public non-sealed interface CatalogPersistenceService<S extends LogRecordReferen
 	 * Appends the given transaction mutation to the write-ahead log (WAL) and appends its mutation chain taken from
 	 * offHeapWithFileBackupReference. After that it discards the specified off-heap data with file backup reference.
 	 *
+	 * The transaction is **not** durable when this method returns - only written. The caller takes over the
+	 * obligation to call {@link #syncWal()} and must not report the transaction as persisted to anyone
+	 * (nor let it be checkpointed into the data files) until that force has completed.
+	 *
+	 * This is what allows one device sync to cover a whole batch of transactions instead of one each:
+	 * the appending thread keeps writing while an earlier force is still in flight.
+	 *
 	 * @param catalogVersion      current version of the catalog
 	 * @param transactionMutation The transaction mutation to append to the WAL.
 	 * @param walReference        The off-heap data with file backup reference to discard.
 	 * @return the number of Bytes written
 	 */
-	long appendWalAndDiscard(
+	long appendWalAndDiscardDeferringSync(
 		long catalogVersion,
 		@Nonnull TransactionMutation transactionMutation,
 		@Nonnull LogRecordReference walReference
 	);
+
+	/**
+	 * Makes everything appended to the WAL so far durable.
+	 *
+	 * Callers that intend to declare a particular catalog version durable must sample that version
+	 * **before** calling this method - appends landing while the force is in flight may or may not be
+	 * covered by it. A WAL that has never been written is a no-op.
+	 */
+	void syncWal();
 
 	/**
 	 * Retrieves the first non-processed transaction in the WAL.

--- a/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/EvitaJfrEventRegistry.java
+++ b/evita_external_api/evita_external_api_observability/src/main/java/io/evitadb/externalApi/observability/metric/EvitaJfrEventRegistry.java
@@ -36,6 +36,7 @@ import io.evitadb.core.metric.event.query.FinishedEvent;
 import io.evitadb.core.metric.event.session.ClosedEvent;
 import io.evitadb.core.metric.event.session.KilledEvent;
 import io.evitadb.core.metric.event.session.OpenedEvent;
+import io.evitadb.core.metric.event.storage.CatalogCheckpointEvent;
 import io.evitadb.core.metric.event.storage.CatalogStatisticsEvent;
 import io.evitadb.core.metric.event.storage.DataFileCompactEvent;
 import io.evitadb.core.metric.event.storage.ObservableOutputChangeEvent;
@@ -120,6 +121,7 @@ public class EvitaJfrEventRegistry {
 		ReadOnlyHandleOpenedEvent.class,
 		ReadOnlyHandleClosedEvent.class,
 		CatalogStatisticsEvent.class,
+		CatalogCheckpointEvent.class,
 		TrafficRecorderStatisticsEvent.class,
 		TrafficRecorderSkippedRecordsEvent.class,
 

--- a/evita_server/src/main/resources/evita-configuration.yaml
+++ b/evita_server/src/main/resources/evita-configuration.yaml
@@ -68,7 +68,8 @@ transaction:
   transactionMemoryRegionCount: ${transaction.memoryRegionCount:256}
   walFileSizeBytes: ${transaction.walFilSize:16M}
   walFileCountKept: ${transaction.walFileCountKept:8}
-  flushFrequencyInMillis: ${transaction.flushFrequencyInMillis:1000}
+  flushFrequencyInMillis: ${transaction.flushFrequencyInMillis:10000}
+  checkpointIntervalInMillis: ${transaction.checkpointIntervalInMillis:1000}
   conflictRingBufferSize: ${transaction.conflictRingBufferSize:65536}
   conflictPolicy: ${transaction.conflictPolicy:[ENTITY]}
 

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/BootstrapWriteOnlyFileHandle.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/BootstrapWriteOnlyFileHandle.java
@@ -31,13 +31,17 @@ import io.evitadb.store.checksum.ChecksumFactory;
 import io.evitadb.store.compression.CompressionFactory;
 import io.evitadb.store.kryo.ObservableOutput;
 import io.evitadb.store.offsetIndex.OffsetIndex;
+import io.evitadb.store.offsetIndex.exception.SyncFailedException;
 import io.evitadb.utils.Assert;
 import lombok.Getter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
@@ -202,6 +206,18 @@ public class BootstrapWriteOnlyFileHandle implements WriteOnlyHandle {
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			throw new GenericEvitaInternalError(operation + " due to interrupt!");
+		}
+	}
+
+	@Override
+	public void forceDurable() {
+		// the bootstrap record is the checkpoint POINTER - it is never itself deferred, because it may only
+		// become durable after everything it addresses already is. This implementation exists to satisfy the
+		// contract; on the deferred-checkpoint path the bootstrap handle keeps syncing inline.
+		try (final FileChannel channel = FileChannel.open(this.targetFile, StandardOpenOption.WRITE)) {
+			channel.force(true);
+		} catch (IOException e) {
+			throw new SyncFailedException(e);
 		}
 	}
 

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/PendingSyncRegistry.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/PendingSyncRegistry.java
@@ -1,0 +1,59 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.offsetIndex.io;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Collects the write handles whose bytes have reached the operating system page cache but have not yet been forced
+ * to the physical device, so that something else can make them durable later.
+ *
+ * A {@link WriteOnlyHandle} constructed with a registry stops issuing its own `fsync` at the end of a write and calls
+ * {@link #noteSyncPending(WriteOnlyHandle)} instead. The buffer flush still happens - only the device flush moves. Whoever
+ * owns the registry is then responsible for calling {@link WriteOnlyHandle#forceDurable()} on everything noted here
+ * **before** writing any record that points at those bytes.
+ *
+ * Handles register themselves rather than being enumerated by the checkpoint, which is what keeps the set from
+ * drifting: a file cannot be written through a deferring handle without landing in the registry.
+ *
+ * Implementations must be safe to call from any thread - the read path forces a soft flush when a caller reads
+ * a record that is still sitting in the write buffer, so this is reached from request threads and not only from
+ * the thread that drives trunk incorporation.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@FunctionalInterface
+public interface PendingSyncRegistry {
+
+	/**
+	 * Records that the given handle has written bytes that are not yet on the physical device.
+	 *
+	 * Called after the buffer has been flushed, so registration always implies the bytes are at least in the page
+	 * cache. Registering a handle that is already registered is a no-op.
+	 *
+	 * @param handle the handle whose target file needs forcing before anything may point at its newest records
+	 */
+	void noteSyncPending(@Nonnull WriteOnlyHandle handle);
+
+}

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/WriteOnlyFileHandle.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/WriteOnlyFileHandle.java
@@ -37,6 +37,7 @@ import io.evitadb.store.offsetIndex.exception.InvalidStoragePathException;
 import io.evitadb.store.offsetIndex.exception.SyncFailedException;
 import io.evitadb.utils.Assert;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -44,7 +45,10 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
@@ -62,6 +66,7 @@ import static io.evitadb.utils.Assert.isPremiseValid;
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2021
  */
+@Slf4j
 public class WriteOnlyFileHandle implements WriteOnlyHandle {
 	/**
 	 * Logical name of the file that backs the {@link OffsetIndex} - used for observability.
@@ -92,6 +97,16 @@ public class WriteOnlyFileHandle implements WriteOnlyHandle {
 	 * Sourced from {@link StorageOptions#syncWrites()}.
 	 */
 	private final boolean syncWrites;
+	/**
+	 * When set, the device flush at the end of each write is handed to this registry instead of being issued inline,
+	 * and the file is made durable later by whoever owns the registry (see {@link PendingSyncRegistry}). The buffer
+	 * flush is unaffected either way.
+	 *
+	 * Null restores the historical behaviour: sync inline whenever {@link #syncWrites} is set. Only the catalog and
+	 * entity collection data files - the ones a trunk round writes and a checkpoint later forces - are given
+	 * a registry; the bootstrap file, the engine files and the write-ahead log keep syncing inline.
+	 */
+	@Nullable private final PendingSyncRegistry pendingSyncRegistry;
 	/**
 	 * Factory for creating checksums for data integrity verification during write operations.
 	 * Sourced from {@link StorageOptions#computeCRC32C()}.
@@ -238,6 +253,49 @@ public class WriteOnlyFileHandle implements WriteOnlyHandle {
 		}
 	}
 
+	/**
+	 * Flushes the write buffer and then either forces the bytes to the device or notes the file as owing a force.
+	 *
+	 * Only the **device** flush is ever deferred. `os.flush()` runs on both paths, so offsets are assigned, the Kryo
+	 * buffer is released and the freshly written records are readable through the page cache exactly as before -
+	 * everything downstream of this call sees the same state either way. What changes is solely when the operating
+	 * system is told to put those pages on the platter.
+	 *
+	 * @param os the output whose buffer is to be flushed
+	 */
+	private void doSyncOrDefer(@Nonnull ObservableOutput<FileOutputStream> os) {
+		if (this.pendingSyncRegistry == null) {
+			doSync(os, this.syncWrites);
+		} else {
+			doSync(os, false);
+			this.pendingSyncRegistry.noteSyncPending(this);
+		}
+	}
+
+	@Override
+	public void forceDurable() {
+		// deliberately opened fresh rather than reusing the output's descriptor: ObservableOutputKeeper owns
+		// that one and may have released it since the write. fsync is a property of the file, not of the
+		// descriptor, so a new channel flushes exactly the same dirty pages. The extra open/close is a couple
+		// of microseconds against a device flush measured at ~5 ms on this class of storage.
+		try (final FileChannel channel = FileChannel.open(this.targetFile, StandardOpenOption.WRITE)) {
+			// force(true) - metadata included. On an appended file the length IS metadata, and a stale length
+			// silently truncates the very records the bootstrap record is about to point at.
+			channel.force(true);
+		} catch (NoSuchFileException e) {
+			// a REAL state, not an unhandled branch: compaction rewrites a data file under a new index and deletes
+			// the old one, so a handle noted as owing a force may name a file that no longer exists by the time the
+			// checkpoint runs. There is nothing left to make durable - no record written from here on can point into
+			// a deleted file, and compaction fsyncs the replacement itself before the bootstrap record naming it is
+			// written. Forcing a file that is gone is not possible and not needed.
+			if (log.isDebugEnabled()) {
+				log.debug("Skipping deferred sync of `{}` - the file no longer exists.", this.targetFile);
+			}
+		} catch (IOException e) {
+			throw new SyncFailedException(e);
+		}
+	}
+
 	public WriteOnlyFileHandle(
 		@Nonnull Path targetFile,
 		int outputBufferSize,
@@ -281,6 +339,38 @@ public class WriteOnlyFileHandle implements WriteOnlyHandle {
 		@Nonnull Path targetFile,
 		@Nonnull ObservableOutputKeeper observableOutputKeeper
 	) {
+		this(
+			catalogName, fileType, logicalName, outputBufferSize, syncWrites,
+			checksumFactory, compressionFactory, targetFile, observableOutputKeeper, null
+		);
+	}
+
+	/**
+	 * Creates a handle whose device flush is deferred to a checkpoint instead of being issued at the end of every
+	 * write.
+	 *
+	 * @param pendingSyncRegistry registry notified after each write instead of issuing `fsync`; null keeps the
+	 *                            historical inline-sync behaviour
+	 */
+	public WriteOnlyFileHandle(
+		@Nullable String catalogName,
+		@Nullable FileType fileType,
+		@Nullable String logicalName,
+		int outputBufferSize,
+		boolean syncWrites,
+		@Nonnull ChecksumFactory checksumFactory,
+		@Nonnull CompressionFactory compressionFactory,
+		@Nonnull Path targetFile,
+		@Nonnull ObservableOutputKeeper observableOutputKeeper,
+		@Nullable PendingSyncRegistry pendingSyncRegistry
+	) {
+		// deferring a sync that would never have been issued would make the checkpoint force files for an operator
+		// who explicitly turned durability off - the two settings are orthogonal and the caller resolves them
+		isPremiseValid(
+			pendingSyncRegistry == null || syncWrites,
+			"Deferred sync must not be configured on a handle that does not sync at all!"
+		);
+		this.pendingSyncRegistry = pendingSyncRegistry;
 		this.catalogName = catalogName;
 		this.fileType = fileType;
 		this.logicalName = logicalName;
@@ -327,7 +417,7 @@ public class WriteOnlyFileHandle implements WriteOnlyHandle {
 						this::createObservableOutput,
 						observableOutput -> {
 							logic.accept(observableOutput);
-							doSync(observableOutput, this.syncWrites);
+							doSyncOrDefer(observableOutput);
 						}
 					);
 					return;
@@ -353,7 +443,7 @@ public class WriteOnlyFileHandle implements WriteOnlyHandle {
 						this::createObservableOutput,
 						observableOutput -> {
 							final S result = logic.apply(observableOutput);
-							doSync(observableOutput, this.syncWrites);
+							doSyncOrDefer(observableOutput);
 							return postExecutionLogic.apply(observableOutput, result);
 						}
 					);

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/WriteOnlyHandle.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/WriteOnlyHandle.java
@@ -76,6 +76,23 @@ public interface WriteOnlyHandle extends Closeable {
 	<S, T> T checkAndExecuteAndSync(@Nonnull String operation, @Nonnull Runnable premise, @Nonnull Function<ObservableOutput<?>, S> logic, @Nonnull BiFunction<ObservableOutput<?>, S, T> postExecutionLogic);
 
 	/**
+	 * Forces everything written through this handle so far to the physical device, out of band with the
+	 * `checkAndExecuteAndSync` methods above.
+	 *
+	 * This exists for the deferred-checkpoint write path: when the data-file fsync is taken off the trunk
+	 * round's critical path, the round writes and flushes its bytes into the page cache and a checkpoint task
+	 * makes them durable afterwards - before the bootstrap record that points at them is written.
+	 *
+	 * Implementations must NOT rely on retaining the descriptor the bytes were written through.
+	 * `ObservableOutputKeeper` owns the lifetime of the output used by `checkAndExecuteAndSync`, and it may
+	 * release it before a deferred sync ever runs. Syncing the file through a freshly opened descriptor is
+	 * equivalent - fsync flushes the *file's* dirty pages, not the descriptor's.
+	 *
+	 * Callers must treat this as the durability point: it returns only once the device has acknowledged.
+	 */
+	void forceDurable();
+
+	/**
 	 * Returns the last position that was already written to the output.
 	 *
 	 * @return last written position

--- a/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/WriteOnlyOffHeapWithFileBackupHandle.java
+++ b/evita_store/evita_store_key_value/src/main/java/io/evitadb/store/offsetIndex/io/WriteOnlyOffHeapWithFileBackupHandle.java
@@ -48,6 +48,7 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -208,6 +209,22 @@ public class WriteOnlyOffHeapWithFileBackupHandle implements WriteOnlyHandle {
 			(o) -> postExecutionLogic.apply(o, logic.apply(o)),
 			true
 		);
+	}
+
+	@Override
+	public void forceDurable() {
+		// this handle backs an isolated transaction WAL, not the checkpointed catalog data files, so it is not
+		// on the deferred-checkpoint path. It is implemented anyway so the contract holds for every handle.
+		// While the content still lives off-heap there is no file to force - that is a real state of this
+		// handle (nothing has spilled yet), not an unhandled branch: the bytes are not on disk at all, so no
+		// fsync could make them durable. Once it has spilled, the backing file is forced like any other.
+		if (this.fileOutput != null) {
+			try (final FileChannel channel = FileChannel.open(this.targetFile, StandardOpenOption.WRITE)) {
+				channel.force(true);
+			} catch (IOException e) {
+				throw new SyncFailedException(e);
+			}
+		}
 	}
 
 	@Override

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/CatalogOffsetIndexStoragePartPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/CatalogOffsetIndexStoragePartPersistenceService.java
@@ -43,6 +43,7 @@ import io.evitadb.store.offsetIndex.OffsetIndex.NonFlushedBlock;
 import io.evitadb.store.offsetIndex.OffsetIndexBuilder;
 import io.evitadb.store.offsetIndex.OffsetIndexDescriptor;
 import io.evitadb.store.offsetIndex.io.CatalogOffHeapMemoryManager;
+import io.evitadb.store.offsetIndex.io.PendingSyncRegistry;
 import io.evitadb.store.offsetIndex.io.WriteOnlyFileHandle;
 import io.evitadb.store.offsetIndex.model.OffsetIndexRecordTypeRegistry;
 import io.evitadb.store.offsetIndex.model.RecordKey;
@@ -88,7 +89,7 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 	/**
 	 * Creates a CatalogOffsetIndexStoragePartPersistenceService object with the given parameters.
 	 * The code cannot be directly in the constructor, because we need to execute
-	 * {@link #loadOffsetIndex(String, Path, StorageSettings, CatalogBootstrap, OffsetIndexRecordTypeRegistry, ObservableOutputKeeper, Function, Consumer, Consumer, Consumer)}
+	 * {@link #loadOffsetIndex(String, Path, StorageSettings, CatalogBootstrap, OffsetIndexRecordTypeRegistry, ObservableOutputKeeper, Function, Consumer, Consumer, Consumer, PendingSyncRegistry)}
 	 * and within it initialize the {@link #currentCatalogHeader} variable. This cannot be done in the consturctor
 	 * because the super constructor needs to be called first.
 	 *
@@ -100,6 +101,10 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 	 * @param offHeapMemoryManager   The off-heap memory manager.
 	 * @param observableOutputKeeper The observable output keeper.
 	 * @param kryoFactory            The factory to create Kryo instances.
+	 * @param nonFlushedBlockObserver Observer notified about the volume of data not yet promoted, or null.
+	 * @param historyKeptObserver    Observer notified about the oldest record still retained, or null.
+	 * @param pendingSyncRegistry    Registry taking over the device flush of the catalog data file, or null to have
+	 *                               each write flushed to the device inline.
 	 * @return A CatalogOffsetIndexStoragePartPersistenceService object.
 	 */
 	@Nonnull
@@ -113,14 +118,15 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 		@Nonnull ObservableOutputKeeper observableOutputKeeper,
 		@Nonnull Function<VersionedKryoKeyInputs, VersionedKryo> kryoFactory,
 		@Nullable Consumer<NonFlushedBlock> nonFlushedBlockObserver,
-		@Nullable Consumer<Optional<OffsetDateTime>> historyKeptObserver
+		@Nullable Consumer<Optional<OffsetDateTime>> historyKeptObserver,
+		@Nullable PendingSyncRegistry pendingSyncRegistry
 	) {
 		final AtomicReference<CatalogHeader<LogFileRecordReference, CollectionFileReference>> catalogHeaderRef = new AtomicReference<>();
 		final OffsetIndex offsetIndex = loadOffsetIndex(
 			catalogName, catalogFilePath, storageSettings,
 			catalogBootstrap, recordRegistry, observableOutputKeeper,
 			kryoFactory, nonFlushedBlockObserver, historyKeptObserver,
-			catalogHeaderRef::set
+			catalogHeaderRef::set, pendingSyncRegistry
 		);
 		return new CatalogOffsetIndexStoragePartPersistenceService(
 			catalogBootstrap.catalogVersion(),
@@ -136,6 +142,8 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 	 * This is a special constructor used only when catalog is renamed. It builds on previous instance of the service
 	 * and reuses all data present in memory. Except the placement on disk nothing else is actually changed.
 	 *
+	 * @param pendingSyncRegistry Registry taking over the device flush of the catalog data file, or null to have each
+	 *                            write flushed to the device inline.
 	 * @return a new instance of the service with the same data as the previous one but different file placement
 	 */
 	@Nonnull
@@ -151,7 +159,8 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 		@Nonnull Function<VersionedKryoKeyInputs, VersionedKryo> kryoFactory,
 		@Nullable Consumer<NonFlushedBlock> nonFlushedBlockObserver,
 		@Nullable Consumer<Optional<OffsetDateTime>> historyKeptObserver,
-		@Nonnull CatalogOffsetIndexStoragePartPersistenceService previous
+		@Nonnull CatalogOffsetIndexStoragePartPersistenceService previous,
+		@Nullable PendingSyncRegistry pendingSyncRegistry
 	) {
 		final CatalogHeader<LogFileRecordReference, CollectionFileReference> catalogHeader = previous.getCatalogHeader(catalogVersion);
 		final OffsetIndex previousOffsetIndex = previous.offsetIndex;
@@ -197,7 +206,8 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 				storageSettings,
 				storageSettings,
 				catalogFilePath,
-				observableOutputKeeper
+				observableOutputKeeper,
+				pendingSyncRegistry
 			),
 			nonFlushedBlockObserver,
 			historyKeptObserver,
@@ -336,6 +346,8 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 	 * @param observableOutputKeeper The observable output keeper.
 	 * @param kryoFactory            The factory to create Kryo instances.
 	 * @param catalogHeaderConsumer  The consumer to accept the catalog header.
+	 * @param pendingSyncRegistry    Registry taking over the device flush of the catalog data file, or null to have
+	 *                               the write handle issue it inline.
 	 * @return The loaded offset index.
 	 */
 	@Nonnull
@@ -349,7 +361,8 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 		@Nonnull Function<VersionedKryoKeyInputs, VersionedKryo> kryoFactory,
 		@Nullable Consumer<NonFlushedBlock> nonFlushedBlockObserver,
 		@Nullable Consumer<Optional<OffsetDateTime>> historyKeptObserver,
-		@Nonnull Consumer<CatalogHeader<LogFileRecordReference, CollectionFileReference>> catalogHeaderConsumer
+		@Nonnull Consumer<CatalogHeader<LogFileRecordReference, CollectionFileReference>> catalogHeaderConsumer,
+		@Nullable PendingSyncRegistry pendingSyncRegistry
 	) {
 		final FileLocation fileLocation = catalogBootstrap.fileLocation();
 		if (fileLocation == null) {
@@ -380,7 +393,8 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 					storageSettings,
 					storageSettings,
 					catalogFilePath,
-					observableOutputKeeper
+					observableOutputKeeper,
+					pendingSyncRegistry
 				),
 				nonFlushedBlockObserver,
 				historyKeptObserver
@@ -418,7 +432,8 @@ public class CatalogOffsetIndexStoragePartPersistenceService extends OffsetIndex
 					storageSettings,
 					storageSettings,
 					catalogFilePath,
-					observableOutputKeeper
+					observableOutputKeeper,
+					pendingSyncRegistry
 				),
 				nonFlushedBlockObserver,
 				historyKeptObserver,

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/CheckpointCoordinator.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/CheckpointCoordinator.java
@@ -1,0 +1,401 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.catalog;
+
+import io.evitadb.core.executor.DelayedAsyncTask;
+import io.evitadb.core.executor.Scheduler;
+import io.evitadb.core.metric.event.storage.CatalogCheckpointEvent;
+import io.evitadb.exception.GenericEvitaInternalError;
+import io.evitadb.store.offsetIndex.io.PendingSyncRegistry;
+import io.evitadb.store.offsetIndex.io.WriteOnlyHandle;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Decouples the cadence at which a trunk round makes its changes **visible** from the cadence at which they are made
+ * **durable on the data files**.
+ *
+ * Without it, every trunk round ends by forcing each written data file to the device and writing a bootstrap record
+ * that points at them - a fixed bill of `N_changed + 2` device flushes. That bill does not shrink with load; it is
+ * merely divided among however many transactions the round managed to collapse, which is why its share of the round
+ * is *largest* on a lightly loaded system (measured 57 % of the round at two concurrent writers, and nothing at
+ * sixty-four).
+ *
+ * With it, rounds keep writing and flushing their bytes exactly as before - so everything downstream sees the same
+ * state - but the device flush and the bootstrap record happen only every
+ * {@link io.evitadb.api.configuration.TransactionOptions#checkpointIntervalInMillis()}.
+ *
+ * **This weakens no promise made to a client.** An acknowledged commit is durable because it is in the write-ahead
+ * log, not because the data files were checkpointed: the bootstrap record is a *checkpoint pointer*, and anything
+ * written after the last one is replayed from the WAL on restart. What the interval does cost is WAL retention and
+ * restart replay time, both bounded by the interval itself.
+ *
+ * Two mechanisms keep the fence honest:
+ *
+ * - Handles **register themselves** through {@link PendingSyncRegistry} rather than being enumerated here, so the set
+ *   of files owing a force cannot drift away from the set actually written.
+ * - {@link #forcePendingSyncs()} is called from the one place that writes a bootstrap record, so the ordering
+ *   invariant - *nothing may point at bytes that are not yet durable* - holds for every caller that writes one, not
+ *   only for trunk rounds.
+ *
+ * A checkpoint is normally driven by a trunk round noticing the interval has elapsed. A **ticker** covers the case
+ * the round-driven trigger structurally cannot: a system that falls silent right after a deferred round would
+ * otherwise leave those changes uncheckpointed until the next write arrived, which may be never. The ticker is
+ * a self-arming one-shot rather than a fixed-rate task, so an idle catalog fires exactly one timer after the last
+ * transaction and then stops waking up.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@Slf4j
+public class CheckpointCoordinator implements PendingSyncRegistry, Closeable {
+	/**
+	 * Name of the catalog this coordinator checkpoints - used for logging and observability.
+	 */
+	private final String catalogName;
+	/**
+	 * Minimal delay between two checkpoints, in milliseconds. Always positive - the persistence service does not
+	 * create a coordinator at all when checkpointing is configured to happen at the end of every round.
+	 */
+	private final long checkpointIntervalMillis;
+	/**
+	 * Performs the checkpoint tail - writes the bootstrap record for the last applied version and advances the WAL
+	 * processing marker. Supplied by the owning persistence service, which holds the state those steps need.
+	 */
+	private final Runnable checkpointAction;
+	/**
+	 * Handles that have written bytes reaching no further than the operating system page cache.
+	 *
+	 * Concurrent because the read path forces a soft flush when a caller reads a record still sitting in the write
+	 * buffer, so entries arrive from request threads as well as from the thread driving trunk incorporation.
+	 */
+	private final Set<WriteOnlyHandle> pendingHandles = ConcurrentHashMap.newKeySet();
+	/**
+	 * Serialises a ticker-driven checkpoint against the trunk round's own end-of-round processing. Both advance the
+	 * catalog offset index and may write a bootstrap record, and a bootstrap record naming version `V` must not be
+	 * built from a descriptor that already contains version `V+1`.
+	 *
+	 * **Owned by the persistence service and handed in**, because the state it guards belongs to that service rather
+	 * than to this class. Sharing one instance is what lets the round lock unconditionally while this class locks
+	 * around its own bookkeeping.
+	 *
+	 * This is a leaf lock - everything taken beneath it (write handle locks, the bootstrap write lock, the WAL lock)
+	 * is taken in the same order on both paths, and nothing beneath it reaches back here.
+	 */
+	private final ReentrantLock checkpointLock;
+	/**
+	 * The ticker that settles the debt of a catalog which went silent after a deferred round.
+	 *
+	 * A {@link DelayedAsyncTask} rather than a bare scheduler call so that it is observable alongside every other
+	 * background task, and because its own guard - arm once, ignore further requests while armed - is exactly the
+	 * one-shot semantics wanted here. The task pauses itself after each run, so the next deferred round re-arms it.
+	 */
+	private final DelayedAsyncTask ticker;
+	/**
+	 * Set once {@link #close()} has run. A {@link DelayedAsyncTask} refuses to be scheduled after it is closed, and
+	 * a round finishing during shutdown must not be turned into a failed transaction by that refusal - nothing is
+	 * lost, because closing forces everything still pending anyway.
+	 */
+	private final AtomicBoolean closed = new AtomicBoolean();
+	/**
+	 * Timestamp (epoch millis) at which the last checkpoint completed. Seeded at construction so that the first
+	 * round after start-up is not immediately treated as overdue.
+	 */
+	private volatile long lastCheckpointCompletedAtMillis = System.currentTimeMillis();
+	/**
+	 * Timestamp (epoch millis) of the first round that deferred its checkpoint since the last completed checkpoint,
+	 * or 0 when none is owed. This is the reference point for the fence depth - how long the oldest uncheckpointed
+	 * change waited for the device.
+	 */
+	private volatile long checkpointOwedSinceMillis;
+	/**
+	 * What every {@link #forcePendingSyncs()} since the last completed checkpoint added up to, drained by the next
+	 * one that completes.
+	 *
+	 * Accumulated rather than overwritten, and atomic rather than two fields, because the fence is reached from more
+	 * threads than the checkpoint path: it sits inside the one method that writes a bootstrap record, so a schema
+	 * update, a restore, a rename or a compaction reaches it without holding {@link #checkpointLock}. Overwriting
+	 * would let one of those publish its numbers as the checkpoint's own, and two separate fields could be read as a
+	 * mismatched pair. Summing is also the more truthful measure: an interval legitimately contains several forces,
+	 * and their total is what the device actually cost.
+	 */
+	private final AtomicReference<ForceStats> forceStats = new AtomicReference<>(ForceStats.EMPTY);
+	/**
+	 * The failure that broke checkpointing, if any.
+	 *
+	 * A failed checkpoint covers every round since the previous one and later rounds are already writing behind it,
+	 * so there is no single client to hand the exception to and no way to make the acknowledgements already given
+	 * true again. Recorded here so the owning persistence service can refuse further work rather than keep
+	 * acknowledging commits it can never checkpoint.
+	 */
+	private final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+	/**
+	 * Creates a coordinator that checkpoints no more often than the given interval.
+	 *
+	 * @param catalogName             name of the catalog being checkpointed, for logging and observability
+	 * @param checkpointIntervalMillis minimal delay between two checkpoints; must be positive, because
+	 *                                "checkpoint at the end of every round" is expressed by not creating
+	 *                                a coordinator at all rather than by an interval of zero
+	 * @param scheduler               scheduler the ticker is armed on
+	 * @param checkpointLock          lock owned by the persistence service, guarding the state both a round and
+	 *                                a checkpoint touch; shared rather than created here so both paths take one lock
+	 * @param checkpointAction        publishes the bootstrap record a round prepared and advances the write-ahead
+	 *                                log marker; supplied by the persistence service, which holds that state
+	 */
+	public CheckpointCoordinator(
+		@Nonnull String catalogName,
+		long checkpointIntervalMillis,
+		@Nonnull Scheduler scheduler,
+		@Nonnull ReentrantLock checkpointLock,
+		@Nonnull Runnable checkpointAction
+	) {
+		if (checkpointIntervalMillis <= 0) {
+			throw new GenericEvitaInternalError(
+				"Checkpoint coordinator requires a positive interval, got " + checkpointIntervalMillis +
+					" - checkpointing at the end of every round is expressed by not creating a coordinator at all!"
+			);
+		}
+		this.catalogName = catalogName;
+		this.checkpointIntervalMillis = checkpointIntervalMillis;
+		this.checkpointLock = checkpointLock;
+		this.checkpointAction = checkpointAction;
+		this.ticker = new DelayedAsyncTask(
+			catalogName,
+			"Catalog checkpoint",
+			scheduler,
+			this::runTickerCheckpoint,
+			checkpointIntervalMillis,
+			TimeUnit.MILLISECONDS,
+			// two checkpoints are never wanted closer together than the configured interval, which is the same bound
+			// the round-driven trigger applies
+			checkpointIntervalMillis
+		);
+	}
+
+	@Override
+	public void noteSyncPending(@Nonnull WriteOnlyHandle handle) {
+		this.pendingHandles.add(handle);
+	}
+
+	/**
+	 * Forces every file written since the last checkpoint to the physical device.
+	 *
+	 * Called immediately before a bootstrap record is written, which is what makes the ordering invariant structural:
+	 * a record pointing into a data file cannot become durable before the bytes it addresses have.
+	 *
+	 * The set is snapshotted, forced and then removed by identity rather than cleared. A handle written between the
+	 * snapshot and the force must stay pending - clearing would drop it and leave a durable pointer to bytes that
+	 * were never synced, whereas forcing it again in the next checkpoint costs a redundant device flush (measured at
+	 * ~0.5 ms) and is harmless.
+	 */
+	public void forcePendingSyncs() {
+		// deliberately no early return on an empty set: the counters below are what the next completed checkpoint
+		// reports, and skipping the update would let it publish the numbers of some earlier unrelated force - a
+		// compaction's, say - as its own
+		final long startNanos = System.nanoTime();
+		final WriteOnlyHandle[] snapshot = this.pendingHandles.toArray(WriteOnlyHandle[]::new);
+		for (final WriteOnlyHandle handle : snapshot) {
+			handle.forceDurable();
+		}
+		// remove exactly what was forced; anything registered in the meantime stays owed
+		for (final WriteOnlyHandle handle : snapshot) {
+			this.pendingHandles.remove(handle);
+		}
+		this.forceStats.accumulateAndGet(
+			new ForceStats(snapshot.length, (System.nanoTime() - startNanos) / 1_000_000L),
+			ForceStats::plus
+		);
+	}
+
+	/**
+	 * Tells whether the checkpoint interval has elapsed since the last completed checkpoint.
+	 *
+	 * @return true when the round that is finishing should checkpoint rather than defer
+	 */
+	public boolean isCheckpointDue() {
+		return System.currentTimeMillis() - this.lastCheckpointCompletedAtMillis >= this.checkpointIntervalMillis;
+	}
+
+	/**
+	 * Records that a round chose not to checkpoint, and arms the ticker so the change still reaches the device if no
+	 * further round ever arrives.
+	 */
+	public void noteCheckpointDeferred() {
+		this.checkpointLock.lock();
+		try {
+			if (this.checkpointOwedSinceMillis == 0L) {
+				this.checkpointOwedSinceMillis = System.currentTimeMillis();
+			}
+			if (!this.closed.get()) {
+				this.ticker.schedule();
+			}
+		} finally {
+			this.checkpointLock.unlock();
+		}
+	}
+
+	/**
+	 * Records that a checkpoint completed: restarts the interval and reports the two intervals that describe how the
+	 * fence is behaving.
+	 *
+	 * An armed ticker is deliberately left armed. It will fire, find nothing owed and pause itself, which is the
+	 * normal outcome on a catalog busy enough to keep checkpointing inline.
+	 */
+	public void noteCheckpointCompleted() {
+		this.checkpointLock.lock();
+		try {
+			final long now = System.currentTimeMillis();
+			final long cadenceMillis = now - this.lastCheckpointCompletedAtMillis;
+			// how long the OLDEST change covered by this checkpoint waited for the device; zero when the round
+			// checkpointed inline and nothing was ever owed
+			final long fenceDepthMillis = this.checkpointOwedSinceMillis == 0L ?
+				0L : now - this.checkpointOwedSinceMillis;
+			this.lastCheckpointCompletedAtMillis = now;
+			this.checkpointOwedSinceMillis = 0L;
+			// emitted here rather than at the end of the round that queued the work: the whole point of the interval
+			// is that those two moments are no longer the same, so reporting at the round would report nothing about
+			// durability
+			final ForceStats forced = this.forceStats.getAndSet(ForceStats.EMPTY);
+			new CatalogCheckpointEvent(this.catalogName)
+				.finish(cadenceMillis, fenceDepthMillis, forced.files(), forced.durationMillis())
+				.commit();
+			if (log.isDebugEnabled()) {
+				log.debug(
+					"Catalog `{}` checkpointed - cadence {} ms, fence depth {} ms.",
+					this.catalogName, cadenceMillis, fenceDepthMillis
+				);
+			}
+		} finally {
+			this.checkpointLock.unlock();
+		}
+	}
+
+	/**
+	 * Checkpoints immediately if one is owed, regardless of whether the interval has elapsed.
+	 *
+	 * This is how the operations that *require* a fully checkpointed catalog get one - notably integrity
+	 * verification, which is followed by obsolete-file purging: purging write-ahead log files covering versions that
+	 * were never checkpointed would discard the only record of them.
+	 *
+	 * Unlike the ticker, failures propagate - these callers have somewhere to report to.
+	 */
+	public void checkpointIfOwed() {
+		this.checkpointLock.lock();
+		try {
+			if (this.checkpointOwedSinceMillis != 0L) {
+				this.checkpointAction.run();
+			}
+		} finally {
+			this.checkpointLock.unlock();
+		}
+	}
+
+	/**
+	 * Returns the failure that broke checkpointing, if any. Once set, the catalog can no longer make its data files
+	 * durable and must stop acknowledging commits.
+	 *
+	 * @return the failure, or null while checkpointing is healthy
+	 */
+	@Nullable
+	public Throwable getFailure() {
+		return this.failure.get();
+	}
+
+	@Override
+	public void close() {
+		if (this.closed.compareAndSet(false, true)) {
+			try {
+				this.ticker.close();
+			} catch (IOException ex) {
+				throw new GenericEvitaInternalError(
+					"Failed to close the checkpoint ticker of catalog `" + this.catalogName + "`!",
+					"Failed to close the checkpoint ticker!",
+					ex
+				);
+			}
+		}
+	}
+
+	/**
+	 * Body of the ticker: checkpoints the catalog if one is still owed by the time the timer fires.
+	 *
+	 * A round may have checkpointed in the meantime, in which case there is nothing to do - the timer is simply
+	 * stale, which is the normal outcome on a busy catalog.
+	 *
+	 * @return always -1, which pauses the task: it is re-armed by the next round that defers, so an idle catalog
+	 * stops waking up entirely once its debt is settled
+	 */
+	private long runTickerCheckpoint() {
+		this.checkpointLock.lock();
+		try {
+			if (this.failure.get() == null) {
+				checkpointIfOwed();
+			}
+		} catch (Throwable ex) {
+			// there is no client waiting on this checkpoint to throw into - the transactions it covers were
+			// acknowledged long ago. Record it so the catalog can stop acknowledging commits it cannot checkpoint,
+			// and make sure it is visible rather than swallowed on a scheduler thread.
+			this.failure.compareAndSet(null, ex);
+			log.error(
+				"Checkpoint of catalog `{}` failed - the data files can no longer be made durable!",
+				this.catalogName, ex
+			);
+		} finally {
+			this.checkpointLock.unlock();
+		}
+		return -1L;
+	}
+
+	/**
+	 * Device-flush work accumulated since the last completed checkpoint.
+	 *
+	 * @param files          number of files forced
+	 * @param durationMillis wall-clock time those forces took, in milliseconds
+	 */
+	private record ForceStats(int files, long durationMillis) {
+		private static final ForceStats EMPTY = new ForceStats(0, 0L);
+
+		/**
+		 * Adds another force's work to this one.
+		 *
+		 * @param other the force to add
+		 * @return the combined totals
+		 */
+		@Nonnull
+		ForceStats plus(@Nonnull ForceStats other) {
+			return new ForceStats(this.files + other.files, this.durationMillis + other.durationMillis);
+		}
+	}
+
+}

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultCatalogPersistenceService.java
@@ -291,7 +291,7 @@ public class DefaultCatalogPersistenceService
 	/**
 	 * Wall-clock time (epoch millis, {@link #CURRENT_TIME_MILLIS}) at which the catalog data file was last compacted.
 	 * Backs the {@code minCompactionIntervalMilliseconds} cadence gate for the catalog-file compaction trigger in
-	 * {@link #recordBootstrap(long, String, int, long, DataStoreMemoryBuffer)}.
+	 * {@link #prepareBootstrap(long, String, int, long, DataStoreMemoryBuffer)}.
 	 */
 	@Getter(AccessLevel.PACKAGE)
 	private long lastCatalogCompactionAtMillis = getNowEpochMillis();
@@ -315,6 +315,52 @@ public class DefaultCatalogPersistenceService
 	 * This lock synchronizes the access to the write ahead log file.
 	 */
 	private final ReentrantLock walWriteLock = new ReentrantLock();
+	/**
+	 * Serialises a trunk round's end-of-round processing against a checkpoint driven from any other thread - the
+	 * ticker, a backup or an integrity check. Both advance the catalog offset index and may write a bootstrap record,
+	 * and a record naming version `V` must not be built from an index that has already absorbed `V+1`.
+	 *
+	 * Lives here rather than on {@link CheckpointCoordinator} because the state it guards is this service's -
+	 * {@link #deferredCheckpointBootstrap}, {@link #bootstrapUsed} and the catalog offset index. The coordinator is
+	 * handed the same instance so both paths take one lock, and it exists even when there is no coordinator, which
+	 * is what lets {@link #storeHeader} lock unconditionally instead of branching.
+	 *
+	 * This is a leaf lock: {@link #bootstrapWriteLock}, {@link #cpsvLock} and the write-handle locks are all taken
+	 * beneath it, in that same order on every path, and nothing beneath it reaches back here.
+	 */
+	private final ReentrantLock checkpointLock = new ReentrantLock();
+	/**
+	 * Takes the device flush of the catalog and entity collection data files off the end of every trunk round and
+	 * performs it on an interval instead, together with the bootstrap record that points at those files.
+	 *
+	 * Null when checkpointing happens at the end of every round - either because
+	 * {@link io.evitadb.api.configuration.TransactionOptions#checkpointIntervalInMillis()} is zero, or because
+	 * {@link io.evitadb.api.configuration.StorageOptions#syncWrites()} is off and there is consequently no device
+	 * flush to defer in the first place.
+	 */
+	@Getter(AccessLevel.PACKAGE)
+	@Nullable private final CheckpointCoordinator checkpointCoordinator;
+	/**
+	 * The catalog version most recently handed to {@link #storeHeader}, whether or not it has been checkpointed yet.
+	 *
+	 * {@link #getLastCatalogVersion()} deliberately keeps reporting the last **checkpointed** version, because its
+	 * callers use it to tell a failure that struck before durability from one that struck after. This field answers
+	 * the different question of what has already been written, which is what a caller deciding whether anything
+	 * changed since the previous round needs.
+	 */
+	private volatile long lastAppliedCatalogVersion;
+	/**
+	 * The bootstrap record a deferred checkpoint still owes: already built by the round that deferred - which is what
+	 * makes it safe for another thread to publish - but not yet written to the bootstrap file.
+	 *
+	 * Written by the round while holding the coordinator's lock and read by whoever settles the debt under that same
+	 * lock. Null when nothing is owed.
+	 *
+	 * It doubles as the baseline the next round builds on: catalog-file compaction bumps the file index inside the
+	 * record, and until the record is written {@link #bootstrapUsed} still names the file index from before the
+	 * compaction.
+	 */
+	@Nullable private volatile CatalogBootstrap deferredCheckpointBootstrap;
 	/**
 	 * Scheduled executor service is used for planning maintenance tasks on the data level.
 	 */
@@ -354,8 +400,14 @@ public class DefaultCatalogPersistenceService
 	private CatalogBootstrap bootstrapUsed;
 	/**
 	 * Contains the instance of {@link CatalogWriteAheadLog} that is used for writing mutations into shared WAL.
+	 *
+	 * `volatile` because {@link #syncWal()} reads it from the thread that forces the WAL, which is not the
+	 * thread that appends. Every other assignment happens in a constructor, and the only runtime one is the
+	 * lazy initialisation inside {@link #doAppendWalAndDiscard}; the appender's publication of that value
+	 * does happen-before the syncer's read through the pending-transaction queue's lock, but relying on a
+	 * chain that long to keep a field safe is exactly how it stops being safe when somebody reorders a call.
 	 */
-	@Nullable private CatalogWriteAheadLog catalogWal;
+	@Nullable private volatile CatalogWriteAheadLog catalogWal;
 	/**
 	 * Contains the millis from the time the non-flushed block was reported.
 	 */
@@ -1105,6 +1157,7 @@ public class DefaultCatalogPersistenceService
 		this.storageSettings = new StorageSettings(storageOptions, transactionOptions);
 		this.bootstrapStorageSettings = this.storageSettings.modifyForBootstrapFile();
 		this.scheduler = scheduler;
+		this.checkpointCoordinator = createCheckpointCoordinator(catalogName, this.storageSettings, scheduler);
 		this.exportService = exportService;
 		this.offHeapMemoryManager = new CatalogOffHeapMemoryManager(
 			catalogName,
@@ -1115,7 +1168,7 @@ public class DefaultCatalogPersistenceService
 		this.catalogName = catalogName;
 		this.walFileNameProvider = index -> CatalogPersistenceService.getWalFileName(catalogName, index);
 		this.catalogStoragePath = pathForCatalog(catalogName, this.storageSettings.storageDirectory());
-		final String verifiedCatalogName = verifyDirectory(this.catalogStoragePath, true);
+		verifyDirectory(this.catalogStoragePath, true);
 		this.observableOutputKeeper = new ObservableOutputKeeper(
 			catalogName,
 			this.storageSettings.outputBufferSize(),
@@ -1160,7 +1213,8 @@ public class DefaultCatalogPersistenceService
 				this.observableOutputKeeper,
 				VERSIONED_KRYO_FACTORY,
 				nonFlushedBlock -> this.reportNonFlushedContents(catalogName, nonFlushedBlock),
-				oldestRecordTimestamp -> reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null))
+				oldestRecordTimestamp -> reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null)),
+				this.checkpointCoordinator
 			)
 		);
 		this.catalogPersistenceServiceVersions = new long[]{catalogVersion};
@@ -1284,6 +1338,7 @@ public class DefaultCatalogPersistenceService
 		this.storageSettings = new StorageSettings(storageOptions, transactionOptions);
 		this.bootstrapStorageSettings = this.storageSettings.modifyForBootstrapFile();
 		this.scheduler = scheduler;
+		this.checkpointCoordinator = createCheckpointCoordinator(catalogName, this.storageSettings, scheduler);
 		this.exportService = exportService;
 		this.offHeapMemoryManager = new CatalogOffHeapMemoryManager(
 			catalogName,
@@ -1343,7 +1398,8 @@ public class DefaultCatalogPersistenceService
 					this.observableOutputKeeper,
 					VERSIONED_KRYO_FACTORY,
 					nonFlushedBlock -> this.reportNonFlushedContents(catalogName, nonFlushedBlock),
-					oldestRecordTimestamp -> reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null))
+					oldestRecordTimestamp -> reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null)),
+					this.checkpointCoordinator
 				),
 				this.bootstrapUsed.catalogVersion(),
 				allowInlineV4ToV5Upgrade
@@ -1421,6 +1477,9 @@ public class DefaultCatalogPersistenceService
 		this.storageSettings = formerService.storageSettings;
 		this.bootstrapStorageSettings = formerService.bootstrapStorageSettings;
 		this.scheduler = formerService.scheduler;
+		// a fresh coordinator rather than the former service's: this service writes different files, and the former
+		// one still owns - and on close forces - whatever it had pending against the paths it was writing
+		this.checkpointCoordinator = createCheckpointCoordinator(catalogName, this.storageSettings, this.scheduler);
 		this.exportService = formerService.exportService;
 		this.offHeapMemoryManager = new CatalogOffHeapMemoryManager(
 			catalogName,
@@ -1474,7 +1533,8 @@ public class DefaultCatalogPersistenceService
 				this.observableOutputKeeper,
 				VERSIONED_KRYO_FACTORY,
 				nonFlushedBlock -> this.reportNonFlushedContents(catalogName, nonFlushedBlock),
-				oldestRecordTimestamp -> reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null))
+				oldestRecordTimestamp -> reportOldestHistoricalRecord(catalogName, oldestRecordTimestamp.orElse(null)),
+				this.checkpointCoordinator
 			),
 			this.bootstrapUsed.catalogVersion(),
 			false
@@ -1531,8 +1591,9 @@ public class DefaultCatalogPersistenceService
 				.orElse(null)
 		).commit();
 		// emit WAL events if it exists
-		if (this.catalogWal != null) {
-			this.catalogWal.emitObservabilityEvents();
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		if (theCatalogWal != null) {
+			theCatalogWal.emitObservabilityEvents();
 		}
 	}
 
@@ -1574,6 +1635,14 @@ public class DefaultCatalogPersistenceService
 	@Override
 	public long getLastCatalogVersion() {
 		return this.bootstrapUsed.catalogVersion();
+	}
+
+	@Override
+	public long getLastAppliedCatalogVersion() {
+		// `bootstrapUsed` moves only at a checkpoint, so without a coordinator the two answers coincide; the field
+		// is seeded lazily by the first storeHeader, hence the fallback for a service that has not stored one yet
+		final long applied = this.lastAppliedCatalogVersion;
+		return applied == 0L ? this.bootstrapUsed.catalogVersion() : applied;
 	}
 
 	@Nonnull
@@ -1725,79 +1794,140 @@ public class DefaultCatalogPersistenceService
 		@Nonnull List<EntityCollectionFileHeader> entityHeaders,
 		@Nonnull DataStoreMemoryBuffer dataStoreMemoryBuffer
 	) {
-		// first we need to execute transition to alive state
-		if (catalogState == CatalogState.ALIVE && catalogVersion == 0L) {
-			this.bootstrapUsed = recordBootstrap(
-				catalogVersion, this.catalogName, this.bootstrapUsed.catalogFileIndex(), dataStoreMemoryBuffer);
-			catalogVersion = 1L;
-		}
-		// first store all entity collection headers if they differ
-		final CatalogOffsetIndexStoragePartPersistenceService storagePartPersistenceService =
-			getStoragePartPersistenceService(catalogVersion);
-		final CatalogHeader<LogFileRecordReference, CollectionFileReference> currentCatalogHeader = storagePartPersistenceService.getCatalogHeader(
-			catalogVersion);
-		for (EntityCollectionFileHeader entityHeader : entityHeaders) {
-			final FileLocation currentLocation = entityHeader.fileLocation();
-			final Optional<FileLocation> previousLocation = currentCatalogHeader
-				.getEntityTypeFileIndexIfExists(entityHeader.entityType())
-				.map(CollectionFileReference::fileLocation);
-			// if the location is different, store the header
-			if (!previousLocation.map(it -> it.equals(currentLocation)).orElse(false)) {
-				storagePartPersistenceService.putStoragePart(catalogVersion, entityHeader);
+		// Serialises the round's end-of-round processing against a ticker-driven or backup-driven checkpoint: both
+		// advance the catalog offset index and may write a bootstrap record, and a record naming version `V` must not
+		// be built from an index that has already absorbed `V+1`.
+		//
+		// Taken unconditionally. Without a coordinator there is no other thread that can take it, so the acquisition
+		// is uncontended and costs nothing against the round's own device flushes - and making it conditional is what
+		// previously forced this method to be split in two around the branch.
+		this.checkpointLock.lock();
+		try {
+			// a checkpoint that failed can never be retried into success - the rounds it covered are long acknowledged
+			// and more have been written behind it. Refuse rather than keep acknowledging commits that cannot be made
+			// durable.
+			if (this.checkpointCoordinator != null) {
+				final Throwable checkpointFailure = this.checkpointCoordinator.getFailure();
+				if (checkpointFailure != null) {
+					throw new UnexpectedIOException(
+						"Catalog `" + this.catalogName + "` can no longer checkpoint its data files!",
+						"Catalog can no longer checkpoint its data files.",
+						checkpointFailure
+					);
+				}
 			}
-		}
+			// first we need to execute transition to alive state
+			if (catalogState == CatalogState.ALIVE && catalogVersion == 0L) {
+				this.bootstrapUsed = recordBootstrap(
+					catalogVersion, this.catalogName, this.bootstrapUsed.catalogFileIndex(), dataStoreMemoryBuffer);
+				catalogVersion = 1L;
+			}
+			// first store all entity collection headers if they differ
+			final CatalogOffsetIndexStoragePartPersistenceService storagePartPersistenceService =
+				getStoragePartPersistenceService(catalogVersion);
+			final CatalogHeader<LogFileRecordReference, CollectionFileReference> currentCatalogHeader = storagePartPersistenceService.getCatalogHeader(
+				catalogVersion);
+			for (EntityCollectionFileHeader entityHeader : entityHeaders) {
+				final FileLocation currentLocation = entityHeader.fileLocation();
+				final Optional<FileLocation> previousLocation = currentCatalogHeader
+					.getEntityTypeFileIndexIfExists(entityHeader.entityType())
+					.map(CollectionFileReference::fileLocation);
+				// if the location is different, store the header
+				if (!previousLocation.map(it -> it.equals(currentLocation)).orElse(false)) {
+					storagePartPersistenceService.putStoragePart(catalogVersion, entityHeader);
+				}
+			}
 
-		storagePartPersistenceService.writeCatalogHeader(
-			STORAGE_PROTOCOL_VERSION,
-			catalogVersion,
-			this.catalogStoragePath,
-			ofNullable(this.catalogWal)
-				.map(cwal -> cwal.getWalFileReference(lastProcessedTransaction))
-				.orElse(null),
-			entityHeaders
-				.stream()
-				.map(
-					it -> new CollectionFileReference(
-						it.entityType(),
-						it.entityTypePrimaryKey(),
-						it.entityTypeFileIndex(),
-						it.fileLocation()
+			storagePartPersistenceService.writeCatalogHeader(
+				STORAGE_PROTOCOL_VERSION,
+				catalogVersion,
+				this.catalogStoragePath,
+				ofNullable(this.catalogWal)
+					.map(cwal -> cwal.getWalFileReference(lastProcessedTransaction))
+					.orElse(null),
+				entityHeaders
+					.stream()
+					.map(
+						it -> new CollectionFileReference(
+							it.entityType(),
+							it.entityTypePrimaryKey(),
+							it.entityTypeFileIndex(),
+							it.fileLocation()
+						)
 					)
-				)
-				.collect(
-					Collectors.toMap(
-						CollectionFileReference::entityType,
-						Function.identity()
-					)
-				),
-			catalogId,
-			this.catalogName,
-			catalogState,
-			lastEntityCollectionPrimaryKey
-		);
-		this.bootstrapUsed = recordBootstrap(
-			catalogVersion,
-			this.catalogName,
-			this.bootstrapUsed.catalogFileIndex(),
-			dataStoreMemoryBuffer
-		);
-
-		// notify WAL that the new version was successfully stored
-		if (this.catalogWal != null) {
-			this.catalogWal.walProcessedUntil(catalogVersion);
-		}
-
-		// emit event if the number of collections has changed
-		if (getNowEpochMillis() - this.lastCatalogStatisticsTimestamp > 1000) {
-			new CatalogStatisticsEvent(
+					.collect(
+						Collectors.toMap(
+							CollectionFileReference::entityType,
+							Function.identity()
+						)
+					),
+				catalogId,
 				this.catalogName,
-				entityHeaders.size(),
-				FileUtils.getDirectorySize(this.catalogStoragePath),
-				getFirstCatalogBootstrap(this.catalogName, this.bootstrapStorageSettings)
-					.map(CatalogBootstrap::timestamp)
-					.orElse(null)
-			).commit();
-			this.lastCatalogStatisticsTimestamp = getNowEpochMillis();
+				catalogState,
+				lastEntityCollectionPrimaryKey
+			);
+			this.lastAppliedCatalogVersion = catalogVersion;
+
+			// Build the bootstrap record HERE, on the round's own thread, whether or not it will be published now.
+			// This is what advances the catalog offset index to this version, and only the writer of those entries
+			// may do it - a checkpoint arriving from the ticker or a backup would otherwise promote the entries of
+			// a round already in flight. Publishing the finished record later is safe; building it later is not.
+			final CatalogBootstrap deferredBootstrap = this.deferredCheckpointBootstrap;
+			final CatalogBootstrap preparedBootstrap = prepareBootstrap(
+				catalogVersion,
+				this.catalogName,
+				// build on the newest record there is, written or not - a compaction inside a deferred round bumped
+				// the file index in that record while `bootstrapUsed` still names the file from before it. Using
+				// `bootstrapUsed` here reuses an index a previous round already took, and the compaction copy then
+				// overwrites a live catalog file - which surfaces as a Kryo buffer underflow, not a clean failure.
+				(deferredBootstrap == null ? this.bootstrapUsed : deferredBootstrap).catalogFileIndex(),
+				getNowEpochMillis(),
+				dataStoreMemoryBuffer
+			);
+
+			// everything above has written its bytes; from here on the only question is when they reach the device
+
+			// warm-up is excluded deliberately: it has no trunk rounds to amortise a checkpoint across, and go-live
+			// depends on everything written during it being addressable from disk before the first transaction runs
+			if (this.checkpointCoordinator != null && catalogState == CatalogState.ALIVE &&
+				!this.checkpointCoordinator.isCheckpointDue()) {
+				this.deferredCheckpointBootstrap = preparedBootstrap;
+				this.checkpointCoordinator.noteCheckpointDeferred();
+				return;
+			}
+
+			this.bootstrapUsed = writeCatalogBootstrap(catalogVersion, this.catalogName, preparedBootstrap);
+			this.deferredCheckpointBootstrap = null;
+
+			// notify WAL that the new version was successfully stored
+			final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+			if (theCatalogWal != null) {
+				theCatalogWal.walProcessedUntil(catalogVersion);
+			}
+
+			// only in ALIVE state: warm-up writes a bootstrap record on every flush, and reporting each of those as
+			// a checkpoint would fill the cadence gauge with the bulk-load round rate. An operator reading a median
+			// cadence of a few milliseconds during a bulk load would conclude checkpointing is healthy while looking
+			// at a phase where the number means nothing at all. Warm-up flushes still force their pending files -
+			// that happens at the fence inside `writeCatalogBootstrap`, independently of this bookkeeping.
+			if (this.checkpointCoordinator != null && catalogState == CatalogState.ALIVE) {
+				this.checkpointCoordinator.noteCheckpointCompleted();
+			}
+
+			// emit event if the number of collections has changed
+			if (getNowEpochMillis() - this.lastCatalogStatisticsTimestamp > 1000) {
+				new CatalogStatisticsEvent(
+					this.catalogName,
+					entityHeaders.size(),
+					FileUtils.getDirectorySize(this.catalogStoragePath),
+					getFirstCatalogBootstrap(this.catalogName, this.bootstrapStorageSettings)
+						.map(CatalogBootstrap::timestamp)
+						.orElse(null)
+				).commit();
+				this.lastCatalogStatisticsTimestamp = getNowEpochMillis();
+			}
+		} finally {
+			this.checkpointLock.unlock();
 		}
 	}
 
@@ -1896,7 +2026,8 @@ public class DefaultCatalogPersistenceService
 						this.storageSettings,
 						this.offHeapMemoryManager,
 						this.observableOutputKeeper,
-						this.recordTypeRegistry
+						this.recordTypeRegistry,
+						this.checkpointCoordinator
 					)
 				);
 				if (dataStoreBuffer instanceof WarmUpDataStoreMemoryBuffer warmUpDataStoreMemoryBuffer) {
@@ -2071,7 +2202,45 @@ public class DefaultCatalogPersistenceService
 	}
 
 	@Override
-	public long appendWalAndDiscard(
+	public long appendWalAndDiscardDeferringSync(
+		long catalogVersion,
+		@Nonnull TransactionMutation transactionMutation,
+		@Nonnull LogRecordReference walReference
+	) {
+		return doAppendWalAndDiscard(catalogVersion, transactionMutation, walReference);
+	}
+
+	@Override
+	public void syncWal() {
+		// deliberately NOT taken under `walWriteLock`: the force is the expensive part of a commit and
+		// holding that lock across it would re-serialize appends behind syncs, which is exactly what the
+		// deferred-sync path exists to avoid. Exclusion against rotation and channel close lives inside
+		// the WAL itself.
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		// a missing WAL must NOT be treated as "nothing to sync": the only caller is the durability
+		// handshake, which asks for a force precisely because it has transactions it is about to declare
+		// durable. Returning quietly here would acknowledge them without anything reaching the device -
+		// the one failure mode of this design that corrupts silently instead of throwing
+		Assert.isPremiseValid(
+			theCatalogWal != null,
+			"Cannot sync the WAL of catalog `" + this.catalogName + "` - it does not exist! " +
+				"A sync was requested for transactions that were supposedly appended to it."
+		);
+		theCatalogWal.syncWal();
+	}
+
+	/**
+	 * Appends the transaction to the shared WAL and discards the isolated WAL contents.
+	 *
+	 * The append is left written but not durable - see {@link #appendWalAndDiscardDeferringSync} for who owes the
+	 * matching {@link #syncWal()}.
+	 *
+	 * @param catalogVersion       the catalog version the transaction is bound to
+	 * @param transactionMutation  the leading transaction mutation
+	 * @param walReference         the reference to the isolated WAL contents
+	 * @return the length of the written WAL contents
+	 */
+	private long doAppendWalAndDiscard(
 		long catalogVersion,
 		@Nonnull TransactionMutation transactionMutation,
 		@Nonnull LogRecordReference walReference
@@ -2096,14 +2265,16 @@ public class DefaultCatalogPersistenceService
 						offHeapReference.getBuffer().isPresent() || offHeapReference.getFilePath().isPresent(),
 						"Unexpected WAL reference - neither off-heap buffer nor file reference present!"
 					);
+					final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
 					Assert.isPremiseValid(
-						this.catalogWal != null,
+						theCatalogWal != null,
 						"Catalog WAL is unexpectedly not present!"
 					);
 
-					return Objects.requireNonNull(
-							this.catalogWal.append(transactionMutation, offHeapReference).fileLocation())
-						.recordLength();
+					final LogFileRecordReference reference = theCatalogWal.appendDeferringSync(
+						transactionMutation, offHeapReference
+					);
+					return Objects.requireNonNull(reference.fileLocation()).recordLength();
 				}
 			} finally {
 				this.walWriteLock.unlock();
@@ -2121,10 +2292,11 @@ public class DefaultCatalogPersistenceService
 	public Optional<TransactionMutation> getFirstNonProcessedTransactionInWal(
 		long catalogVersion
 	) {
-		if (this.catalogWal == null) {
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		if (theCatalogWal == null) {
 			return Optional.empty();
 		} else {
-			return this.catalogWal.getFirstNonProcessedTransaction(getCatalogHeader(catalogVersion).walFileReference())
+			return theCatalogWal.getFirstNonProcessedTransaction(getCatalogHeader(catalogVersion).walFileReference())
 				.map(TransactionMutationWithWalFileReference::transactionMutation);
 		}
 	}
@@ -2365,20 +2537,35 @@ public class DefaultCatalogPersistenceService
 	@Nonnull
 	@Override
 	public Stream<CatalogBoundMutation> getCommittedMutationStream(long catalogVersion) {
-		if (this.catalogWal == null) {
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		if (theCatalogWal == null) {
 			return Stream.empty();
 		} else {
-			return this.catalogWal.getCommittedMutationStream(catalogVersion);
+			return theCatalogWal.getCommittedMutationStream(catalogVersion);
 		}
 	}
 
 	@Nonnull
 	@Override
 	public Stream<CatalogBoundMutation> getReversedCommittedMutationStream(@Nullable Long catalogVersion) {
-		if (this.catalogWal == null) {
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		if (theCatalogWal == null) {
 			return Stream.empty();
 		} else {
-			return this.catalogWal.getCommittedReversedMutationStream(getLastCatalogVersion());
+			// Honour the requested starting version - the argument used to be discarded, which contradicted both this
+			// method's own contract and its engine-side counterpart
+			// (`DefaultEnginePersistenceService#getReversedCommittedMutationStream`), and made every caller asking for
+			// history from an older version walk the whole write-ahead log back from the head instead. The result was
+			// still correct because the change-capture predicate filters on the same version afterwards; only the
+			// amount of log scanned was wrong.
+			//
+			// When no version is requested the walk starts at the newest APPLIED version rather than the newest
+			// checkpointed one: with a checkpoint interval configured the latter lags by up to a whole interval, and
+			// starting there would hide every mutation committed since. The two coincide when every round
+			// checkpoints.
+			return theCatalogWal.getCommittedReversedMutationStream(
+				catalogVersion == null ? getLastAppliedCatalogVersion() : catalogVersion
+			);
 		}
 	}
 
@@ -2386,10 +2573,11 @@ public class DefaultCatalogPersistenceService
 	@Override
 	public Stream<CatalogBoundMutation> getCommittedLiveMutationStream(
 		long startCatalogVersion, long requestedCatalogVersion) {
-		if (this.catalogWal == null) {
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		if (theCatalogWal == null) {
 			return Stream.empty();
 		} else {
-			return this.catalogWal.getCommittedMutationStreamAvoidingPartiallyWrittenBuffer(
+			return theCatalogWal.getCommittedMutationStreamAvoidingPartiallyWrittenBuffer(
 				startCatalogVersion, requestedCatalogVersion
 			);
 		}
@@ -2397,19 +2585,21 @@ public class DefaultCatalogPersistenceService
 
 	@Override
 	public long getLastCatalogVersionInMutationStream() {
-		if (this.catalogWal == null) {
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		if (theCatalogWal == null) {
 			return 0L;
 		} else {
-			return this.catalogWal.getLastWrittenVersion();
+			return theCatalogWal.getLastWrittenVersion();
 		}
 	}
 
 	@Override
 	public long getFirstCatalogVersionInMutationStream() {
-		if (this.catalogWal == null) {
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		if (theCatalogWal == null) {
 			return -1L;
 		} else {
-			return this.catalogWal.getFirstVersionOfCurrentWalFile();
+			return theCatalogWal.getFirstVersionOfCurrentWalFile();
 		}
 	}
 
@@ -2541,7 +2731,8 @@ public class DefaultCatalogPersistenceService
 	@Nonnull
 	@Override
 	public List<WriteAheadLogVersionDescriptor> getCatalogVersionDescriptors(long... catalogVersion) {
-		if (catalogVersion.length == 0 || this.catalogWal == null) {
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		if (catalogVersion.length == 0 || theCatalogWal == null) {
 			return Collections.emptyList();
 		}
 		final String bootstrapFileName = getCatalogBootstrapFileName(this.catalogName);
@@ -2557,7 +2748,7 @@ public class DefaultCatalogPersistenceService
 
 			final WriteAheadLogVersionDescriptor[] result = new WriteAheadLogVersionDescriptor[catalogVersion.length];
 			for (MaterializedVersionBlock materializedVersionBlock : storedVersions) {
-				final List<WriteAheadLogVersionDescriptor> descriptors = this.catalogWal.getWriteAheadLogVersionDescriptor(
+				final List<WriteAheadLogVersionDescriptor> descriptors = theCatalogWal.getWriteAheadLogVersionDescriptor(
 					lookedUpVersions,
 					materializedVersionBlock
 				);
@@ -2649,6 +2840,12 @@ public class DefaultCatalogPersistenceService
 		@Nullable LongConsumer onStart,
 		@Nullable LongConsumer onComplete
 	) throws TemporalDataNotAvailableException {
+		// A backup is only as recent as the bootstrap record it copies, and it may be taken WITHOUT the write-ahead
+		// log - in which case that record is the sole pointer to the data and a stale one silently yields an older
+		// catalog rather than a broken one. Settle any outstanding checkpoint first. This also makes an explicitly
+		// requested `catalogVersion` that was committed moments ago resolvable, instead of reading as not yet
+		// existing.
+		checkpoint();
 		final CatalogBootstrap bootstrapRecord;
 		if (catalogVersion != null) {
 			bootstrapRecord = getCatalogBootstrapForSpecificVersion(
@@ -2674,6 +2871,8 @@ public class DefaultCatalogPersistenceService
 		@Nullable LongConsumer onStart,
 		@Nullable LongConsumer onComplete
 	) {
+		// same reasoning as createBackupTask - the task captures the last checkpointed version on construction
+		checkpoint();
 		return new FullBackupTask(
 			this.catalogName,
 			this.exportService,
@@ -2777,15 +2976,20 @@ public class DefaultCatalogPersistenceService
 
 	@Override
 	public void verifyIntegrity() {
+		// both assertions below are "the catalog is fully checkpointed" assertions, and callers follow this method
+		// with `purgeAllObsoleteFiles()` - so settle any outstanding checkpoint first. Purging write-ahead log files
+		// covering versions whose bootstrap record was never written would throw away the only record of them.
+		checkpoint();
 		Assert.isPremiseValid(
 			getCatalogHeader(this.bootstrapUsed.catalogVersion()).version() == this.bootstrapUsed.catalogVersion(),
 			"Catalog version mismatch! Expected `" + this.bootstrapUsed.catalogVersion() + "` but found `" + getCatalogHeader(
 				this.bootstrapUsed.catalogVersion()).version() + "`!"
 		);
-		if (this.catalogWal != null) {
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		if (theCatalogWal != null) {
 			Assert.isPremiseValid(
-				this.catalogWal.getLastWrittenVersion() == this.bootstrapUsed.catalogVersion(),
-				"Catalog WAL version mismatch! Expected `" + this.bootstrapUsed.catalogVersion() + "` but found `" + this.catalogWal.getLastWrittenVersion() + "`!"
+				theCatalogWal.getLastWrittenVersion() == this.bootstrapUsed.catalogVersion(),
+				"Catalog WAL version mismatch! Expected `" + this.bootstrapUsed.catalogVersion() + "` but found `" + theCatalogWal.getLastWrittenVersion() + "`!"
 			);
 		}
 	}
@@ -2833,11 +3037,31 @@ public class DefaultCatalogPersistenceService
 	public void close() {
 		if (!this.closed) {
 			this.closed = true;
+			// stop the ticker and settle the debt before anything is torn down: no service may go away still owing
+			// a device flush, or the bytes it wrote would depend on the operating system getting round to them.
+			// The bootstrap record is deliberately NOT written here - it is a checkpoint pointer, and leaving it at
+			// the last checkpoint simply means restart resumes from there and replays the rest from the WAL.
+			if (this.checkpointCoordinator != null) {
+				try {
+					this.checkpointCoordinator.forcePendingSyncs();
+				} catch (RuntimeException ex) {
+					// deliberately NOT quiet: shutdown must not be aborted by this, but a final device flush that
+					// failed means bytes this service wrote may never reach the disk, and an operator who is never
+					// told cannot know that the catalog needs its write-ahead log to come back whole
+					log.error(
+						"Final device flush of catalog `{}` failed - data written since the last checkpoint may not " +
+							"have reached the disk and will have to be replayed from the write-ahead log!",
+						this.catalogName, ex
+					);
+				}
+				IOUtils.closeQuietly(this.checkpointCoordinator::close);
+			}
 			// close WAL
-			if (this.catalogWal != null) {
+			final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+			if (theCatalogWal != null) {
 				this.walWriteLock.lock();
 				try {
-					IOUtils.closeQuietly(this.catalogWal::close);
+					IOUtils.closeQuietly(theCatalogWal::close);
 				} finally {
 					this.walWriteLock.unlock();
 				}
@@ -2987,7 +3211,8 @@ public class DefaultCatalogPersistenceService
 			this.observableOutputKeeper,
 			VERSIONED_KRYO_FACTORY,
 			nonFlushedBlock -> this.reportNonFlushedContents(this.catalogName, nonFlushedBlock),
-			oldestRecordTimestamp -> reportOldestHistoricalRecord(this.catalogName, oldestRecordTimestamp.orElse(null))
+			oldestRecordTimestamp -> reportOldestHistoricalRecord(this.catalogName, oldestRecordTimestamp.orElse(null)),
+			this.checkpointCoordinator
 		);
 	}
 
@@ -3009,7 +3234,8 @@ public class DefaultCatalogPersistenceService
 			this.storageSettings,
 			this.offHeapMemoryManager,
 			this.observableOutputKeeper,
-			this.recordTypeRegistry
+			this.recordTypeRegistry,
+			this.checkpointCoordinator
 		);
 	}
 
@@ -3021,6 +3247,73 @@ public class DefaultCatalogPersistenceService
 	@Nonnull
 	public Checksum createChecksum() {
 		return this.storageSettings.createChecksum();
+	}
+
+	/**
+	 * Creates the coordinator that defers the data file device flush to an interval, or returns null when every
+	 * round is to checkpoint on its own.
+	 *
+	 * There is nothing to defer when {@link StorageOptions#syncWrites()} is off - the writes never reach the device
+	 * on that setting anyway - so the two options stay orthogonal instead of one silently re-enabling the other.
+	 *
+	 * @param catalogName     name of the catalog, for observability
+	 * @param storageSettings settings carrying both the interval and the sync-writes switch
+	 * @param scheduler       scheduler used to arm the ticker
+	 * @return the coordinator, or null to checkpoint at the end of every round
+	 */
+	@Nullable
+	private CheckpointCoordinator createCheckpointCoordinator(
+		@Nonnull String catalogName,
+		@Nonnull StorageSettings storageSettings,
+		@Nonnull Scheduler scheduler
+	) {
+		final long checkpointInterval = storageSettings.checkpointIntervalInMillis();
+		return checkpointInterval > 0 && storageSettings.syncWrites() ?
+			new CheckpointCoordinator(
+				catalogName, checkpointInterval, scheduler, this.checkpointLock, this::performDeferredCheckpoint
+			) :
+			null;
+	}
+
+	/**
+	 * Makes everything written so far durable and writes the bootstrap record that points at it, if a checkpoint is
+	 * still owed. Does nothing when checkpointing happens at the end of every round.
+	 *
+	 * Callers are the operations that need the on-disk catalog to be **self-sufficient** rather than merely
+	 * crash-consistent - notably a backup, which may be taken without the write-ahead log, leaving the bootstrap
+	 * record as the only pointer to the data. A stale pointer there does not produce a corrupt backup; it produces a
+	 * silently **older** one, which is worse for being plausible.
+	 */
+	public void checkpoint() {
+		if (this.checkpointCoordinator != null) {
+			this.checkpointCoordinator.checkpointIfOwed();
+		}
+	}
+
+	/**
+	 * Publishes the checkpoint a previous round deferred: writes the bootstrap record that round already built and
+	 * lets the write-ahead log know it may stop retaining everything up to it.
+	 *
+	 * Deliberately does **nothing** to the catalog offset index. The round that deferred left the index at its own
+	 * version and built the matching record; all that is left here is to make the bytes durable - which happens at
+	 * the fence inside {@link #writeCatalogBootstrap} - and publish the pointer. That is what makes this callable
+	 * from the ticker or a backup thread while another round is in flight.
+	 *
+	 * Runs under the coordinator's lock, and only when a checkpoint is genuinely owed.
+	 */
+	private void performDeferredCheckpoint() {
+		final CatalogBootstrap preparedBootstrap = Objects.requireNonNull(
+			this.deferredCheckpointBootstrap,
+			"A checkpoint is owed but no bootstrap record was prepared for it!"
+		);
+		final long catalogVersion = preparedBootstrap.catalogVersion();
+		this.bootstrapUsed = writeCatalogBootstrap(catalogVersion, this.catalogName, preparedBootstrap);
+		this.deferredCheckpointBootstrap = null;
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		if (theCatalogWal != null) {
+			theCatalogWal.walProcessedUntil(catalogVersion);
+		}
+		Objects.requireNonNull(this.checkpointCoordinator).noteCheckpointCompleted();
 	}
 
 	/**
@@ -3044,7 +3337,11 @@ public class DefaultCatalogPersistenceService
 	}
 
 	/**
-	 * Records a bootstrap in the catalog.
+	 * Records a bootstrap in the catalog: builds the record and immediately writes it.
+	 *
+	 * Callers that must not publish the pointer yet - a trunk round running under a checkpoint interval - use
+	 * {@link #prepareBootstrap} and {@link #writeCatalogBootstrap} separately instead. Everything ordering-sensitive
+	 * lives in the former, so it has to run on the thread that wrote the storage parts being pointed at.
 	 *
 	 * @param catalogVersion        the version of the catalog
 	 * @param newCatalogName        the name of the new catalog
@@ -3055,6 +3352,38 @@ public class DefaultCatalogPersistenceService
 	 */
 	@Nonnull
 	CatalogBootstrap recordBootstrap(
+		long catalogVersion,
+		@Nonnull String newCatalogName,
+		int catalogFileIndex,
+		long timestamp,
+		@Nullable DataStoreMemoryBuffer dataStoreMemoryBuffer
+	) {
+		return writeCatalogBootstrap(
+			catalogVersion,
+			newCatalogName,
+			prepareBootstrap(
+				catalogVersion, newCatalogName, catalogFileIndex, timestamp, dataStoreMemoryBuffer)
+		);
+	}
+
+	/**
+	 * Builds the bootstrap record for the given version **without publishing it**: advances the catalog offset index
+	 * to that version and, when the thresholds say so, compacts the catalog data file first.
+	 *
+	 * **This must run on the thread that wrote the storage parts the record will address.** Promotion asserts that the
+	 * version being flushed is at least the newest one present in the index, so a thread doing this for version `V`
+	 * while a round is midway through writing `V+1` fails that assertion - and would otherwise have produced a record
+	 * naming `V` while addressing `V+1`. Deferring the *write* of the record is safe; deferring this is not.
+	 *
+	 * @param catalogVersion        the version of the catalog
+	 * @param newCatalogName        the name of the new catalog
+	 * @param catalogFileIndex      the index of the catalog file to build upon
+	 * @param timestamp             the timestamp of the boot record
+	 * @param dataStoreMemoryBuffer the data store memory buffer
+	 * @return the bootstrap record, not yet written to the bootstrap file
+	 */
+	@Nonnull
+	private CatalogBootstrap prepareBootstrap(
 		long catalogVersion,
 		@Nonnull String newCatalogName,
 		int catalogFileIndex,
@@ -3088,11 +3417,23 @@ public class DefaultCatalogPersistenceService
 			final int newCatalogFileIndex = catalogFileIndex + 1;
 			final String compactedFileName = getCatalogDataStoreFileName(newCatalogName, newCatalogFileIndex);
 			final OffsetIndexDescriptor compactedDescriptor;
-			try (final OutputStream fos = new BufferedOutputStream(
-				new FileOutputStream(this.catalogStoragePath.resolve(compactedFileName).toFile()),
-				COMPACTION_OUTPUT_BUFFER_SIZE
-			)) {
+			try (
+				final FileOutputStream compactedFileStream = new FileOutputStream(
+					this.catalogStoragePath.resolve(compactedFileName).toFile()
+				);
+				final OutputStream fos = new BufferedOutputStream(
+					compactedFileStream, COMPACTION_OUTPUT_BUFFER_SIZE
+				)
+			) {
 				compactedDescriptor = storagePartPersistenceService.copySnapshotTo(catalogVersion, fos, null);
+				// The bootstrap record built right below points into this file and is itself fsynced. Closing a
+				// BufferedOutputStream only pushes its buffer into the page cache, so without this the durable
+				// pointer could outlive the data it addresses: a crash here would leave recovery following a
+				// committed bootstrap record into a file that was never written.
+				fos.flush();
+				if (this.storageSettings.syncWrites()) {
+					compactedFileStream.getFD().sync();
+				}
 			} catch (IOException e) {
 				throw new UnexpectedIOException(
 					"Error occurred while compacting catalog data file: " + e.getMessage(),
@@ -3122,7 +3463,8 @@ public class DefaultCatalogPersistenceService
 					VERSIONED_KRYO_FACTORY,
 					nonFlushedBlock -> this.reportNonFlushedContents(this.catalogName, nonFlushedBlock),
 					oldestRecordTimestamp -> DefaultCatalogPersistenceService.reportOldestHistoricalRecord(
-						this.catalogName, oldestRecordTimestamp.orElse(null))
+						this.catalogName, oldestRecordTimestamp.orElse(null)),
+					this.checkpointCoordinator
 				);
 				final CatalogOffsetIndexStoragePartPersistenceService previousService = this.catalogStoragePartPersistenceService.put(
 					catalogVersion,
@@ -3179,7 +3521,7 @@ public class DefaultCatalogPersistenceService
 				flushedDescriptor.fileLocation()
 			);
 		}
-		return writeCatalogBootstrap(catalogVersion, newCatalogName, bootstrapRecord);
+		return bootstrapRecord;
 	}
 
 	/**
@@ -3249,10 +3591,11 @@ public class DefaultCatalogPersistenceService
 	 * @return the first catalog version corresponding to the provided CatalogBootstrap instance or -1 if the WAL is not available.
 	 */
 	private long resolveFirstCatalogVersionOfCatalogBootstrap(@Nonnull CatalogBootstrap catalogBootstrap) {
-		if (this.catalogWal == null) {
+		final CatalogWriteAheadLog theCatalogWal = this.catalogWal;
+		if (theCatalogWal == null) {
 			return -1L;
 		} else {
-			return this.catalogWal.getFirstVersionOf(catalogBootstrap.catalogFileIndex());
+			return theCatalogWal.getFirstVersionOf(catalogBootstrap.catalogFileIndex());
 		}
 	}
 
@@ -3387,6 +3730,13 @@ public class DefaultCatalogPersistenceService
 		final Kryo kryo = this.walKryoPool.obtain();
 		try {
 			this.bootstrapWriteLock.lockInterruptibly();
+			// THE FENCE. A bootstrap record is a pointer into the data files, and it must never become durable
+			// before the bytes it addresses have. Forcing here rather than at the call sites makes that structural:
+			// every writer of a bootstrap record - trunk round, compaction, go-live, rename, restore - is covered,
+			// including ones added later that would never think to ask.
+			if (this.checkpointCoordinator != null) {
+				this.checkpointCoordinator.forcePendingSyncs();
+			}
 			final BootstrapWriteOnlyFileHandle originalBootstrapHandle = this.bootstrapWriteHandle.get();
 			final BootstrapWriteOnlyFileHandle bootstrapHandle = getOrCreateNewBootstrapTempWriteHandle(
 				catalogVersion, newCatalogName, originalBootstrapHandle

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/DefaultEntityCollectionPersistenceService.java
@@ -96,6 +96,7 @@ import io.evitadb.store.offsetIndex.OffsetIndex;
 import io.evitadb.store.offsetIndex.OffsetIndex.NonFlushedBlock;
 import io.evitadb.store.offsetIndex.OffsetIndexDescriptor;
 import io.evitadb.store.offsetIndex.io.CatalogOffHeapMemoryManager;
+import io.evitadb.store.offsetIndex.io.PendingSyncRegistry;
 import io.evitadb.store.offsetIndex.io.WriteOnlyFileHandle;
 import io.evitadb.store.offsetIndex.model.OffsetIndexRecordTypeRegistry;
 import io.evitadb.store.offsetIndex.model.StorageRecord;
@@ -158,6 +159,14 @@ public class DefaultEntityCollectionPersistenceService
 	 * into far fewer, larger writes.
 	 */
 	private static final int COMPACTION_OUTPUT_BUFFER_SIZE = 65_536;
+	/**
+	 * Mirrors {@link io.evitadb.api.configuration.StorageOptions#syncWrites()}.
+	 *
+	 * Retained because the compaction path writes its output file through a raw stream rather than through a
+	 * {@link io.evitadb.store.offsetIndex.io.WriteOnlyHandle}, so it has to honour the setting itself instead of
+	 * inheriting it from the handle.
+	 */
+	private final boolean syncWrites;
 	/**
 	 * Factory function that configures new instance of the versioned kryo factory.
 	 */
@@ -480,6 +489,20 @@ public class DefaultEntityCollectionPersistenceService
 		return Collections.emptyList();
 	}
 
+	/**
+	 * Creates the persistence service backing a single entity collection's data file.
+	 *
+	 * @param catalogVersion                the catalog version the collection is being opened at
+	 * @param catalogName                   name of the owning catalog
+	 * @param catalogStoragePath            directory the collection file lives in
+	 * @param entityTypeHeader              header describing the collection file and its location
+	 * @param storageSettings               storage settings, including whether writes are flushed to the device
+	 * @param offHeapMemoryManager          manager handing out off-heap buffers for isolated writes
+	 * @param observableOutputKeeper        keeper owning the lifetime of the write output
+	 * @param offsetIndexRecordTypeRegistry registry mapping storage part types to their record ids
+	 * @param pendingSyncRegistry           registry taking over the device flush of this collection's data file, or
+	 *                                      null to have each write flushed to the device inline
+	 */
 	public DefaultEntityCollectionPersistenceService(
 		long catalogVersion,
 		@Nonnull String catalogName,
@@ -488,7 +511,8 @@ public class DefaultEntityCollectionPersistenceService
 		@Nonnull StorageSettings storageSettings,
 		@Nonnull CatalogOffHeapMemoryManager offHeapMemoryManager,
 		@Nonnull ObservableOutputKeeper observableOutputKeeper,
-		@Nonnull OffsetIndexRecordTypeRegistry offsetIndexRecordTypeRegistry
+		@Nonnull OffsetIndexRecordTypeRegistry offsetIndexRecordTypeRegistry,
+		@Nullable PendingSyncRegistry pendingSyncRegistry
 	) {
 		this.entityCollectionFileReference = new CollectionFileReference(
 			entityTypeHeader.entityType(),
@@ -497,6 +521,7 @@ public class DefaultEntityCollectionPersistenceService
 			entityTypeHeader.fileLocation()
 		);
 		this.entityCollectionFile = this.entityCollectionFileReference.toFilePath(catalogStoragePath);
+		this.syncWrites = storageSettings.syncWrites();
 		this.entityCollectionHeader = entityTypeHeader;
 		this.offsetIndexRecordTypeRegistry = offsetIndexRecordTypeRegistry;
 		this.observableOutputKeeper = observableOutputKeeper;
@@ -510,7 +535,8 @@ public class DefaultEntityCollectionPersistenceService
 			storageSettings,
 			storageSettings,
 			this.entityCollectionFile,
-			observableOutputKeeper
+			observableOutputKeeper,
+			pendingSyncRegistry
 		);
 		try {
 			this.storagePartPersistenceService = new OffsetIndexStoragePartPersistenceService(
@@ -972,10 +998,18 @@ public class DefaultEntityCollectionPersistenceService
 		final Path catalogStoragePath = this.entityCollectionFile.getParent();
 		final Path newFilePath = newReference.toFilePath(catalogStoragePath);
 		final OffsetIndexDescriptor offsetIndexDescriptor;
-		try (final OutputStream fos = new BufferedOutputStream(
-			new FileOutputStream(newFilePath.toFile()), COMPACTION_OUTPUT_BUFFER_SIZE
-		)) {
+		try (
+			final FileOutputStream compactedFileStream = new FileOutputStream(newFilePath.toFile());
+			final OutputStream fos = new BufferedOutputStream(compactedFileStream, COMPACTION_OUTPUT_BUFFER_SIZE)
+		) {
 			offsetIndexDescriptor = this.storagePartPersistenceService.copySnapshotTo(catalogVersion, fos, null);
+			// The collection header produced below points into this file and reaches the disk behind a fsynced
+			// bootstrap record. Closing a BufferedOutputStream only pushes its buffer into the page cache, so
+			// without this a crash could leave a durable pointer addressing data that was never written.
+			fos.flush();
+			if (this.syncWrites) {
+				compactedFileStream.getFD().sync();
+			}
 		} catch (IOException e) {
 			throw new UnexpectedIOException(
 				"Error occurred while compacting entity " + this.entityCollectionFile + " data file: " + e.getMessage(),

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/task/FullBackupTask.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/catalog/task/FullBackupTask.java
@@ -89,6 +89,8 @@ public class FullBackupTask extends ClientCallableTask<BackupSettings, FileForFe
 		this.catalogPersistenceService = new AtomicReference<>(catalogPersistenceService);
 		this.exportFileService = new AtomicReference<>(exportService);
 		this.onComplete = new AtomicReference<>(onComplete);
+		// note the version read here is only as recent as the last checkpoint - the factory that builds this task
+		// settles any outstanding one first, see DefaultCatalogPersistenceService#createFullBackupTask
 		this.lastCatalogVersion = catalogPersistenceService.getLastCatalogVersion();
 		if (onStart != null) {
 			onStart.accept(this.lastCatalogVersion);

--- a/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
+++ b/evita_store/evita_store_server/src/main/java/io/evitadb/store/wal/AbstractMutationLog.java
@@ -93,6 +93,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.IntFunction;
 import java.util.function.LongSupplier;
 import java.util.stream.Stream;
@@ -192,6 +193,22 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	 * Contains information about the last catalog version that was successfully stored (and its WAL contents processed).
 	 */
 	protected final AtomicLong processedVersion;
+	/**
+	 * Serializes {@link #syncWal()} against {@link #rotateWalFile()}.
+	 *
+	 * Appends themselves are **not** guarded by this lock - that is the entire point of
+	 * {@link #appendDeferringSync(TransactionMutation, OffHeapWithFileBackupReference)}, which lets the
+	 * appending thread write the next transaction while a force is still in flight. `FileChannel` permits
+	 * a concurrent `write` and `force`; the only thing that must not overlap is a force with the rotation
+	 * that closes the very channel being forced, which would surface as a `ClosedChannelException` on a
+	 * transaction the caller is about to acknowledge as durable.
+	 *
+	 * Holding this lock across the whole rotation also makes rotation's own force of the outgoing channel
+	 * atomic with the swap: once a syncing thread observes the incoming channel, everything written to
+	 * the outgoing one has already been forced, so a snapshot taken before the force stays covered no
+	 * matter which side of the rotation the force landed on.
+	 */
+	private final ReentrantLock walSyncLock = new ReentrantLock();
 	/**
 	 * Contains reference to the asynchronous task executor that removes the obsolete WAL files.
 	 */
@@ -611,7 +628,8 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	 *
 	 * @param walFilePath        The path to the WAL file
 	 * @param ex                 The exception that occurred
-	 * @param corruptionFactory  factory yielding the flavor-specific WAL corruption exception
+	 * @param walKind            which write-ahead log the failure belongs to - it selects the flavor of the
+	 *                           corruption exception raised when a generic exception has to be wrapped
 	 * @throws EvitaInternalError Always throws — either rethrows an existing WAL-corruption exception
 	 *                            (catalog or engine flavor) or wraps a generic exception in one.
 	 */
@@ -636,6 +654,99 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 				ex
 			);
 		}
+	}
+
+	/**
+	 * Makes everything written to the given WAL channel durable on the storage device.
+	 *
+	 * The WAL channels are deliberately **not** opened with `StandardOpenOption.DSYNC`: that option
+	 * syncs every single `write` call separately, and a single transaction append issues three of them
+	 * (head, content, trailing cumulative checksum), so the transaction paid three device syncs where
+	 * one suffices. Measured on a LUKS+xfs volume, dropping DSYNC in favour of one explicit force per
+	 * append cuts the durability cost of an append to a third.
+	 *
+	 * The durability *point* is unchanged - every caller forces before it reports success - but the
+	 * write *ordering* guarantee is: with DSYNC a crash always left a clean prefix, whereas now the
+	 * writes since the last force may reach the device in any order. That is safe here only because
+	 * each force covers everything written before it **on that channel**, so an incompletely written
+	 * region can exist solely in the append that was in flight when the process died - i.e. at the
+	 * tail, which recovery already truncates. Any new writer on these channels must preserve that
+	 * property: force before anything may observe the write as committed, and never leave a completed
+	 * record unforced.
+	 *
+	 * Note the qualifier: a force orders nothing on a *different* channel. Rotation therefore cannot
+	 * lean on the next append's force to cover what it wrote - it spans two files - which is why it
+	 * forces the outgoing file's tail before closing it and the incoming file's checksum seed straight
+	 * after writing it, rather than leaving either to be swept up later.
+	 *
+	 * `force(true)` (metadata included) is used rather than `force(false)`, because these channels are
+	 * opened in APPEND mode where the file length itself is metadata - a durable record behind a stale
+	 * length is unreadable. It was measured to cost no more than `force(false)` on xfs.
+	 *
+	 * @param walFileChannel the WAL file channel to make durable
+	 * @throws IOException if the underlying force operation fails
+	 */
+	private static void forceDurable(@Nonnull FileChannel walFileChannel) throws IOException {
+		walFileChannel.force(true);
+	}
+
+	/**
+	 * Opens a WAL channel, choosing between the two ways a crash can be survived.
+	 *
+	 * Surviving a crash needs **either** write ordering **or** hole detection, and the two are traded
+	 * against each other here:
+	 *
+	 * - **Hole detection (fast, the default).** Without `DSYNC` the writes between two forces may reach
+	 *   the device in any order, so a crash can leave a *hole* — bytes missing in the middle of a
+	 *   transaction while later bytes landed. The file length is unchanged, so the framing still parses
+	 *   and nothing about the record looks wrong; the only thing that can tell a hole from valid data is
+	 *   the cumulative CRC32C chain, which recovery verifies per transaction and reacts to by truncating.
+	 * - **Write ordering (slow, the fallback).** With `computeCRC32C` switched off that chain degrades to
+	 *   {@link io.evitadb.store.checksum.Checksum#NO_OP}, whose comparison always answers "matches" — so a
+	 *   hole is waved straight through recovery and replayed as if it were real history. There is then no
+	 *   way to detect the damage, so the damage must be made impossible instead: `DSYNC` syncs every
+	 *   individual write, which restores the guarantee that a crash can only ever leave a clean prefix.
+	 *
+	 * This costs a device sync per write rather than per transaction, which is precisely the cost the
+	 * explicit-force design exists to avoid - so it applies only to the non-default configuration that
+	 * cannot pay for correctness any other way.
+	 *
+	 * Historically this coupling did not exist because `DSYNC` was unconditional, which silently made the
+	 * checksum optional. Removing it turned hole tolerance into a correctness requirement, and the two
+	 * settings became linked whether or not anyone said so.
+	 *
+	 * @param walFilePath path of the WAL file to open
+	 * @return the opened channel
+	 * @throws IOException if the file cannot be opened
+	 */
+	@Nonnull
+	private FileChannel openWalChannel(@Nonnull Path walFilePath) throws IOException {
+		return requiresWriteOrdering(this.storageSettings) ?
+			FileChannel.open(
+				walFilePath,
+				StandardOpenOption.WRITE, StandardOpenOption.APPEND, StandardOpenOption.DSYNC
+			) :
+			FileChannel.open(
+				walFilePath,
+				StandardOpenOption.WRITE, StandardOpenOption.APPEND
+			);
+	}
+
+	/**
+	 * Decides which of the two crash-survival strategies described on {@link #openWalChannel(Path)} this
+	 * WAL has to use: TRUE demands write ordering from the device, FALSE relies on detecting the damage
+	 * afterwards.
+	 *
+	 * Deliberately a named predicate rather than an inline condition, because it is the one place where
+	 * the two settings are tied together and the tie is not otherwise visible - `computeCRC32C` reads like
+	 * an integrity/performance trade-off, and nothing about its name suggests that switching it off also
+	 * changes how the WAL must be written.
+	 *
+	 * @param storageSettings settings the WAL is operating under
+	 * @return TRUE when the WAL must be opened with `DSYNC` because holes could not otherwise be detected
+	 */
+	static boolean requiresWriteOrdering(@Nonnull StorageSettings storageSettings) {
+		return !storageSettings.computeCRC32C();
 	}
 
 	/**
@@ -674,6 +785,10 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 			written == AbstractMutationLog.WAL_TAIL_LENGTH,
 			"Failed to write tail to WAL file!"
 		);
+		// the tail is authoritative for readers - `MutationSupplier` derives end-of-file arithmetic from
+		// it - so it must never survive a crash that the data it describes did not. This channel belongs
+		// to a `RandomAccessFile` opened "rw" and so was never covered by DSYNC either.
+		forceDurable(walFileChannel);
 	}
 
 	/**
@@ -763,10 +878,7 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 			// create the WAL file if it does not exist
 			final boolean created = createWalFile(walFilePath, true, this.walKind);
 
-			final FileChannel walFileChannel = FileChannel.open(
-				walFilePath,
-				StandardOpenOption.WRITE, StandardOpenOption.APPEND, StandardOpenOption.DSYNC
-			);
+			final FileChannel walFileChannel = openWalChannel(walFilePath);
 
 			final ObservableOutput<ByteArrayOutputStream> theOutput = new ObservableOutput<>(
 				this.transactionMutationOutputStream,
@@ -787,6 +899,10 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 					walFileChannel.write(this.contentLengthBuffer) == CUMULATIVE_CRC32_SIZE,
 					"Failed to write initial cumulative checksum to WAL file!"
 				);
+				// every transaction appended later chains its checksum onto this seed, so it has to be on
+				// the device before any of them - the first append's force would cover it, but this file
+				// is created once and the sync is not worth economising on
+				forceDurable(walFileChannel);
 			}
 
 			this.currentWalFile.set(
@@ -952,17 +1068,90 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	}
 
 	/**
+	 * Appends a transaction mutation to the Write-Ahead Log (WAL) file and makes it durable before
+	 * returning, so the caller may report the transaction as persisted the moment this method returns.
+	 *
+	 * @param transactionMutation The transaction mutation to append.
+	 * @param walReference        The reference to the WAL file.
+	 * @return the reference to the appended record
+	 */
+	@Nonnull
+	public LogFileRecordReference append(
+		@Nonnull TransactionMutation transactionMutation,
+		@Nonnull OffHeapWithFileBackupReference walReference
+	) {
+		return doAppend(transactionMutation, walReference, true);
+	}
+
+	/**
+	 * Appends a transaction mutation to the WAL **without** making it durable - the bytes reach the page
+	 * cache, and the caller takes over the obligation to call {@link #syncWal()} before it reports the
+	 * transaction as persisted to anyone.
+	 *
+	 * This exists so a single-threaded appender can keep writing while a force for earlier transactions
+	 * is still in flight: one later force then covers every append that accumulated meanwhile, which is
+	 * what turns a per-transaction device sync into a per-batch one. It is a strictly more dangerous API
+	 * than {@link #append(TransactionMutation, OffHeapWithFileBackupReference)} and is meant only for
+	 * callers that own an explicit durability handshake - anything else must use the plain variant.
+	 *
+	 * @param transactionMutation The transaction mutation to append.
+	 * @param walReference        The reference to the WAL file.
+	 * @return the reference to the appended record
+	 */
+	@Nonnull
+	public LogFileRecordReference appendDeferringSync(
+		@Nonnull TransactionMutation transactionMutation,
+		@Nonnull OffHeapWithFileBackupReference walReference
+	) {
+		return doAppend(transactionMutation, walReference, false);
+	}
+
+	/**
+	 * Makes everything appended to this WAL so far durable.
+	 *
+	 * The caller must sample whatever it intends to declare durable **before** invoking this method -
+	 * appends that land while the force is in flight may or may not be covered by it, and crediting them
+	 * afterwards would acknowledge a transaction the device has not necessarily seen.
+	 *
+	 * @throws UnexpectedIOException if the force fails - the WAL must then be treated as non-durable
+	 */
+	public void syncWal() {
+		// when the channel demands write ordering it is opened with DSYNC, so every write was already
+		// synced on return and there is nothing left to force. Skipping it is not a micro-optimization:
+		// measured on a LUKS+xfs volume, a force with no dirty pages still costs 0.49 ms - roughly a tenth
+		// of a real one - because the filesystem issues a device cache flush regardless of dirty state.
+		// Paying that per batch on the path that is already the slower of the two would be pure waste
+		if (requiresWriteOrdering(this.storageSettings)) {
+			return;
+		}
+		this.walSyncLock.lock();
+		try {
+			forceDurable(this.currentWalFile.get().getWalFileChannel());
+		} catch (IOException e) {
+			throw new UnexpectedIOException(
+				"Failed to sync WAL `" + this.currentWalFile.get() + "`!",
+				"Failed to sync WAL!",
+				e
+			);
+		} finally {
+			this.walSyncLock.unlock();
+		}
+	}
+
+	/**
 	 * Appends a transaction mutation to the Write-Ahead Log (WAL) file.
 	 *
 	 * @param transactionMutation The transaction mutation to append.
 	 * @param walReference        The reference to the WAL file.
-	 * @return the number of Bytes written
+	 * @param syncOnCompletion    whether the append must be durable by the time this method returns
+	 * @return the reference to the appended record
 	 */
 	@Nonnull
 	@SuppressWarnings("StringConcatenationMissingWhitespace")
-	public LogFileRecordReference append(
+	private LogFileRecordReference doAppend(
 		@Nonnull TransactionMutation transactionMutation,
-		@Nonnull OffHeapWithFileBackupReference walReference
+		@Nonnull OffHeapWithFileBackupReference walReference,
+		boolean syncOnCompletion
 	) {
 		Assert.isTrue(
 			transactionMutation.getWalSizeInBytes() <= this.maxWalFileSizeBytes,
@@ -1089,6 +1278,15 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 				8 == walFileChannel.write(this.contentLengthBuffer),
 				"Failed to write cumulative checksum to WAL file!"
 			);
+
+			// The transaction is complete on the channel. Unless the caller has taken over the durability
+			// handshake (see `appendDeferringSync`), make it durable before returning, because the caller
+			// completes `WAIT_FOR_WAL_PERSISTENCE` off the back of this method and that stage promises the
+			// client the change survives a crash. This single force replaces the three separate device
+			// syncs that DSYNC used to perform for the writes above.
+			if (syncOnCompletion) {
+				forceDurable(walFileChannel);
+			}
 
 			final int writtenLength = writtenHead + writtenContent + AbstractMutationLog.CUMULATIVE_CRC32_SIZE;
 			theCurrentWalFile.updateLastWrittenVersion(
@@ -1303,7 +1501,15 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	@Override
 	public void close() throws IOException {
 		IOUtils.closeQuietly(
-			() -> this.currentWalFile.get().close(),
+			// closing the channel is exclusive with `syncWal` for the same reason rotation is
+			() -> {
+				this.walSyncLock.lock();
+				try {
+					this.currentWalFile.get().close();
+				} finally {
+					this.walSyncLock.unlock();
+				}
+			},
 			this.transactionMutationOutputStream::close,
 			this.cutWalCacheTask::close,
 			this.removeWalFileTask::close
@@ -1799,13 +2005,30 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 	}
 
 	/**
-	 * Rotates the Write-Ahead Log (WAL) file.
-	 * Increments the WAL file index and performs the necessary operations to close the current WAL file,
-	 * create a new one, and delete any excess WAL files beyond the configured limit.
+	 * Rotates the Write-Ahead Log (WAL) file under {@link #walSyncLock}, because rotation forces and then
+	 * closes the very channel a concurrent {@link #syncWal()} may be forcing.
 	 *
 	 * @throws WriteAheadLogCorruptedException if an error occurs during the rotation process.
 	 */
 	private void rotateWalFile() {
+		this.walSyncLock.lock();
+		try {
+			rotateWalFileInternal();
+		} finally {
+			this.walSyncLock.unlock();
+		}
+	}
+
+	/**
+	 * Rotates the Write-Ahead Log (WAL) file.
+	 * Increments the WAL file index and performs the necessary operations to close the current WAL file,
+	 * create a new one, and delete any excess WAL files beyond the configured limit.
+	 *
+	 * Must be called only from {@link #rotateWalFile()}, which holds {@link #walSyncLock} around it.
+	 *
+	 * @throws WriteAheadLogCorruptedException if an error occurs during the rotation process.
+	 */
+	private void rotateWalFileInternal() {
 		final WalRotationEvent event = createWalRotationEvent();
 
 		final CurrentMutationLogFile theCurrentWalFile = this.currentWalFile.get();
@@ -1831,6 +2054,9 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 
 			// write tail to the file
 			finalCumulativeChecksum = writeWalTail(firstCvInFile, lastCvInFile, theCurrentWalFile.getWalFileChannel());
+			// the tail must reach the device before the channel is dropped: `close()` does not sync, and
+			// a tail marker outliving the transactions it describes would be read as authoritative
+			forceDurable(theCurrentWalFile.getWalFileChannel());
 			theCurrentWalFile.close();
 		} catch (IOException e) {
 			throw new WriteAheadLogCorruptedException(this.walKind,
@@ -1847,10 +2073,7 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 
 			// create the WAL file if it does not exist
 			AbstractMutationLog.createWalFile(walFilePath, false, this.walKind);
-			final FileChannel walFileChannel = FileChannel.open(
-				walFilePath,
-				StandardOpenOption.WRITE, StandardOpenOption.APPEND, StandardOpenOption.DSYNC
-			);
+			final FileChannel walFileChannel = openWalChannel(walFilePath);
 
 			final ObservableOutput<ByteArrayOutputStream> theOutput = new ObservableOutput<>(
 				this.transactionMutationOutputStream,
@@ -1872,6 +2095,8 @@ public abstract class AbstractMutationLog<T extends Mutation> implements AutoClo
 				8 == walFileChannel.write(this.contentLengthBuffer),
 				"Failed to write cumulative checksum to WAL file!"
 			);
+			// seeds the checksum chain of the freshly rotated file - same reasoning as at construction
+			forceDurable(walFileChannel);
 
 			this.currentWalFile.set(
 				new CurrentMutationLogFile(

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/configuration/TransactionOptionsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/configuration/TransactionOptionsTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.EnumSet;
+
 import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -398,6 +398,7 @@ class TransactionOptionsTest {
 					TransactionOptions
 						.DEFAULT_WAIT_FOR_TRANSACTION_ACCEPTANCE,
 					TransactionOptions.DEFAULT_FLUSH_FREQUENCY,
+					TransactionOptions.DEFAULT_CHECKPOINT_INTERVAL,
 					TransactionOptions
 						.DEFAULT_CONFLICT_RING_BUFFER_SIZE,
 					TransactionOptions.DEFAULT_CONFLICT_RESOLUTION

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/stage/ConflictResolutionAndWalAppendingTransactionStageTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/stage/ConflictResolutionAndWalAppendingTransactionStageTest.java
@@ -33,13 +33,22 @@ import io.evitadb.spi.store.catalog.shared.model.LogRecordReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Tag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -47,6 +56,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.TRANSACTION;
@@ -224,6 +235,139 @@ class ConflictResolutionAndWalAppendingTransactionStageTest {
 		} catch (Throwable ex) {
 			stage.handleException(task, ex);
 		}
+	}
+
+	/**
+	 * The point of the deferred WAL sync: transactions appended while a force is in flight must be carried
+	 * by **one** subsequent force rather than paying for one each.
+	 *
+	 * The test pins both halves of that contract. It holds the first force open, feeds two more
+	 * transactions through the stage while it is blocked — which only returns if the appender genuinely
+	 * does not wait for the device — and then asserts that three transactions cost two forces, with the
+	 * second one covering both stragglers at once.
+	 *
+	 * It also pins the durability ordering: while the first force is in flight, no transaction may be
+	 * reported as WAL-persisted, because nothing has reached the device yet.
+	 */
+	@Test
+	@DisplayName("should carry every transaction appended during a force with one single subsequent force")
+	void shouldCoverTransactionsAppendedDuringAForceWithASingleForce() throws Exception {
+		final AtomicLong lastAssigned = new AtomicLong(0L);
+		final AtomicLong lastWritten = new AtomicLong(0L);
+		final TransactionManager tm = buildTransactionManagerMock(lastAssigned, lastWritten);
+
+		// the sync task needs a thread of its own - running it inline would make the appender the forcing
+		// thread again and there would be nothing to overlap
+		final ExecutorService syncExecutor = Executors.newSingleThreadExecutor();
+		try {
+			final CountDownLatch firstForceEntered = new CountDownLatch(1);
+			final CountDownLatch releaseFirstForce = new CountDownLatch(1);
+			final AtomicInteger forceCount = new AtomicInteger();
+			final List<Long> publishedDurableVersions = Collections.synchronizedList(new ArrayList<>());
+
+			doNothing().when(tm).identifyConflicts(anyLong(), anyLong(), any(), any());
+			doAnswer(inv -> 0L).when(tm).appendWalAndDiscard(any(), any(), any());
+			doAnswer(inv -> {
+				publishedDurableVersions.add(inv.getArgument(0));
+				return null;
+			}).when(tm).updateLastDurableCatalogVersion(anyLong());
+			doAnswer(inv -> {
+				if (forceCount.incrementAndGet() == 1) {
+					firstForceEntered.countDown();
+					assertTrue(
+						releaseFirstForce.await(10, TimeUnit.SECONDS),
+						"The test never released the first force!"
+					);
+				}
+				return null;
+			}).when(tm).syncWal();
+
+			final ConflictResolutionAndWalAppendingTransactionStage stage =
+				new ConflictResolutionAndWalAppendingTransactionStage(
+					syncExecutor,
+					100,
+					tm,
+					(task, ex) -> {}
+				);
+
+			final ConflictResolutionAndWalAppendingTransactionTask t1 = newTask();
+			feed(stage, t1);
+			assertTrue(
+				firstForceEntered.await(10, TimeUnit.SECONDS),
+				"The first transaction must trigger a force straight away - batching may never add latency " +
+					"to an otherwise idle commit path"
+			);
+
+			// these two only get through while the device is busy if the appender really does not wait for it
+			final ConflictResolutionAndWalAppendingTransactionTask t2 = newTask();
+			feed(stage, t2);
+			final ConflictResolutionAndWalAppendingTransactionTask t3 = newTask();
+			feed(stage, t3);
+
+			assertFalse(
+				t1.commitProgress().onWalAppended().toCompletableFuture().isDone(),
+				"No transaction may be reported as WAL-persisted before the force covering it completed"
+			);
+
+			releaseFirstForce.countDown();
+
+			t1.commitProgress().onWalAppended().toCompletableFuture().get(10, TimeUnit.SECONDS);
+			t2.commitProgress().onWalAppended().toCompletableFuture().get(10, TimeUnit.SECONDS);
+			t3.commitProgress().onWalAppended().toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+			assertEquals(
+				2, forceCount.get(),
+				"Three transactions must cost two forces: one for the transaction that started the batch " +
+					"and one covering everything that arrived while it was in flight"
+			);
+			assertEquals(
+				List.of(1L, 3L), publishedDurableVersions,
+				"The first force may only publish the version sampled before it started; the second must " +
+					"publish both stragglers at once"
+			);
+		} finally {
+			syncExecutor.shutdownNow();
+		}
+	}
+
+	/**
+	 * A force that fails means the device stopped accepting the log. Every transaction waiting on that
+	 * force must be failed rather than silently acknowledged, and the stage must stop accepting new work -
+	 * continuing would hand out commit acknowledgements that could never be honoured.
+	 */
+	@Test
+	@DisplayName("should fail pending transactions and stop accepting more when the WAL cannot be forced")
+	void shouldFailPendingTransactionsWhenForceFails() {
+		final AtomicLong lastAssigned = new AtomicLong(0L);
+		final AtomicLong lastWritten = new AtomicLong(0L);
+		final TransactionManager tm = buildTransactionManagerMock(lastAssigned, lastWritten);
+
+		doNothing().when(tm).identifyConflicts(anyLong(), anyLong(), any(), any());
+		doAnswer(inv -> 0L).when(tm).appendWalAndDiscard(any(), any(), any());
+		doThrow(new RuntimeException("simulated device failure")).when(tm).syncWal();
+
+		final ConflictResolutionAndWalAppendingTransactionStage stage =
+			new ConflictResolutionAndWalAppendingTransactionStage(
+				Runnable::run,
+				100,
+				tm,
+				(task, ex) -> {}
+			);
+
+		final ConflictResolutionAndWalAppendingTransactionTask t1 = newTask();
+		feed(stage, t1);
+		assertTrue(
+			t1.commitProgress().onWalAppended().toCompletableFuture().isCompletedExceptionally(),
+			"A transaction whose force failed must be failed, never acknowledged"
+		);
+
+		final ConflictResolutionAndWalAppendingTransactionTask t2 = newTask();
+		feed(stage, t2);
+		assertTrue(
+			t2.commitProgress().onWalAppended().toCompletableFuture().isCompletedExceptionally(),
+			"Once the WAL cannot be made durable the stage must refuse further transactions"
+		);
+		verify(tm, times(1)).appendWalAndDiscard(any(), any(), any());
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/stage/TrunkIncorporationTransactionStageTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/core/transaction/stage/TrunkIncorporationTransactionStageTest.java
@@ -31,11 +31,13 @@ import io.evitadb.core.transaction.TransactionManager;
 import io.evitadb.core.transaction.stage.TrunkIncorporationTransactionStage.TrunkIncorporationTransactionTask;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,6 +45,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.TRANSACTION;
@@ -114,6 +117,58 @@ class TrunkIncorporationTransactionStageTest {
 			progress.onChangesVisible().toCompletableFuture().isCompletedExceptionally(),
 			"The empty-Optional path reflects a concurrent task completing our transaction, which is " +
 				"not a failure — the commit progress should complete successfully"
+		);
+	}
+
+	/**
+	 * The configured `flushFrequencyInMillis` budget has to reach
+	 * {@link TransactionManager#processTransactions(long, long, boolean, boolean, java.util.function.LongConsumer)}
+	 * in **milliseconds**, because that is the unit its `timeoutMs` argument is compared in (against a
+	 * `System.currentTimeMillis()` delta).
+	 *
+	 * This previously passed nanoseconds, which inflated the default 1 s budget to roughly 11.6 days —
+	 * the greedy batching loop then never terminated on time and drained the whole WAL backlog present
+	 * at round open regardless of the configured budget, leaving the knob silently inert.
+	 */
+	@Test
+	@DisplayName("should hand the greedy batching budget to processTransactions in milliseconds")
+	void shouldPassGreedyBatchingBudgetInMilliseconds() {
+		final TransactionManager tm = mock(TransactionManager.class);
+		when(tm.getCatalogName()).thenReturn(CATALOG_NAME);
+		when(tm.getLastFinalizedCatalogVersion()).thenReturn(10L);
+		when(tm.processTransactions(anyLong(), anyLong(), anyBoolean(), anyBoolean(), any()))
+			.thenReturn(Optional.empty());
+		final ObservableExecutorService synchronousExecutor = mock(ObservableExecutorService.class);
+		doAnswer(inv -> {
+			((Runnable) inv.getArgument(0)).run();
+			return null;
+		}).when(synchronousExecutor).execute(any(Runnable.class));
+		when(tm.getRequestExecutor()).thenReturn(synchronousExecutor);
+
+		final long flushFrequencyInMillis = 1_000L;
+		final TrunkIncorporationTransactionStage stage = new TrunkIncorporationTransactionStage(
+			tm, flushFrequencyInMillis, (task, ex) -> {}
+		);
+
+		final CommitProgressRecord progress = new CommitProgressRecord();
+		final CommitVersions versions = new CommitVersions(20L, 1);
+		progress.complete(CommitBehavior.WAIT_FOR_CONFLICT_RESOLUTION, versions, synchronousExecutor);
+		progress.complete(CommitBehavior.WAIT_FOR_WAL_PERSISTENCE, versions, synchronousExecutor);
+
+		stage.handleNext(
+			new TrunkIncorporationTransactionTask(
+				CATALOG_NAME, 20L, 1, UUID.randomUUID(), progress
+			)
+		);
+
+		final ArgumentCaptor<Long> timeoutCaptor = ArgumentCaptor.forClass(Long.class);
+		verify(tm).processTransactions(
+			anyLong(), timeoutCaptor.capture(), anyBoolean(), anyBoolean(), any()
+		);
+		assertEquals(
+			flushFrequencyInMillis, timeoutCaptor.getValue(),
+			"The greedy batching budget must be passed in milliseconds — processTransactions compares " +
+				"it against a System.currentTimeMillis() delta, so any other unit makes the knob inert"
 		);
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/CheckpointCoordinatorTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/CheckpointCoordinatorTest.java
@@ -1,0 +1,271 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.catalog;
+
+import io.evitadb.core.executor.Scheduler;
+import io.evitadb.store.kryo.ObservableOutput;
+import io.evitadb.store.offsetIndex.io.ReadOnlyHandle;
+import io.evitadb.store.offsetIndex.io.WriteOnlyHandle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static io.evitadb.test.TestTags.STORAGE;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the two properties the deferred-checkpoint design rests on: that no file owing a device flush is ever
+ * dropped from the pending set, and that a catalog which falls silent still gets checkpointed.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Checkpoint coordinator")
+@Tag(STORAGE)
+@Tag(TRANSACTION)
+class CheckpointCoordinatorTest {
+	private static final String CATALOG_NAME = "testCatalog";
+
+	private final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(2);
+	private final Scheduler scheduler = new Scheduler(this.executor);
+	private CheckpointCoordinator coordinator;
+
+	@AfterEach
+	void tearDown() {
+		if (this.coordinator != null) {
+			this.coordinator.close();
+		}
+		this.executor.shutdownNow();
+	}
+
+	@Test
+	@DisplayName("should force every registered handle")
+	void shouldForceEveryRegisteredHandle() {
+		this.coordinator = new CheckpointCoordinator(CATALOG_NAME, 1_000, this.scheduler, new ReentrantLock(), () -> {});
+
+		final RecordingHandle first = new RecordingHandle();
+		final RecordingHandle second = new RecordingHandle();
+		this.coordinator.noteSyncPending(first);
+		this.coordinator.noteSyncPending(second);
+		// registering twice must not force twice - the set is keyed by handle, not by write
+		this.coordinator.noteSyncPending(first);
+
+		this.coordinator.forcePendingSyncs();
+
+		assertEquals(1, first.forceCount.get());
+		assertEquals(1, second.forceCount.get());
+
+		// nothing left owing, so a second checkpoint has no work
+		this.coordinator.forcePendingSyncs();
+		assertEquals(1, first.forceCount.get());
+		assertEquals(1, second.forceCount.get());
+	}
+
+	@Test
+	@DisplayName("should keep a handle registered during the force still pending afterwards")
+	void shouldKeepHandleRegisteredDuringForceStillPending() {
+		this.coordinator = new CheckpointCoordinator(CATALOG_NAME, 1_000, this.scheduler, new ReentrantLock(), () -> {});
+
+		try (final RecordingHandle lateComer = new RecordingHandle()) {
+			// models the real race: `doSoftFlush` runs on a request thread and may register a handle while the
+			// checkpoint is already forcing. Clearing the set instead of removing the forced snapshot would drop this
+			// handle, leaving a durable bootstrap record pointing at bytes that were never synced.
+			final RecordingHandle registeringHandle = new RecordingHandle(
+				() -> this.coordinator.noteSyncPending(lateComer)
+			);
+			this.coordinator.noteSyncPending(registeringHandle);
+
+			this.coordinator.forcePendingSyncs();
+
+			assertEquals(1, registeringHandle.forceCount.get());
+			assertEquals(
+				0, lateComer.forceCount.get(),
+				"The handle registered mid-force was not part of the snapshot, so it must not have been forced yet."
+			);
+
+			// and it must still be owed, not silently dropped
+			this.coordinator.forcePendingSyncs();
+			assertEquals(
+				1, lateComer.forceCount.get(),
+				"The handle registered mid-force was dropped from the pending set instead of being carried over!"
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("should checkpoint a silent catalog through the ticker")
+	void shouldCheckpointSilentCatalogThroughTicker() throws InterruptedException {
+		final CountDownLatch checkpointed = new CountDownLatch(1);
+		this.coordinator = new CheckpointCoordinator(
+			CATALOG_NAME, 100, this.scheduler, new ReentrantLock(),
+			() -> {
+				checkpointed.countDown();
+				this.coordinator.noteCheckpointCompleted();
+			}
+		);
+
+		// exactly one deferred round and then silence - nothing else will ever drive a checkpoint
+		this.coordinator.noteCheckpointDeferred();
+
+		assertTrue(
+			checkpointed.await(5, TimeUnit.SECONDS),
+			"A catalog that went silent after a deferred round was never checkpointed!"
+		);
+	}
+
+	@Test
+	@DisplayName("should not run the ticker checkpoint when a round already checkpointed")
+	void shouldNotRunTickerCheckpointWhenRoundAlreadyCheckpointed() throws InterruptedException {
+		final AtomicInteger checkpointCount = new AtomicInteger();
+		this.coordinator = new CheckpointCoordinator(
+			CATALOG_NAME, 100, this.scheduler, new ReentrantLock(), checkpointCount::incrementAndGet
+		);
+
+		this.coordinator.noteCheckpointDeferred();
+		// a subsequent round found the interval elapsed and checkpointed inline, which disarms the ticker
+		this.coordinator.noteCheckpointCompleted();
+
+		Thread.sleep(500);
+		assertEquals(
+			0, checkpointCount.get(),
+			"The ticker checkpointed even though a round had already settled the debt."
+		);
+	}
+
+	@Test
+	@DisplayName("should record the failure when a ticker checkpoint throws")
+	void shouldRecordFailureWhenTickerCheckpointThrows() throws InterruptedException {
+		final IllegalStateException failure = new IllegalStateException("device is gone");
+		final CountDownLatch attempted = new CountDownLatch(1);
+		this.coordinator = new CheckpointCoordinator(
+			CATALOG_NAME, 100, this.scheduler, new ReentrantLock(),
+			() -> {
+				attempted.countDown();
+				throw failure;
+			}
+		);
+
+		this.coordinator.noteCheckpointDeferred();
+		assertTrue(attempted.await(5, TimeUnit.SECONDS), "The ticker never ran!");
+
+		// there is no client left to throw into - the failure has to be observable so the catalog can stop
+		// acknowledging commits it can no longer make durable
+		Throwable recorded = null;
+		for (int i = 0; i < 50 && recorded == null; i++) {
+			recorded = this.coordinator.getFailure();
+			if (recorded == null) {
+				Thread.sleep(20);
+			}
+		}
+		assertNotNull(recorded, "A failed checkpoint was swallowed on the scheduler thread!");
+		assertSame(failure, recorded);
+	}
+
+	@Test
+	@DisplayName("should report a checkpoint as due only once the interval has elapsed")
+	void shouldReportCheckpointDueOnlyAfterInterval() throws InterruptedException {
+		this.coordinator = new CheckpointCoordinator(CATALOG_NAME, 200, this.scheduler, new ReentrantLock(), () -> {});
+
+		assertNull(this.coordinator.getFailure());
+		// freshly constructed - the interval is counted from construction so the first round does not
+		// immediately checkpoint
+		assertFalse(this.coordinator.isCheckpointDue(), "A brand new coordinator reported a checkpoint as overdue.");
+
+		Thread.sleep(300);
+		assertTrue(this.coordinator.isCheckpointDue(), "The checkpoint interval elapsed but no checkpoint was due.");
+	}
+
+	/**
+	 * Minimal {@link WriteOnlyHandle} that only counts {@link #forceDurable()} calls and optionally runs a hook
+	 * while forcing, so the mid-force registration race can be reproduced deterministically.
+	 */
+	private static class RecordingHandle implements WriteOnlyHandle {
+		private final AtomicInteger forceCount = new AtomicInteger();
+		private final Runnable onForce;
+
+		RecordingHandle() {
+			this(null);
+		}
+
+		RecordingHandle(@Nullable Runnable onForce) {
+			this.onForce = onForce;
+		}
+
+		@Override
+		public <T> T checkAndExecute(@Nonnull String operation, @Nonnull Runnable premise, @Nonnull Function<ObservableOutput<?>, T> logic) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void checkAndExecuteAndSync(@Nonnull String operation, @Nonnull Runnable premise, @Nonnull Consumer<ObservableOutput<?>> logic) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public <S, T> T checkAndExecuteAndSync(@Nonnull String operation, @Nonnull Runnable premise, @Nonnull Function<ObservableOutput<?>, S> logic, @Nonnull BiFunction<ObservableOutput<?>, S, T> postExecutionLogic) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void forceDurable() {
+			this.forceCount.incrementAndGet();
+			if (this.onForce != null) {
+				this.onForce.run();
+			}
+		}
+
+		@Override
+		public long getLastWrittenPosition() {
+			return 0;
+		}
+
+		@Nonnull
+		@Override
+		public ReadOnlyHandle toReadOnlyHandle() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DefaultCatalogPersistenceServiceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DefaultCatalogPersistenceServiceTest.java
@@ -540,11 +540,13 @@ class DefaultCatalogPersistenceServiceTest implements EvitaTestSupport {
 				Mockito.mock(ExportFileService.class)
 			)
 		) {
-			cps.appendWalAndDiscard(
+			cps.appendWalAndDiscardDeferringSync(
 				2L,
 				writtenTransactionMutation,
 				walReference
 			);
+			// the append only writes; this test reads the file back, so make it durable first
+			cps.syncWal();
 		}
 
 		// READ THE WAL AGAIN
@@ -609,11 +611,12 @@ class DefaultCatalogPersistenceServiceTest implements EvitaTestSupport {
 				final OffHeapWithFileBackupReference walReference = OffHeapWithFileBackupReference.withFilePath(
 					tempFile.toPath(), 0, 0L, tempFile::delete
 				);
-				ioService.appendWalAndDiscard(
+				ioService.appendWalAndDiscardDeferringSync(
 					catalogVersion,
 					new TransactionMutation(UUIDUtil.randomUUID(), catalogVersion, 0, 0, OffsetDateTime.now()),
 					walReference
 				);
+				ioService.syncWal();
 			}
 
 			final PaginatedList<MaterializedVersionBlock> catalogVersions = ioService.getCatalogVersions(TimeFlow.FROM_OLDEST_TO_NEWEST, 1, 5);
@@ -736,11 +739,12 @@ class DefaultCatalogPersistenceServiceTest implements EvitaTestSupport {
 				final OffHeapWithFileBackupReference walReference = OffHeapWithFileBackupReference.withFilePath(
 					tempFile.toPath(), 0, 0L, tempFile::delete
 				);
-				ioService.appendWalAndDiscard(
+				ioService.appendWalAndDiscardDeferringSync(
 					catalogVersion,
 					new TransactionMutation(UUIDUtil.randomUUID(), catalogVersion, 0, 0, OffsetDateTime.now()),
 					walReference
 				);
+				ioService.syncWal();
 			}
 
 			final PaginatedList<MaterializedVersionBlock> catalogVersions = ioService.getCatalogVersions(TimeFlow.FROM_NEWEST_TO_OLDEST, 1, 5);
@@ -880,6 +884,7 @@ class DefaultCatalogPersistenceServiceTest implements EvitaTestSupport {
 			TransactionOptions.DEFAULT_WAL_FILE_COUNT_KEPT,
 			TransactionOptions.DEFAULT_WAIT_FOR_TRANSACTION_ACCEPTANCE,
 			TransactionOptions.DEFAULT_FLUSH_FREQUENCY,
+			TransactionOptions.DEFAULT_CHECKPOINT_INTERVAL,
 			TransactionOptions.DEFAULT_CONFLICT_RING_BUFFER_SIZE,
 			TransactionOptions.DEFAULT_CONFLICT_RESOLUTION
 		);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DeferredCheckpointPersistenceTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/catalog/DeferredCheckpointPersistenceTest.java
@@ -1,0 +1,556 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.store.catalog;
+
+import io.evitadb.api.CatalogContract;
+import io.evitadb.api.CatalogState;
+import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.TransactionOptions;
+import io.evitadb.api.proxy.mock.EmptyEntitySchemaAccessor;
+import io.evitadb.api.requestResponse.schema.CatalogEvolutionMode;
+import io.evitadb.api.requestResponse.schema.dto.CatalogSchema;
+import io.evitadb.core.buffer.WarmUpDataStoreMemoryBuffer;
+import io.evitadb.core.executor.Scheduler;
+import io.evitadb.exception.UnexpectedIOException;
+import io.evitadb.export.file.ExportFileService;
+import io.evitadb.spi.store.catalog.persistence.CatalogPersistenceService;
+import io.evitadb.spi.store.catalog.persistence.storageParts.schema.CatalogSchemaStoragePart;
+import io.evitadb.test.EvitaTestSupport;
+import io.evitadb.utils.NamingConvention;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.evitadb.test.TestTags.STORAGE;
+import static io.evitadb.test.TestTags.TRANSACTION;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that a configured checkpoint interval actually defers the bootstrap record, and that the two version
+ * accessors keep telling apart "written" from "durable" while it does.
+ *
+ * The distinction is the whole point of the design and is easy to get wrong in either direction: reporting the
+ * applied version as persisted would make a pre-durability failure look like a post-durability one, while deciding
+ * whether anything changed from the persisted version would make every round between two checkpoints look dirty.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Deferred checkpoint persistence")
+@Tag(STORAGE)
+@Tag(TRANSACTION)
+class DeferredCheckpointPersistenceTest implements EvitaTestSupport {
+	private static final String DIR_DEFERRED_CHECKPOINT_TEST = "deferredCheckpointTest";
+	private static final String TX_DIR_DEFERRED_CHECKPOINT_TEST = "deferredCheckpointTest_tx";
+	private static final String CATALOG_NAME = "deferredCheckpointCatalog";
+	/**
+	 * Long enough that no checkpoint can fire on its own during the test - every checkpoint observed here is one the
+	 * test deliberately provoked.
+	 */
+	private static final long NEVER_ELAPSES_MILLIS = 3_600_000L;
+	private static final CatalogSchema CATALOG_SCHEMA = CatalogSchema._internalBuild(
+		CATALOG_NAME, NamingConvention.generate(CATALOG_NAME), null,
+		EnumSet.allOf(CatalogEvolutionMode.class), EmptyEntitySchemaAccessor.INSTANCE
+	);
+
+	@BeforeEach
+	void setUp() {
+		getTestDirectory().resolve(DIR_DEFERRED_CHECKPOINT_TEST).toFile().mkdirs();
+	}
+
+	@AfterEach
+	void tearDown() throws IOException {
+		cleanTestSubDirectory(DIR_DEFERRED_CHECKPOINT_TEST);
+		cleanTestSubDirectory(TX_DIR_DEFERRED_CHECKPOINT_TEST);
+	}
+
+	@Test
+	@DisplayName("should not advance the persisted version while a checkpoint is deferred")
+	void shouldNotAdvancePersistedVersionWhileDeferred() {
+		try (final DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS)) {
+			assertNotNull(
+				cps.getCheckpointCoordinator(),
+				"Precondition: a positive interval with sync writes on must create a coordinator, or this test " +
+					"would assert deferral against a service that never defers."
+			);
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+
+			final long versionBeforeStore = cps.getLastCatalogVersion();
+			storeHeaderAt(cps, 2L);
+
+			assertEquals(
+				2L, cps.getLastAppliedCatalogVersion(),
+				"The applied version must advance as soon as the header is written."
+			);
+			assertEquals(
+				versionBeforeStore, cps.getLastCatalogVersion(),
+				"The persisted version must NOT advance while the checkpoint is still deferred - the bootstrap " +
+					"record pointing at that version has not been written yet."
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("should advance the persisted version once a checkpoint is due")
+	void shouldAdvancePersistedVersionOnceCheckpointDue() throws InterruptedException {
+		// a tiny interval so the SECOND round finds the checkpoint due and settles the debt inline
+		try (final DefaultCatalogPersistenceService cps = createService(50L)) {
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+
+			storeHeaderAt(cps, 2L);
+			Thread.sleep(120);
+			storeHeaderAt(cps, 3L);
+
+			assertEquals(
+				3L, cps.getLastAppliedCatalogVersion(),
+				"The applied version must track the newest written header."
+			);
+			assertEquals(
+				3L, cps.getLastCatalogVersion(),
+				"The round that found the interval elapsed must have checkpointed, advancing the persisted version."
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("should checkpoint on close so no service goes away owing a device flush")
+	void shouldCheckpointPendingSyncsOnClose() {
+		try (DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS)) {
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+			storeHeaderAt(cps, 2L);
+			assertTrue(
+				cps.getLastCatalogVersion() < cps.getLastAppliedCatalogVersion(),
+				"Precondition: the checkpoint must still be outstanding."
+			);
+		}
+		// must not throw - close settles the outstanding device flushes rather than abandoning them
+
+		// reopening lands on the last CHECKPOINTED version, which is the state a restart legitimately sees:
+		// everything past it is replayed from the write-ahead log
+		try (final DefaultCatalogPersistenceService reopened = createLoadingService(NEVER_ELAPSES_MILLIS)) {
+			assertTrue(
+				reopened.getLastCatalogVersion() < 2L,
+				"A version whose bootstrap record was never written must not come back as persisted."
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("should settle an owed checkpoint while a newer round is still writing the catalog index")
+	void shouldSettleOwedCheckpointWhileNewerRoundWritesCatalogIndex() {
+		try (final DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS)) {
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+
+			// a round finishes and defers its checkpoint
+			storeHeaderAt(cps, 2L);
+
+			// the next round starts: `flushTrappedUpdates` stamps catalog-level storage parts with ITS version and
+			// writes them into the very same catalog offset index, well before it gets as far as storing its header.
+			// This is not a contrived interleaving - it is what every round does, and it is the reason the offset
+			// index must be advanced by the round itself rather than by whoever happens to checkpoint later.
+			cps.getStoragePartPersistenceService(3L)
+				.putStoragePart(3L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+
+			// a backup, an integrity check or the ticker now settles the outstanding debt from its own thread
+			assertDoesNotThrow(
+				cps::checkpoint,
+				"A checkpoint must never be built from the catalog offset index as a newer round left it - the " +
+					"bootstrap record would name one version while addressing another."
+			);
+
+			assertEquals(
+				2L, cps.getLastCatalogVersion(),
+				"The checkpoint must publish the version that was actually applied, not the one a round in flight " +
+					"has merely started writing."
+			);
+
+			// the in-flight round must still be able to finish - the checkpoint may not have consumed state it owns
+			assertDoesNotThrow(
+				() -> storeHeaderAt(cps, 3L),
+				"The round that was in flight during the checkpoint must still be able to store its header."
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("should never defer a checkpoint while the catalog is warming up")
+	void shouldNeverDeferCheckpointDuringWarmUp() {
+		try (final DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS)) {
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+
+			storeHeaderAt(cps, CatalogState.WARMING_UP, 2L);
+
+			// warm-up has no trunk rounds to amortise a checkpoint across, and going live needs everything written
+			// during it to be addressable from disk before the first transaction runs
+			assertEquals(
+				cps.getLastAppliedCatalogVersion(), cps.getLastCatalogVersion(),
+				"A warm-up flush must checkpoint immediately, never defer."
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("should not defer anything when writes are never flushed to the device")
+	void shouldNotDeferCheckpointWhenSyncWritesDisabled() {
+		// with sync writes off there is no device flush to defer, so no coordinator is created at all - the two
+		// settings stay orthogonal instead of one silently re-enabling the other
+		try (final DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS, false)) {
+			assertNull(
+				cps.getCheckpointCoordinator(),
+				"No checkpoint coordinator may be created when writes never reach the device."
+			);
+
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+
+			storeHeaderAt(cps, 2L);
+
+			assertEquals(
+				2L, cps.getLastCatalogVersion(),
+				"With sync writes disabled every round must checkpoint, regardless of the configured interval."
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("should checkpoint every round when the interval is switched off")
+	void shouldCheckpointEveryRoundWhenIntervalIsZero() {
+		// zero is the documented off-switch, and what `TransactionOptions.temporary()` relies on
+		try (final DefaultCatalogPersistenceService cps = createService(0L)) {
+			assertNull(
+				cps.getCheckpointCoordinator(),
+				"Interval 0 must be expressed by having no coordinator at all, not by a coordinator that never defers."
+			);
+
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+
+			storeHeaderAt(cps, 2L);
+			assertEquals(2L, cps.getLastCatalogVersion(), "Interval 0 must checkpoint at the end of every round.");
+
+			storeHeaderAt(cps, 3L);
+			assertEquals(3L, cps.getLastCatalogVersion(), "Interval 0 must checkpoint at the end of every round.");
+		}
+	}
+
+	@Test
+	@DisplayName("should settle an owed checkpoint before verifying integrity")
+	void shouldSettleOwedCheckpointBeforeVerifyingIntegrity() {
+		try (final DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS)) {
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+
+			storeHeaderAt(cps, 2L);
+			assertTrue(
+				cps.getLastCatalogVersion() < 2L,
+				"Precondition: the checkpoint must still be outstanding."
+			);
+
+			// integrity verification asserts the catalog is fully checkpointed AND its callers follow it with
+			// `purgeAllObsoleteFiles()` - purging write-ahead log files covering versions that were never
+			// checkpointed would discard the only record of them
+			assertDoesNotThrow(cps::verifyIntegrity, "Verifying integrity must settle an outstanding checkpoint.");
+
+			assertEquals(
+				2L, cps.getLastCatalogVersion(),
+				"Integrity verification must leave the catalog fully checkpointed."
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("should build on the compacted file index when a compaction happened inside a deferred round")
+	void shouldBuildOnCompactedFileIndexWhenCompactionHappenedInDeferredRound() {
+		// Compaction bumps the catalog file index INSIDE the record a deferred round prepared, while `bootstrapUsed`
+		// still names the file from before it. The next round must therefore build on the prepared record, not on
+		// `bootstrapUsed` - otherwise it reuses an index the previous round already took and the published record
+		// ends up naming a file that is not the one holding its data.
+		try (final DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS, true, true)) {
+			assertNotNull(cps.getCheckpointCoordinator(), "Precondition: deferral must be active.");
+
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+
+			// first deferred round - compacts, so its prepared record carries file index 1
+			storeHeaderAt(cps, 2L);
+			assertTrue(
+				catalogDataFileExists(1),
+				"Precondition: the first round must actually have compacted, or this test proves nothing."
+			);
+			assertTrue(
+				cps.getLastCatalogVersion() < 2L,
+				"Precondition: the first round's checkpoint must still be outstanding."
+			);
+
+			// second deferred round - must build on index 1 and produce 2. Building on `bootstrapUsed` would
+			// recompute index 1 and collide with the file the previous round just wrote.
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+			storeHeaderAt(cps, 3L);
+
+			assertTrue(
+				catalogDataFileExists(2),
+				"The second deferred round must build on the file index its predecessor prepared, not on the one " +
+					"the last written bootstrap record still names."
+			);
+
+			cps.checkpoint();
+			assertEquals(
+				3L, cps.getLastCatalogVersion(),
+				"The settled checkpoint must publish the newest prepared record."
+			);
+		}
+
+		// the published record must address a catalog file that exists, and reopening must accept it
+		try (final DefaultCatalogPersistenceService reopened = createLoadingService(NEVER_ELAPSES_MILLIS)) {
+			assertEquals(
+				3L, reopened.getLastCatalogVersion(),
+				"A reopened catalog must load from the compacted file the published record names."
+			);
+		}
+	}
+
+	@Test
+	@DisplayName("should refuse to store a header once checkpointing has failed")
+	void shouldRefuseStoreHeaderWhenCheckpointFailed() {
+		try (final DefaultCatalogPersistenceService cps = createService(NEVER_ELAPSES_MILLIS)) {
+			cps.getStoragePartPersistenceService(0L)
+				.putStoragePart(0L, new CatalogSchemaStoragePart(CATALOG_SCHEMA));
+
+			// a real round defers first - the state a checkpoint failure is actually discovered in
+			storeHeaderAt(cps, 2L);
+
+			final CheckpointCoordinator coordinator = cps.getCheckpointCoordinator();
+			assertNotNull(coordinator, "Precondition: a deferring service must have a coordinator.");
+			final IllegalStateException checkpointFailure = new IllegalStateException("device is gone");
+			recordCheckpointFailure(coordinator, checkpointFailure);
+			assertSame(
+				checkpointFailure, coordinator.getFailure(),
+				"Precondition: the failure must be visible to the persistence service."
+			);
+
+			final UnexpectedIOException thrown = assertThrows(
+				UnexpectedIOException.class,
+				() -> storeHeaderAt(cps, 3L),
+				"A catalog that can no longer checkpoint kept accepting headers - each one is an acknowledgement " +
+					"it can never make durable."
+			);
+			assertSame(
+				checkpointFailure, thrown.getCause(),
+				"The original failure must reach whoever suspends the catalog, not be replaced by it."
+			);
+			assertEquals(
+				2L, cps.getLastAppliedCatalogVersion(),
+				"The refusal must come before anything is written - a header that got as far as advancing the " +
+					"applied version was accepted, not refused."
+			);
+		}
+	}
+
+	/**
+	 * Records a checkpoint failure on the coordinator the way a failed ticker checkpoint would.
+	 *
+	 * Reached through the field rather than through the ticker because the service here is built with a mocked
+	 * scheduler - which is what makes every test in this class deterministic - so no ticker ever fires. That the
+	 * ticker records what it catches is covered by `CheckpointCoordinatorTest`; what is asserted here is only what
+	 * the persistence service does once the failure is there.
+	 *
+	 * @param coordinator the coordinator to poison
+	 * @param failure     the failure to record
+	 */
+	@SuppressWarnings("unchecked")
+	private static void recordCheckpointFailure(
+		@Nonnull CheckpointCoordinator coordinator,
+		@Nonnull Throwable failure
+	) {
+		try {
+			final Field field = CheckpointCoordinator.class.getDeclaredField("failure");
+			field.setAccessible(true);
+			((AtomicReference<Throwable>) field.get(coordinator)).set(failure);
+		} catch (ReflectiveOperationException ex) {
+			throw new IllegalStateException("Failed to record the checkpoint failure", ex);
+		}
+	}
+
+	/**
+	 * Tells whether the catalog data file with the given index exists on disk.
+	 *
+	 * @param fileIndex the catalog file index to look for
+	 * @return true when the file exists
+	 */
+	private boolean catalogDataFileExists(int fileIndex) {
+		return getTestDirectory()
+			.resolve(DIR_DEFERRED_CHECKPOINT_TEST)
+			.resolve(CATALOG_NAME)
+			.resolve(CatalogPersistenceService.getCatalogDataStoreFileName(CATALOG_NAME, fileIndex))
+			.toFile()
+			.exists();
+	}
+
+	/**
+	 * Writes a catalog header for the given version in the ALIVE state - the state deferral applies to.
+	 */
+	private static void storeHeaderAt(@Nonnull DefaultCatalogPersistenceService cps, long catalogVersion) {
+		storeHeaderAt(cps, CatalogState.ALIVE, catalogVersion);
+	}
+
+	/**
+	 * Writes a catalog header for the given version in the given catalog state.
+	 */
+	private static void storeHeaderAt(
+		@Nonnull DefaultCatalogPersistenceService cps,
+		@Nonnull CatalogState catalogState,
+		long catalogVersion
+	) {
+		cps.storeHeader(
+			UUID.randomUUID(),
+			catalogState,
+			catalogVersion,
+			0,
+			null,
+			Collections.emptyList(),
+			new WarmUpDataStoreMemoryBuffer(cps.getStoragePartPersistenceService(0L))
+		);
+	}
+
+	@Nonnull
+	private DefaultCatalogPersistenceService createService(long checkpointIntervalMillis) {
+		return createService(checkpointIntervalMillis, true);
+	}
+
+	@Nonnull
+	private DefaultCatalogPersistenceService createService(long checkpointIntervalMillis, boolean syncWrites) {
+		return createService(checkpointIntervalMillis, syncWrites, false);
+	}
+
+	@Nonnull
+	private DefaultCatalogPersistenceService createService(
+		long checkpointIntervalMillis,
+		boolean syncWrites,
+		boolean compactEagerly
+	) {
+		return new DefaultCatalogPersistenceService(
+			CATALOG_NAME,
+			storageOptions(syncWrites, compactEagerly),
+			transactionOptions(checkpointIntervalMillis),
+			Mockito.mock(Scheduler.class),
+			Mockito.mock(ExportFileService.class)
+		);
+	}
+
+	@Nonnull
+	private DefaultCatalogPersistenceService createLoadingService(long checkpointIntervalMillis) {
+		return new DefaultCatalogPersistenceService(
+			Mockito.mock(CatalogContract.class),
+			CATALOG_NAME,
+			storageOptions(),
+			transactionOptions(checkpointIntervalMillis),
+			Mockito.mock(Scheduler.class),
+			Mockito.mock(ExportFileService.class)
+		);
+	}
+
+	@Nonnull
+	private StorageOptions storageOptions() {
+		// syncWrites MUST be true - with it off there is no device flush to defer and no coordinator is created
+		return storageOptions(true);
+	}
+
+	/**
+	 * Storage settings for the test catalog.
+	 *
+	 * Built through the builder rather than the positional constructor deliberately: the tests below differ from
+	 * each other in one field at a time, which a twelve-argument call renders unreadable and any new field breaks.
+	 *
+	 * @param syncWrites whether writes are flushed to the device at all - with this off no coordinator is created
+	 *                   and nothing is ever deferred
+	 * @return the storage settings
+	 */
+	@Nonnull
+	private StorageOptions storageOptions(boolean syncWrites) {
+		return storageOptions(syncWrites, false);
+	}
+
+	/**
+	 * Storage settings for the test catalog.
+	 *
+	 * @param syncWrites    whether writes are flushed to the device at all - with this off no coordinator is created
+	 *                      and nothing is ever deferred
+	 * @param compactEagerly when true the catalog-file compaction thresholds are opened so that every prepared
+	 *                      bootstrap record compacts; `shouldCompact` fires on `activeRecordShare < maxWasteActiveShare`
+	 *                      alone, so no compaction-cadence gate has to be defeated
+	 * @return the storage settings
+	 */
+	@Nonnull
+	private StorageOptions storageOptions(boolean syncWrites, boolean compactEagerly) {
+		final Path directory = getTestDirectory().resolve(DIR_DEFERRED_CHECKPOINT_TEST);
+		return StorageOptions.builder()
+			.storageDirectory(directory)
+			.workDirectory(directory)
+			.lockTimeoutSeconds(60)
+			.waitOnCloseSeconds(60)
+			.outputBufferSize(StorageOptions.DEFAULT_OUTPUT_BUFFER_SIZE)
+			.maxOpenedReadHandles(1)
+			.syncWrites(syncWrites)
+			.compress(false)
+			.computeCRC32(true)
+			.minimalActiveRecordShare(compactEagerly ? 1.0 : 0.01)
+			.maxWasteActiveShare(compactEagerly ? 1.1 : StorageOptions.DEFAULT_MAX_WASTE_ACTIVE_SHARE)
+			.fileSizeCompactionThresholdBytes(compactEagerly ? 1L : 1_000_000L)
+			.minCompactionIntervalMilliseconds(compactEagerly ? 0L : StorageOptions.DEFAULT_MIN_COMPACTION_INTERVAL_MILLISECONDS)
+			.timeTravelEnabled(false)
+			.build();
+	}
+
+	@Nonnull
+	private TransactionOptions transactionOptions(long checkpointIntervalMillis) {
+		return TransactionOptions.builder()
+			.transactionWorkDirectory(getTestDirectory().resolve(TX_DIR_DEFERRED_CHECKPOINT_TEST))
+			.checkpointIntervalInMillis(checkpointIntervalMillis)
+			.build();
+	}
+
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexKeyCompressorLifecycleTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/OffsetIndexKeyCompressorLifecycleTest.java
@@ -362,6 +362,11 @@ class OffsetIndexKeyCompressorLifecycleTest {
 		}
 
 		@Override
+		public void forceDurable() {
+			this.delegate.forceDurable();
+		}
+
+		@Override
 		public long getLastWrittenPosition() {
 			return this.delegate.getLastWrittenPosition();
 		}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/io/WriteOnlyFileHandleTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/offsetIndex/io/WriteOnlyFileHandleTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -55,11 +56,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.jupiter.api.Tag;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static io.evitadb.test.TestTags.STORAGE;
 import static io.evitadb.test.TestTags.MANAGEMENT;
+import static io.evitadb.test.TestTags.STORAGE;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link WriteOnlyFileHandle} verifying write operations, concurrency handling,
@@ -917,6 +917,148 @@ class WriteOnlyFileHandleTest implements EvitaTestSupport {
 					});
 				}
 			}
+		}
+	}
+
+	@Nested
+	@DisplayName("Deferred device flush")
+	class DeferredSyncTest {
+
+		/**
+		 * Creates a handle that defers its device flush to the supplied registry.
+		 *
+		 * @param filePath the target file path
+		 * @param registry the registry notified instead of an inline `fsync`
+		 * @return a new WriteOnlyFileHandle instance
+		 */
+		@Nonnull
+		private WriteOnlyFileHandle createDeferringHandle(
+			@Nonnull Path filePath,
+			@Nonnull PendingSyncRegistry registry
+		) {
+			return new WriteOnlyFileHandle(
+				null, null, null,
+				StorageOptions.DEFAULT_OUTPUT_BUFFER_SIZE,
+				true,
+				Crc32CChecksumFactory.INSTANCE,
+				CompressionFactory.NO_COMPRESSION,
+				filePath,
+				WriteOnlyFileHandleTest.this.outputKeeper,
+				registry
+			);
+		}
+
+		@Test
+		@DisplayName("should register with the registry instead of syncing, on the consuming overload")
+		void shouldRegisterInsteadOfSyncingOnConsumingOverload() {
+			final Path filePath = WriteOnlyFileHandleTest.this.targetDirectory
+				.resolve(UUIDUtil.randomUUID() + ".tmp");
+			final List<WriteOnlyHandle> registered = new ArrayList<>(1);
+
+			try (final WriteOnlyFileHandle handle = createDeferringHandle(filePath, registered::add)) {
+				handle.checkAndExecuteAndSync(
+					"deferred write",
+					() -> {},
+					output -> output.writeString("deferred")
+				);
+			}
+
+			assertEquals(
+				1, registered.size(),
+				"A handle configured with a registry must register itself rather than flush to the device."
+			);
+		}
+
+		@Test
+		@DisplayName("should register with the registry instead of syncing, on the post-processing overload")
+		void shouldRegisterInsteadOfSyncingOnPostProcessingOverload() {
+			final Path filePath = WriteOnlyFileHandleTest.this.targetDirectory
+				.resolve(UUIDUtil.randomUUID() + ".tmp");
+			final List<WriteOnlyHandle> registered = new ArrayList<>(1);
+
+			// both overloads route through `doSyncOrDefer`; asserting only one of them lets a refactor fix
+			// the covered path and silently leave the other syncing inline
+			try (final WriteOnlyFileHandle handle = createDeferringHandle(filePath, registered::add)) {
+				final String result = handle.checkAndExecuteAndSync(
+					"deferred write",
+					() -> {},
+					output -> {
+						output.writeString("deferred");
+						return "written";
+					},
+					(output, written) -> written
+				);
+				assertEquals("written", result);
+			}
+
+			assertEquals(
+				1, registered.size(),
+				"The post-processing overload must defer its device flush just like the consuming one."
+			);
+		}
+
+		@Test
+		@DisplayName("should tolerate a pending file that a compaction already deleted")
+		void shouldTolerateForceOfDeletedFile() throws IOException {
+			final Path filePath = WriteOnlyFileHandleTest.this.targetDirectory
+				.resolve(UUIDUtil.randomUUID() + ".tmp");
+			final List<WriteOnlyHandle> registered = new ArrayList<>(1);
+
+			try (final WriteOnlyFileHandle handle = createDeferringHandle(filePath, registered::add)) {
+				handle.checkAndExecuteAndSync(
+					"deferred write",
+					() -> {},
+					output -> output.writeString("deferred")
+				);
+				assertEquals(
+					1, registered.size(),
+					"The write must leave the handle owing a device flush, or the force below is not the " +
+						"one a checkpoint would actually issue."
+				);
+
+				// a file may be compacted away between the write that registered it and the checkpoint that
+				// forces it - there is then nothing left to make durable, and the successor file carries the
+				// data. This is a real state rather than an unhandled branch, so it must not throw.
+				Files.delete(filePath);
+				// forced through the registered reference rather than the local one: a checkpoint holds only
+				// what the registry handed it, so that is the reference whose behaviour is under test
+				final WriteOnlyHandle pending = registered.get(0);
+				assertDoesNotThrow(
+					pending::forceDurable,
+					"Forcing a file a compaction already removed must not fail the checkpoint."
+				);
+			}
+		}
+
+		@Test
+		@DisplayName("should refuse a deferred sync on a handle that never syncs")
+		void shouldRefuseDeferredSyncWhenSyncWritesDisabled() {
+			final Path filePath = WriteOnlyFileHandleTest.this.targetDirectory
+				.resolve(UUIDUtil.randomUUID() + ".tmp");
+
+			// deferring a flush that would never have been issued would make a checkpoint force files for an
+			// operator who deliberately turned durability off. The registry is rejected for merely being
+			// present, so it can never be handed anything - a no-op is the honest stand-in
+			assertThrows(
+				GenericEvitaInternalError.class,
+				() -> {
+					//noinspection EmptyTryBlock
+					try (
+						final WriteOnlyFileHandle __ = new WriteOnlyFileHandle(
+							null, null, null,
+							StorageOptions.DEFAULT_OUTPUT_BUFFER_SIZE,
+							false,
+							Crc32CChecksumFactory.INSTANCE,
+							CompressionFactory.NO_COMPRESSION,
+							filePath,
+							WriteOnlyFileHandleTest.this.outputKeeper,
+							pending -> {}
+						)
+					) {
+						// do nothing - should throw
+					}
+				}
+			);
 		}
 	}
 }

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/store/wal/CatalogWriteAheadLogTest.java
@@ -50,6 +50,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
@@ -306,6 +308,159 @@ class CatalogWriteAheadLogTest implements EvitaTestSupport {
 			assertNotNull(
 				CatalogWriteAheadLogTest.this.tested.checkAndTruncate(CatalogWriteAheadLogTest.this.walFilePath, CatalogWriteAheadLogTest.this.catalogKryoPool, CatalogWriteAheadLogTest.this.walFileReference).logFileRecordReference(),
 				"Corrupted WAL file should be detected and return new reference"
+			);
+		}
+
+		/**
+		 * The WAL channel is not opened with `DSYNC`; durability comes from one explicit `force` per
+		 * append instead. That trades away write *ordering*: previously each `write` was synced on its
+		 * own, so a crash could only ever leave a clean prefix, whereas now the writes of the append
+		 * that was in flight may reach the device in any order and leave a **hole** — bytes missing in
+		 * the middle of the last transaction while later bytes made it.
+		 *
+		 * Such a hole is confined to the last transaction (every force covers everything written before
+		 * it), and that transaction was never acknowledged to a client, so losing it is correct. What
+		 * must not happen is recovery reporting it as corruption: `WriteAheadLogCorruptedException` here
+		 * is precisely the signature of the lost ordering guarantee and would turn a routine crash into
+		 * an unopenable catalog. Recovery has to truncate instead.
+		 *
+		 * The hole is punched without changing the file length — a shortened file is the old, already
+		 * covered torn-tail shape, whereas out-of-order writeback preserves the length.
+		 *
+		 * @param bytesBackFromEnd where the 8-byte hole starts, counted back from the end of the file
+		 */
+		@ParameterizedTest(name = "hole {0} bytes back from the end of the WAL")
+		@ValueSource(ints = {9, 12, 16, 20, 24, 30, 36, 42, 48, 54, 60})
+		@DisplayName("should truncate rather than report corruption when the last transaction has a hole")
+		void shouldTruncateWhenLastTransactionHasHole(int bytesBackFromEnd) throws IOException {
+			final long originalLength = modifyWalFile(raf -> {
+				raf.seek(raf.length() - bytesBackFromEnd);
+				raf.write(new byte[]{0, 0, 0, 0, 0, 0, 0, 0});
+				return null;
+			});
+
+			assertEquals(
+				originalLength, CatalogWriteAheadLogTest.this.walFilePath.toFile().length(),
+				"Precondition: the hole must preserve the file length, otherwise this degenerates into " +
+					"the torn-tail case already covered by shouldTruncatePartiallyWrittenWal"
+			);
+
+			assertDoesNotThrow(
+				() -> CatalogWriteAheadLogTest.this.tested.checkAndTruncate(
+					CatalogWriteAheadLogTest.this.walFilePath,
+					CatalogWriteAheadLogTest.this.catalogKryoPool,
+					CatalogWriteAheadLogTest.this.walFileReference
+				),
+				"A hole in the last (unacknowledged) transaction must be truncated, not surfaced as " +
+					"corruption — throwing here means a crash mid-append leaves an unopenable catalog"
+			);
+
+			// without this the test would pass even if recovery never looked at the file: the damaged
+			// transaction has to actually be gone, otherwise a corrupt record stays readable
+			assertTrue(
+				CatalogWriteAheadLogTest.this.walFilePath.toFile().length() < originalLength,
+				"The holed transaction must actually be truncated away — file length stayed at " +
+					originalLength + ", so the damage went undetected"
+			);
+		}
+
+		/**
+		 * Group commit widened the window the test above covers. With one force per append the unforced
+		 * region was a single transaction, so a hole could only ever land in the last one. Now a force
+		 * covers a whole *batch*, and every transaction appended since the previous force is unforced at
+		 * once — so out-of-order writeback can leave a hole several transactions back from the end while
+		 * the transactions after it landed intact.
+		 *
+		 * That is still safe, but for a reason worth stating: nothing in the unforced batch was ever
+		 * acknowledged (clients are notified only after the force that covers them), so discarding the
+		 * hole *and everything behind it* loses nothing a client was promised. What recovery must not do
+		 * is throw, and it must not keep the transactions that follow the damage — those sit behind a gap
+		 * in the cumulative checksum chain and would be read as valid history that never happened.
+		 *
+		 * @param bytesBackFromEnd where the 8-byte hole starts, counted back from the end of the file —
+		 *                         far enough back to land in a transaction that is not the last one
+		 */
+		@ParameterizedTest(name = "hole {0} bytes back from the end, several transactions deep")
+		@ValueSource(ints = {150, 250, 350, 450})
+		@DisplayName("should truncate the whole unforced batch when a hole lands before its last transaction")
+		void shouldTruncateWhenAnEarlierTransactionOfTheBatchHasHole(int bytesBackFromEnd) throws IOException {
+			final long originalLength = modifyWalFile(raf -> {
+				raf.seek(raf.length() - bytesBackFromEnd);
+				raf.write(new byte[]{0, 0, 0, 0, 0, 0, 0, 0});
+				return null;
+			});
+			final long holeOffset = originalLength - bytesBackFromEnd;
+
+			assertEquals(
+				originalLength, CatalogWriteAheadLogTest.this.walFilePath.toFile().length(),
+				"Precondition: the hole must preserve the file length, otherwise this degenerates into " +
+					"the torn-tail case already covered by shouldTruncatePartiallyWrittenWal"
+			);
+			assertTrue(
+				holeOffset > 0,
+				"Precondition: the fixture WAL must be long enough for the hole to land inside it"
+			);
+
+			assertDoesNotThrow(
+				() -> CatalogWriteAheadLogTest.this.tested.checkAndTruncate(
+					CatalogWriteAheadLogTest.this.walFilePath,
+					CatalogWriteAheadLogTest.this.catalogKryoPool,
+					CatalogWriteAheadLogTest.this.walFileReference
+				),
+				"A hole anywhere in the unforced batch must be truncated, not surfaced as corruption — " +
+					"throwing here means a crash mid-batch leaves an unopenable catalog"
+			);
+
+			final long recoveredLength = CatalogWriteAheadLogTest.this.walFilePath.toFile().length();
+			assertTrue(
+				recoveredLength <= holeOffset,
+				"Recovery must drop the damaged transaction AND every transaction appended after it — " +
+					"the file was truncated to " + recoveredLength + " but the damage starts at " +
+					holeOffset + ", so records sitting behind a gap in the checksum chain survived"
+			);
+		}
+
+		/**
+		 * Hole tolerance rests entirely on the cumulative CRC32C chain — it is the only thing that can tell
+		 * a hole apart from valid data, because a hole preserves the file length and so leaves the
+		 * transaction framing intact.
+		 *
+		 * That chain is optional. With {@link StorageOptions#computeCRC32C()} off, the storage layer swaps
+		 * in `Checksum.NO_OP`, whose `equalsTo` unconditionally returns TRUE — so the scan waves every
+		 * transaction through, and the damage surfaces only when the last transaction is deserialized,
+		 * where `handleTransactionReadException` turns it into a hard failure instead of a truncation.
+		 *
+		 * This was harmless while the WAL was opened with `DSYNC`, because every write was synced in order
+		 * and a crash could only ever leave a clean prefix — holes were not physically possible, so nothing
+		 * depended on detecting them. Dropping DSYNC made hole tolerance a correctness requirement, and
+		 * batching the force across several transactions widened the window it has to cover. The checksum
+		 * therefore stopped being an integrity nicety and became load-bearing, and it must not be possible
+		 * to switch it off.
+		 */
+		@Test
+		@DisplayName("should demand write ordering from the device when CRC32C computation is switched off")
+		void shouldRequireWriteOrderingWhenChecksumsAreDisabled() {
+			assertTrue(
+				AbstractMutationLog.requiresWriteOrdering(
+					new StorageSettings(
+						StorageOptions.builder().computeCRC32(false).build(),
+						TransactionOptions.builder().build()
+					)
+				),
+				"With no checksum chain a hole cannot be detected — verified by experiment: recovery does " +
+					"not throw and does not truncate, it accepts the damaged transaction and replays it as " +
+					"real history. The damage must therefore be made impossible instead, by syncing every " +
+					"individual write so a crash can only leave a clean prefix"
+			);
+			assertFalse(
+				AbstractMutationLog.requiresWriteOrdering(
+					new StorageSettings(
+						StorageOptions.builder().computeCRC32(true).build(),
+						TransactionOptions.builder().build()
+					)
+				),
+				"With the checksum chain present holes are detected and truncated, so the WAL may take the " +
+					"fast path of one force per batch instead of one device sync per write"
 			);
 		}
 

--- a/evita_test/evita_performance_tests/pom.xml
+++ b/evita_test/evita_performance_tests/pom.xml
@@ -194,6 +194,20 @@
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<mainClass>io.evitadb.performance.ArtificialTestRunner</mainClass>
+									<manifestEntries>
+										<!--
+											Byte Buddy generates classes reflectively at runtime and needs these packages
+											opened on JDK 17+; without them every benchmark that boots an Evita instance
+											dies during state setup with "Cannot define class using reflection", which JMH
+											then reports as a finished run with no score rather than as a failure.
+											Mirrors the surefire argLine in the root pom. This covers the launching process
+											only: it applies to `java -jar` (not `-cp`), and JMH starts its forked
+											benchmark JVM with `-cp`, so a benchmark that boots Evita must ALSO declare
+											the same flags in its own `@Fork(jvmArgsAppend = ...)` - see
+											CommitThroughputBenchmark for the worked example.
+										-->
+										<Add-Opens>java.base/java.lang java.base/java.lang.invoke java.base/java.math java.base/java.util</Add-Opens>
+									</manifestEntries>
 								</transformer>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
 							</transformers>

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/ArtificialTestRunner.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/ArtificialTestRunner.java
@@ -25,22 +25,73 @@ package io.evitadb.performance;
 
 import org.openjdk.jmh.results.format.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.CommandLineOptions;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
 /**
- * A class executing all the benchmarks.
+ * Entry point of the benchmark uber-jar.
+ *
+ * With no arguments it runs the curated external-API suite below. With arguments it hands over verbatim to
+ * {@link org.openjdk.jmh.Main}, so the jar behaves like any other JMH uber-jar:
+ *
+ * ```
+ * java -jar benchmarks.jar                          # curated external-API suite
+ * java -jar benchmarks.jar CommitThroughputBenchmark -t 8 -f 1
+ * ```
+ *
+ * The delegation matters. This class used to be wired in as the jar's `Main-Class` while ignoring `args`
+ * entirely, so the perfectly reasonable `java -jar benchmarks.jar SomeBenchmark` quietly ran the whole
+ * external-API suite instead of the requested benchmark — costing a long run and producing results for
+ * something nobody asked for, with no diagnostic pointing at the cause.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 public class ArtificialTestRunner {
 
+	/**
+	 * JVM arguments every forked benchmark JVM needs.
+	 *
+	 * Byte Buddy generates classes reflectively while an Evita instance boots and cannot do so on JDK 17+ without
+	 * these packages opened. They have to be applied to the **forked** JVM: JMH starts it with `-cp`, so neither the
+	 * flags of the launching process nor the uber-jar's `Add-Opens` manifest entry reach the process that actually
+	 * runs the benchmark. Missing them, state setup fails with "Cannot define class using reflection" and JMH prints
+	 * an empty result table rather than reporting an error - a failure that reads like "the benchmark produced no
+	 * score" instead of "the benchmark never ran".
+	 */
+	private static final String[] FORK_JVM_ARGS = {
+		"--add-opens", "java.base/java.lang=ALL-UNNAMED",
+		"--add-opens", "java.base/java.lang.invoke=ALL-UNNAMED",
+		"--add-opens", "java.base/java.math=ALL-UNNAMED",
+		"--add-opens", "java.base/java.util=ALL-UNNAMED"
+	};
+
 	public static void main(String[] args) throws Exception {
+		if (args.length > 0) {
+			// A caller who passes arguments wants JMH's own command line, not the curated suite. The parsed command
+			// line is used as the parent of a builder that appends the fork arguments, so every benchmark launched
+			// through this jar gets them without each benchmark class having to declare its own `@Fork(jvmArgsAppend)`.
+			new Runner(
+				new OptionsBuilder()
+					.parent(new CommandLineOptions(args))
+					.jvmArgsAppend(FORK_JVM_ARGS)
+					.build()
+			).run();
+			return;
+		}
+
+		System.out.println(
+			"No arguments given - running the curated external-API benchmark suite.\n" +
+				"Pass a benchmark name (and any JMH options) to run something specific, e.g.:\n" +
+				"    java -jar benchmarks.jar CommitThroughputBenchmark -t 8 -f 1\n"
+		);
+
 		Options opt = new OptionsBuilder()
 			.include("io.evitadb.performance.externalApi.*")
 			.threads(6)
 			.forks(1)
+			.jvmArgsAppend(FORK_JVM_ARGS)
 			.warmupTime(TimeValue.seconds(60))
 			.measurementTime(TimeValue.seconds(60))
 			.warmupIterations(1)

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/artificial/ArtificialEntitiesLatencyBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/artificial/ArtificialEntitiesLatencyBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.artificial;
 
 import io.evitadb.performance.artificial.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -42,6 +44,14 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode({Mode.AverageTime})
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class ArtificialEntitiesLatencyBenchmark extends ArtificialEntitiesBenchmark {
 
 	@Benchmark

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/artificial/ArtificialEntitiesThroughputBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/artificial/ArtificialEntitiesThroughputBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.artificial;
 
 import io.evitadb.performance.artificial.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Threads;
@@ -40,6 +42,14 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode({Mode.Throughput})
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class ArtificialEntitiesThroughputBenchmark extends ArtificialEntitiesBenchmark {
 
 	@Benchmark

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/committhroughput/CommitThroughputBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/committhroughput/CommitThroughputBenchmark.java
@@ -1,0 +1,103 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.performance.committhroughput;
+
+import io.evitadb.performance.committhroughput.state.CommitThroughputBenchmarkState;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
+import io.evitadb.performance.setup.EvitaCatalogSetup;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures **commit** throughput: how many small transactions the write pipeline can carry per second.
+ *
+ * Each invocation opens a session, writes one generated product and commits, so every invocation walks
+ * the full pipeline - conflict resolution, WAL append (one device sync per transaction) and trunk
+ * incorporation. That is deliberately different from the artificial write benchmarks, which keep one
+ * session open for an entire iteration and therefore commit once per iteration; those measure how fast
+ * mutations enter the transactional memory layer, not what a commit costs.
+ *
+ * Two knobs make this benchmark useful for tuning rather than just reporting:
+ *
+ * - `-Devita.benchmark.flushFrequencyInMillis=N` bounds how long trunk incorporation greedily drains
+ *   the WAL before cutting a catalog version. Sweeping it maps the trade between commit throughput
+ *   (fewer, larger merges) and how long a client waits for its changes to become visible.
+ * - `-t N` (JMH) sets the number of concurrent writers. This matters more than it looks: the greedy
+ *   batching budget can only bite once writers outrun trunk incorporation and a backlog forms, so a
+ *   single-writer run will show the flush-frequency sweep as a flat line no matter how it is set.
+ *
+ * Example sweep:
+ *
+ * ```
+ * java -jar target/evita-performance-tests.jar CommitThroughputBenchmark -t 8 \
+ *   -Devita.benchmark.flushFrequencyInMillis=1000
+ * ```
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 10)
+@Measurement(iterations = 3, time = 10)
+@Fork(
+	value = 1,
+	// see BenchmarkForkArgs for why a benchmark booting Evita has to declare these itself
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
+public class CommitThroughputBenchmark implements EvitaCatalogSetup {
+
+	/**
+	 * Commits one single-entity transaction per invocation.
+	 *
+	 * `updateCatalog` opens the session, runs the body and commits it, waiting for the configured
+	 * commit behaviour before returning - so the measured operation is a whole durable commit rather
+	 * than an enqueue. The body is a block lambda on purpose: a void-bodied expression lambda is
+	 * ambiguous against the value-returning `updateCatalog` overload and fails to compile.
+	 *
+	 * @param state the shared transactional catalog and product source
+	 */
+	@Benchmark
+	public void commitSingleEntityTransaction(CommitThroughputBenchmarkState state) {
+		state.getEvita().updateCatalog(
+			state.getCatalogNameForBenchmark(),
+			session -> {
+				session.upsertEntity(state.nextProduct());
+			}
+		);
+		state.recordCommit();
+	}
+
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/committhroughput/state/CommitThroughputBenchmarkState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/committhroughput/state/CommitThroughputBenchmarkState.java
@@ -1,0 +1,196 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.performance.committhroughput.state;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.requestResponse.data.EntityEditor.EntityBuilder;
+import io.evitadb.performance.artificial.ArtificialBenchmarkState;
+import io.evitadb.performance.committhroughput.CommitThroughputBenchmark;
+import io.evitadb.performance.setup.EvitaCatalogSetup;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Shared state for {@link CommitThroughputBenchmark}: a transactional (ALIVE) catalog seeded with
+ * a modest set of products, against which the benchmark commits many small transactions.
+ *
+ * This state exists because the sibling `ArtificialTransactionalWriteBenchmarkState` cannot measure
+ * commit throughput: it caches a single read-write session for the whole iteration and closes it only
+ * in tear-down, so an entire iteration is **one** transaction and the commit pipeline is exercised
+ * exactly once. Here every benchmark invocation opens, writes and commits its own transaction, which
+ * is what puts load on WAL appending and trunk incorporation.
+ *
+ * The database is built once per **trial** rather than per iteration - seeding is far more expensive
+ * than a measurement iteration, and nothing a commit does invalidates the seed.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@State(Scope.Benchmark)
+public class CommitThroughputBenchmarkState extends ArtificialBenchmarkState
+	implements EvitaCatalogSetup {
+	/**
+	 * Count of products present in the database before the measured phase starts. Deliberately smaller
+	 * than the sibling artificial benchmarks use - the subject here is commit cost, not index size, and
+	 * a smaller seed keeps trial setup short enough to sweep a configuration axis.
+	 */
+	public static final int INITIAL_COUNT_OF_PRODUCTS = 2_000;
+
+	/**
+	 * Counts committed transactions across all worker threads, reported in tear-down as a sanity check
+	 * that the measured phase really did commit (rather than, say, failing every transaction silently).
+	 */
+	private final AtomicInteger committedTransactions = new AtomicInteger(0);
+
+	/**
+	 * Seeds the catalog and switches it to the transactional (ALIVE) state.
+	 *
+	 * Mirrors the reference entity set of the artificial benchmarks - brands, categories, price lists
+	 * and stores - so generated products have something to reference and the produced mutations are
+	 * representative rather than degenerate.
+	 */
+	@Setup(Level.Trial)
+	public void setUp() {
+		this.dataGenerator.clear();
+		this.generatedEntities.clear();
+		this.committedTransactions.set(0);
+		final String catalogName = getCatalogName();
+		this.evita = createEmptyEvitaInstance(catalogName);
+		this.evita.updateCatalog(
+			catalogName,
+			session -> {
+				this.dataGenerator.generateEntities(
+						this.dataGenerator.getSampleBrandSchema(session),
+						this.randomEntityPicker,
+						SEED
+					)
+					.limit(5)
+					.forEach(it -> createEntity(session, this.generatedEntities, it));
+
+				this.dataGenerator.generateEntities(
+						this.dataGenerator.getSampleCategorySchema(session),
+						this.randomEntityPicker,
+						SEED
+					)
+					.limit(10)
+					.forEach(it -> createEntity(session, this.generatedEntities, it));
+
+				this.dataGenerator.generateEntities(
+						this.dataGenerator.getSamplePriceListSchema(session),
+						this.randomEntityPicker,
+						SEED
+					)
+					.limit(4)
+					.forEach(it -> createEntity(session, this.generatedEntities, it));
+
+				this.dataGenerator.generateEntities(
+						this.dataGenerator.getSampleStoreSchema(session),
+						this.randomEntityPicker,
+						SEED
+					)
+					.limit(12)
+					.forEach(it -> createEntity(session, this.generatedEntities, it));
+
+				this.productSchema = this.dataGenerator.getSampleProductSchema(session);
+				this.dataGenerator.generateEntities(
+						this.productSchema,
+						this.randomEntityPicker,
+						SEED
+					)
+					.limit(INITIAL_COUNT_OF_PRODUCTS)
+					.forEach(session::upsertEntity);
+
+				// from here on every write goes through the transactional commit pipeline
+				session.goLiveAndClose();
+			}
+		);
+		this.productIterator = getProductStream().iterator();
+	}
+
+	/**
+	 * Hands out the next generated product.
+	 *
+	 * The underlying generator is an infinite sequence, so every caller receives a distinct entity and
+	 * concurrent workers never contend for the same primary key - upserting a shared entity from several
+	 * threads would measure conflict resolution rather than commit cost. Access is synchronized because
+	 * the iterator is not thread safe; generating an entity is cheap next to the device sync a commit
+	 * pays, but at high worker counts this lock is the first thing to suspect if throughput plateaus.
+	 *
+	 * @return a freshly generated product builder, never shared with another invocation
+	 */
+	@Nonnull
+	public synchronized EntityBuilder nextProduct() {
+		return this.productIterator.next();
+	}
+
+	/**
+	 * Records that a transaction was committed.
+	 */
+	public void recordCommit() {
+		this.committedTransactions.incrementAndGet();
+	}
+
+	/**
+	 * We need writable sessions here.
+	 */
+	@Override
+	public EvitaSessionContract getSession() {
+		return getSession(() -> this.evita.createReadWriteSession(getCatalogName()));
+	}
+
+	/**
+	 * Returns name of the test catalog.
+	 */
+	@Override
+	protected String getCatalogName() {
+		return TEST_CATALOG + "_commitThroughput";
+	}
+
+	/**
+	 * Publicly reachable alias of {@link #getCatalogName()} - the inherited accessor is protected and the
+	 * benchmark class lives in a different package.
+	 *
+	 * @return name of the catalog the benchmark commits into
+	 */
+	@Nonnull
+	public String getCatalogNameForBenchmark() {
+		return getCatalogName();
+	}
+
+	/**
+	 * Shuts the instance down and reports how many transactions the trial actually committed.
+	 */
+	@TearDown(Level.Trial)
+	public void closeEvita() {
+		this.evita.close();
+		System.out.println("\nSeeded with " + INITIAL_COUNT_OF_PRODUCTS + " products.");
+		System.out.println("Committed " + this.committedTransactions.get() + " transactions in trial.");
+	}
+
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/graphql/artificial/GraphQLArtificialEntitiesLatencyBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/graphql/artificial/GraphQLArtificialEntitiesLatencyBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.externalApi.graphql.artificial;
 
 import io.evitadb.performance.externalApi.graphql.artificial.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -43,6 +45,14 @@ import java.util.concurrent.TimeUnit;
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @Threads(Threads.MAX)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class GraphQLArtificialEntitiesLatencyBenchmark extends GraphQLArtificialEntitiesBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/graphql/artificial/GraphQLArtificialEntitiesThroughputBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/graphql/artificial/GraphQLArtificialEntitiesThroughputBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.externalApi.graphql.artificial;
 
 import io.evitadb.performance.externalApi.graphql.artificial.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Threads;
@@ -41,6 +43,14 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode({Mode.Throughput})
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @Threads(Threads.MAX)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class GraphQLArtificialEntitiesThroughputBenchmark extends GraphQLArtificialEntitiesBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/grpc/artificial/GrpcArtificialEntitiesLatencyBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/grpc/artificial/GrpcArtificialEntitiesLatencyBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.externalApi.grpc.artificial;
 
 import io.evitadb.performance.externalApi.grpc.artificial.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -43,6 +45,14 @@ import java.util.concurrent.TimeUnit;
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @Threads(Threads.MAX)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class GrpcArtificialEntitiesLatencyBenchmark extends GrpcArtificialEntitiesBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/grpc/artificial/GrpcArtificialEntitiesThroughputBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/grpc/artificial/GrpcArtificialEntitiesThroughputBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.externalApi.grpc.artificial;
 
 import io.evitadb.performance.externalApi.grpc.artificial.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Threads;
@@ -41,6 +43,14 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode({Mode.Throughput})
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @Threads(Threads.MAX)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class GrpcArtificialEntitiesThroughputBenchmark extends GrpcArtificialEntitiesBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/javaDriver/artificial/JavaDriverArtificialEntitiesLatencyBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/javaDriver/artificial/JavaDriverArtificialEntitiesLatencyBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.externalApi.javaDriver.artificial;
 
 import io.evitadb.performance.externalApi.javaDriver.artificial.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -43,6 +45,14 @@ import java.util.concurrent.TimeUnit;
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @Threads(Threads.MAX)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class JavaDriverArtificialEntitiesLatencyBenchmark extends JavaDriverArtificialEntitiesBenchmark {
 
 	@Benchmark

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/javaDriver/artificial/JavaDriverArtificialEntitiesThroughputBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/javaDriver/artificial/JavaDriverArtificialEntitiesThroughputBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.externalApi.javaDriver.artificial;
 
 import io.evitadb.performance.externalApi.javaDriver.artificial.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Threads;
@@ -41,6 +43,14 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode({Mode.Throughput})
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @Threads(Threads.MAX)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class JavaDriverArtificialEntitiesThroughputBenchmark extends JavaDriverArtificialEntitiesBenchmark {
 
 	@Benchmark

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/rest/artificial/RestArtificialEntitiesLatencyBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/rest/artificial/RestArtificialEntitiesLatencyBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.externalApi.rest.artificial;
 
 import io.evitadb.performance.externalApi.rest.artificial.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -43,6 +45,14 @@ import java.util.concurrent.TimeUnit;
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @Threads(Threads.MAX)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class RestArtificialEntitiesLatencyBenchmark extends RestArtificialEntitiesBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/rest/artificial/RestArtificialEntitiesThroughputBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/externalApi/rest/artificial/RestArtificialEntitiesThroughputBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.externalApi.rest.artificial;
 
 import io.evitadb.performance.externalApi.rest.artificial.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Threads;
@@ -41,6 +43,14 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode({Mode.Throughput})
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @Threads(Threads.MAX)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class RestArtificialEntitiesThroughputBenchmark extends RestArtificialEntitiesBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/keramikaSoukup/KeramikaSoukupLatencyBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/keramikaSoukup/KeramikaSoukupLatencyBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.keramikaSoukup;
 
 import io.evitadb.performance.keramikaSoukup.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -42,6 +44,14 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode({Mode.AverageTime})
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class KeramikaSoukupLatencyBenchmark extends KeramikaSoukupBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/keramikaSoukup/KeramikaSoukupThroughputBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/keramikaSoukup/KeramikaSoukupThroughputBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.keramikaSoukup;
 
 import io.evitadb.performance.keramikaSoukup.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.infra.Blackhole;
@@ -36,6 +38,14 @@ import org.openjdk.jmh.infra.Blackhole;
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2022
  */
 @BenchmarkMode({Mode.Throughput})
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class KeramikaSoukupThroughputBenchmark extends KeramikaSoukupBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/senesi/SenesiLatencyBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/senesi/SenesiLatencyBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.senesi;
 
 import io.evitadb.performance.senesi.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -42,6 +44,14 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode({Mode.AverageTime})
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class SenesiLatencyBenchmark extends SenesiBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/senesi/SenesiThroughputBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/senesi/SenesiThroughputBenchmark.java
@@ -24,8 +24,10 @@
 package io.evitadb.performance.senesi;
 
 import io.evitadb.performance.senesi.state.*;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Threads;
@@ -40,6 +42,14 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode({Mode.Throughput})
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class SenesiThroughputBenchmark extends SenesiBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/setup/BenchmarkForkArgs.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/setup/BenchmarkForkArgs.java
@@ -1,0 +1,80 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.performance.setup;
+
+import org.openjdk.jmh.annotations.Fork;
+
+/**
+ * JVM arguments that every benchmark booting an embedded evitaDB instance must pass to its forked JVM.
+ *
+ * evitaDB uses Byte Buddy to generate classes reflectively while an instance boots, which JDK 17+ refuses unless
+ * these packages are opened. The flags have to reach the **forked** JVM specifically: JMH starts it with `-cp`, so
+ * neither the launching process's own command line nor the uber-jar's `Add-Opens` manifest entry applies to the
+ * process that actually runs the benchmark.
+ *
+ * When they are missing, benchmark state setup fails with `UnsupportedOperationException: Cannot define class using
+ * reflection`, and JMH reports that as a completed run with an empty result table rather than as an error - so the
+ * run looks like it merely produced no score, and the cause is nowhere near the symptom.
+ *
+ * Declare them on the benchmark class as:
+ *
+ * ```java
+ * @Fork(jvmArgsAppend = {
+ *     BenchmarkForkArgs.OPEN_LANG, BenchmarkForkArgs.ALL_UNNAMED,
+ *     ...
+ * })
+ * ```
+ *
+ * Annotation values must be compile-time constants, which is why this is a set of individual `String` constants
+ * rather than a single `String[]` - an array constant cannot be referenced from an annotation.
+ *
+ * Note {@link Fork#value()} defaults to `-1` ("unset"), so a class that only needs the JVM arguments should NOT
+ * also specify `value` - doing so would silently change how many forks that benchmark runs.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+public interface BenchmarkForkArgs {
+
+	/**
+	 * The `--add-opens` flag itself; each opened package is passed as this flag followed by its descriptor.
+	 */
+	String ADD_OPENS = "--add-opens";
+	/**
+	 * Byte Buddy defines generated classes through `java.lang.ClassLoader` internals.
+	 */
+	String OPEN_LANG = "java.base/java.lang=ALL-UNNAMED";
+	/**
+	 * Method handles used by the generated accessors.
+	 */
+	String OPEN_LANG_INVOKE = "java.base/java.lang.invoke=ALL-UNNAMED";
+	/**
+	 * `BigDecimal` internals touched by the price and attribute serializers.
+	 */
+	String OPEN_MATH = "java.base/java.math=ALL-UNNAMED";
+	/**
+	 * Collection internals touched during Kryo deserialization.
+	 */
+	String OPEN_UTIL = "java.base/java.util=ALL-UNNAMED";
+
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/setup/EvitaCatalogReusableSetup.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/setup/EvitaCatalogReusableSetup.java
@@ -50,7 +50,9 @@ public interface EvitaCatalogReusableSetup extends EvitaCatalogSetup, EvitaTestS
 			EvitaConfiguration.builder()
 				.storage(
 					StorageOptions.builder()
-						.storageDirectory(getTestDirectory())
+						// must resolve through the same helper the empty-instance path uses, otherwise this cannot
+						// find the catalog that path built - see EvitaCatalogSetup#benchmarkStorageDirectory
+						.storageDirectory(benchmarkStorageDirectory(catalogName))
 						.build()
 				)
 				.cache(
@@ -111,7 +113,8 @@ public interface EvitaCatalogReusableSetup extends EvitaCatalogSetup, EvitaTestS
 
 	@Override
 	default boolean isCatalogAvailable(@Nonnull String catalogName) {
-		final File targetDirectory = getTestDirectory().resolve(catalogName).toFile();
+		// the catalog lives inside the benchmark-owned storage root, one level deeper than it used to
+		final File targetDirectory = benchmarkStorageDirectory(catalogName).resolve(catalogName).toFile();
 		return targetDirectory.exists() && FileUtils.sizeOfDirectory(targetDirectory) > 0;
 	}
 

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/setup/EvitaCatalogSetup.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/setup/EvitaCatalogSetup.java
@@ -27,10 +27,12 @@ import io.evitadb.api.configuration.CacheOptions;
 import io.evitadb.api.configuration.EvitaConfiguration;
 import io.evitadb.api.configuration.ServerOptions;
 import io.evitadb.api.configuration.StorageOptions;
+import io.evitadb.api.configuration.TransactionOptions;
 import io.evitadb.core.Evita;
 import io.evitadb.test.EvitaTestSupport;
 
 import javax.annotation.Nonnull;
+import java.nio.file.Path;
 
 /**
  * Base implementation for InMemory tests that doesn't allow catalog recurring usage.
@@ -39,9 +41,103 @@ import javax.annotation.Nonnull;
  */
 public interface EvitaCatalogSetup extends CatalogSetup, EvitaTestSupport {
 
+	/**
+	 * System property overriding {@link TransactionOptions#flushFrequencyInMillis()} for a benchmark run.
+	 *
+	 * The value bounds how long trunk incorporation keeps greedily draining the WAL before it cuts a new
+	 * catalog version, so it trades commit throughput (fewer, larger merges) against how long a client
+	 * waiting for its changes to become visible is kept. Left unset the engine default applies, which
+	 * keeps every existing benchmark on exactly the configuration it had before this knob was exposed.
+	 */
+	String FLUSH_FREQUENCY_PROPERTY = "evita.benchmark.flushFrequencyInMillis";
+
+	/**
+	 * System property switching {@link StorageOptions#syncWrites()} off, so a run can attribute how much of
+	 * its cost is the data-file fsync that trunk incorporation performs when it checkpoints a round.
+	 *
+	 * This is a measurement knob, never a deployment one: with it off a crash can lose acknowledged data.
+	 */
+	String SYNC_WRITES_PROPERTY = "evita.benchmark.syncWrites";
+
+	/**
+	 * System property overriding {@link TransactionOptions#checkpointIntervalInMillis()} for a benchmark run.
+	 *
+	 * Set it to `0` to make every trunk round checkpoint - the behaviour that predates the interval - so a run can
+	 * be compared against the engine default without a recompile.
+	 *
+	 * Note how this differs from {@link #SYNC_WRITES_PROPERTY}: switching sync writes off removes the device flush
+	 * altogether and loses acknowledged data on a crash, whereas the interval only decides how often it happens.
+	 * A `syncWrites=false` run therefore measures the **upper bound** of what the interval can deliver, not the
+	 * interval itself - a deferred-checkpoint run scoring at or above that bound means the checkpoint never fired.
+	 */
+	String CHECKPOINT_INTERVAL_PROPERTY = "evita.benchmark.checkpointIntervalInMillis";
+
+	/**
+	 * Returns the storage root a benchmarked instance should own exclusively.
+	 *
+	 * evitaDB treats **every** sub-directory of its storage directory as a catalog and refuses to boot when one of
+	 * them cannot be read as such. Pointing a benchmark at the shared test directory therefore makes it inherit every
+	 * catalog any other test or benchmark ever left behind there — including half-written ones from runs that were
+	 * killed — and the instance dies during construction with a storm of `SchemaNotFoundException` /
+	 * `InvalidClassifierFormatException`. JMH reports that as a finished run with no measured operations, so the
+	 * failure is easy to mistake for a benchmark that simply produced no score.
+	 *
+	 * Giving each catalog its own root removes the whole class of failure: the instance can only ever see its own
+	 * data, no matter what else is lying around. The path is derived deterministically from the catalog name rather
+	 * than randomised, because {@link EvitaCatalogReusableSetup} has to find the catalog a previous run built.
+	 *
+	 * The `benchmark_` prefix is not cosmetic — the functional test suite writes its catalogs straight into
+	 * {@link #getTestDirectory()} as `<base>/<catalogName>`, so an unprefixed root would collide with those and
+	 * reintroduce exactly the problem this method exists to prevent.
+	 *
+	 * @param catalogName name of the catalog the instance will serve
+	 * @return directory that will contain this catalog and nothing else
+	 */
+	@Nonnull
+	default Path benchmarkStorageDirectory(@Nonnull String catalogName) {
+		return getTestDirectory().resolve(BENCHMARK_STORAGE_PREFIX + catalogName);
+	}
+
+	/**
+	 * Prefix distinguishing benchmark-owned storage roots from the catalogs the functional test suite writes directly
+	 * into the shared test directory.
+	 */
+	String BENCHMARK_STORAGE_PREFIX = "benchmark_";
+
+	/**
+	 * Builds the transaction options for a benchmarked instance, honouring {@link #FLUSH_FREQUENCY_PROPERTY}
+	 * when it is set so a run can sweep the greedy batching budget without a recompile.
+	 *
+	 * @return transaction options with the configured flush frequency, or the engine defaults when unset
+	 */
+	@Nonnull
+	default TransactionOptions benchmarkTransactionOptions() {
+		final TransactionOptions.Builder builder = TransactionOptions.builder();
+		final String flushFrequency = System.getProperty(FLUSH_FREQUENCY_PROPERTY);
+		if (flushFrequency != null) {
+			builder.flushFrequencyInMillis(Long.parseLong(flushFrequency));
+		}
+		final String checkpointInterval = System.getProperty(CHECKPOINT_INTERVAL_PROPERTY);
+		if (checkpointInterval != null) {
+			builder.checkpointIntervalInMillis(Long.parseLong(checkpointInterval));
+		}
+		return builder.build();
+	}
+
+	/**
+	 * Returns the configured {@link StorageOptions#syncWrites()} for a benchmarked instance, honouring
+	 * {@link #SYNC_WRITES_PROPERTY} when it is set.
+	 *
+	 * @return FALSE only when explicitly switched off for a measurement, the engine default otherwise
+	 */
+	default boolean benchmarkSyncWrites() {
+		final String syncWrites = System.getProperty(SYNC_WRITES_PROPERTY);
+		return syncWrites == null || Boolean.parseBoolean(syncWrites);
+	}
+
 	@Override
 	default Evita createEmptyEvitaInstance(@Nonnull String catalogName) {
-		cleanTestSubDirectoryWithRethrow(catalogName);
+		cleanTestSubDirectoryWithRethrow(BENCHMARK_STORAGE_PREFIX + catalogName);
 		// create new empty database
 		final Evita evita = new Evita(
 			EvitaConfiguration.builder()
@@ -54,15 +150,17 @@ public interface EvitaCatalogSetup extends CatalogSetup, EvitaTestSupport {
 				)
 				.storage(
 					StorageOptions.builder()
-						.storageDirectory(getTestDirectory())
+						.storageDirectory(benchmarkStorageDirectory(catalogName))
 						.lockTimeoutSeconds(50)
 						.waitOnCloseSeconds(50)
 						.outputBufferSize(4_194_304)
 						.maxOpenedReadHandles(Runtime.getRuntime().availableProcessors() * 4)
 						.computeCRC32(true)
 						.minimalActiveRecordShare(0.01)
+						.syncWrites(benchmarkSyncWrites())
 						.build()
 				)
+				.transaction(benchmarkTransactionOptions())
 				.cache(
 					CacheOptions.builder()
 						.enabled(true)

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/signal/SignalLatencyBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/signal/SignalLatencyBenchmark.java
@@ -23,9 +23,11 @@
 
 package io.evitadb.performance.signal;
 
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import io.evitadb.performance.signal.state.*;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -42,6 +44,14 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode({Mode.AverageTime})
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class SignalLatencyBenchmark extends SignalBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/signal/SignalThroughputBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/signal/SignalThroughputBenchmark.java
@@ -23,9 +23,11 @@
 
 package io.evitadb.performance.signal;
 
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import io.evitadb.performance.signal.state.*;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Threads;
@@ -40,6 +42,14 @@ import java.util.concurrent.TimeUnit;
  */
 @BenchmarkMode({Mode.Throughput})
 @Measurement(time = 1, timeUnit = TimeUnit.MINUTES)
+@Fork(
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 public class SignalThroughputBenchmark extends SignalBenchmark {
 
 	@Override

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/walreplay/WalReplayBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/walreplay/WalReplayBenchmark.java
@@ -23,6 +23,7 @@
 
 package io.evitadb.performance.walreplay;
 
+import io.evitadb.performance.setup.BenchmarkForkArgs;
 import io.evitadb.performance.walreplay.state.WalReplayState;
 import lombok.extern.slf4j.Slf4j;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -64,7 +65,15 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @BenchmarkMode(Mode.SingleShotTime)
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Fork(1)
+@Fork(
+	value = 1,
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL
+	}
+)
 @Warmup(iterations = 0)
 @Measurement(iterations = 1)
 public class WalReplayBenchmark {

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/SortAnchorExtractor.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/SortAnchorExtractor.java
@@ -163,7 +163,9 @@ public class SortAnchorExtractor {
 				observableOutputKeeper,
 				KRYO_FACTORY,
 				nonFlushed -> { },
-				oldest -> { }
+				oldest -> { },
+				// read-only spike: nothing is written, so there is no deferred sync to coordinate
+				null
 			);
 
 		try {
@@ -209,7 +211,9 @@ public class SortAnchorExtractor {
 					storageSettings,
 					offHeapMemoryManager,
 					observableOutputKeeper,
-					recordTypeRegistry
+					recordTypeRegistry,
+					// read-only spike: nothing is written, so there is no deferred sync to coordinate
+					null
 				);
 			try {
 				run(collectionService);

--- a/pom.xml
+++ b/pom.xml
@@ -815,7 +815,7 @@
 				<configuration>
 					<llmProvider>openai</llmProvider>
 					<llmUrl>https://api.openai.com/v1</llmUrl>
-					<llmToken>${OPENAI_API_KEY}</llmToken>
+					<llmToken>${env.OPENAI_API_KEY}</llmToken>
 					<llmModel>gpt-4.1</llmModel>
 					<customFrontMatter>
 						<translated>true</translated>


### PR DESCRIPTION
Removes the two sources of device flushes that capped commit throughput, without weakening any durability promise. Four commits, each independently reviewable.

## What changed

**WAL, per transaction.** The channel was opened with `DSYNC`, which syncs every `write()` separately — and one append issues three (head, content, trailing checksum). Measured on LUKS+xfs: 15.5 ms/tx versus 5.1 ms for a single explicit force, exactly 3x, flat from 512 B to 8 MB. `DSYNC` is replaced by one `force(true)` at the end of `append()`, with explicit forces at every other writer on those channels — rotation tails, seed checksums, the recovery tail. A tail marker outliving its data would be read as authoritative, so those are not optional.

**WAL, across transactions.** The appender now writes and returns; a sync task samples the queue tail, forces once, and releases everything that force covered. Transactions arriving during the force form the next batch. Note this is *not* textbook group commit — the reactive pipeline requests one item at a time, so there are no concurrent committers to batch; the batching is across sequentially appended transactions.

| clients | force-per-tx | group commit | speedup |
|---|---|---|---|
| 1 | 194.8 tx/s | 192.3 | **0.99x** |
| 4 | 195.5 | 382.7 | 1.96x |
| 16 | 194.6 | 1370.8 | 7.04x |
| 32 | 194.8 | 2714.0 | 13.93x |

Self-validating: force-per-tx is pinned at ~195 tx/s at every client count, i.e. exactly 1/5.13 ms — the serial force ceiling. The device performs the same number of forces in both modes; throughput tracks transactions-per-force linearly. One client measures neutral, which is the "no regression when there is nothing to batch" bar.

**Data files, per round.** A round issued `N_changed + 2` syncs, measured at 16.8 ms — 28% of the round. These now happen at most once per `checkpointIntervalInMillis` (default 1s). Rounds still write and flush to page cache every time; only the device flush and the bootstrap record are deferred. Handles register with a `PendingSyncRegistry`, and `writeCatalogBootstrap` forces the pending set before writing the record — one choke point covering trunk rounds, compaction, go-live, rename and restore alike. **2.11x at two writers, no regression at 64.**

## Two further defects found on the way

- **`computeCRC32C=false` was a silent-corruption switch.** It installs a no-op checksum whose `equalsTo` returns `true`, so a holed transaction was replayed as genuine history rather than truncated — worse than an unopenable catalog. Since dropping `DSYNC` makes hole detection load-bearing, the WAL now keeps write ordering precisely when checksums are off.
- **Compaction wrote a durable pointer to unsynced data.** Compacted output went through a buffered stream that was closed but never synced, while the bootstrap record pointing into it *was* synced.

## The part worth reviewing most carefully

Deferring the checkpoint splits "written" from "durable" for the first time. Three readers had never needed to distinguish them, and all three were wrong under deferral — each caught by the suite, not by inspection:

1. `verifyIntegrity()` purges obsolete files immediately afterwards, so a stale bootstrap meant discarding WAL files covering versions never recorded — a real data-loss window.
2. Backup takes an `includingWAL` flag; with the WAL excluded, a stale bootstrap yields a backup that is not corrupt but quietly out of date.
3. Change data capture went blind to everything committed since the last checkpoint.

They now ask for `getLastAppliedCatalogVersion()`. Remaining callers of `getLastCatalogVersion()` were audited and genuinely want the checkpointed answer.

## Verification

- `(cdc | transaction | wal | storage) & !slow & !flaky`: **3,536 / 0**
- full functional suite: **20,666 / 0** (one unrelated error — `ExportS3ServiceTest` needs Docker)
- long-running transactional tiers: **32 / 0**
- Mechanism verified by JFR rather than inferred from throughput: checkpoint cadence median 1,024 ms (n=31), and the baseline arm emitted no checkpoint events at all — the negative control.

## Two caveats stated deliberately

- **The +10.5% at 64 writers is unattributed.** My explanation for it was measured and refuted, so it should not be quoted as a benefit of this change. The load-bearing claims are the 2.11x at two writers and the no-regression gate.
- **The `flushFrequencyInMillis` default (1s -> 10s) is now an unmeasured choice.** The sweep that picked it was flat because the un-batched WAL capped throughput at ~195/s, so no backlog could form — the very condition under which the budget would bite. Bounded and defensible, but re-running that sweep is the honest follow-up.

`metrics.md` and `jfr-events.md` are generated by the `JfrDocumentation` runner, not hand-edited.