### PR TITLE
chore: correct dev version to 2026.2-SNAPSHOT

### DIFF
--- a/evita_api/pom.xml
+++ b/evita_api/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/evita_common/pom.xml
+++ b/evita_common/pom.xml
@@ -33,7 +33,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 

--- a/evita_db/pom.xml
+++ b/evita_db/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/evita_engine/pom.xml
+++ b/evita_engine/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/evita_export/evita_export_fs/pom.xml
+++ b/evita_export/evita_export_fs/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/evita_export/evita_export_s3/pom.xml
+++ b/evita_export/evita_export_s3/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/evita_external_api/evita_external_api_core/pom.xml
+++ b/evita_external_api/evita_external_api_core/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_external_api</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/evita_external_api/evita_external_api_graphql/pom.xml
+++ b/evita_external_api/evita_external_api_graphql/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>io.evitadb</groupId>
         <artifactId>evita_external_api</artifactId>
-        <version>2026.2.RC1-SNAPSHOT</version>
+        <version>2026.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/evita_external_api/evita_external_api_grpc/client/pom.xml
+++ b/evita_external_api/evita_external_api_grpc/client/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 	<dependencies>

--- a/evita_external_api/evita_external_api_grpc/client_all_in_one/pom.xml
+++ b/evita_external_api/evita_external_api_grpc/client_all_in_one/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 	<dependencies>

--- a/evita_external_api/evita_external_api_grpc/client_observability/pom.xml
+++ b/evita_external_api/evita_external_api_grpc/client_observability/pom.xml
@@ -33,7 +33,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../../pom.xml</relativePath>
 	</parent>
 

--- a/evita_external_api/evita_external_api_grpc/server/pom.xml
+++ b/evita_external_api/evita_external_api_grpc/server/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_external_api</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/evita_external_api/evita_external_api_grpc/shared/pom.xml
+++ b/evita_external_api/evita_external_api_grpc/shared/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_external_api</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<properties>

--- a/evita_external_api/evita_external_api_lab/pom.xml
+++ b/evita_external_api/evita_external_api_lab/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_external_api</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/evita_external_api/evita_external_api_observability/pom.xml
+++ b/evita_external_api/evita_external_api_observability/pom.xml
@@ -32,7 +32,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_external_api</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencyManagement>
@@ -130,19 +130,19 @@
 		<dependency>
 			<groupId>io.evitadb</groupId>
 			<artifactId>evita_external_api_grpc</artifactId>
-			<version>2026.2.RC1-SNAPSHOT</version>
+			<version>2026.2-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.evitadb</groupId>
 			<artifactId>evita_external_api_graphql</artifactId>
-			<version>2026.2.RC1-SNAPSHOT</version>
+			<version>2026.2-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.evitadb</groupId>
 			<artifactId>evita_external_api_rest</artifactId>
-			<version>2026.2.RC1-SNAPSHOT</version>
+			<version>2026.2-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/evita_external_api/evita_external_api_rest/pom.xml
+++ b/evita_external_api/evita_external_api_rest/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_external_api</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/evita_external_api/evita_external_api_system/pom.xml
+++ b/evita_external_api/evita_external_api_system/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_external_api</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/evita_external_api/pom.xml
+++ b/evita_external_api/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.evitadb</groupId>
         <artifactId>evita_root</artifactId>
-        <version>2026.2.RC1-SNAPSHOT</version>
+        <version>2026.2-SNAPSHOT</version>
     </parent>
 
     <!--

--- a/evita_query/pom.xml
+++ b/evita_query/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 	<properties>
 		<antlr4.version>4.13.2</antlr4.version>

--- a/evita_roaring_bitmap/pom.xml
+++ b/evita_roaring_bitmap/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<!--

--- a/evita_server/pom.xml
+++ b/evita_server/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>io.evitadb</groupId>
         <artifactId>evita_root</artifactId>
-        <version>2026.2.RC1-SNAPSHOT</version>
+        <version>2026.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/evita_store/evita_store_entity/pom.xml
+++ b/evita_store/evita_store_entity/pom.xml
@@ -32,7 +32,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_store</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/evita_store/evita_store_key_value/pom.xml
+++ b/evita_store/evita_store_key_value/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_store</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/evita_store/evita_store_server/pom.xml
+++ b/evita_store/evita_store_server/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_store</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/evita_store/evita_traffic_engine/pom.xml
+++ b/evita_store/evita_traffic_engine/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_store</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/evita_store/pom.xml
+++ b/evita_store/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>io.evitadb</groupId>
         <artifactId>evita_root</artifactId>
-        <version>2026.2.RC1-SNAPSHOT</version>
+        <version>2026.2-SNAPSHOT</version>
     </parent>
 
     <modules>

--- a/evita_test/evita_documentation_tests/pom.xml
+++ b/evita_test/evita_documentation_tests/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/evita_test/evita_functional_tests/pom.xml
+++ b/evita_test/evita_functional_tests/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/evita_test/evita_long_running_tests/pom.xml
+++ b/evita_test/evita_long_running_tests/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/evita_test/evita_performance_tests/pom.xml
+++ b/evita_test/evita_performance_tests/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/evita_test/evita_test_support/pom.xml
+++ b/evita_test/evita_test_support/pom.xml
@@ -31,7 +31,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/jacoco/pom.xml
+++ b/jacoco/pom.xml
@@ -30,7 +30,7 @@
 	<parent>
 		<groupId>io.evitadb</groupId>
 		<artifactId>evita_root</artifactId>
-		<version>2026.2.RC1-SNAPSHOT</version>
+		<version>2026.2-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>io.evitadb</groupId>
 	<artifactId>evita_root</artifactId>
-	<version>2026.2.RC1-SNAPSHOT</version>
+	<version>2026.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>evitaDB - Root &amp; modules aggregator</name>
 	<url>https://evitadb.io</url>


### PR DESCRIPTION
## What's Changed

Corrects the reactor version left over from release-candidate testing. The `2026.2.RC1-SNAPSHOT` qualifier was never reset before Release 2026.2 (#1328) merged to master, so both `dev` and `master` were left pointing at a pre-release version string instead of the clean `2026.2-SNAPSHOT` development snapshot.

Updates all 33 module `pom.xml` files (root + parent references + the internal dependency versions in `evita_external_api_observability`) from `2026.2.RC1-SNAPSHOT` to `2026.2-SNAPSHOT`. No functional changes.