### PR TITLE
fix: exclude evita_long_running_tests from PGP/duplicate-class CI checks

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -52,12 +52,17 @@ jobs:
         mvn -T 1C -B -P full -Dmaven.test.skip=true install -pl '!:evita_long_running_tests' --file pom.xml
 
     - name: PGP Keys Check
+      # `evita_long_running_tests` is excluded for the same reason as in Compilation Check:
+      # this is a bare goal invocation, so it never runs `package` for `evita_functional_tests`,
+      # and that module's test-jar (consumed by `evita_long_running_tests`) is never produced or
+      # installed (`maven.install.skip=true`), so dependency resolution would fail otherwise.
       run: |
-        mvn org.simplify4u.plugins:pgpverify-maven-plugin:check
+        mvn org.simplify4u.plugins:pgpverify-maven-plugin:check -pl '!:evita_long_running_tests'
 
     - name: Duplicate Classes Check
+      # See PGP Keys Check above for why `evita_long_running_tests` is excluded.
       run: |
-        mvn duplicate-finder:check
+        mvn duplicate-finder:check -pl '!:evita_long_running_tests'
 
     - name: Resolve new release version
       id: release_version


### PR DESCRIPTION
## Summary
- The `PGP Keys Check` and `Duplicate Classes Check` steps in `ci-master.yml` invoke `pgpverify:check` / `duplicate-finder:check` as bare goals, so the `package` phase never runs for `evita_functional_tests` in that step's own `mvn` invocation, and its test-jar (needed by `evita_long_running_tests`, and never installed locally since `evita_functional_tests` sets `maven.install.skip=true`) can't be resolved. Both steps therefore fail before their own check logic ever runs against `evita_long_running_tests`.
- This surfaced for the first time on the `master` branch in run [30308099426](https://github.com/FgForrest/evitaDB/actions/runs/30308099426/job/90117087151), triggered by PR #1329 merging into `master` — it's a pre-existing gap, not something that PR introduced.
- Apply the same `-pl '!:evita_long_running_tests'` exclusion that `cbd60faf1` already added to the `Compilation Check` step for the identical reason, but never propagated to these two steps.

## Verification
- Locally ran `mvn duplicate-finder:check -pl '!:evita_long_running_tests'` across all 29 other modules: `BUILD SUCCESS`, no duplicate classes found — confirming the check itself passes once the dependency-resolution plumbing is fixed.

## Test plan
- [ ] Merge into `dev`; next `dev` → `master` release PR will carry the fix into `ci-master.yml`, where it can be confirmed on the following master push.