### PR TITLE
perf: cut allocation and descent cost from the sort-attribute insert path

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/transaction/Transaction.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/Transaction.java
@@ -329,6 +329,11 @@ public final class Transaction implements TransactionContract {
 	 * Unlike {@link #getTransaction()} this does not wrap the result in an {@link Optional}, which allocates on the
 	 * transaction-present branch.
 	 *
+	 * **Retention contract:** the returned reference is valid only for the current operation on the current thread.
+	 * The value is thread-confined, so passing it down a call chain on the same thread is exactly the intended use -
+	 * but do not store it in a field, hang it off a long-lived object, or hand it to another thread. Doing so would
+	 * let one thread read another's uncommitted diff layer.
+	 *
 	 * @return the transaction bound to the current thread, or `null` when the thread is outside a transaction
 	 */
 	@Nullable

--- a/evita_engine/src/main/java/io/evitadb/core/transaction/Transaction.java
+++ b/evita_engine/src/main/java/io/evitadb/core/transaction/Transaction.java
@@ -317,6 +317,27 @@ public final class Transaction implements TransactionContract {
 	}
 
 	/**
+	 * Allocation-free variant of {@link #getTransaction()} for hot read paths: returns the thread's current
+	 * transaction, or `null` when none is bound.
+	 *
+	 * Every `getTransactionalMemoryLayerIfExists`-style helper on this class starts by reading the same
+	 * {@link #CURRENT_TRANSACTION} ThreadLocal, so a method that resolves several transactional fields pays that
+	 * lookup once per field. Callers that touch more than one transactional member in a single operation should
+	 * resolve the transaction ONCE through this accessor and pass it down - `ThreadLocal` machinery is 5.25 % of
+	 * busy-thread wall time on the sort-attribute insert path (issue #1332).
+	 *
+	 * Unlike {@link #getTransaction()} this does not wrap the result in an {@link Optional}, which allocates on the
+	 * transaction-present branch.
+	 *
+	 * @return the transaction bound to the current thread, or `null` when the thread is outside a transaction
+	 */
+	@Nullable
+	public static Transaction getCurrentTransactionIfAvailable() {
+		// safe for the same reason as getTransaction() - the value is thread-confined
+		return CURRENT_TRANSACTION.get();
+	}
+
+	/**
 	 * Creates a transactional persistence service based on the given storage part persistence service.
 	 * If a transaction is active, it creates a transactional service using the current transaction identifier.
 	 * Registers the transactional service with the transaction's finalizer for cleanup.

--- a/evita_engine/src/main/java/io/evitadb/index/array/TransactionalUnorderedIntArray.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/TransactionalUnorderedIntArray.java
@@ -336,22 +336,23 @@ public class TransactionalUnorderedIntArray
 	}
 
 	/**
-	 * Binary-searches the ascending record ids on indexes `[fromIndex, toIndex)` and returns the index at which
-	 * `recordId` belongs — the first index holding a greater or equal record id, or `toIndex` when every id in the
-	 * range is smaller.
+	 * Binary-searches the ascending record ids on indexes `[fromIndex, toIndex)` for the place `recordId` belongs and
+	 * returns the record id immediately preceding it, or {@link Integer#MIN_VALUE} when it belongs at index zero —
+	 * i.e. the `previousRecordId` argument {@link #add(int, int)} expects. An empty range is legal and yields the
+	 * record at `fromIndex - 1`.
 	 *
-	 * Prefer this over a caller-side binary search built from {@link #get(int)}: the whole search shares a single
-	 * resolved leaf, so probes that converge into one leaf cost an array read rather than a fresh tree descent. See
-	 * {@link UnorderedLookupTree#findInsertionPositionInRange(int, int, int)} for why the search has to live inside
-	 * the tree to get that.
+	 * Prefer this over a caller-side binary search built from {@link #get(int)}: the search and its final predecessor
+	 * read all share a single resolved leaf, so every probe converging into that leaf costs an array read rather than
+	 * a fresh tree descent. See {@link UnorderedLookupTree#findPredecessorInRange(int, int, int)} for why this has to
+	 * live inside the tree to get that.
 	 *
 	 * @param fromIndex first index of the searched range, inclusive
 	 * @param toIndex   last index of the searched range, exclusive
-	 * @param recordId  the record id whose insertion index is sought
-	 * @return the insertion index within `[fromIndex, toIndex]`
+	 * @param recordId  the record id whose predecessor is sought
+	 * @return the preceding record id, or {@link Integer#MIN_VALUE} when `recordId` belongs at index zero
 	 */
-	public int findInsertionPositionInRange(int fromIndex, int toIndex, int recordId) {
-		return this.positionTree.findInsertionPositionInRange(fromIndex, toIndex, recordId);
+	public int findPredecessorInRange(int fromIndex, int toIndex, int recordId) {
+		return this.positionTree.findPredecessorInRange(fromIndex, toIndex, recordId);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/array/TransactionalUnorderedIntArray.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/TransactionalUnorderedIntArray.java
@@ -44,7 +44,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
-import java.util.OptionalLong;
 import java.util.PrimitiveIterator.OfInt;
 
 /**
@@ -395,20 +394,24 @@ public class TransactionalUnorderedIntArray
 	 * ({@link Integer#MIN_VALUE} adds it to the head).
 	 */
 	public void add(int previousRecordId, int recordId) {
+		// order-keys minted by the position tree are always non-negative (the first container is 0 and every mint is
+		// additive), so Long.MIN_VALUE is a collision-proof "absent" sentinel that lets us skip the OptionalLong
+		// allocation `search(int)` would incur - the same trick `indexOf` relies on. The guard stays (it protects
+		// against index corruption), it is just no longer a second full descent plus a boxed result.
 		Assert.isTrue(
-			this.valueIndex.search(recordId).isEmpty(),
-			"Record with id " + recordId + " is already part of the array!"
+			this.valueIndex.searchOrDefault(recordId, Long.MIN_VALUE) == Long.MIN_VALUE,
+			() -> "Record with id " + recordId + " is already part of the array!"
 		);
 		if (previousRecordId == Integer.MIN_VALUE) {
 			this.positionTree.insertAtPosition(0, recordId, this);
 		} else {
-			final OptionalLong previousOrderKey = this.valueIndex.search(previousRecordId);
+			final long previousOrderKey = this.valueIndex.searchOrDefault(previousRecordId, Long.MIN_VALUE);
 			Assert.isTrue(
-				previousOrderKey.isPresent(),
-				"Record with id " + previousRecordId + " is not present in the array,"
+				previousOrderKey != Long.MIN_VALUE,
+				() -> "Record with id " + previousRecordId + " is not present in the array,"
 					+ " cannot add record " + recordId + " after it!"
 			);
-			this.positionTree.insertAfter(previousOrderKey.getAsLong(), previousRecordId, recordId, this);
+			this.positionTree.insertAfter(previousOrderKey, previousRecordId, recordId, this);
 		}
 	}
 
@@ -417,8 +420,8 @@ public class TransactionalUnorderedIntArray
 	 */
 	public void addOnIndex(int index, int recordId) {
 		Assert.isTrue(
-			this.valueIndex.search(recordId).isEmpty(),
-			"Record with id " + recordId + " is already part of the array!"
+			this.valueIndex.searchOrDefault(recordId, Long.MIN_VALUE) == Long.MIN_VALUE,
+			() -> "Record with id " + recordId + " is already part of the array!"
 		);
 		this.positionTree.insertAtPosition(index, recordId, this);
 	}
@@ -442,8 +445,8 @@ public class TransactionalUnorderedIntArray
 	public void appendAll(int... recordIds) {
 		for (final int recordId : recordIds) {
 			Assert.isTrue(
-				this.valueIndex.search(recordId).isEmpty(),
-				"Record with id " + recordId + " is already part of the array!"
+				this.valueIndex.searchOrDefault(recordId, Long.MIN_VALUE) == Long.MIN_VALUE,
+				() -> "Record with id " + recordId + " is already part of the array!"
 			);
 			this.positionTree.insertAtPosition(this.positionTree.size(), recordId, this);
 		}

--- a/evita_engine/src/main/java/io/evitadb/index/array/TransactionalUnorderedIntArray.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/TransactionalUnorderedIntArray.java
@@ -336,6 +336,25 @@ public class TransactionalUnorderedIntArray
 	}
 
 	/**
+	 * Binary-searches the ascending record ids on indexes `[fromIndex, toIndex)` and returns the index at which
+	 * `recordId` belongs — the first index holding a greater or equal record id, or `toIndex` when every id in the
+	 * range is smaller.
+	 *
+	 * Prefer this over a caller-side binary search built from {@link #get(int)}: the whole search shares a single
+	 * resolved leaf, so probes that converge into one leaf cost an array read rather than a fresh tree descent. See
+	 * {@link UnorderedLookupTree#findInsertionPositionInRange(int, int, int)} for why the search has to live inside
+	 * the tree to get that.
+	 *
+	 * @param fromIndex first index of the searched range, inclusive
+	 * @param toIndex   last index of the searched range, exclusive
+	 * @param recordId  the record id whose insertion index is sought
+	 * @return the insertion index within `[fromIndex, toIndex]`
+	 */
+	public int findInsertionPositionInRange(int fromIndex, int toIndex, int recordId) {
+		return this.positionTree.findInsertionPositionInRange(fromIndex, toIndex, recordId);
+	}
+
+	/**
 	 * Method returns last record in the array.
 	 *
 	 * @return record id

--- a/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
@@ -564,7 +564,8 @@ public class UnorderedLookupTree implements
 		// and each would otherwise start with its own `CURRENT_TRANSACTION` ThreadLocal read - two per positional
 		// probe, at ~13 probes per sort-attribute insert across 40 low-cardinality attributes per entity. ThreadLocal
 		// machinery is 5.25 % of busy-thread wall on that path (issue #1332). The dispatch itself stays HERE, in the
-		// public read method, as INV-2 of the STM rules requires - only its duplication is removed.
+		// public read method, as INV-2 of the STM rules requires (see
+		// `documentation/developer/stm/rules-and-invariants.md`) - only its duplication is removed.
 		final Transaction transaction = Transaction.getCurrentTransactionIfAvailable();
 		final Node<?> theRoot = getRoot(transaction);
 		if (position < 0 || position >= size(transaction) || theRoot == null) {
@@ -596,8 +597,21 @@ public class UnorderedLookupTree implements
 	 * {@link Integer#MIN_VALUE} when it belongs at the very start of the array. That is exactly the
 	 * `previousRecordId` contract of {@link TransactionalUnorderedIntArray#add(int, int)}.
 	 *
+	 * **Caller obligation:** the record ids occupying `[fromPosition, toPosition)` must be in ascending id order.
+	 * This array is *unordered* as a whole — only a single value's sort block is ordered — so that ordering is a
+	 * property of the range the caller picks, not of the structure. A binary search cannot detect a violation, so
+	 * passing a non-ascending range yields an undefined answer rather than an error.
+	 *
+	 * **The answer is not confined to the range.** When every id in `[fromPosition, toPosition)` is greater than
+	 * `recordId`, the search converges at `fromPosition` and the predecessor returned is the record at
+	 * `fromPosition - 1` — the last record of the *preceding* block. That is deliberate: the caller is inserting into
+	 * a globally ordered array and needs the true predecessor, not a block-local one.
+	 *
 	 * An empty range (`fromPosition == toPosition`) is legal and skips the search: the answer is then simply the
-	 * record sitting at `fromPosition - 1`, which is what an insert of a brand-new value block needs.
+	 * record sitting at `fromPosition - 1`, which is what an insert of a brand-new value block needs. On a
+	 * completely empty tree that degenerates to `findPredecessorInRange(0, 0, id)` returning
+	 * {@link Integer#MIN_VALUE} — the first insert of the first value, and the most-executed shape at the start of a
+	 * bulk load.
 	 *
 	 * The whole search runs **inside the tree** rather than as a caller-side loop over {@link #getRecordAt(int)} for
 	 * one reason: consecutive probes of a binary search converge, so after the first descent the following probes

--- a/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
@@ -591,9 +591,13 @@ public class UnorderedLookupTree implements
 	}
 
 	/**
-	 * Binary-searches the ascending record ids occupying logical positions `[fromPosition, toPosition)` and returns
-	 * the position at which `recordId` belongs — the first position holding a record id greater than or equal to
-	 * `recordId`, or `toPosition` when every id in the range is smaller.
+	 * Binary-searches the ascending record ids occupying logical positions `[fromPosition, toPosition)` for the place
+	 * `recordId` belongs, and returns the record id **immediately preceding** that place —
+	 * {@link Integer#MIN_VALUE} when it belongs at the very start of the array. That is exactly the
+	 * `previousRecordId` contract of {@link TransactionalUnorderedIntArray#add(int, int)}.
+	 *
+	 * An empty range (`fromPosition == toPosition`) is legal and skips the search: the answer is then simply the
+	 * record sitting at `fromPosition - 1`, which is what an insert of a brand-new value block needs.
 	 *
 	 * The whole search runs **inside the tree** rather than as a caller-side loop over {@link #getRecordAt(int)} for
 	 * one reason: consecutive probes of a binary search converge, so after the first descent the following probes
@@ -603,6 +607,10 @@ public class UnorderedLookupTree implements
 	 * sort-attribute insert at 10M records with 1000 distinct values, across 40 low-cardinality attributes per
 	 * entity, which is what makes those descents 19.4 % of busy-thread wall in the profile behind issue #1332.
 	 *
+	 * Returning the predecessor — rather than the insertion position for the caller to read separately — is what lets
+	 * the **final** read share that same window. It is the read most likely to hit it: the predecessor sits one
+	 * position below where the search converged, so it is almost always inside the leaf the last probe resolved.
+	 *
 	 * The retained window is safe **because it cannot outlive this method**: the search is a pure read and nothing
 	 * mutates the tree between two probes, so a leaf resolved for one probe is still the leaf covering its position
 	 * for the next. Do not hoist the window into a field or into the caller — that assumption stops holding the
@@ -610,11 +618,11 @@ public class UnorderedLookupTree implements
 	 *
 	 * @param fromPosition first logical position of the searched range, inclusive
 	 * @param toPosition   last logical position of the searched range, exclusive
-	 * @param recordId     the record id whose insertion position is sought
-	 * @return the insertion position within `[fromPosition, toPosition]`
+	 * @param recordId     the record id whose predecessor is sought
+	 * @return the preceding record id, or {@link Integer#MIN_VALUE} when `recordId` belongs at position zero
 	 * @throws GenericEvitaInternalError when the range does not lie within the tree
 	 */
-	public int findInsertionPositionInRange(int fromPosition, int toPosition, int recordId) {
+	public int findPredecessorInRange(int fromPosition, int toPosition, int recordId) {
 		// resolved once for the whole search, exactly as getRecordAt does it for a single probe (INV-2)
 		final Transaction transaction = Transaction.getCurrentTransactionIfAvailable();
 		final Node<?> theRoot = getRoot(transaction);
@@ -673,7 +681,21 @@ public class UnorderedLookupTree implements
 				high = middle - 1;
 			}
 		}
-		return insertionPosition;
+		// the predecessor sits immediately before the insertion point; a negative position means `recordId` belongs
+		// at the very front of the array and therefore has no predecessor
+		final int predecessorPosition = insertionPosition - 1;
+		if (predecessorPosition < 0) {
+			return Integer.MIN_VALUE;
+		}
+		if (windowLeaf != null && predecessorPosition >= windowBase
+			&& predecessorPosition < windowBase + windowCount) {
+			return windowLeaf.getRecordIds()[predecessorPosition - windowBase];
+		}
+		// Window miss - the predecessor lies outside the leaf the search ended in. It can even sit BELOW the searched
+		// range, at `fromPosition - 1`, which is the last record of the preceding value block. Delegating to the
+		// ordinary single-position read costs one redundant transaction resolution, which is negligible next to the
+		// descent it performs, and keeps the descent written once.
+		return getRecordAt(predecessorPosition);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
@@ -591,6 +591,92 @@ public class UnorderedLookupTree implements
 	}
 
 	/**
+	 * Binary-searches the ascending record ids occupying logical positions `[fromPosition, toPosition)` and returns
+	 * the position at which `recordId` belongs — the first position holding a record id greater than or equal to
+	 * `recordId`, or `toPosition` when every id in the range is smaller.
+	 *
+	 * The whole search runs **inside the tree** rather than as a caller-side loop over {@link #getRecordAt(int)} for
+	 * one reason: consecutive probes of a binary search converge, so after the first descent the following probes
+	 * usually land in the leaf that descent already resolved. Keeping the search here lets that leaf be retained
+	 * across probes in plain locals — a probe inside the retained window costs one array read instead of a fresh
+	 * root-to-leaf order-statistic descent. `SortIndexChanges.computePreviousRecord` issues about 13 such probes per
+	 * sort-attribute insert at 10M records with 1000 distinct values, across 40 low-cardinality attributes per
+	 * entity, which is what makes those descents 19.4 % of busy-thread wall in the profile behind issue #1332.
+	 *
+	 * The retained window is safe **because it cannot outlive this method**: the search is a pure read and nothing
+	 * mutates the tree between two probes, so a leaf resolved for one probe is still the leaf covering its position
+	 * for the next. Do not hoist the window into a field or into the caller — that assumption stops holding the
+	 * moment the window survives across a mutation.
+	 *
+	 * @param fromPosition first logical position of the searched range, inclusive
+	 * @param toPosition   last logical position of the searched range, exclusive
+	 * @param recordId     the record id whose insertion position is sought
+	 * @return the insertion position within `[fromPosition, toPosition]`
+	 * @throws GenericEvitaInternalError when the range does not lie within the tree
+	 */
+	public int findInsertionPositionInRange(int fromPosition, int toPosition, int recordId) {
+		// resolved once for the whole search, exactly as getRecordAt does it for a single probe (INV-2)
+		final Transaction transaction = Transaction.getCurrentTransactionIfAvailable();
+		final Node<?> theRoot = getRoot(transaction);
+		if (fromPosition < 0 || toPosition > size(transaction) || fromPosition > toPosition
+			|| (theRoot == null && fromPosition != toPosition)) {
+			throw new GenericEvitaInternalError(
+				"Range [" + fromPosition + ", " + toPosition + ") is not within the array!",
+				"Unknown position in the array!"
+			);
+		}
+		// the retained leaf window: the leaf resolved by the most recent descent and the logical positions it covers
+		LeafNode windowLeaf = null;
+		int windowBase = 0;
+		int windowCount = 0;
+		int low = fromPosition;
+		int high = toPosition - 1;
+		// stays at the range end when every id in the range is smaller than the sought one
+		int insertionPosition = toPosition;
+		while (low <= high) {
+			final int middle = (low + high) >>> 1;
+			final int middleRecordId;
+			if (windowLeaf != null && middle >= windowBase && middle < windowBase + windowCount) {
+				middleRecordId = windowLeaf.getRecordIds()[middle - windowBase];
+			} else {
+				// window miss - descend from the root and retain the leaf this probe lands in. The descent is
+				// inlined rather than delegated because it cannot report both the leaf and its base position
+				// without allocating; the sibling readers in this class inline it for the same reason.
+				Node<?> node = theRoot;
+				int remaining = middle;
+				while (node instanceof final InternalNode internal) {
+					final int childCount = internal.getChildCount();
+					final int[] counts = internal.getCounts();
+					final Node<?>[] children = internal.getChildren();
+					int childIndex = 0;
+					while (childIndex < childCount - 1 && remaining >= counts[childIndex]) {
+						remaining -= counts[childIndex];
+						childIndex++;
+					}
+					node = children[childIndex];
+				}
+				final LeafNode leaf = (LeafNode) node;
+				windowLeaf = leaf;
+				// `remaining` is the probe's offset inside the leaf, so the leaf starts `remaining` positions back
+				windowBase = middle - remaining;
+				// the LOGICAL record count - the physical array is leaf-capacity wide regardless of occupancy
+				windowCount = leaf.getCount();
+				middleRecordId = leaf.getRecordIds()[remaining];
+			}
+			if (middleRecordId < recordId) {
+				low = middle + 1;
+			} else {
+				insertionPosition = middle;
+				if (middleRecordId == recordId) {
+					break;
+				}
+				high = middle - 1;
+			}
+		}
+		return insertionPosition;
+	}
+
+	/**
 	 * Returns the last record id in the logical array.
 	 *
 	 * @throws ArrayIndexOutOfBoundsException when the tree is empty

--- a/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/array/UnorderedLookupTree.java
@@ -299,6 +299,18 @@ public class UnorderedLookupTree implements
 	}
 
 	/**
+	 * Same as {@link #size()}, but reads through an already-resolved transaction so a caller touching several
+	 * transactional members pays the `CURRENT_TRANSACTION` ThreadLocal read once rather than once per member.
+	 *
+	 * @param transaction the caller-resolved current transaction, or `null` when outside a transaction
+	 * @return the number of record ids visible to the given transaction
+	 */
+	int size(@Nullable Transaction transaction) {
+		final Integer theSize = this.size.get(transaction);
+		return theSize == null ? 0 : theSize;
+	}
+
+	/**
 	 * Returns true when the tree holds no records.
 	 */
 	public boolean isEmpty() {
@@ -548,8 +560,14 @@ public class UnorderedLookupTree implements
 	 * @throws GenericEvitaInternalError when the position is out of bounds
 	 */
 	public int getRecordAt(int position) {
-		final Node<?> theRoot = getRoot();
-		if (position < 0 || position >= size() || theRoot == null) {
+		// Resolve the thread's transaction ONCE. `getRoot()` and `size()` read two different TransactionalReferences,
+		// and each would otherwise start with its own `CURRENT_TRANSACTION` ThreadLocal read - two per positional
+		// probe, at ~13 probes per sort-attribute insert across 40 low-cardinality attributes per entity. ThreadLocal
+		// machinery is 5.25 % of busy-thread wall on that path (issue #1332). The dispatch itself stays HERE, in the
+		// public read method, as INV-2 of the STM rules requires - only its duplication is removed.
+		final Transaction transaction = Transaction.getCurrentTransactionIfAvailable();
+		final Node<?> theRoot = getRoot(transaction);
+		if (position < 0 || position >= size(transaction) || theRoot == null) {
 			throw new GenericEvitaInternalError(
 				"Position " + position + " not found!",
 				"Unknown position in the array!"
@@ -1231,6 +1249,18 @@ public class UnorderedLookupTree implements
 	@Nullable
 	private Node<?> getRoot() {
 		return this.root.get();
+	}
+
+	/**
+	 * Same as {@link #getRoot()}, but reads through an already-resolved transaction - see
+	 * {@link #size(Transaction)} for why the two are paired.
+	 *
+	 * @param transaction the caller-resolved current transaction, or `null` when outside a transaction
+	 * @return the root node visible to the given transaction, or `null` for an empty tree
+	 */
+	@Nullable
+	private Node<?> getRoot(@Nullable Transaction transaction) {
+		return this.root.get(transaction);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndexChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndexChanges.java
@@ -236,23 +236,13 @@ public class SortIndexChanges
 			// are sorted in natural integer order, so the search is the same one `computeInsertPositionOfIntInOrderedArray`
 			// performs — it just reads each probe through the position tree (O(depth), no allocation) rather than out of
 			// a copy of the WHOLE sort index, which this method used to build on every single sort-attribute insert.
-			int low = blockStart;
-			int high = blockEnd - 1;
-			// absolute index the record would be inserted at; stays at the block end when every id in the block is smaller
-			int insertionIndex = blockEnd;
-			while (low <= high) {
-				final int middle = (low + high) >>> 1;
-				final int middleRecordId = this.sortIndex.sortedRecords.get(middle);
-				if (middleRecordId < recordId) {
-					low = middle + 1;
-				} else {
-					insertionIndex = middle;
-					if (middleRecordId == recordId) {
-						break;
-					}
-					high = middle - 1;
-				}
-			}
+			// The search is delegated to the array rather than looped here so that all of its probes share one resolved
+			// leaf; a binary search converges, so most probes after the first land in the leaf the first descent already
+			// reached and cost an array read instead of a whole descent (issue #1332).
+			// absolute index the record would be inserted at; the block end when every id in the block is smaller
+			final int insertionIndex = this.sortIndex.sortedRecords.findInsertionPositionInRange(
+				blockStart, blockEnd, recordId
+			);
 			// the target record id sits immediately before the insertion point
 			final int recordPosition = insertionIndex - 1;
 			// a negative position means the record should be placed as the very first record of the sort index

--- a/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndexChanges.java
+++ b/evita_engine/src/main/java/io/evitadb/index/attribute/SortIndexChanges.java
@@ -229,31 +229,21 @@ public class SortIndexChanges
 		final CumulativeWeightBPlusTree<Serializable> valueTree = getValueTree();
 		// block start = cumulative weight (rank) of all strictly-smaller values
 		final int blockStart = valueTree.rankOf(value);
-		if (valueTree.containsKey(value)) {
-			// the value already owns a record block; its size equals the value's cardinality (its weight)
-			final int blockEnd = blockStart + valueTree.weightOf(value);
-			// Binary-search the block through positional reads instead of materializing it. Within the block record ids
-			// are sorted in natural integer order, so the search is the same one `computeInsertPositionOfIntInOrderedArray`
-			// performs — it just reads each probe through the position tree (O(depth), no allocation) rather than out of
-			// a copy of the WHOLE sort index, which this method used to build on every single sort-attribute insert.
-			// The search is delegated to the array rather than looped here so that all of its probes share one resolved
-			// leaf; a binary search converges, so most probes after the first land in the leaf the first descent already
-			// reached and cost an array read instead of a whole descent (issue #1332).
-			// absolute index the record would be inserted at; the block end when every id in the block is smaller
-			final int insertionIndex = this.sortIndex.sortedRecords.findInsertionPositionInRange(
-				blockStart, blockEnd, recordId
-			);
-			// the target record id sits immediately before the insertion point
-			final int recordPosition = insertionIndex - 1;
-			// a negative position means the record should be placed as the very first record of the sort index
-			return recordPosition >= 0 ? this.sortIndex.sortedRecords.get(recordPosition) : Integer.MIN_VALUE;
-		} else {
-			// the value is absent and starts a fresh block at `blockStart`; the predecessor is the record immediately
-			// before that offset, or none when the value sorts before every present value
-			return blockStart == 0
-				? Integer.MIN_VALUE
-				: this.sortIndex.sortedRecords.get(blockStart - 1);
-		}
+		// A value that already owns a record block spans its cardinality (its weight); a value seen for the first time
+		// starts a fresh, EMPTY block at the same offset. Both cases are the same query — "what precedes the place this
+		// record id belongs within `[blockStart, blockEnd)`" — and the empty range simply skips the search and answers
+		// with the last record of the preceding block.
+		final int blockEnd = valueTree.containsKey(value)
+			? blockStart + valueTree.weightOf(value)
+			: blockStart;
+		// Binary-search the block through positional reads instead of materializing it. Within the block record ids are
+		// sorted in natural integer order, so the search is the same one `computeInsertPositionOfIntInOrderedArray`
+		// performs — it just reads each probe through the position tree (O(depth), no allocation) rather than out of a
+		// copy of the WHOLE sort index, which this method used to build on every single sort-attribute insert.
+		// The search is delegated to the array rather than looped here so that its probes AND its final predecessor
+		// read all share one resolved leaf; a binary search converges, so most reads after the first land in the leaf
+		// the first descent already reached and cost an array read instead of a whole descent (issue #1332).
+		return this.sortIndex.sortedRecords.findPredecessorInRange(blockStart, blockEnd, recordId);
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/AbstractIntKeyedInternalNode.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/AbstractIntKeyedInternalNode.java
@@ -632,6 +632,18 @@ abstract class AbstractIntKeyedInternalNode<SELF extends AbstractIntKeyedInterna
 	 * Searches for the child index that should contain the given key. This method avoids allocating a NodeWithIndex
 	 * record.
 	 *
+	 * Allocation-free: {@link Arrays#binarySearch(int[], int, int, int)} is folded directly into the child-index
+	 * mapping instead of routing through `ArrayUtils.computeInsertPositionOfIntInOrderedArray`, which allocates an
+	 * `ArrayUtils.InsertionPosition` record this method immediately collapsed to a single `int` in BOTH branches.
+	 * Escape analysis was measurably not eliminating it - the record accounted for 1.59 GB of allocation per 60 s of
+	 * bulk ingest, the single largest allocation site on the sort-attribute insert path.
+	 *
+	 * A non-negative `binarySearch` result means an exact key hit, which routes to the child one slot to the RIGHT
+	 * (the former `alreadyPresent ? position + 1` branch); a negative result encodes `-insertionPoint - 1`, and the
+	 * insertion point IS the child index (the former `: position` branch). At `peek == 0` a binary search over an
+	 * empty range returns `-1`, yielding child index `0` - matching the `toIndex <= fromIndex` guard the previous
+	 * implementation inherited from `computeInsertPositionOfIntInOrderedArray`.
+	 *
 	 * @param key the integer key to search for within the B+ tree.
 	 * @return the index of the child that should contain the specified key.
 	 */
@@ -639,17 +651,10 @@ abstract class AbstractIntKeyedInternalNode<SELF extends AbstractIntKeyedInterna
 		final SELF layer = this.transactionalLayer ?
 			Transaction.getTransactionalMemoryLayerIfExists(this) :
 			null;
-		if (layer == null) {
-			final InsertionPosition insertionPosition = computeInsertPositionOfIntInOrderedArray(
-				key, this.keys, 0, this.peek);
-			return insertionPosition.alreadyPresent() ?
-				insertionPosition.position() + 1 : insertionPosition.position();
-		} else {
-			final InsertionPosition insertionPosition = computeInsertPositionOfIntInOrderedArray(
-				key, layer.keys, 0, layer.peek);
-			return insertionPosition.alreadyPresent() ?
-				insertionPosition.position() + 1 : insertionPosition.position();
-		}
+		final int[] theKeys = layer == null ? this.keys : layer.keys;
+		final int thePeek = layer == null ? this.peek : layer.peek;
+		final int index = Arrays.binarySearch(theKeys, 0, thePeek, key);
+		return index >= 0 ? index + 1 : -index - 1;
 	}
 
 	@Override

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalIntToLongBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalIntToLongBPlusTree.java
@@ -41,7 +41,6 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.PrimitiveIterator.OfLong;
@@ -187,16 +186,27 @@ public class TransactionalIntToLongBPlusTree extends AbstractIntKeyedBPlusTree i
 		// insert can actually overflow the leaf - roughly one insert in `valueBlockSize`.
 		final BPlusLeafTreeNode leaf = (BPlusLeafTreeNode) findLeafNode(key);
 		// Capture BEFORE mutating: the split machinery replaces this leaf in its parent, so the path has to reflect
-		// the pre-mutation tree. A leaf reaches `isFull()` (peek == valueBlockSize - 1) only from
-		// peek >= valueBlockSize - 2, so this guard is exact rather than merely conservative.
-		final Cursor cursor = leaf.getPeek() >= this.valueBlockSize - 2 ? createCursor(key) : null;
+		// the pre-mutation tree. `isNearlyFull` reads `peek` and the capacity from the same resolved state that
+		// `isFull` does, so it can never fail to fire for an insert that will split. It is not exact in the other
+		// direction: a same-key overwrite one slot from full leaves `peek` unchanged, so the cursor is captured and
+		// discarded. That waste is bounded and rare. (In `upsert` the guard sits inside the key-absent branch, so
+		// the overwrite case cannot reach it and the guard IS exact there.)
+		final Cursor cursor = leaf.isNearlyFull() ? createCursor(key) : null;
 		if (leaf.insert(key, value)) {
 			this.size.set(size() + 1);
 		}
 
 		// Split the leaf node if it exceeds the block size
 		if (leaf.isFull()) {
-			splitLeafNode(leaf, Objects.requireNonNull(cursor));
+			if (cursor == null) {
+				throw new GenericEvitaInternalError(
+					"Leaf is full but no cursor path was captured - `isNearlyFull` failed to predict `isFull` " +
+						"(peek: " + leaf.getPeek() + ", capacity: " + leaf.getKeys().length +
+						", tree block size: " + this.valueBlockSize + ")!",
+					"Leaf is full but no cursor path was captured!"
+				);
+			}
+			splitLeafNode(leaf, cursor);
 		}
 	}
 
@@ -222,7 +232,7 @@ public class TransactionalIntToLongBPlusTree extends AbstractIntKeyedBPlusTree i
 			final long previousValue = values[existingIndex];
 			values[existingIndex] = updater.applyAsLong(previousValue);
 		} else {
-			final Cursor cursor = leaf.getPeek() >= this.valueBlockSize - 2 ? createCursor(key) : null;
+			final Cursor cursor = leaf.isNearlyFull() ? createCursor(key) : null;
 			// insert the new value
 			if (leaf.insert(key, updater.applyAsLong(0L))) {
 				this.size.set(size() + 1);
@@ -230,7 +240,15 @@ public class TransactionalIntToLongBPlusTree extends AbstractIntKeyedBPlusTree i
 
 			// Split the leaf node if it exceeds the block size
 			if (leaf.isFull()) {
-				splitLeafNode(leaf, Objects.requireNonNull(cursor));
+				if (cursor == null) {
+					throw new GenericEvitaInternalError(
+						"Leaf is full but no cursor path was captured - `isNearlyFull` failed to predict `isFull` " +
+							"(peek: " + leaf.getPeek() + ", capacity: " + leaf.getKeys().length +
+							", tree block size: " + this.valueBlockSize + ")!",
+						"Leaf is full but no cursor path was captured!"
+					);
+				}
+				splitLeafNode(leaf, cursor);
 			}
 		}
 	}
@@ -788,6 +806,24 @@ public class TransactionalIntToLongBPlusTree extends AbstractIntKeyedBPlusTree i
 		public boolean isFull() {
 			final BPlusLeafTreeNode current = currentState();
 			return current.peek == current.values.length - 1;
+		}
+
+		/**
+		 * Whether a single insert of a **new** key could make this leaf {@link #isFull()}, i.e. whether the caller
+		 * must capture a cursor path before mutating so a split has one.
+		 *
+		 * Deliberately mirrors {@link #isFull()} - it reads `peek` and the capacity from the **same** resolved state,
+		 * so the two can never disagree. Comparing against the tree's configured `valueBlockSize` instead would work
+		 * only while every leaf array happens to be allocated at exactly that size, and nothing enforces that
+		 * coupling; a shorter array would reach `isFull()` without ever tripping the guard.
+		 *
+		 * Resolves the transactional layer exactly once, so it costs no more than the `getPeek()` call it replaces.
+		 *
+		 * @return true when one more key could fill this leaf
+		 */
+		public boolean isNearlyFull() {
+			final BPlusLeafTreeNode current = currentState();
+			return current.peek >= current.values.length - 2;
 		}
 
 		@Override

--- a/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalIntToLongBPlusTree.java
+++ b/evita_engine/src/main/java/io/evitadb/index/bPlusTree/TransactionalIntToLongBPlusTree.java
@@ -41,6 +41,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.PrimitiveIterator.OfInt;
 import java.util.PrimitiveIterator.OfLong;
@@ -179,15 +180,23 @@ public class TransactionalIntToLongBPlusTree extends AbstractIntKeyedBPlusTree i
 	 * @param value the value associated with the key
 	 */
 	public void insert(int key, long value) {
-		final Cursor cursor = createCursor(key);
-		final BPlusLeafTreeNode leaf = cursor.leafNode();
+		// The cursor path exists ONLY to cascade a split upward, but it was allocated on EVERY insert - an
+		// ArrayList, its backing array, a one-element root sibling array, a CursorLevel per level and the Cursor
+		// itself (2.25 GB / 60 s of bulk ingest across this family). `findLeafNode` reaches the same leaf by the
+		// identical `searchIndex` descent without capturing anything, so the path is now captured only when this
+		// insert can actually overflow the leaf - roughly one insert in `valueBlockSize`.
+		final BPlusLeafTreeNode leaf = (BPlusLeafTreeNode) findLeafNode(key);
+		// Capture BEFORE mutating: the split machinery replaces this leaf in its parent, so the path has to reflect
+		// the pre-mutation tree. A leaf reaches `isFull()` (peek == valueBlockSize - 1) only from
+		// peek >= valueBlockSize - 2, so this guard is exact rather than merely conservative.
+		final Cursor cursor = leaf.getPeek() >= this.valueBlockSize - 2 ? createCursor(key) : null;
 		if (leaf.insert(key, value)) {
 			this.size.set(size() + 1);
 		}
 
 		// Split the leaf node if it exceeds the block size
 		if (leaf.isFull()) {
-			splitLeafNode(leaf, cursor);
+			splitLeafNode(leaf, Objects.requireNonNull(cursor));
 		}
 	}
 
@@ -201,8 +210,9 @@ public class TransactionalIntToLongBPlusTree extends AbstractIntKeyedBPlusTree i
 	 * @param updater a function to compute a new value, must not be null
 	 */
 	public void upsert(int key, @Nonnull LongUnaryOperator updater) {
-		final Cursor cursor = createCursor(key);
-		final BPlusLeafTreeNode leaf = cursor.leafNode();
+		// see `insert` - the cursor path is captured lazily and pre-mutation. The update branch below replaces a
+		// value in place and can never overflow the leaf, so it needs no path at all.
+		final BPlusLeafTreeNode leaf = (BPlusLeafTreeNode) findLeafNode(key);
 
 		final int existingIndex = leaf.getValueIndex(key);
 		if (existingIndex >= 0) {
@@ -212,6 +222,7 @@ public class TransactionalIntToLongBPlusTree extends AbstractIntKeyedBPlusTree i
 			final long previousValue = values[existingIndex];
 			values[existingIndex] = updater.applyAsLong(previousValue);
 		} else {
+			final Cursor cursor = leaf.getPeek() >= this.valueBlockSize - 2 ? createCursor(key) : null;
 			// insert the new value
 			if (leaf.insert(key, updater.applyAsLong(0L))) {
 				this.size.set(size() + 1);
@@ -219,7 +230,7 @@ public class TransactionalIntToLongBPlusTree extends AbstractIntKeyedBPlusTree i
 
 			// Split the leaf node if it exceeds the block size
 			if (leaf.isFull()) {
-				splitLeafNode(leaf, cursor);
+				splitLeafNode(leaf, Objects.requireNonNull(cursor));
 			}
 		}
 	}

--- a/evita_engine/src/main/java/io/evitadb/index/reference/TransactionalReference.java
+++ b/evita_engine/src/main/java/io/evitadb/index/reference/TransactionalReference.java
@@ -107,6 +107,30 @@ public class TransactionalReference<T>
 		}
 	}
 
+	/**
+	 * Same as {@link #get()}, but reads through an ALREADY-RESOLVED transaction instead of resolving the thread's
+	 * transaction itself.
+	 *
+	 * {@link #get()} begins with a `ThreadLocal` read of the current transaction. An operation that touches several
+	 * transactional references pays that read once per reference even though the answer is identical for all of them;
+	 * this overload lets the caller resolve it once (via
+	 * {@link Transaction#getCurrentTransactionIfAvailable()}) and thread it down. Behaviour is otherwise identical -
+	 * `null` transaction means read the committed value, exactly as an absent layer does.
+	 *
+	 * @param transaction the caller-resolved current transaction, or `null` when outside a transaction
+	 * @return the value visible to the given transaction
+	 */
+	@Nullable
+	public T get(@Nullable Transaction transaction) {
+		final ReferenceChanges<T> layer = transaction == null ?
+			null : transaction.getTransactionalMemory().getTransactionalMemoryLayerIfExists(this);
+		if (layer == null) {
+			return this.value.get();
+		} else {
+			return layer.get();
+		}
+	}
+
 	@Nonnull
 	@Override
 	public ReferenceChanges<T> createLayer() {

--- a/evita_engine/src/main/java/io/evitadb/index/reference/TransactionalReference.java
+++ b/evita_engine/src/main/java/io/evitadb/index/reference/TransactionalReference.java
@@ -117,6 +117,15 @@ public class TransactionalReference<T>
 	 * {@link Transaction#getCurrentTransactionIfAvailable()}) and thread it down. Behaviour is otherwise identical -
 	 * `null` transaction means read the committed value, exactly as an absent layer does.
 	 *
+	 * **Caller obligation — pass only the calling thread's own transaction.** Unlike {@link #get()}, which resolves
+	 * the current thread's transaction and therefore cannot be misused, this overload reads through whatever
+	 * transaction it is handed. Handing it another thread's transaction reads that thread's *uncommitted* diff layer.
+	 * Resolve it within the same operation, use it for the duration of that operation, and then drop it: never cache
+	 * it in a field, store it on the object, or pass it across threads.
+	 *
+	 * Because the transactional-memory dispatch is hoisted out of this method, the read-dispatch obligation described
+	 * by INV-2 in `documentation/developer/stm/rules-and-invariants.md` moves to the caller.
+	 *
 	 * @param transaction the caller-resolved current transaction, or `null` when outside a transaction
 	 * @return the value visible to the given transaction
 	 */

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalUnorderedIntArrayTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/TransactionalUnorderedIntArrayTest.java
@@ -1141,6 +1141,92 @@ class TransactionalUnorderedIntArrayTest {
 			);
 		}
 
+		/**
+		 * Verifies the duplicate-record guard of `add` rejects a record id the array already holds - both a record
+		 * inserted inside the very same transaction (visible only through the transactional layer of the value index)
+		 * and one coming from the committed state.
+		 */
+		@Test
+		@DisplayName("throws when adding record that is already part of the array")
+		void shouldFailToAddRecordAlreadyPresent() {
+			final TransactionalUnorderedIntArray array = new TransactionalUnorderedIntArray(new int[]{1, 2});
+
+			assertStateAfterCommit(
+				array,
+				original -> {
+					// from here on record 3 lives in the transactional layer only
+					array.add(1, 3);
+					final IllegalArgumentException layerHit = assertThrows(
+						IllegalArgumentException.class, () -> array.add(2, 3)
+					);
+					assertEquals("Record with id 3 is already part of the array!", layerHit.getMessage());
+					// ... while record 1 was there before the transaction started
+					assertThrows(IllegalArgumentException.class, () -> array.add(1, 1));
+				},
+				(original, committed) -> {
+					assertTransactionalArrayIs(new int[]{1, 2}, original);
+					assertArrayEquals(new int[]{1, 3, 2}, committed.getArray());
+				}
+			);
+		}
+
+		/**
+		 * Verifies the duplicate-record guard of `addOnIndex` rejects a record id the array already holds, whether it
+		 * was added inside the running transaction or committed before it.
+		 */
+		@Test
+		@DisplayName("throws when adding record on index that is already part of the array")
+		void shouldFailToAddRecordAlreadyPresentOnIndex() {
+			final TransactionalUnorderedIntArray array = new TransactionalUnorderedIntArray(new int[]{1, 2});
+
+			assertStateAfterCommit(
+				array,
+				original -> {
+					// from here on record 3 lives in the transactional layer only
+					array.addOnIndex(0, 3);
+					final IllegalArgumentException layerHit = assertThrows(
+						IllegalArgumentException.class, () -> array.addOnIndex(2, 3)
+					);
+					assertEquals("Record with id 3 is already part of the array!", layerHit.getMessage());
+					// ... while record 1 was there before the transaction started
+					assertThrows(IllegalArgumentException.class, () -> array.addOnIndex(1, 1));
+				},
+				(original, committed) -> {
+					assertTransactionalArrayIs(new int[]{1, 2}, original);
+					assertArrayEquals(new int[]{3, 1, 2}, committed.getArray());
+				}
+			);
+		}
+
+		/**
+		 * Verifies the duplicate-record guard of `appendAll` rejects a record id the array already holds and leaves the
+		 * array untouched when it fires - again for both the committed state and the transactional layer.
+		 */
+		@Test
+		@DisplayName("throws when appending record that is already part of the array")
+		void shouldFailToAppendRecordAlreadyPresent() {
+			final TransactionalUnorderedIntArray array = new TransactionalUnorderedIntArray(new int[]{1, 2});
+
+			assertStateAfterCommit(
+				array,
+				original -> {
+					// the guard fires before anything is appended, so the array keeps its shape
+					assertThrows(IllegalArgumentException.class, () -> array.appendAll(1));
+					assertTransactionalArrayIs(new int[]{1, 2}, array);
+					// from here on record 3 lives in the transactional layer only
+					array.appendAll(3);
+					final IllegalArgumentException layerHit = assertThrows(
+						IllegalArgumentException.class, () -> array.appendAll(3)
+					);
+					assertEquals("Record with id 3 is already part of the array!", layerHit.getMessage());
+				},
+				(original, committed) -> {
+					assertTransactionalArrayIs(new int[]{1, 2}, original);
+					assertArrayEquals(new int[]{1, 2, 3}, committed.getArray());
+				}
+			);
+		}
+
 	}
 
 	/**

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/UnorderedLookupTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/UnorderedLookupTreeTest.java
@@ -1391,8 +1391,8 @@ class UnorderedLookupTreeTest {
 	}
 
 	@Nested
-	@DisplayName("Ranged insertion search (leaf window retained across probes)")
-	class RangedInsertionSearchTest {
+	@DisplayName("Ranged predecessor search (leaf window retained across probes)")
+	class RangedPredecessorSearchTest {
 
 		/**
 		 * Builds the logical shape a {@link io.evitadb.index.attribute.SortIndex} produces: a sequence of value
@@ -1454,27 +1454,30 @@ class UnorderedLookupTreeTest {
 		}
 
 		/**
-		 * The naive oracle: the first position in `[from, to)` holding a record id greater than or equal to
-		 * `recordId`, resolved through {@link UnorderedLookupTree#getRecordAt(int)} one position at a time.
+		 * The naive oracle: finds the first position in `[from, to)` holding a record id greater than or equal to
+		 * `recordId` — resolved through {@link UnorderedLookupTree#getRecordAt(int)} one position at a time — and
+		 * returns the record id one position below it, or {@link Integer#MIN_VALUE} when that is position zero.
 		 *
 		 * @param tested   the tree under test
 		 * @param from     first position of the range, inclusive
 		 * @param to       last position of the range, exclusive
-		 * @param recordId the record id whose insertion position is sought
-		 * @return the expected insertion position
+		 * @param recordId the record id whose predecessor is sought
+		 * @return the expected preceding record id
 		 */
 		private int oracle(@Nonnull TreeWithIndex tested, int from, int to, int recordId) {
+			int insertionPosition = to;
 			for (int position = from; position < to; position++) {
 				if (tested.tree.getRecordAt(position) >= recordId) {
-					return position;
+					insertionPosition = position;
+					break;
 				}
 			}
-			return to;
+			return insertionPosition == 0 ? Integer.MIN_VALUE : tested.tree.getRecordAt(insertionPosition - 1);
 		}
 
 		/**
-		 * Asserts the ranged search matches the oracle for every present id of every ascending run, for the gaps
-		 * between them, and for ids falling before and after the whole run.
+		 * Asserts the ranged predecessor search matches the oracle for every present id of every ascending run, for
+		 * the gaps between them, and for ids falling before and after the whole run.
 		 *
 		 * @param tested  the tree under test
 		 * @param logical the logical record id sequence mirroring the tree
@@ -1489,14 +1492,27 @@ class UnorderedLookupTreeTest {
 					for (final int probe : new int[]{presentId, presentId - 1}) {
 						assertEquals(
 							oracle(tested, from, to, probe),
-							tested.tree.findInsertionPositionInRange(from, to, probe),
+							tested.tree.findPredecessorInRange(from, to, probe),
 							"mismatch for id " + probe + " in run [" + from + ", " + to + ")"
 						);
 					}
 				}
-				// below every id in the run, and above every id in the run
-				assertEquals(from, tested.tree.findInsertionPositionInRange(from, to, logical.get(from) - 100));
-				assertEquals(to, tested.tree.findInsertionPositionInRange(from, to, logical.get(to - 1) + 100));
+				// below every id in the run (predecessor falls BELOW the range, or off the array entirely), and above
+				// every id in the run (predecessor is the run's own last record)
+				final int belowAll = logical.get(from) - 100;
+				assertEquals(
+					oracle(tested, from, to, belowAll), tested.tree.findPredecessorInRange(from, to, belowAll)
+				);
+				final int aboveAll = logical.get(to - 1) + 100;
+				assertEquals(
+					aboveAll > 0 ? logical.get(to - 1) : Integer.MIN_VALUE,
+					tested.tree.findPredecessorInRange(from, to, aboveAll)
+				);
+				// the empty range at the run's start - the shape a brand-new value block produces
+				assertEquals(
+					from == 0 ? Integer.MIN_VALUE : logical.get(from - 1),
+					tested.tree.findPredecessorInRange(from, from, belowAll)
+				);
 			}
 		}
 
@@ -1538,20 +1554,23 @@ class UnorderedLookupTreeTest {
 		}
 
 		@Test
-		@DisplayName("returns the range start for an empty range and handles a single-element range")
+		@DisplayName("resolves the predecessor for empty, single-element and whole-array ranges")
 		void shouldHandleDegenerateRanges() {
 			final TreeWithIndex tested = new TreeWithIndex(3, UnorderedLookupTree.DEFAULT_ORDER_KEY_GAP);
 			tested.bulkLoad(new int[]{10, 20, 30, 40, 50});
-			// empty range - nothing to compare against, the insertion position is the range itself
-			assertEquals(2, tested.tree.findInsertionPositionInRange(2, 2, 25));
-			// single element
-			assertEquals(2, tested.tree.findInsertionPositionInRange(2, 3, 25));
-			assertEquals(2, tested.tree.findInsertionPositionInRange(2, 3, 30));
-			assertEquals(3, tested.tree.findInsertionPositionInRange(2, 3, 35));
+			// empty range - no search runs, the answer is simply the record below the range
+			assertEquals(20, tested.tree.findPredecessorInRange(2, 2, 25));
+			// empty range at the very front - no predecessor exists
+			assertEquals(Integer.MIN_VALUE, tested.tree.findPredecessorInRange(0, 0, 5));
+			// single element; every answer here falls BELOW the searched range
+			assertEquals(20, tested.tree.findPredecessorInRange(2, 3, 25));
+			assertEquals(20, tested.tree.findPredecessorInRange(2, 3, 30));
+			// ... except this one, where the single element itself precedes the insertion point
+			assertEquals(30, tested.tree.findPredecessorInRange(2, 3, 35));
 			// the whole array
-			assertEquals(0, tested.tree.findInsertionPositionInRange(0, 5, 5));
-			assertEquals(5, tested.tree.findInsertionPositionInRange(0, 5, 55));
-			assertEquals(3, tested.tree.findInsertionPositionInRange(0, 5, 40));
+			assertEquals(Integer.MIN_VALUE, tested.tree.findPredecessorInRange(0, 5, 5));
+			assertEquals(50, tested.tree.findPredecessorInRange(0, 5, 55));
+			assertEquals(30, tested.tree.findPredecessorInRange(0, 5, 40));
 		}
 
 		@Test
@@ -1560,13 +1579,13 @@ class UnorderedLookupTreeTest {
 			final TreeWithIndex tested = new TreeWithIndex();
 			tested.bulkLoad(new int[]{10, 20, 30});
 			assertThrows(
-				GenericEvitaInternalError.class, () -> tested.tree.findInsertionPositionInRange(-1, 2, 15)
+				GenericEvitaInternalError.class, () -> tested.tree.findPredecessorInRange(-1, 2, 15)
 			);
 			assertThrows(
-				GenericEvitaInternalError.class, () -> tested.tree.findInsertionPositionInRange(0, 4, 15)
+				GenericEvitaInternalError.class, () -> tested.tree.findPredecessorInRange(0, 4, 15)
 			);
 			assertThrows(
-				GenericEvitaInternalError.class, () -> tested.tree.findInsertionPositionInRange(2, 1, 15)
+				GenericEvitaInternalError.class, () -> tested.tree.findPredecessorInRange(2, 1, 15)
 			);
 		}
 	}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/UnorderedLookupTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/UnorderedLookupTreeTest.java
@@ -1501,17 +1501,20 @@ class UnorderedLookupTreeTest {
 				// every id in the run (predecessor is the run's own last record)
 				final int belowAll = logical.get(from) - 100;
 				assertEquals(
-					oracle(tested, from, to, belowAll), tested.tree.findPredecessorInRange(from, to, belowAll)
+					oracle(tested, from, to, belowAll), tested.tree.findPredecessorInRange(from, to, belowAll),
+					"mismatch for id " + belowAll + " below run [" + from + ", " + to + ")"
 				);
 				final int aboveAll = logical.get(to - 1) + 100;
 				assertEquals(
-					aboveAll > 0 ? logical.get(to - 1) : Integer.MIN_VALUE,
-					tested.tree.findPredecessorInRange(from, to, aboveAll)
+					logical.get(to - 1),
+					tested.tree.findPredecessorInRange(from, to, aboveAll),
+					"mismatch for id " + aboveAll + " above run [" + from + ", " + to + ")"
 				);
 				// the empty range at the run's start - the shape a brand-new value block produces
 				assertEquals(
 					from == 0 ? Integer.MIN_VALUE : logical.get(from - 1),
-					tested.tree.findPredecessorInRange(from, from, belowAll)
+					tested.tree.findPredecessorInRange(from, from, belowAll),
+					"mismatch for id " + belowAll + " in empty run [" + from + ", " + from + ")"
 				);
 			}
 		}
@@ -1571,6 +1574,22 @@ class UnorderedLookupTreeTest {
 			assertEquals(Integer.MIN_VALUE, tested.tree.findPredecessorInRange(0, 5, 5));
 			assertEquals(50, tested.tree.findPredecessorInRange(0, 5, 55));
 			assertEquals(30, tested.tree.findPredecessorInRange(0, 5, 40));
+		}
+
+		/**
+		 * Covers the un-populated tree, which every value block starts from on the first insert of a bulk load - the
+		 * only shape where the search runs with no root at all.
+		 */
+		@Test
+		@DisplayName("resolves an empty range on an empty tree and rejects a non-empty one")
+		void shouldHandleRangesOnEmptyTree() {
+			final TreeWithIndex tested = new TreeWithIndex();
+			// nothing is indexed yet, so there is no record preceding the (empty) range
+			assertEquals(Integer.MIN_VALUE, tested.tree.findPredecessorInRange(0, 0, 42));
+			// ... and no position exists, so any non-empty range lies outside the array
+			assertThrows(
+				GenericEvitaInternalError.class, () -> tested.tree.findPredecessorInRange(0, 1, 42)
+			);
 		}
 
 		@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/UnorderedLookupTreeTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/array/UnorderedLookupTreeTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -1386,6 +1387,187 @@ class UnorderedLookupTreeTest {
 			final UnorderedLookupTree.PositionCursor cursor = tested.tree.reversePositionCursor();
 			assertThrows(GenericEvitaInternalError.class, () -> cursor.recordAt(3));
 			assertThrows(GenericEvitaInternalError.class, () -> cursor.recordAt(-1));
+		}
+	}
+
+	@Nested
+	@DisplayName("Ranged insertion search (leaf window retained across probes)")
+	class RangedInsertionSearchTest {
+
+		/**
+		 * Builds the logical shape a {@link io.evitadb.index.attribute.SortIndex} produces: a sequence of value
+		 * blocks that are ascending **inside** a block and unordered across blocks. Records are inserted one by one
+		 * (rather than bulk-loaded) so the tree carries real split history and partially-filled leaves.
+		 *
+		 * @param tested        the tree to fill
+		 * @param blockCount    number of value blocks to lay out
+		 * @param maxBlockWidth largest number of records a single block may hold
+		 * @param seed          random seed for reproducibility
+		 * @return the logical record id sequence, mirroring the tree's array
+		 */
+		@Nonnull
+		private List<Integer> fillWithValueBlocks(
+			@Nonnull TreeWithIndex tested, int blockCount, int maxBlockWidth, long seed
+		) {
+			final Random random = new Random(seed);
+			// each block draws its ids from a private 1000-wide id space, so ids never collide across blocks;
+			// the spaces are handed out in shuffled order, so the array is NOT globally ascending
+			final List<Integer> spaces = new ArrayList<>(blockCount);
+			for (int i = 0; i < blockCount; i++) {
+				spaces.add(i);
+			}
+			Collections.shuffle(spaces, random);
+			final List<Integer> logical = new ArrayList<>();
+			for (int block = 0; block < blockCount; block++) {
+				final int width = 1 + random.nextInt(maxBlockWidth);
+				final int base = spaces.get(block) * 1000;
+				// ascending ids with gaps, so ids ABSENT from the block exist between present ones
+				int id = base + 1 + random.nextInt(5);
+				for (int i = 0; i < width; i++) {
+					tested.addAtPosition(logical.size(), id);
+					logical.add(id);
+					id += 1 + random.nextInt(5);
+				}
+			}
+			return logical;
+		}
+
+		/**
+		 * Returns the boundaries `[from, to)` of every maximal ascending run of the logical array — exactly the
+		 * ranges the ranged search is contracted to accept. Recomputing them keeps the assertions valid after
+		 * removals have reshaped the blocks.
+		 *
+		 * @param logical the logical record id sequence
+		 * @return the ascending runs, in logical order
+		 */
+		@Nonnull
+		private List<int[]> ascendingRuns(@Nonnull List<Integer> logical) {
+			final List<int[]> runs = new ArrayList<>();
+			int start = 0;
+			for (int i = 1; i <= logical.size(); i++) {
+				if (i == logical.size() || logical.get(i) < logical.get(i - 1)) {
+					runs.add(new int[]{start, i});
+					start = i;
+				}
+			}
+			return runs;
+		}
+
+		/**
+		 * The naive oracle: the first position in `[from, to)` holding a record id greater than or equal to
+		 * `recordId`, resolved through {@link UnorderedLookupTree#getRecordAt(int)} one position at a time.
+		 *
+		 * @param tested   the tree under test
+		 * @param from     first position of the range, inclusive
+		 * @param to       last position of the range, exclusive
+		 * @param recordId the record id whose insertion position is sought
+		 * @return the expected insertion position
+		 */
+		private int oracle(@Nonnull TreeWithIndex tested, int from, int to, int recordId) {
+			for (int position = from; position < to; position++) {
+				if (tested.tree.getRecordAt(position) >= recordId) {
+					return position;
+				}
+			}
+			return to;
+		}
+
+		/**
+		 * Asserts the ranged search matches the oracle for every present id of every ascending run, for the gaps
+		 * between them, and for ids falling before and after the whole run.
+		 *
+		 * @param tested  the tree under test
+		 * @param logical the logical record id sequence mirroring the tree
+		 */
+		private void assertMatchesOracleOnEveryRun(@Nonnull TreeWithIndex tested, @Nonnull List<Integer> logical) {
+			for (final int[] run : ascendingRuns(logical)) {
+				final int from = run[0];
+				final int to = run[1];
+				for (int position = from; position < to; position++) {
+					final int presentId = logical.get(position);
+					// a present id, and the absent id immediately below it (the gap left by the generator)
+					for (final int probe : new int[]{presentId, presentId - 1}) {
+						assertEquals(
+							oracle(tested, from, to, probe),
+							tested.tree.findInsertionPositionInRange(from, to, probe),
+							"mismatch for id " + probe + " in run [" + from + ", " + to + ")"
+						);
+					}
+				}
+				// below every id in the run, and above every id in the run
+				assertEquals(from, tested.tree.findInsertionPositionInRange(from, to, logical.get(from) - 100));
+				assertEquals(to, tested.tree.findInsertionPositionInRange(from, to, logical.get(to - 1) + 100));
+			}
+		}
+
+		@Test
+		@DisplayName("matches a naive oracle when a searched range spans many leaves")
+		void shouldMatchOracleWhenRangeSpansManyLeaves() {
+			// block size 3 splits leaves every 3 records, so a 40-wide block spans well over a dozen leaves and
+			// most probes MISS the retained window - this is the fall-through-and-refresh path
+			final TreeWithIndex tested = new TreeWithIndex(3, UnorderedLookupTree.DEFAULT_ORDER_KEY_GAP);
+			final List<Integer> logical = fillWithValueBlocks(tested, 30, 40, 20260728L);
+			assertMatchesOracleOnEveryRun(tested, logical);
+			assertEquals(ConsistencyState.CONSISTENT, tested.tree.getConsistencyReport().state());
+		}
+
+		@Test
+		@DisplayName("matches a naive oracle when a searched range fits inside a single leaf")
+		void shouldMatchOracleWhenRangeFitsSingleLeaf() {
+			// production fan-out: leaves hold up to 64 records, so a block narrower than that resolves every probe
+			// after the first from the retained window - this is the window-HIT path
+			final TreeWithIndex tested = new TreeWithIndex();
+			final List<Integer> logical = fillWithValueBlocks(tested, 40, 30, 987654321L);
+			assertMatchesOracleOnEveryRun(tested, logical);
+			assertEquals(ConsistencyState.CONSISTENT, tested.tree.getConsistencyReport().state());
+		}
+
+		@Test
+		@DisplayName("matches a naive oracle after interleaved removals have reshaped the leaves")
+		void shouldMatchOracleAfterRemovals() {
+			final TreeWithIndex tested = new TreeWithIndex(3, UnorderedLookupTree.DEFAULT_ORDER_KEY_GAP);
+			final List<Integer> logical = fillWithValueBlocks(tested, 30, 40, 4242L);
+			final Random random = new Random(4242L);
+			// removals drive steals and merges, leaving leaves at varying occupancy and shifting every base position
+			for (int i = 0; i < 200 && logical.size() > 1; i++) {
+				final int position = random.nextInt(logical.size());
+				tested.remove(logical.remove(position));
+			}
+			assertMatchesOracleOnEveryRun(tested, logical);
+			assertEquals(ConsistencyState.CONSISTENT, tested.tree.getConsistencyReport().state());
+		}
+
+		@Test
+		@DisplayName("returns the range start for an empty range and handles a single-element range")
+		void shouldHandleDegenerateRanges() {
+			final TreeWithIndex tested = new TreeWithIndex(3, UnorderedLookupTree.DEFAULT_ORDER_KEY_GAP);
+			tested.bulkLoad(new int[]{10, 20, 30, 40, 50});
+			// empty range - nothing to compare against, the insertion position is the range itself
+			assertEquals(2, tested.tree.findInsertionPositionInRange(2, 2, 25));
+			// single element
+			assertEquals(2, tested.tree.findInsertionPositionInRange(2, 3, 25));
+			assertEquals(2, tested.tree.findInsertionPositionInRange(2, 3, 30));
+			assertEquals(3, tested.tree.findInsertionPositionInRange(2, 3, 35));
+			// the whole array
+			assertEquals(0, tested.tree.findInsertionPositionInRange(0, 5, 5));
+			assertEquals(5, tested.tree.findInsertionPositionInRange(0, 5, 55));
+			assertEquals(3, tested.tree.findInsertionPositionInRange(0, 5, 40));
+		}
+
+		@Test
+		@DisplayName("rejects a range that does not lie within the array")
+		void shouldRejectRangeOutsideArray() {
+			final TreeWithIndex tested = new TreeWithIndex();
+			tested.bulkLoad(new int[]{10, 20, 30});
+			assertThrows(
+				GenericEvitaInternalError.class, () -> tested.tree.findInsertionPositionInRange(-1, 2, 15)
+			);
+			assertThrows(
+				GenericEvitaInternalError.class, () -> tested.tree.findInsertionPositionInRange(0, 4, 15)
+			);
+			assertThrows(
+				GenericEvitaInternalError.class, () -> tested.tree.findInsertionPositionInRange(2, 1, 15)
+			);
 		}
 	}
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/SortIndexTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/index/attribute/SortIndexTest.java
@@ -59,11 +59,14 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Currency;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Random;
 import java.util.function.UnaryOperator;
 
 import static io.evitadb.utils.AssertionUtils.assertStateAfterCommit;
@@ -1583,6 +1586,143 @@ class SortIndexTest {
 
 			// a further quiescent read again reuses the freshly rebuilt array - the reuse contract survives the churn
 			assertSame(afterRemove, sortIndex.getAscendingOrderRecordsSupplier().getSortedRecordIds());
+		}
+	}
+
+	@Nested
+	@DisplayName("Low-cardinality ordering against a materialise-and-sort oracle")
+	class LowCardinalityOrderingTest {
+
+		/**
+		 * Sorts the recorded `(value, recordId)` pairs the way the sort index is contracted to order them — by value
+		 * first, then by record id — and returns just the record ids.
+		 *
+		 * @param pairs the `(value, recordId)` pairs in insertion order
+		 * @return the record ids in the expected sort order
+		 */
+		@Nonnull
+		private int[] expectedOrder(@Nonnull List<int[]> pairs) {
+			final List<int[]> sorted = new ArrayList<>(pairs);
+			sorted.sort((a, b) -> a[0] != b[0] ? Integer.compare(a[0], b[0]) : Integer.compare(a[1], b[1]));
+			final int[] result = new int[sorted.size()];
+			for (int i = 0; i < result.length; i++) {
+				result[i] = sorted.get(i)[1];
+			}
+			return result;
+		}
+
+		/**
+		 * Inserts `recordCount` records spread over `distinctValues` distinct values, so every insert after the first
+		 * few lands inside an existing record block and drives the block binary search. Removals are interleaved when
+		 * requested, which leaves the blocks at uneven widths.
+		 *
+		 * @param distinctValues number of distinct attribute values (drives the block width)
+		 * @param recordCount    number of records to insert
+		 * @param withRemovals   whether to interleave removals of already-inserted records
+		 * @param seed           random seed for reproducibility
+		 */
+		private void assertOrderMatchesOracle(
+			int distinctValues, int recordCount, boolean withRemovals, long seed
+		) {
+			final Random random = new Random(seed);
+			final SortIndex sortIndex = new OwnerSortIndex(
+				Integer.class, new AttributeIndexKey(null, "a", null)
+			);
+			final List<int[]> pairs = new ArrayList<>(recordCount);
+			for (int recordId = 1; recordId <= recordCount; recordId++) {
+				final int value = random.nextInt(distinctValues);
+				sortIndex.addRecord(value, recordId);
+				pairs.add(new int[]{value, recordId});
+				// remove an earlier record every now and then, so the blocks stop growing monotonically
+				if (withRemovals && pairs.size() > 1 && random.nextInt(4) == 0) {
+					final int[] victim = pairs.remove(random.nextInt(pairs.size() - 1));
+					sortIndex.removeRecord(victim[0], victim[1]);
+				}
+			}
+			assertArrayEquals(expectedOrder(pairs), sortIndex.getSortedRecords());
+			// the query-path view has to agree with the maintained order as well
+			assertArrayEquals(
+				expectedOrder(pairs), sortIndex.getAscendingOrderRecordsSupplier().getSortedRecordIds()
+			);
+		}
+
+		@Test
+		@DisplayName("should order records identically when value blocks are narrower than a leaf")
+		void shouldOrderIdenticallyWhenBlocksFitSingleLeaf() {
+			// 1000 distinct values over 50 000 records => ~50-wide blocks, narrower than the 64-record leaf
+			assertOrderMatchesOracle(1000, 50_000, false, 42L);
+		}
+
+		@Test
+		@DisplayName("should order records identically when value blocks span many leaves")
+		void shouldOrderIdenticallyWhenBlocksSpanManyLeaves() {
+			// 50 distinct values over 50 000 records => ~1000-wide blocks, spanning some sixteen leaves each, so the
+			// block binary search repeatedly leaves the leaf its previous probe resolved
+			assertOrderMatchesOracle(50, 50_000, false, 4242L);
+		}
+
+		@Test
+		@DisplayName("should order records identically when inserts are interleaved with removals")
+		void shouldOrderIdenticallyWithInterleavedRemovals() {
+			assertOrderMatchesOracle(200, 30_000, true, 987654321L);
+		}
+
+		@Test
+		@DisplayName("should order records identically after every single mutation of a churned index")
+		void shouldOrderIdenticallyAfterEveryMutation() {
+			// Asserting only the END state lets a wrong predecessor be masked: the misplaced record can be shifted
+			// back into its correct slot by a later insert, or land somewhere the final comparison cannot tell apart.
+			// Re-asserting after EVERY mutation pins the divergence to the operation that caused it. Removals matter
+			// as much as inserts here - they leave leaves at low occupancy, which is when a leaf window that trusts
+			// the physical array length instead of the logical record count over-claims by tens of positions.
+			final Random random = new Random(31337L);
+			final SortIndex sortIndex = new OwnerSortIndex(
+				Integer.class, new AttributeIndexKey(null, "a", null)
+			);
+			final List<int[]> pairs = new ArrayList<>();
+			for (int recordId = 1; recordId <= 2_000; recordId++) {
+				// only 6 distinct values, so blocks run several hundred records wide and span many leaves
+				final int value = random.nextInt(6);
+				sortIndex.addRecord(value, recordId);
+				pairs.add(new int[]{value, recordId});
+				assertArrayEquals(
+					expectedOrder(pairs), sortIndex.getSortedRecords(),
+					"order diverged when adding record " + recordId
+				);
+				if (pairs.size() > 1 && random.nextInt(3) == 0) {
+					final int[] victim = pairs.remove(random.nextInt(pairs.size() - 1));
+					sortIndex.removeRecord(victim[0], victim[1]);
+					assertArrayEquals(
+						expectedOrder(pairs), sortIndex.getSortedRecords(),
+						"order diverged when removing record " + victim[1]
+					);
+				}
+			}
+		}
+
+		@Test
+		@DisplayName("should order records identically when the inserts run inside a transaction")
+		void shouldOrderIdenticallyUnderTransaction() {
+			final SortIndex sortIndex = new OwnerSortIndex(
+				Integer.class, new AttributeIndexKey(null, "a", null)
+			);
+			final Random random = new Random(20260728L);
+			final List<int[]> pairs = new ArrayList<>();
+			// ~500-wide blocks so the search spans leaves on the transactional path too
+			for (int recordId = 1; recordId <= 10_000; recordId++) {
+				pairs.add(new int[]{random.nextInt(20), recordId});
+			}
+			final int[] expected = expectedOrder(pairs);
+
+			assertStateAfterCommit(
+				sortIndex,
+				original -> {
+					for (final int[] pair : pairs) {
+						original.addRecord(pair[0], pair[1]);
+					}
+				},
+				(original, committed) -> assertArrayEquals(expected, committed.getSortedRecords())
+			);
 		}
 	}
 

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/SortAttributeIngestBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/SortAttributeIngestBenchmark.java
@@ -40,25 +40,31 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * B3 of issue #1332 — the end-to-end WARM_UP bulk ingest the profile was taken from.
+ * End-to-end WARM_UP bulk ingest of the sort-attribute shape the issue #1332 profile was taken from.
  *
  * The existing benchmarks reach the sort-attribute insert path only in isolation: `SortIndexTimingBenchmark` drives a
  * bare `SortIndex` and `UnorderedLookupTreeBenchmark` a bare position tree. Both answer "did this data structure get
  * cheaper"; neither answers "did an ingest get cheaper", because neither carries the rest of the write pipeline -
  * entity building, price indexing, facet indexing, storage - that the sort index competes with for wall time. This
- * benchmark exists to size the win against that whole, and its schema is the one that produced the profile:
+ * benchmark exists to size the win against that whole. The attribute shape is the one that produced the profile -
  * 40 sortable `Integer` attributes over 1000 distinct values, 5 near-unique sortable `OffsetDateTime` attributes as
- * the narrow-block control, 30 faceted references. See {@link SortAttributeIngestBenchmarkState} for the shape and,
- * importantly, for why the batch is built directly rather than through `DataGenerator`.
+ * the narrow-block control, 30 faceted references - with the block widths scaled down to what a single invocation can
+ * afford: at `entityCount = 20 000` the two `distinctValues` settings give blocks 20 and 1000 records wide, against
+ * the profiled ~10 000. See
+ * {@link SortAttributeIngestBenchmarkState} for the shape and, importantly, for why the batch is built directly
+ * rather than through `DataGenerator`.
  *
  * **What this benchmark can and cannot measure.** Its honest deliverable is *allocation*: how much of a full ingest's
- * allocation the allocation-side findings (F3/F4/F6/F7) remove, measured cross-jar against the base engine. It is
- * {@link Mode#SingleShotTime} so entities per second is `entityCount / score`, but at the iteration counts it can
- * afford the wall-clock number is far too noisy to trust (this issue saw ±258 % on `ns/op` against ±0.75 % on
- * allocation in the same run), so **read `gc.alloc.rate.norm`, not the score**, and run with `-prof gc`. Note that the
- * CPU-only findings are invisible here: F1 changes no allocation, and F5 removes a single duplicate ThreadLocal read
- * that no end-to-end wall-clock measurement can separate from noise - F5 is kept as strictly-fewer-operations, not on
- * a measured end-to-end delta.
+ * allocation the branch's allocation-side changes remove - the dropped `InsertionPosition` record in the int-keyed
+ * internal-node search, the lazily captured B+ tree cursor path, the allocation-free unordered-array guards -
+ * measured cross-jar against the base engine. It is {@link Mode#SingleShotTime} so entities per second is
+ * `entityCount / score`, but at the iteration counts it can afford the wall-clock number is far too noisy to trust
+ * (this issue saw ±258 % on `ns/op` against ±0.75 % on allocation in the same run), so **read `gc.alloc.rate.norm`,
+ * not the score**, and run with `-prof gc` - reading that figure the way {@link SortAttributeIngestBenchmarkState}
+ * prescribes, because the per-invocation fixture's allocation is counted inside it. Note that the CPU-only changes
+ * are invisible here: the retained-leaf block search alters no allocation, and resolving the thread's transaction
+ * once per positional read removes a single duplicate `ThreadLocal` read that no end-to-end wall-clock measurement
+ * can separate from noise - it is kept on strictly-fewer-operations grounds, not on a measured end-to-end delta.
  *
  * Heap is sized explicitly in the fork arguments on purpose. The profiled process ran without `-Xmx`, so JVM
  * ergonomics handed it 23.4 GiB and it sat at 92 % old-gen occupancy with the young generation squeezed to 320 MB;

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/SortAttributeIngestBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/SortAttributeIngestBenchmark.java
@@ -1,0 +1,110 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.performance.sortattribute;
+
+import io.evitadb.api.requestResponse.data.EntityEditor.EntityBuilder;
+import io.evitadb.performance.setup.BenchmarkForkArgs;
+import io.evitadb.performance.setup.EvitaCatalogSetup;
+import io.evitadb.performance.sortattribute.state.SortAttributeIngestBenchmarkState;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * B3 of issue #1332 — the end-to-end WARM_UP bulk ingest the profile was taken from.
+ *
+ * The existing benchmarks reach the sort-attribute insert path only in isolation: `SortIndexTimingBenchmark` drives a
+ * bare `SortIndex` and `UnorderedLookupTreeBenchmark` a bare position tree. Both answer "did this data structure get
+ * cheaper"; neither answers "did an ingest get cheaper", because neither carries the rest of the write pipeline -
+ * entity building, price indexing, facet indexing, storage - that the sort index competes with for wall time. This
+ * benchmark exists to size the win against that whole, and its schema is the one that produced the profile:
+ * 40 sortable `Integer` attributes over 1000 distinct values, 5 near-unique sortable `OffsetDateTime` attributes as
+ * the narrow-block control, 30 faceted references. See {@link SortAttributeIngestBenchmarkState} for the shape and,
+ * importantly, for why the batch is built directly rather than through `DataGenerator`.
+ *
+ * **What this benchmark can and cannot measure.** Its honest deliverable is *allocation*: how much of a full ingest's
+ * allocation the allocation-side findings (F3/F4/F6/F7) remove, measured cross-jar against the base engine. It is
+ * {@link Mode#SingleShotTime} so entities per second is `entityCount / score`, but at the iteration counts it can
+ * afford the wall-clock number is far too noisy to trust (this issue saw ±258 % on `ns/op` against ±0.75 % on
+ * allocation in the same run), so **read `gc.alloc.rate.norm`, not the score**, and run with `-prof gc`. Note that the
+ * CPU-only findings are invisible here: F1 changes no allocation, and F5 removes a single duplicate ThreadLocal read
+ * that no end-to-end wall-clock measurement can separate from noise - F5 is kept as strictly-fewer-operations, not on
+ * a measured end-to-end delta.
+ *
+ * Heap is sized explicitly in the fork arguments on purpose. The profiled process ran without `-Xmx`, so JVM
+ * ergonomics handed it 23.4 GiB and it sat at 92 % old-gen occupancy with the young generation squeezed to 320 MB;
+ * an unsized run here would measure GC pressure rather than insert cost.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 1)
+@Measurement(iterations = 3)
+@Fork(
+	value = 1,
+	// see BenchmarkForkArgs for why a benchmark booting Evita has to declare these itself
+	jvmArgsAppend = {
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_LANG_INVOKE,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_MATH,
+		BenchmarkForkArgs.ADD_OPENS, BenchmarkForkArgs.OPEN_UTIL,
+		// sized explicitly - see the class JavaDoc
+		"-Xmx8g"
+	}
+)
+public class SortAttributeIngestBenchmark implements EvitaCatalogSetup {
+
+	/**
+	 * Bulk-loads `entityCount` products into a freshly created catalog in WARM_UP state.
+	 *
+	 * This is the profiled path exactly: a catalog that has not yet gone live indexes in place rather than through
+	 * per-transaction diff layers, so every `upsertEntity` drives `SortIndex.addRecord` - and therefore
+	 * `SortIndexChanges.computePreviousRecord` - once per sortable attribute, 45 times per entity here.
+	 *
+	 * @param state the freshly booted catalog and its product source
+	 * @param bh    sink for the ingested count, so the loop cannot be optimised away
+	 */
+	@Benchmark
+	public void warmUpIngest(SortAttributeIngestBenchmarkState state, Blackhole bh) {
+		final List<EntityBuilder> products = state.productBatch();
+		state.getEvita().updateCatalog(
+			state.getCatalogNameForBenchmark(),
+			session -> {
+				for (int i = 0; i < products.size(); i++) {
+					bh.consume(session.upsertEntity(products.get(i)));
+				}
+			}
+		);
+	}
+
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/state/SortAttributeIngestBenchmarkState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/state/SortAttributeIngestBenchmarkState.java
@@ -72,12 +72,12 @@ import java.util.Random;
  *    silent failure because the benchmark would still run and report a score. Building the values here with an explicit
  *    `random.nextInt(distinctValues)` keeps the cardinality at {@link #distinctValues} exactly.
  * 2. *`DataGenerator.pickRandomFromSet` infinite-loops at this reference count.* Its per-entity reference selection does
- *    not terminate once a schema carries enough reference types (see `docs/plans/1332-datagenerator-bug.md`); thirty
- *    faceted references trip it. That is a latent bug in shared test infrastructure, not something #1332 should touch,
- *    so this benchmark sidesteps it by never entering that code path.
- * 3. *Determinism across the A/B pair.* B3 is measured cross-jar (this branch's engine against the base engine in a
- *    sibling worktree), so the two runs must ingest byte-for-byte identical batches. A fresh `Random(SEED)` walked in
- *    primary-key order gives exactly that; Javafaker's per-locale faker caches do not.
+ *    not terminate once a schema carries enough reference types; thirty faceted references trip it. That is a latent
+ *    bug in shared test infrastructure, not something #1332 should touch, so this benchmark sidesteps it by never
+ *    entering that code path.
+ * 3. *Determinism across the A/B pair.* This benchmark is measured cross-jar (this branch's engine against the base
+ *    engine in a sibling worktree), so the two runs must ingest byte-for-byte identical batches. A fresh
+ *    `Random(SEED)` walked in primary-key order gives exactly that; Javafaker's per-locale faker caches do not.
  * 4. *Setup cost.* Direct construction is far cheaper than Javafaker per entity, which is what makes a large
  *    `entityCount` affordable and keeps generation from dwarfing the ingest it is meant to feed.
  *
@@ -88,9 +88,20 @@ import java.util.Random;
  *
  * **Read `gc.alloc.rate.norm`, not wall time.** At the iteration counts this benchmark can afford, wall clock is far
  * too noisy to carry a signal (this issue saw ±258 % on `ns/op` against ±0.75 % on allocation in the same run), and
- * B3 is inherently a cross-jar comparison that cannot be paired inside one JVM. The honest, measurable question it
- * answers is therefore *how much of a full ingest's allocation the allocation-side findings (F3/F4/F6/F7) remove* - run
- * it with `-prof gc` and compare the normalised allocation rate against the base worktree.
+ * this benchmark is inherently a cross-jar comparison that cannot be paired inside one JVM. The honest, measurable
+ * question it answers is therefore *how much of a full ingest's allocation the branch's allocation-side changes
+ * remove* - the dropped `InsertionPosition` record in the int-keyed internal-node search, the lazily captured B+ tree
+ * cursor path, the allocation-free unordered-array guards - so run it with `-prof gc` and compare the normalised
+ * allocation rate against the base worktree.
+ *
+ * **The reported bytes/op is `fixture + ingest`, so compare the ABSOLUTE difference.** `setUp()` is annotated
+ * `@Setup(Level.Invocation)` and boots a full Evita instance, defines the schema and materialises the whole batch;
+ * JMH's `GCProfiler` snapshots its counters in `beforeIteration` / `afterIteration`, bracketing the entire iteration
+ * including per-invocation fixtures, so the fixture's allocation is counted inside the reported figure. The fixture
+ * is identical on both sides of the A/B pair and therefore cancels in the **absolute** GB/op difference - that number
+ * is trustworthy. The **percentage** is not: its denominator is diluted by fixture allocation, so it understates the
+ * change and must never be read as a fraction of the ingest's own allocation. Quantifying the fixture would take a
+ * control `@Benchmark` with an empty body taking this same state; no such control exists today.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
@@ -130,7 +141,7 @@ public class SortAttributeIngestBenchmarkState extends ArtificialBenchmarkState
 	/**
 	 * Distinct values each low-cardinality attribute draws from. Block width is `entityCount / distinctValues`, so
 	 * the two defaults give 20-wide blocks (inside one leaf) and 1000-wide blocks (spanning many leaves) - the two
-	 * regimes issue #1332's findings behave differently in.
+	 * regimes the sort-block search behaves differently in.
 	 */
 	@Param({"1000", "20"})
 	public int distinctValues;
@@ -170,7 +181,6 @@ public class SortAttributeIngestBenchmarkState extends ArtificialBenchmarkState
 	 */
 	@Setup(Level.Invocation)
 	public void setUp() {
-		this.generatedEntities.clear();
 		final String catalogName = getCatalogName();
 		this.evita = createEmptyEvitaInstance(catalogName);
 		this.evita.updateCatalog(

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/state/SortAttributeIngestBenchmarkState.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/performance/sortattribute/state/SortAttributeIngestBenchmarkState.java
@@ -1,0 +1,304 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.performance.sortattribute.state;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.requestResponse.data.EntityEditor.EntityBuilder;
+import io.evitadb.api.requestResponse.data.structure.InitialEntityBuilder;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.EntitySchemaContract;
+import io.evitadb.api.requestResponse.schema.EntitySchemaEditor.EntitySchemaBuilder;
+import io.evitadb.performance.artificial.ArtificialBenchmarkState;
+import io.evitadb.performance.setup.EvitaCatalogSetup;
+import io.evitadb.performance.sortattribute.SortAttributeIngestBenchmark;
+import io.evitadb.test.Entities;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import javax.annotation.Nonnull;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Shared state for {@link SortAttributeIngestBenchmark}: an empty WARM_UP catalog plus a pre-built batch of products
+ * carrying the attribute shape that produced the profile behind issue #1332.
+ *
+ * The shape is the whole point, so it is spelled out here rather than inherited:
+ *
+ * - **{@link #LOW_CARDINALITY_ATTRIBUTE_COUNT} sortable `Integer` attributes** drawn from {@link #distinctValues}
+ *   distinct values, so each value block holds `entityCount / distinctValues` records. That block width is the axis
+ *   the issue turns on - it is what `SortIndexChanges.computePreviousRecord` binary-searches on every insert - and it
+ *   is a {@link Param} rather than a constant precisely so it can be varied without changing the batch size.
+ * - **{@link #NEAR_UNIQUE_ATTRIBUTE_COUNT} sortable `OffsetDateTime` attributes** that are strictly increasing, so
+ *   their blocks are one record wide. **These are the control**: an optimisation aimed at wide blocks must not
+ *   regress them.
+ * - **{@link #FACETED_REFERENCE_COUNT} faceted references** and {@link #PLAIN_STRING_ATTRIBUTE_COUNT} non-indexed
+ *   strings, so the sort-index work is measured against realistic competing indexing load - facet indexing plus
+ *   entity building and storage serialisation - rather than in isolation.
+ *
+ * **Why this class builds its products directly** rather than through `DataGenerator`:
+ *
+ * 1. *Cardinality control.* `DataGenerator` funnels every sortable attribute that has no explicitly registered value
+ *    generator through `getUniqueAttribute()`, which forces the values distinct. Forty sortable `Integer` attributes
+ *    would therefore come out near-unique - one record per block, the exact opposite of the profiled workload, and a
+ *    silent failure because the benchmark would still run and report a score. Building the values here with an explicit
+ *    `random.nextInt(distinctValues)` keeps the cardinality at {@link #distinctValues} exactly.
+ * 2. *`DataGenerator.pickRandomFromSet` infinite-loops at this reference count.* Its per-entity reference selection does
+ *    not terminate once a schema carries enough reference types (see `docs/plans/1332-datagenerator-bug.md`); thirty
+ *    faceted references trip it. That is a latent bug in shared test infrastructure, not something #1332 should touch,
+ *    so this benchmark sidesteps it by never entering that code path.
+ * 3. *Determinism across the A/B pair.* B3 is measured cross-jar (this branch's engine against the base engine in a
+ *    sibling worktree), so the two runs must ingest byte-for-byte identical batches. A fresh `Random(SEED)` walked in
+ *    primary-key order gives exactly that; Javafaker's per-locale faker caches do not.
+ * 4. *Setup cost.* Direct construction is far cheaper than Javafaker per entity, which is what makes a large
+ *    `entityCount` affordable and keeps generation from dwarfing the ingest it is meant to feed.
+ *
+ * The references are **unmanaged** and `ZERO_OR_ONE`. Unmanaged means each is filled with a plain integer id rather
+ * than a resolved seeded entity, so thirty reference types cost nothing to set up and need no target catalogs.
+ * `ZERO_OR_ONE` (not `ZERO_OR_MORE`) keeps it at one reference per type: the profiled workload attaches a single facet
+ * per group, and ten-per-type would bury the sort-index work under facet indexing.
+ *
+ * **Read `gc.alloc.rate.norm`, not wall time.** At the iteration counts this benchmark can afford, wall clock is far
+ * too noisy to carry a signal (this issue saw ±258 % on `ns/op` against ±0.75 % on allocation in the same run), and
+ * B3 is inherently a cross-jar comparison that cannot be paired inside one JVM. The honest, measurable question it
+ * answers is therefore *how much of a full ingest's allocation the allocation-side findings (F3/F4/F6/F7) remove* - run
+ * it with `-prof gc` and compare the normalised allocation rate against the base worktree.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@State(Scope.Benchmark)
+public class SortAttributeIngestBenchmarkState extends ArtificialBenchmarkState
+	implements EvitaCatalogSetup {
+
+	/** Number of low-cardinality sortable `Integer` attributes - the subject of issue #1332. */
+	public static final int LOW_CARDINALITY_ATTRIBUTE_COUNT = 40;
+	/** Number of strictly-increasing sortable attributes kept as the narrow-block control. */
+	public static final int NEAR_UNIQUE_ATTRIBUTE_COUNT = 5;
+	/** Number of faceted reference types providing competing indexing load. */
+	public static final int FACETED_REFERENCE_COUNT = 30;
+	/** Number of non-indexed string attributes providing representative entity bulk. */
+	public static final int PLAIN_STRING_ATTRIBUTE_COUNT = 5;
+	/** Distinct facet ids each reference draws from, so facets share groups the way a real dataset does. */
+	public static final int FACET_GROUP_SIZE = 100;
+
+	/** Name prefix of the low-cardinality sortable attributes. */
+	public static final String ATTRIBUTE_LOW_CARDINALITY_PREFIX = "sortableInt";
+	/** Name prefix of the near-unique sortable attributes. */
+	public static final String ATTRIBUTE_NEAR_UNIQUE_PREFIX = "sortableMoment";
+	/** Name prefix of the non-indexed string attributes. */
+	public static final String ATTRIBUTE_PLAIN_PREFIX = "plainText";
+	/** Entity-type prefix of the unmanaged faceted references. */
+	public static final String REFERENCE_TYPE_PREFIX = "FACET_GROUP_";
+
+	/** Anchor for the strictly-increasing control moments, offset per entity so their blocks stay one record wide. */
+	private static final OffsetDateTime BASE_MOMENT = OffsetDateTime.of(
+		2020, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC
+	);
+
+	/** Number of products ingested per measured invocation. */
+	@Param({"20000"})
+	public int entityCount;
+
+	/**
+	 * Distinct values each low-cardinality attribute draws from. Block width is `entityCount / distinctValues`, so
+	 * the two defaults give 20-wide blocks (inside one leaf) and 1000-wide blocks (spanning many leaves) - the two
+	 * regimes issue #1332's findings behave differently in.
+	 */
+	@Param({"1000", "20"})
+	public int distinctValues;
+
+	/** The fully materialised batch to ingest - built in setup so generation stays out of the measurement. */
+	private List<EntityBuilder> productBatch;
+
+	/**
+	 * Name of the low-cardinality sortable attribute with the given ordinal.
+	 *
+	 * @param ordinal zero-based attribute ordinal
+	 * @return the attribute name
+	 */
+	@Nonnull
+	public static String lowCardinalityAttribute(int ordinal) {
+		return ATTRIBUTE_LOW_CARDINALITY_PREFIX + ordinal;
+	}
+
+	/**
+	 * Name of the near-unique sortable attribute with the given ordinal.
+	 *
+	 * @param ordinal zero-based attribute ordinal
+	 * @return the attribute name
+	 */
+	@Nonnull
+	public static String nearUniqueAttribute(int ordinal) {
+		return ATTRIBUTE_NEAR_UNIQUE_PREFIX + ordinal;
+	}
+
+	/**
+	 * Boots an empty catalog, defines the product schema and materialises the batch to ingest, **without** ingesting
+	 * anything - the ingest itself is the measured operation.
+	 *
+	 * This runs per invocation rather than per trial because the subject is a cold WARM_UP bulk load: a catalog that
+	 * already held the previous invocation's entities would start with wide blocks and grow them wider, so successive
+	 * invocations would not be measuring the same thing.
+	 */
+	@Setup(Level.Invocation)
+	public void setUp() {
+		this.generatedEntities.clear();
+		final String catalogName = getCatalogName();
+		this.evita = createEmptyEvitaInstance(catalogName);
+		this.evita.updateCatalog(
+			catalogName,
+			session -> {
+				final EntitySchemaBuilder schemaBuilder = session.defineEntitySchema(Entities.PRODUCT);
+				declareSortAttributeShape(schemaBuilder);
+				this.productSchema = session.updateAndFetchEntitySchema(schemaBuilder);
+			}
+		);
+		// materialise the whole batch OUTSIDE the measured method - see the class JavaDoc. A fresh Random(SEED) walked
+		// in primary-key order makes the batch identical on every invocation and, crucially, across the A/B jars.
+		final List<EntityBuilder> batch = new ArrayList<>(this.entityCount);
+		final Random valueRandom = new Random(SEED);
+		for (int primaryKey = 1; primaryKey <= this.entityCount; primaryKey++) {
+			batch.add(buildProduct(this.productSchema, primaryKey, valueRandom, this.distinctValues));
+		}
+		this.productBatch = batch;
+	}
+
+	/**
+	 * Builds one product entity directly, filling exactly the #1332 shape.
+	 *
+	 * The low-cardinality integers are drawn from `[0, distinctValues)` so their sort blocks are `entityCount /
+	 * distinctValues` wide; the control moments are strictly increasing (base plus a per-entity, per-attribute offset)
+	 * so their blocks stay one record wide; the references get a bounded random id so facets share groups.
+	 *
+	 * @param schema         the product schema the builder validates against
+	 * @param primaryKey     the entity primary key, also the driver of the strictly-increasing control moments
+	 * @param random         the shared, seeded randomiser - walked in key order to stay deterministic across jars
+	 * @param distinctValues distinct values each low-cardinality attribute may take
+	 * @return a detached builder ready to be upserted
+	 */
+	@Nonnull
+	private static EntityBuilder buildProduct(
+		@Nonnull EntitySchemaContract schema, int primaryKey, @Nonnull Random random, int distinctValues
+	) {
+		final EntityBuilder builder = new InitialEntityBuilder(schema, primaryKey);
+		for (int i = 0; i < LOW_CARDINALITY_ATTRIBUTE_COUNT; i++) {
+			builder.setAttribute(lowCardinalityAttribute(i), random.nextInt(distinctValues));
+		}
+		for (int i = 0; i < NEAR_UNIQUE_ATTRIBUTE_COUNT; i++) {
+			// unique across the whole batch: primaryKey blocks of NEAR_UNIQUE_ATTRIBUTE_COUNT seconds, one per attribute
+			builder.setAttribute(
+				nearUniqueAttribute(i),
+				BASE_MOMENT.plusSeconds((long) primaryKey * NEAR_UNIQUE_ATTRIBUTE_COUNT + i)
+			);
+		}
+		for (int i = 0; i < PLAIN_STRING_ATTRIBUTE_COUNT; i++) {
+			builder.setAttribute(ATTRIBUTE_PLAIN_PREFIX + i, Long.toString(random.nextLong(), Character.MAX_RADIX));
+		}
+		for (int i = 0; i < FACETED_REFERENCE_COUNT; i++) {
+			builder.setReference(REFERENCE_TYPE_PREFIX + i, 1 + random.nextInt(FACET_GROUP_SIZE));
+		}
+		return builder;
+	}
+
+	/**
+	 * Declares the #1332 attribute shape on a fresh product schema.
+	 *
+	 * @param schemaBuilder builder of the product schema
+	 */
+	private static void declareSortAttributeShape(@Nonnull EntitySchemaBuilder schemaBuilder) {
+		for (int i = 0; i < LOW_CARDINALITY_ATTRIBUTE_COUNT; i++) {
+			schemaBuilder.withAttribute(
+				lowCardinalityAttribute(i), Integer.class, whichIs -> whichIs.sortable().filterable()
+			);
+		}
+		for (int i = 0; i < NEAR_UNIQUE_ATTRIBUTE_COUNT; i++) {
+			schemaBuilder.withAttribute(
+				nearUniqueAttribute(i), OffsetDateTime.class, whichIs -> whichIs.sortable()
+			);
+		}
+		for (int i = 0; i < PLAIN_STRING_ATTRIBUTE_COUNT; i++) {
+			schemaBuilder.withAttribute(
+				ATTRIBUTE_PLAIN_PREFIX + i, String.class, whichIs -> whichIs.nullable()
+			);
+		}
+		for (int i = 0; i < FACETED_REFERENCE_COUNT; i++) {
+			// ZERO_OR_ONE, not ZERO_OR_MORE - see the class JavaDoc for why the cardinality matters here
+			schemaBuilder.withReferenceTo(
+				REFERENCE_TYPE_PREFIX + i, REFERENCE_TYPE_PREFIX + i, Cardinality.ZERO_OR_ONE,
+				whichIs -> whichIs.indexedForFilteringAndPartitioning().faceted()
+			);
+		}
+	}
+
+	/**
+	 * Returns the pre-built batch the measured method ingests.
+	 *
+	 * @return the materialised products, exactly `entityCount` of them
+	 */
+	@Nonnull
+	public List<EntityBuilder> productBatch() {
+		return this.productBatch;
+	}
+
+	/**
+	 * We need writable sessions here.
+	 */
+	@Override
+	public EvitaSessionContract getSession() {
+		return getSession(() -> this.evita.createReadWriteSession(getCatalogName()));
+	}
+
+	@Override
+	protected String getCatalogName() {
+		return TEST_CATALOG + "_sortAttributeIngest";
+	}
+
+	/**
+	 * Publicly reachable alias of {@link #getCatalogName()} - the inherited accessor is protected and the benchmark
+	 * class lives in a different package.
+	 *
+	 * @return name of the catalog the benchmark ingests into
+	 */
+	@Nonnull
+	public String getCatalogNameForBenchmark() {
+		return getCatalogName();
+	}
+
+	/**
+	 * Shuts the instance down and releases the batch after every measured ingest.
+	 */
+	@TearDown(Level.Invocation)
+	public void closeEvita() {
+		this.evita.close();
+		this.productBatch = null;
+	}
+
+}

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/SortIndexBenchSupport.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/SortIndexBenchSupport.java
@@ -140,8 +140,9 @@ final class SortIndexBenchSupport {
 	 */
 
 	/**
-	 * Returns the value blocks for the named scenario: `anchor` (real ean distribution) or `synth_<n>` (synthetic shape
-	 * replica at N distinct values, e.g. `synth_10k`, `synth_100k`, `synth_1m`).
+	 * Returns the value blocks for the named scenario: `anchor` (real ean distribution), `synth_<n>` (synthetic shape
+	 * replica at N distinct values, e.g. `synth_10k`, `synth_100k`, `synth_1m`), or
+	 * `uniform_<distinctValues>_<recordCount>` (evenly-sized blocks, e.g. `uniform_1k_1m`, `uniform_1k_10m`).
 	 */
 	@Nonnull
 	static List<ValueBlock> blocksFor(@Nonnull String scenario) {
@@ -151,6 +152,15 @@ final class SortIndexBenchSupport {
 			}
 			if (scenario.startsWith("synth_")) {
 				return synthetic(parseScenarioCount(scenario.substring("synth_".length())));
+			}
+			if (scenario.startsWith("uniform_")) {
+				final String[] parts = scenario.substring("uniform_".length()).split("_");
+				if (parts.length != 2) {
+					throw new IllegalArgumentException(
+						"Uniform scenario must be `uniform_<distinctValues>_<recordCount>`, got: " + scenario
+					);
+				}
+				return uniform(parseScenarioCount(parts[0]), parseScenarioCount(parts[1]));
 			}
 			throw new IllegalArgumentException("Unknown scenario: " + scenario);
 		} catch (Exception ex) {
@@ -194,6 +204,37 @@ final class SortIndexBenchSupport {
 		// the remaining N-1 values are singletons
 		for (int v = 1; v < distinctValues; v++) {
 			blocks.add(new ValueBlock(String.format("%013d", v), new int[]{nextRecordId++}));
+		}
+		return blocks;
+	}
+
+	/**
+	 * Generates a UNIFORM distribution: `distinctValues` values, each owning a block of `recordCount / distinctValues`
+	 * records (the leading blocks absorb the division remainder, so widths stay within one of each other).
+	 *
+	 * This is the low-cardinality e-commerce attribute shape — rating 1-5, stock level, discount band, brand id,
+	 * priority, availability flag — which {@link #synthetic(int)} deliberately does NOT produce. `synthetic` emits one
+	 * `0.3 * N` bucket plus `N - 1` singletons, so ~99.999 % of its inserts land in a width-1 block, take the
+	 * single-probe `else` branch of `SortIndexChanges.computePreviousRecord`, and never enter the block binary search
+	 * at all — the branch that dominates the WARM_UP profile behind issue #1332.
+	 *
+	 * @param distinctValues the number of distinct values
+	 * @param recordCount    the total number of records spread evenly across them
+	 * @return the uniform blocks in ascending value order
+	 */
+	@Nonnull
+	static List<ValueBlock> uniform(int distinctValues, int recordCount) {
+		final int baseWidth = recordCount / distinctValues;
+		final int remainder = recordCount % distinctValues;
+		final List<ValueBlock> blocks = new ArrayList<>(distinctValues);
+		int nextRecordId = 1;
+		for (int v = 0; v < distinctValues; v++) {
+			final int width = baseWidth + (v < remainder ? 1 : 0);
+			final int[] recordIds = new int[width];
+			for (int i = 0; i < width; i++) {
+				recordIds[i] = nextRecordId++;
+			}
+			blocks.add(new ValueBlock(String.format("%013d", v), recordIds));
 		}
 		return blocks;
 	}
@@ -298,8 +339,18 @@ final class SortIndexBenchSupport {
 	}
 
 	/**
-	 * Picks a deterministic existing value whose cardinality is exactly one (a singleton block) — the churn target grown
-	 * to cardinality two. Scans from the middle ordinal forward, then falls back to any singleton.
+	 * Picks a deterministic existing value to use as the churn target — the value grown by one record to produce an
+	 * incremental-commit emission. Prefers a singleton block (cardinality one, grown to two), scanning from the middle
+	 * ordinal forward and then from the start, which is what the `anchor` and `synth_*` distributions always provide.
+	 *
+	 * A `uniform_*` distribution has NO singleton block by construction — every value owns exactly
+	 * `recordCount / distinctValues` records — so this falls back to the NARROWEST block available. Growing a block of
+	 * width `w` to `w + 1` is the same single-record incremental churn; only the starting width differs. Throwing here
+	 * instead (the previous behaviour) made every uniform scenario fail in the trial `@Setup` that `churnSerialize`
+	 * shares, taking `insertRecord` down with it even though `insertRecord` never touches the churn fixture.
+	 *
+	 * @param blocks the scenario's value blocks, never empty
+	 * @return the value to grow for the churn measurement
 	 */
 	@Nonnull
 	static Serializable singletonValue(@Nonnull List<ValueBlock> blocks) {
@@ -314,7 +365,17 @@ final class SortIndexBenchSupport {
 				return block.value();
 			}
 		}
-		throw new IllegalStateException("No singleton value present to grow for churn measurement!");
+		// no singleton (a uniform distribution) - grow the narrowest block instead
+		ValueBlock narrowest = null;
+		for (final ValueBlock block : blocks) {
+			if (narrowest == null || block.recordIds().length < narrowest.recordIds().length) {
+				narrowest = block;
+			}
+		}
+		if (narrowest == null) {
+			throw new IllegalStateException("No value present to grow for churn measurement — empty distribution!");
+		}
+		return narrowest.value();
 	}
 
 	/**

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/SortIndexTimingBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/SortIndexTimingBenchmark.java
@@ -56,15 +56,22 @@ import java.util.concurrent.TimeUnit;
 /**
  * JMH timing benchmark for the OWNER-mode {@link OwnerSortIndex} granular persistence story on branch #760. It mirrors
  * the structure of {@link SortIndexChurnReport} (shared via {@link SortIndexBenchSupport}) so a `dev`-branch mirror can
- * be lined up cell-for-cell. Three operations are timed per scenario:
+ * be lined up cell-for-cell. Four operations are timed per scenario:
  *
  * - `loadDeserialize` (P5, the new load cost): deserialize the root + every leaf page from the pre-serialized bytes and
  *   rebuild a live {@link OwnerSortIndex} via {@link OwnerSortIndex#fromPersistedPages} (+ `reconstructSortedRecords`).
  * - `readOrderBy` (P3): obtain the ascending sorted record ids from the live index.
  * - `churnSerialize` (P1, serialization time): serialize the captured incremental-commit parts to bytes.
+ * - `insertRecord`: add fresh records into an already-populated index - the sort-attribute INSERT path. It carries no
+ *   P-number because the P numbering belongs to an earlier report that has no slot for it, and it is the one
+ *   measurement here that runs `Mode.SingleShotTime` in milliseconds instead of `Mode.AverageTime` in microseconds.
+ *   Its `gc.alloc.rate.norm` is fixture-dominated and must not be read as insert allocation - see its own JavaDoc.
  *
- * Scenarios are the real `anchor` ean distribution and the `synth_100k` shape replica. Run with `-prof gc` to capture
- * the normalized allocation rate alongside the average time.
+ * Scenarios are the real `anchor` ean distribution, the `synth_100k` shape replica, and the `uniform_1k_100k` /
+ * `uniform_1k_1m` pair. The uniform pair exists because `anchor` and `synth_*` are singleton-dominated: nearly every
+ * insert into them lands in a width-1 block, takes the single-probe `else` branch and never enters the block binary
+ * search at all (see `SortIndexBenchSupport.uniform`), whereas the uniform shapes give evenly-sized wide blocks that
+ * do exercise it. Run with `-prof gc` to capture the normalized allocation rate alongside the average time.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
  */
@@ -77,7 +84,9 @@ import java.util.concurrent.TimeUnit;
 public class SortIndexTimingBenchmark {
 
 	/**
-	 * The measured scenarios (a real anchor + a synthetic 100k shape replica).
+	 * The measured scenarios: the real `anchor` ean distribution, the `synth_100k` shape replica, and the
+	 * `uniform_1k_100k` / `uniform_1k_1m` pair whose evenly-sized wide blocks are the only ones that actually enter
+	 * the block binary search.
 	 */
 	@Param({"anchor", "synth_100k", "uniform_1k_100k", "uniform_1k_1m"})
 	private String scenario;
@@ -151,7 +160,7 @@ public class SortIndexTimingBenchmark {
 	}
 
 	/**
-	 * P — the INSERT cost: add fresh records into an already-populated sort index. This is
+	 * The INSERT cost: add fresh records into an already-populated sort index. This is
 	 * `SortIndex.addRecordInternal`, 57.5 % of busy-thread wall and 18.9 % of allocation during bulk ingest
 	 * (issue #1332), and no benchmark in this suite measured it before — the three benchmarks above measure
 	 * deserialize / read / serialize, and the inserts that build their fixtures happen in `@Setup`.
@@ -161,7 +170,13 @@ public class SortIndexTimingBenchmark {
 	 * single-probe `else` branch. Keep both in the param set — they are the guard that a fix tuned for wide blocks
 	 * does not regress the narrow-block case that dominates real `ean`-style attributes.
 	 *
-	 * Run with `-prof gc`: findings 3, 4, 6 and 7 of #1332 are allocation-only and invisible on `ns/op` alone.
+	 * The trustworthy output here is `ns/op`: {@link Mode#SingleShotTime} times the benchmark method only, so the
+	 * per-invocation rebuild stays out of the wall clock. The `gc.alloc.rate.norm` figure is NOT trustworthy -
+	 * `InsertState.setUp` is `@Setup(Level.Invocation)` and rebuilds the whole owner before every measured batch
+	 * (100 000 records for `uniform_1k_100k`, ~130 000 for `synth_100k`, 1 000 000 for `uniform_1k_1m`) against a
+	 * measured `BATCH_SIZE` of 10 000, and JMH's `GCProfiler` snapshots its counters in `beforeIteration` /
+	 * `afterIteration`, bracketing the whole iteration including per-invocation fixtures. The reported allocation is
+	 * therefore 10:1 to 100:1 fixture and must not be read as the insert path's allocation.
 	 */
 	@Benchmark
 	@BenchmarkMode(Mode.SingleShotTime)

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/SortIndexTimingBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/SortIndexTimingBenchmark.java
@@ -48,7 +48,9 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
+import java.io.Serializable;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -77,7 +79,7 @@ public class SortIndexTimingBenchmark {
 	/**
 	 * The measured scenarios (a real anchor + a synthetic 100k shape replica).
 	 */
-	@Param({"anchor", "synth_100k"})
+	@Param({"anchor", "synth_100k", "uniform_1k_100k", "uniform_1k_1m"})
 	private String scenario;
 
 	/**
@@ -146,6 +148,88 @@ public class SortIndexTimingBenchmark {
 			}
 		}
 		bh.consume(total);
+	}
+
+	/**
+	 * P — the INSERT cost: add fresh records into an already-populated sort index. This is
+	 * `SortIndex.addRecordInternal`, 57.5 % of busy-thread wall and 18.9 % of allocation during bulk ingest
+	 * (issue #1332), and no benchmark in this suite measured it before — the three benchmarks above measure
+	 * deserialize / read / serialize, and the inserts that build their fixtures happen in `@Setup`.
+	 *
+	 * Under a `uniform_*` scenario the inserted records land mid-block and drive the block binary search in
+	 * `SortIndexChanges.computePreviousRecord`; under `anchor` / `synth_*` they land in a width-1 block and take the
+	 * single-probe `else` branch. Keep both in the param set — they are the guard that a fix tuned for wide blocks
+	 * does not regress the narrow-block case that dominates real `ean`-style attributes.
+	 *
+	 * Run with `-prof gc`: findings 3, 4, 6 and 7 of #1332 are allocation-only and invisible on `ns/op` alone.
+	 */
+	@Benchmark
+	@BenchmarkMode(Mode.SingleShotTime)
+	@OutputTimeUnit(TimeUnit.MILLISECONDS)
+	public void insertRecord(@Nonnull InsertState state, @Nonnull Blackhole bh) {
+		bh.consume(state.insertBatch());
+	}
+
+	/**
+	 * Per-INVOCATION insert state for {@link #insertRecord}: inserts mutate the index, so the trial-scoped
+	 * {@link #liveOwner} cannot be reused and the owner is rebuilt from scratch before every measured batch.
+	 *
+	 * Two design choices deserve their reasons recorded, because the obvious alternatives silently measure the wrong
+	 * thing:
+	 *
+	 * 1. **The batch spreads across ALL distinct values, not one block.** Hammering a single value would grow that
+	 *    one block by the whole batch, so late inserts in a batch would search a far wider block than early ones and
+	 *    the benchmark would drift into measuring block growth. Spreading `batchSize` inserts over `distinctValues`
+	 *    blocks grows each by `batchSize / distinctValues`, which is noise. It is also exactly what the profiled
+	 *    workload does — 40 sortable attributes filled from `numberBetween(0, 1000)`.
+	 * 2. **`SingleShotTime` + `Level.Invocation`, not `AverageTime` + `Level.Iteration`.** Under `AverageTime` JMH
+	 *    packs as many invocations as fit the time window, so a mutating benchmark accumulates hundreds of thousands
+	 *    of inserts within one iteration and the block widths run away from the scenario's definition. One shot per
+	 *    iteration keeps every measurement anchored to the scenario's actual shape; the rebuild is paid in `@Setup`
+	 *    and is not measured.
+	 */
+	@State(Scope.Thread)
+	public static class InsertState {
+		/**
+		 * Records inserted per measured batch - large enough to sit well above the timer's resolution, small enough
+		 * that spread across the distinct values it barely widens any block.
+		 */
+		private static final int BATCH_SIZE = 10_000;
+
+		private OwnerSortIndex owner;
+		/** The value each batch slot inserts under, pre-picked so no RNG cost lands inside the measured loop. */
+		private Serializable[] batchValues;
+		private int nextRecordId;
+
+		@Setup(Level.Invocation)
+		public void setUp(@Nonnull SortIndexTimingBenchmark benchmark) {
+			final List<ValueBlock> blocks = SortIndexBenchSupport.blocksFor(benchmark.scenario);
+			this.owner = SortIndexBenchSupport.buildOwner(blocks);
+			this.nextRecordId = SortIndexBenchSupport.maxRecordId(blocks) + 1;
+			// pre-pick the values OUTSIDE the measured region; a fixed seed keeps every fork comparable
+			final Random random = new Random(42);
+			this.batchValues = new Serializable[BATCH_SIZE];
+			for (int i = 0; i < BATCH_SIZE; i++) {
+				this.batchValues[i] = blocks.get(random.nextInt(blocks.size())).value();
+			}
+		}
+
+		/**
+		 * Inserts {@link #BATCH_SIZE} fresh records spread across the scenario's distinct values and returns the
+		 * resulting index size, so the whole batch is observable to the blackhole.
+		 *
+		 * @return the sort index size after the batch
+		 */
+		int insertBatch() {
+			final OwnerSortIndex theOwner = this.owner;
+			final Serializable[] values = this.batchValues;
+			int recordId = this.nextRecordId;
+			for (int i = 0; i < values.length; i++) {
+				theOwner.addRecord(values[i], recordId++);
+			}
+			this.nextRecordId = recordId;
+			return theOwner.size();
+		}
 	}
 
 	private <T extends StoragePart> int writeBytes(

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/UnorderedLookupTreeBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/UnorderedLookupTreeBenchmark.java
@@ -183,7 +183,9 @@ public class UnorderedLookupTreeBenchmark {
 					high = middle - 1;
 				}
 			}
-			sum += insertionIndex;
+			// the trailing predecessor read the sort index needs - its own descent, on top of the search
+			final int predecessorPosition = insertionIndex - 1;
+			sum += predecessorPosition < 0 ? Integer.MIN_VALUE : tree.getRecordAt(predecessorPosition);
 		}
 		bh.consume(sum);
 		return sum;
@@ -191,8 +193,9 @@ public class UnorderedLookupTreeBenchmark {
 
 	/**
 	 * P2b — the OPTIMISED half of the block-search pair: the identical search issued through
-	 * {@link UnorderedLookupTree#findInsertionPositionInRange(int, int, int)}, which retains the leaf resolved by one
-	 * probe and serves any following probe landing inside it without descending again.
+	 * {@link UnorderedLookupTree#findPredecessorInRange(int, int, int)}, which retains the leaf resolved by one probe
+	 * and serves any following read landing inside it - the trailing predecessor read included - without descending
+	 * again.
 	 *
 	 * Returns the same sum as {@link #blockSearchPerProbeDescent(BlockSearchState, Blackhole)} by construction — the
 	 * equivalence itself is asserted by the functional oracle tests, not here.
@@ -206,7 +209,7 @@ public class UnorderedLookupTreeBenchmark {
 		int sum = 0;
 		for (int i = 0; i < blockStarts.length; i++) {
 			final int blockStart = blockStarts[i];
-			sum += tree.findInsertionPositionInRange(blockStart, blockStart + blockWidth, targets[i]);
+			sum += tree.findPredecessorInRange(blockStart, blockStart + blockWidth, targets[i]);
 		}
 		bh.consume(sum);
 		return sum;

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/UnorderedLookupTreeBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/UnorderedLookupTreeBenchmark.java
@@ -145,6 +145,73 @@ public class UnorderedLookupTreeBenchmark {
 		return sum;
 	}
 
+	/**
+	 * P2a — the BASELINE half of the block-search pair: the block binary search driven the way
+	 * `SortIndexChanges.computePreviousRecord` used to drive it, as a caller-side loop where every probe is an
+	 * independent {@link UnorderedLookupTree#getRecordAt(int)} root-to-leaf descent.
+	 *
+	 * Paired with {@link #blockSearchWindowed(BlockSearchState, Blackhole)}, which performs the identical search
+	 * through the windowed entry point. The two run as siblings in ONE JVM on purpose: an A/A run of
+	 * {@link #positionalRead(PositionalReadState, Blackhole)} measured 0.4–16.4 % of drift between two runs of the
+	 * same jar, which is the same order as the effect being looked for. Sibling benchmarks share the fork, the JIT
+	 * state and the machine state, so their difference is paired rather than compared across runs.
+	 */
+	@Benchmark
+	public int blockSearchPerProbeDescent(@Nonnull BlockSearchState state, @Nonnull Blackhole bh) {
+		final UnorderedLookupTree tree = state.index.positionTree;
+		final int[] blockStarts = state.blockStarts;
+		final int[] targets = state.targets;
+		final int blockWidth = state.blockWidth;
+		int sum = 0;
+		for (int i = 0; i < blockStarts.length; i++) {
+			final int blockStart = blockStarts[i];
+			final int blockEnd = blockStart + blockWidth;
+			final int recordId = targets[i];
+			int low = blockStart;
+			int high = blockEnd - 1;
+			int insertionIndex = blockEnd;
+			while (low <= high) {
+				final int middle = (low + high) >>> 1;
+				final int middleRecordId = tree.getRecordAt(middle);
+				if (middleRecordId < recordId) {
+					low = middle + 1;
+				} else {
+					insertionIndex = middle;
+					if (middleRecordId == recordId) {
+						break;
+					}
+					high = middle - 1;
+				}
+			}
+			sum += insertionIndex;
+		}
+		bh.consume(sum);
+		return sum;
+	}
+
+	/**
+	 * P2b — the OPTIMISED half of the block-search pair: the identical search issued through
+	 * {@link UnorderedLookupTree#findInsertionPositionInRange(int, int, int)}, which retains the leaf resolved by one
+	 * probe and serves any following probe landing inside it without descending again.
+	 *
+	 * Returns the same sum as {@link #blockSearchPerProbeDescent(BlockSearchState, Blackhole)} by construction — the
+	 * equivalence itself is asserted by the functional oracle tests, not here.
+	 */
+	@Benchmark
+	public int blockSearchWindowed(@Nonnull BlockSearchState state, @Nonnull Blackhole bh) {
+		final UnorderedLookupTree tree = state.index.positionTree;
+		final int[] blockStarts = state.blockStarts;
+		final int[] targets = state.targets;
+		final int blockWidth = state.blockWidth;
+		int sum = 0;
+		for (int i = 0; i < blockStarts.length; i++) {
+			final int blockStart = blockStarts[i];
+			sum += tree.findInsertionPositionInRange(blockStart, blockStart + blockWidth, targets[i]);
+		}
+		bh.consume(sum);
+		return sum;
+	}
+
 	/* =========================================================================================== */
 
 	/**
@@ -264,6 +331,54 @@ public class UnorderedLookupTreeBenchmark {
 				}
 			}
 			return result;
+		}
+	}
+
+	/**
+	 * Pre-built chain plus the `(blockStart, targetRecordId)` pairs of {@link #SIMULATED_INSERTS} simulated
+	 * sort-attribute inserts, shared by the two block-search benchmarks so both search exactly the same blocks for
+	 * exactly the same record ids.
+	 *
+	 * The chain is `1 → 2 → … → recordCount`, so the record id at logical position `p` is `p + 1`. That makes EVERY
+	 * range ascending — the precondition the ranged search is contracted on — and makes a target record id inside a
+	 * block trivially derivable from a position.
+	 */
+	@State(Scope.Benchmark)
+	public static class BlockSearchState {
+		/** Number of simulated sort-attribute inserts performed per measured invocation. */
+		private static final int SIMULATED_INSERTS = 10_000;
+
+		/** Length of the pre-built chain the searches run over. */
+		@Param({"1000000"})
+		public int recordCount;
+		/** Width of the simulated value block the binary search runs over. */
+		@Param({"1", "10", "100", "1000", "10000"})
+		public int blockWidth;
+
+		CompositeIndex index;
+		/** First logical position of each simulated insert's value block. */
+		int[] blockStarts;
+		/** The record id each simulated insert searches its block for. */
+		int[] targets;
+
+		@Setup(Level.Trial)
+		public void setUp() {
+			final CompositeIndex theIndex = new CompositeIndex();
+			theIndex.addHead(1);
+			for (int recordId = 2; recordId <= this.recordCount; recordId++) {
+				theIndex.addAfter(recordId - 1, recordId);
+			}
+			this.index = theIndex;
+			final Random random = new Random(42);
+			this.blockStarts = new int[SIMULATED_INSERTS];
+			this.targets = new int[SIMULATED_INSERTS];
+			for (int i = 0; i < SIMULATED_INSERTS; i++) {
+				final int blockStart = this.blockWidth >= this.recordCount
+					? 0 : random.nextInt(this.recordCount - this.blockWidth);
+				this.blockStarts[i] = blockStart;
+				// the record id living at position `p` is `p + 1`, so this targets a random slot inside the block
+				this.targets[i] = blockStart + random.nextInt(this.blockWidth) + 1;
+			}
 		}
 	}
 

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/UnorderedLookupTreeBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/UnorderedLookupTreeBenchmark.java
@@ -45,23 +45,31 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Microbenchmark of the **write** behaviour of the two-tree backing introduced under issue #760 — the count-augmented
- * position tree {@link UnorderedLookupTree} paired with the no-boxing `int → long` value index
- * {@link TransactionalIntToLongBPlusTree}, exactly the pair that sits behind `TransactionalUnorderedIntArray`.
+ * Microbenchmark of the **write** and positional-**read** behaviour of the two-tree backing introduced under issue
+ * #760 — the count-augmented position tree {@link UnorderedLookupTree} paired with the no-boxing `int → long` value
+ * index {@link TransactionalIntToLongBPlusTree}, exactly the pair that sits behind `TransactionalUnorderedIntArray`.
  *
  * The single property this benchmark guards is **asymptotic write cost**: the array delegate the two-tree backing
  * replaces renumbers an `O(N)` suffix on every positional insert / move, so building and churning a long chain costs
- * `O(N²)`. The tree touches only the `O(log N)` cursor path, so both phases must scale **linearly**. This is a write
- * hot-path benchmark; read addressing and the correctness of the structure are covered by the functional oracle suite
- * and the generational long-running soak, not here.
+ * `O(N²)`. The tree touches only the `O(log N)` cursor path, so both write phases must scale **linearly**. Beyond that
+ * the class also sizes the positional-READ cost the sort-attribute insert path pays; what it does not cover is the
+ * structural **correctness** of the tree, which stays with the functional oracle suite and the generational
+ * long-running soak.
  *
- * Two phases are measured, each in {@link Mode#SingleShotTime} (the natural unit is "time to apply the whole batch"):
+ * Five benchmarks are measured - two write phases and three read phases - each in {@link Mode#SingleShotTime} (the
+ * natural unit is "time to run the whole batch"):
  *
  * 1. {@code buildChain} — builds a single chain `1 → 2 → … → N` via `recordCount` individual `insertAfter` writes,
  *    starting from an empty backing each invocation. Measures the per-write cost as the chain grows.
  * 2. {@code churnChain} — over a pre-built chain, repeatedly moves a random record to sit after another random record
  *    (a predecessor update = remove + re-insert), `churnOperations` times. Measures steady-state move cost at a fixed
  *    chain length.
+ * 3. {@code positionalRead} — replays the pre-generated probe positions a block binary search issues, every one of
+ *    them an independent root-to-leaf order-statistic descent. Measures the raw per-probe read cost.
+ * 4. {@code blockSearchPerProbeDescent} — the baseline half of the block-search pair: the whole search driven as a
+ *    caller-side loop of independent descents, plus the trailing predecessor read.
+ * 5. {@code blockSearchWindowed} — the optimised half of that pair: the identical search issued through the ranged
+ *    entry point that retains the leaf one probe already resolved.
  *
  * The chain length ({@code recordCount}) and the churn batch size ({@code churnOperations}) are {@link Param}s so the
  * linear (or non-linear) trend can be read directly by comparing successive sizes; doubling `recordCount` should at
@@ -122,7 +130,7 @@ public class UnorderedLookupTreeBenchmark {
 	}
 
 	/**
-	 * P — the READ cost the sort-attribute insert path actually pays. `SortIndexChanges.computePreviousRecord`
+	 * The READ cost the sort-attribute insert path actually pays. `SortIndexChanges.computePreviousRecord`
 	 * binary-searches a value's record block through positional reads, and every probe is a fresh root-to-leaf
 	 * order-statistic descent — `UnorderedLookupTree.getRecordAt`, the 19.4 % self-time frame of the WARM_UP profile
 	 * behind issue #1332, which no benchmark in this suite reached before (`buildChain` / `churnChain` are both
@@ -146,15 +154,17 @@ public class UnorderedLookupTreeBenchmark {
 	}
 
 	/**
-	 * P2a — the BASELINE half of the block-search pair: the block binary search driven the way
+	 * The BASELINE half of the block-search pair: the block binary search driven the way
 	 * `SortIndexChanges.computePreviousRecord` used to drive it, as a caller-side loop where every probe is an
 	 * independent {@link UnorderedLookupTree#getRecordAt(int)} root-to-leaf descent.
 	 *
 	 * Paired with {@link #blockSearchWindowed(BlockSearchState, Blackhole)}, which performs the identical search
-	 * through the windowed entry point. The two run as siblings in ONE JVM on purpose: an A/A run of
+	 * through the windowed entry point. The two are measured inside ONE JMH invocation on purpose: an A/A run of
 	 * {@link #positionalRead(PositionalReadState, Blackhole)} measured 0.4–16.4 % of drift between two runs of the
-	 * same jar, which is the same order as the effect being looked for. Sibling benchmarks share the fork, the JIT
-	 * state and the machine state, so their difference is paired rather than compared across runs.
+	 * same jar, which is the same order as the effect being looked for. JMH forks per benchmark method (and per
+	 * parameter combination), so the two do NOT share a fork or a JIT state - what the pairing buys is that they run
+	 * back-to-back from the same jar, on the same machine, in the same thermal and load state. That removes the
+	 * cross-RUN drift the A/A measured; it does not remove per-fork variance.
 	 */
 	@Benchmark
 	public int blockSearchPerProbeDescent(@Nonnull BlockSearchState state, @Nonnull Blackhole bh) {
@@ -192,7 +202,7 @@ public class UnorderedLookupTreeBenchmark {
 	}
 
 	/**
-	 * P2b — the OPTIMISED half of the block-search pair: the identical search issued through
+	 * The OPTIMISED half of the block-search pair: the identical search issued through
 	 * {@link UnorderedLookupTree#findPredecessorInRange(int, int, int)}, which retains the leaf resolved by one probe
 	 * and serves any following read landing inside it - the trailing predecessor read included - without descending
 	 * again.

--- a/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/UnorderedLookupTreeBenchmark.java
+++ b/evita_test/evita_performance_tests/src/main/java/io/evitadb/spike/UnorderedLookupTreeBenchmark.java
@@ -121,6 +121,30 @@ public class UnorderedLookupTreeBenchmark {
 		return size;
 	}
 
+	/**
+	 * P — the READ cost the sort-attribute insert path actually pays. `SortIndexChanges.computePreviousRecord`
+	 * binary-searches a value's record block through positional reads, and every probe is a fresh root-to-leaf
+	 * order-statistic descent — `UnorderedLookupTree.getRecordAt`, the 19.4 % self-time frame of the WARM_UP profile
+	 * behind issue #1332, which no benchmark in this suite reached before (`buildChain` / `churnChain` are both
+	 * write-only).
+	 *
+	 * The probe sequence is pre-generated in `@Setup`, never inside the measured method, so the measurement contains
+	 * the tree descents and nothing else. Parameterising on `blockWidth` is what lets a descent-COUNT fix (a
+	 * re-seekable cursor) be told apart from a per-level COST fix (prefix-sum child counts): the former moves only
+	 * wide blocks, the latter moves every width including 1.
+	 */
+	@Benchmark
+	public int positionalRead(@Nonnull PositionalReadState state, @Nonnull Blackhole bh) {
+		final UnorderedLookupTree tree = state.index.positionTree;
+		final int[] probes = state.probes;
+		int sum = 0;
+		for (int i = 0; i < probes.length; i++) {
+			sum += tree.getRecordAt(probes[i]);
+		}
+		bh.consume(sum);
+		return sum;
+	}
+
 	/* =========================================================================================== */
 
 	/**
@@ -160,6 +184,86 @@ public class UnorderedLookupTreeBenchmark {
 			}
 			this.index = theIndex;
 			this.random = new Random(42);
+		}
+	}
+
+	/**
+	 * Pre-built chain plus a pre-generated probe sequence for {@link UnorderedLookupTreeBenchmark#positionalRead}.
+	 *
+	 * The probe sequence replays exactly the positions a binary search over a block of {@link #blockWidth} records
+	 * issues — the access pattern `SortIndexChanges.computePreviousRecord` produces on every sort-attribute insert.
+	 * Each simulated insert picks a random block and a random target offset inside it, then records the midpoints the
+	 * search visits. Short searches are padded so every simulated insert contributes the same probe count, keeping
+	 * `ns/op` directly comparable across `blockWidth` values.
+	 */
+	@State(Scope.Benchmark)
+	public static class PositionalReadState {
+		/**
+		 * Number of simulated sort-attribute inserts whose probe sequences are concatenated into {@link #probes}.
+		 */
+		private static final int SIMULATED_INSERTS = 10_000;
+
+		/** Length of the pre-built chain the probes read from. */
+		@Param({"1000000", "10000000"})
+		public int recordCount;
+		/** Width of the simulated value block the binary search runs over. */
+		@Param({"1", "10", "100", "1000", "10000"})
+		public int blockWidth;
+
+		CompositeIndex index;
+		/** Flattened probe positions: `ceil(log2(blockWidth))` consecutive probes per simulated insert. */
+		int[] probes;
+
+		@Setup(Level.Trial)
+		public void setUp() {
+			final CompositeIndex theIndex = new CompositeIndex();
+			theIndex.addHead(1);
+			for (int recordId = 2; recordId <= this.recordCount; recordId++) {
+				theIndex.addAfter(recordId - 1, recordId);
+			}
+			this.index = theIndex;
+			this.probes = generateProbes(this.recordCount, this.blockWidth);
+		}
+
+		/**
+		 * Generates the concatenated probe sequences of {@link #SIMULATED_INSERTS} binary searches, each over a block
+		 * of `blockWidth` consecutive positions starting at a pseudo-random offset.
+		 *
+		 * @param recordCount total number of positions available in the tree
+		 * @param blockWidth  width of the simulated value block
+		 * @return the flattened probe positions, `SIMULATED_INSERTS * ceil(log2(blockWidth))` of them
+		 */
+		@Nonnull
+		private static int[] generateProbes(int recordCount, int blockWidth) {
+			final Random random = new Random(42);
+			// ceil(log2(blockWidth)) - the number of probes a binary search over `blockWidth` slots issues
+			final int probesPerSearch = Math.max(1, 32 - Integer.numberOfLeadingZeros(blockWidth));
+			final int[] result = new int[SIMULATED_INSERTS * probesPerSearch];
+			int cursor = 0;
+			for (int i = 0; i < SIMULATED_INSERTS; i++) {
+				final int blockStart = blockWidth >= recordCount ? 0 : random.nextInt(recordCount - blockWidth);
+				// the position the inserted record id would occupy inside the block - the search target
+				final int target = blockStart + random.nextInt(blockWidth);
+				int low = blockStart;
+				int high = blockStart + blockWidth - 1;
+				int emitted = 0;
+				while (low <= high && emitted < probesPerSearch) {
+					final int middle = (low + high) >>> 1;
+					result[cursor++] = middle;
+					emitted++;
+					if (middle < target) {
+						low = middle + 1;
+					} else {
+						high = middle - 1;
+					}
+				}
+				// pad a short search so every simulated insert contributes the same probe count
+				while (emitted < probesPerSearch) {
+					result[cursor++] = target;
+					emitted++;
+				}
+			}
+			return result;
 		}
 	}
 


### PR DESCRIPTION
Closes #1332

Cuts allocation and descent cost out of the sort-attribute insert path, driven by live WARM_UP profiling. Seven findings were investigated; five landed, two were rejected on measurement.

## What changed

| Commit | Change |
|---|---|
| `b19d3956a` | Int-keyed internal-node descent no longer allocates an `InsertionPosition` record per level — the child index is returned as a plain `int`. |
| `b5c2ef82b` | `TransactionalUnorderedIntArray` guards are lazy and single-probe: the assertion message is built only on the throwing branch, and the duplicate check reuses the probe the insert already performed instead of issuing a second one. |
| `7869c5fdc` | `TransactionalIntToLongBPlusTree` captures the cursor path only when the target leaf can actually overflow, instead of on every insert. |
| `1e6d1daa0` | `UnorderedLookupTree.getRecordAt` resolves the thread's transaction once per positional read rather than once per `TransactionalReference` it touches. Adds `TransactionalReference.get(Transaction)` and `Transaction.getCurrentTransactionIfAvailable()`. |
| `600671ffa` | The sort-block binary search moved *into* `UnorderedLookupTree` as `findPredecessorInRange`, resolving converging probes from one retained leaf instead of a fresh root-to-leaf descent per probe. Replaces the previous full-array copy per insert in `SortIndexChanges.computePreviousRecord`. |
| `de9614fd9` | The trailing predecessor read is served from that same retained leaf — which is why the method returns a predecessor id rather than an insertion position. |
| `46b4fecf3` | Hardens the lazy-cursor guard: the "can this leaf overflow" predicate now reads the leaf's own capacity through a single transactional-layer resolution (`isNearlyFull()`), and a mispredicted split raises a diagnostic `GenericEvitaInternalError` instead of an opaque NPE. |

Rejected after measurement, with the evidence recorded in `docs/plans/1332-measurements/RESULTS.md`: F2 (no measurable signal) and the F1-b packed-`long` window prototype (slower than the committed F1-a).

## Measurements

All allocation figures are `gc.alloc.rate.norm`, which reproduces to well under 1 % here; `ns/op` on the same runs carries error bars up to 2.6× the score and is reported only where the confidence intervals are disjoint.

**Allocation, JMH A/B across jars:**

| Benchmark | Scenario | Before | After | Delta |
|---|---|---|---|---|
| `buildChain` | 1 000 000 records | 1 711 486 741 B/op | 986 619 485 B/op | **−42.4 %** |
| `insertRecord` | `synth_100k` (narrow blocks) | 680 712 842 B/op | 489 723 378 B/op | **−28.1 %** |
| `insertRecord` | `uniform_1k_100k` (wide blocks) | 393 607 701 B/op | 245 689 589 B/op | **−37.6 %** |

**Latency, paired A/B on the block-search path** (`blockSearchWindowed` vs `blockSearchPerProbeDescent`, 6 forks):

| Block width | Before | After | Delta |
|---|---|---|---|
| 1 | 1 213.212 ± 95.744 us/op | 732.957 ± 38.879 | **−39.6 %** |
| 10 | 2 357.545 ± 54.592 | 1 293.894 ± 387.554 | **−45.1 %** |
| 100 | 4 225.957 ± 201.743 | 2 253.938 ± 110.466 | **−46.7 %** |
| 1000 | 6 328.074 ± 239.036 | 4 561.653 ± 444.765 | **−27.9 %** |
| 10000 | 10 233.450 ± 1 383.637 | 7 563.951 ± 700.237 | **−26.1 %** |

**End-to-end ingest** (new `SortAttributeIngestBenchmark`, cross-jar, `-p entityCount=5000`):

| Distinct values | Block width | Before | After | Absolute delta | Reduction |
|---|---|---|---|---|---|
| 1000 | ~5 | 29.358 GB/op | 25.566 GB/op | **−3.792 GB/op** | **−12.92 %** |
| 20 | ~250 | 26.064 GB/op | 22.121 GB/op | **−3.943 GB/op** | **−15.13 %** |

These are **ingest-only** figures, corrected under #1335. The raw harness output was 29.712 → 25.920 and 26.415 → 22.472 GB/op, but JMH's `GCProfiler` brackets the whole iteration including the `@Setup(Level.Invocation)` fixture, so those totals were `fixture + ingest`. #1335 added an empty-body control benchmark that measures the fixture alone (0.354 and 0.351 GB/op at this configuration); subtracting it per `distinctValues` gives the table above. The absolute deltas are unchanged — the fixture always cancelled in the subtraction — but the percentages were previously diluted by roughly 0.2 points, understating the win.

The two regimes' absolute deltas agree within 4 % while their totals differ by 3.3 GB/op — the signature of a fixed per-operation saving over a common fixture.

Note for anyone reproducing: these runs used `-p entityCount=5000`, not the benchmark's committed `@Param` default of 20 000 (the block widths above only follow from 5 000). At the default the figures are 3.4–3.6× larger and not comparable to this table.

The final guard-hardening commit was re-measured and is allocation-neutral: `buildChain` at 1 000 000 records moved by **+0.003 %** (986 619 485 → 986 646 896 B/op), well inside the noise floor.

## Testing

- Full functional suite: **20 720 tests, 0 failures, 0 errors**
- Full savepoint fuzz suite, all 34 classes: **89 tests, 0 failures, 0 errors**
- Targeted long-running generative suite over every class this branch touches plus their consumers — `UnorderedLookupTree`, `TransactionalUnorderedIntArray`, `SortIndex`, `ChainIndex`, `AttributeIndex`, `TransactionalIntToLongBPlusTree`, `TransactionalElementBPlusTree`, `TransactionalReference`, each in both generational and savepoint rollback/commit form: **26 tests, 0 failures, 0 errors**

`TransactionalElementBPlusTree` is included because it shares `AbstractIntKeyedInternalNode` with the tree changed in `b19d3956a`. `ChainIndex` is included because it is the other consumer of `TransactionalUnorderedIntArray`, so it exercises the lazy-guard change from an independent direction.

## Follow-ups filed

- #1333 — the remaining transactional B+ trees still allocate a cursor path on every insert; the lazy-cursor optimisation was not portable to them as-is, so the issue carries staged GO/NO-GO benchmarking gates
- #1334 — `DataGenerator.pickRandomFromSet` does not terminate for schemas with many reference types (found while building the ingest benchmark)
- #1335 — the ingest benchmark reports fixture allocation as ingest allocation (**resolved**; the end-to-end figures above are restated ingest-only)

