### PR TITLE
fix: query telemetry is truncated to the EXECUTION subtree

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/QueryTelemetry.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/QueryTelemetry.java
@@ -51,7 +51,11 @@ public class QueryTelemetry implements EvitaResponseExtraResult {
 	 */
 	@Getter private final QueryPhase operation;
 	/**
-	 * Date and time of the start of this step in nanoseconds.
+	 * Start of this step as read from {@link System#nanoTime()} in nanoseconds.
+	 *
+	 * This is a monotonic counter with no defined epoch - it is NOT a wall-clock timestamp and must not be
+	 * rendered as a date. It is only meaningful relative to another `start` from the same tree, typically as an
+	 * offset from the root step.
 	 */
 	@Getter private final long start;
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanningContext.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryPlanningContext.java
@@ -609,11 +609,16 @@ public class QueryPlanningContext implements LocaleProvider, PrefetchStrategyRes
 
 	/**
 	 * Returns {@link QueryTelemetry} root or throws an exception if no telemetry is initialized.
+	 *
+	 * The root is the *bottom* of the stack - the node seeded when this context was created. `push()` on
+	 * an {@link ArrayDeque} is `addFirst()`, so the head of the deque is the innermost still-open step
+	 * (that is what {@link #getCurrentStep()} returns); reading the head here would hand out whichever step
+	 * happens to be open at the time of the call rather than the root of the tree.
 	 */
 	@Nonnull
 	public QueryTelemetry getTelemetryRoot() {
 		Assert.isPremiseValid(!this.telemetryStack.isEmpty(), "The telemetry is not initialized!");
-		return this.telemetryStack.getFirst();
+		return this.telemetryStack.getLast();
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/model/extraResult/QueryTelemetryDescriptor.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/model/extraResult/QueryTelemetryDescriptor.java
@@ -51,7 +51,9 @@ public interface QueryTelemetryDescriptor {
 	PropertyDescriptor START = PropertyDescriptor.builder()
 		.name("start")
 		.description("""
-            Date and time of the start of this step in nanoseconds.
+            Start of this step in nanoseconds, read from a monotonic counter with no defined epoch.
+            This is not a wall-clock timestamp - it is only meaningful relative to another `start`
+            from the same telemetry tree, typically as an offset from the root step.
 			""")
 		.type(nonNull(Long.class))
 		.build();

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/query/QueryTelemetryRootFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/query/QueryTelemetryRootFunctionalTest.java
@@ -1,0 +1,238 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.query;
+
+import io.evitadb.api.EvitaSessionContract;
+import io.evitadb.api.query.Query;
+import io.evitadb.api.requestResponse.EvitaResponse;
+import io.evitadb.api.requestResponse.data.structure.EntityReference;
+import io.evitadb.api.requestResponse.extraResult.QueryTelemetry;
+import io.evitadb.api.requestResponse.extraResult.QueryTelemetry.QueryPhase;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.core.Evita;
+import io.evitadb.test.Entities;
+import io.evitadb.test.EvitaTestSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static io.evitadb.api.query.QueryConstraints.attributeStartsWith;
+import static io.evitadb.api.query.QueryConstraints.collection;
+import static io.evitadb.api.query.QueryConstraints.filterBy;
+import static io.evitadb.api.query.QueryConstraints.queryTelemetry;
+import static io.evitadb.api.query.QueryConstraints.require;
+import static io.evitadb.test.TestTags.ENGINE;
+import static io.evitadb.test.TestTags.QUERY;
+import static io.evitadb.test.TestTags.REQUIRE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the *shape* of the {@link QueryTelemetry} tree that a client actually receives - specifically that the tree
+ * handed to the client is rooted at {@link QueryPhase#OVERALL} and therefore still carries the whole
+ * {@link QueryPhase#PLANNING} subtree.
+ *
+ * This is deliberately separate from asserting that some phase exists *somewhere* in the tree. A tree-walking
+ * `containsPhase` check - the shape used by {@link PreferIndexScanDebugModeFunctionalTest} - cannot see this class of
+ * defect: when the root is truncated to the `EXECUTION` node, every execution-phase step it looks for is still
+ * reachable below that node, so the walk keeps succeeding while the planning half of the tree has silently vanished
+ * from the response. The planning half is the part that carries the index-selection decision and its estimated costs,
+ * which is the most valuable diagnostic the telemetry produces, so its loss is invisible exactly where it matters.
+ *
+ * The three assertions here are not redundant. The first catches a truncated root directly. The second catches the
+ * *reachability* regression - a future refactor could hand back an `OVERALL`-labelled node that is not the real root,
+ * which the first assertion alone would not notice. The third pins the payload the planning subtree exists to deliver.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Query telemetry is delivered rooted at the OVERALL phase")
+@Tag(ENGINE)
+@Tag(QUERY)
+@Tag(REQUIRE)
+class QueryTelemetryRootFunctionalTest implements EvitaTestSupport {
+
+	private static final String ATTRIBUTE_CODE = "code";
+	private static final int PRODUCT_COUNT = 4;
+
+	private TestPaths paths;
+	private Evita evita;
+
+	@BeforeEach
+	void setUp() {
+		this.paths = createTestPaths("QueryTelemetryRoot");
+		this.evita = new Evita(newTestEvitaConfigurationBuilder(this.paths).build());
+		seed();
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (this.evita != null && this.evita.isActive()) {
+			this.evita.close();
+		}
+		cleanupTestPaths(this.paths);
+	}
+
+	@Test
+	@DisplayName("the root node reports the OVERALL phase")
+	void shouldRootTelemetryAtOverallPhase() {
+		final QueryTelemetry telemetry = queryTelemetryOf();
+		assertEquals(
+			QueryPhase.OVERALL, telemetry.getOperation(),
+			"The telemetry handed to the client must be the root of the tree - a node reporting `" +
+				telemetry.getOperation() + "` means the response carries only a subtree!"
+		);
+
+		// the root is captured while it is still open - `fabricateExtraResults` runs before the telemetry is
+		// finalized - so its duration is only ever written by the later `finalizeTelemetry()` pass mutating the
+		// already-handed-out object. A zero here would mean the client gets the tree without its total time
+		assertTrue(
+			telemetry.getSpentTime() > 0,
+			"The root step must report a duration - the client reads it as the total query time!"
+		);
+	}
+
+	@Test
+	@DisplayName("the planning subtree survives into the delivered tree")
+	void shouldExposePlanningSubtreeInTelemetry() {
+		final QueryTelemetry telemetry = queryTelemetryOf();
+		assertTrue(
+			containsPhase(telemetry, QueryPhase.PLANNING),
+			"The `PLANNING` step must be reachable from the delivered telemetry root!"
+		);
+		assertTrue(
+			containsPhase(telemetry, QueryPhase.PLANNING_INDEX_USAGE),
+			"The `PLANNING_INDEX_USAGE` step must be reachable - it records which indexes the planner considered!"
+		);
+		// asserting the planning half alone would still pass on a node that merely *looks* like the root, so pin
+		// the execution half too - only the genuine root parents both
+		assertTrue(
+			containsPhase(telemetry, QueryPhase.EXECUTION),
+			"The `EXECUTION` step must be reachable from the same root that carries `PLANNING`!"
+		);
+	}
+
+	@Test
+	@DisplayName("the selected index and its estimated cost reach the client")
+	void shouldExposeSelectedIndexArgumentInTelemetry() {
+		final QueryTelemetry telemetry = queryTelemetryOf();
+		final QueryTelemetry planningFilter = findPhase(telemetry, QueryPhase.PLANNING_FILTER);
+		assertNotNull(planningFilter, "The `PLANNING_FILTER` step must be reachable from the delivered root!");
+
+		// this argument is written when the step is *finished* (`popStep(message)`), so it is the one piece of
+		// planner reasoning - the chosen index plus its estimated cost - that escapes the engine to the client
+		final String[] arguments = planningFilter.getArguments();
+		assertEquals(
+			1, arguments.length,
+			"The `PLANNING_FILTER` step must carry exactly one argument naming the selected index!"
+		);
+		assertTrue(
+			arguments[0].startsWith("Selected index:"),
+			"The `PLANNING_FILTER` argument must name the selected index but was `" + arguments[0] + "`!"
+		);
+	}
+
+	/**
+	 * Builds a handful of products carrying a filterable code attribute in a warm-up catalog.
+	 */
+	private void seed() {
+		this.evita.defineCatalog(TEST_CATALOG);
+		this.evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::filterable)
+					.updateVia(session);
+
+				for (int pk = 1; pk <= PRODUCT_COUNT; pk++) {
+					session.upsertEntity(
+						session.createNewEntity(Entities.PRODUCT, pk)
+							.setAttribute(ATTRIBUTE_CODE, "garmin-" + pk)
+					);
+				}
+			}
+		);
+	}
+
+	/**
+	 * Runs a query that forces a real index selection and returns the telemetry it produced.
+	 *
+	 * @return the telemetry extra result of the executed query
+	 */
+	@Nonnull
+	private QueryTelemetry queryTelemetryOf() {
+		try (final EvitaSessionContract session = this.evita.createReadOnlySession(TEST_CATALOG)) {
+			final EvitaResponse<EntityReference> response = session.query(
+				Query.query(
+					collection(Entities.PRODUCT),
+					filterBy(attributeStartsWith(ATTRIBUTE_CODE, "garmin")),
+					require(queryTelemetry())
+				),
+				EntityReference.class
+			);
+			final QueryTelemetry telemetry = response.getExtraResult(QueryTelemetry.class);
+			assertNotNull(telemetry, "Query telemetry must be present - it is the observable this test reads!");
+			return telemetry;
+		}
+	}
+
+	/**
+	 * Walks the telemetry tree looking for a step of the given phase.
+	 *
+	 * @param telemetry the telemetry node to start from
+	 * @param phase     the phase to look for
+	 * @return true when the phase is present anywhere in the tree
+	 */
+	private static boolean containsPhase(@Nonnull QueryTelemetry telemetry, @Nonnull QueryPhase phase) {
+		return findPhase(telemetry, phase) != null;
+	}
+
+	/**
+	 * Walks the telemetry tree and returns the first step of the given phase.
+	 *
+	 * @param telemetry the telemetry node to start from
+	 * @param phase     the phase to look for
+	 * @return the first matching step, or `null` when the phase is absent from the tree
+	 */
+	@Nullable
+	private static QueryTelemetry findPhase(@Nonnull QueryTelemetry telemetry, @Nonnull QueryPhase phase) {
+		if (telemetry.getOperation() == phase) {
+			return telemetry;
+		}
+		for (final QueryTelemetry step : telemetry.getSteps()) {
+			final QueryTelemetry found = findPhase(step, phase);
+			if (found != null) {
+				return found;
+			}
+		}
+		return null;
+	}
+
+}


### PR DESCRIPTION
Closes #1337

## Problem

`QueryPlanningContext.getTelemetryRoot()` returned `telemetryStack.getFirst()`. The stack is an `ArrayDeque` driven by `push()`/`pop()`, and `ArrayDeque.push()` is `addFirst()` — so `getFirst()` returns the **top** of the stack, not the bottom. That made the "root" accessor behaviourally identical to `getCurrentStep()`, which returns `peek()` a few lines above it.

At the only call site — `QueryPlan.fabricateExtraResults()` — the stack is `[EXECUTION, OVERALL]`, because extra results are fabricated inside the `EXECUTION` step. Clients therefore received the `EXECUTION` node, and the `OVERALL` root plus the **entire `PLANNING` subtree — including the index-selection decision and its estimated costs — never reached any client**.

The captured node still ended up with a correct `spentTime`, because `finalizeTelemetry()` runs afterwards and force-finishes every still-open node, mutating the already-handed-out object. That is why the defect produced a plausible-looking payload rather than an obviously broken one.

## Fix

Return the bottom of the stack (`getLast()`).

This is sufficient: `getTelemetryRoot()` only ever runs on the outer query context. Nested contexts are seeded with `queryContext.getCurrentStep()` (`EntityCollection.createQueryContext`) and their plans are used only for `.getSorters()` / `.getFilter()` — `planNestedQuery` results never have `.execute()` called on them, so `fabricateExtraResults()` is never reached on a nested context.

Also corrects the `start` JavaDoc on `QueryTelemetry` and the matching description on `QueryTelemetryDescriptor`. Both described a wall-clock "date and time" for what is `System.nanoTime()` — a monotonic counter with no defined epoch, which must not be rendered as a date. Same defect class (a contract that does not match behaviour), and it is part of what made the payload bug hard to see.

## Why no test caught it

- `PreferIndexScanDebugModeFunctionalTest` reads telemetry, but through a `containsPhase` tree-walk looking for `EXECUTION_PREFETCH` — a phase that stays reachable below the truncated `EXECUTION` root, so the walk kept succeeding while the planning half was missing.
- `QueryTelemetryTest` is a pure unit test: every case constructs `new QueryTelemetry(QueryPhase.X)` by hand and asserts on the object it just built. Nothing asserted the shape of the telemetry a client actually receives.

`QueryTelemetryRootFunctionalTest` closes that gap. It was written first and verified RED against unmodified engine code:

```
shouldRootTelemetryAtOverallPhase
  expected: <OVERALL> but was: <EXECUTION>
shouldExposePlanningSubtreeInTelemetry
  The `PLANNING` step must be reachable from the delivered telemetry root! expected: <true> but was: <false>
shouldExposeSelectedIndexArgumentInTelemetry
  The `PLANNING_FILTER` step must be reachable from the delivered root! expected: not <null>
```

Its assertions are deliberately non-redundant: the root phase catches truncation directly; `PLANNING` **and** `EXECUTION` both being reachable proves the node returned is the one that parents both halves rather than merely being labelled `OVERALL`; the `PLANNING_FILTER` argument pins the payload the planning subtree exists to deliver; and a nonzero root `spentTime` pins the mutation-after-capture behaviour described above.

## Verification

- New test green on the embedded path.
- 372 tests green across all 11 telemetry-touching classes, including both gRPC extra-result builders (`GrpcQueryTelemetryBuilderTest`, `GrpcExtraResultsBuilderTest`) and the driver path (`EvitaClientReadOnlyTest`, `EvitaSessionServiceFunctionalTest`).
- The truncation was reproduced **pre-fix** against the public demo server on REST and GraphQL. Those two surfaces were **not** re-verified post-fix — the fix is verified on the embedded path only, and all four surfaces share the single call site.
- Full suite not run locally; left to CI.

## Scope

Out-of-scope follow-ups are recorded on #1337 and deliberately not addressed here:

- REST OpenAPI schema/payload mismatch — `QueryTelemetryDescriptor` declares 5 properties with `spentTime` typed `String`, while the payload has 6 with `spentTime` as a number.
- `telemetry.md` documents a GraphQL `format` argument that no longer exists in the builder.
- Telemetry carries no structured cardinalities or costs; estimated cost survives only as a substring of prose.

Note that this fix makes the existing `telemetry.md` samples correct again — they always showed the full `OVERALL → PLANNING + EXECUTION` tree — so no documentation regeneration is needed. Their `formattedSpentTime` staleness remains, and is on the follow-up list.
