### PR TITLE
feat: report telemetry start as an offset and anchor the tree with startedAt

### DIFF
--- a/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/QueryTelemetry.java
+++ b/evita_api/src/main/java/io/evitadb/api/requestResponse/extraResult/QueryTelemetry.java
@@ -31,8 +31,10 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import java.io.Serial;
+import java.time.OffsetDateTime;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -51,11 +53,16 @@ public class QueryTelemetry implements EvitaResponseExtraResult {
 	 */
 	@Getter private final QueryPhase operation;
 	/**
-	 * Start of this step as read from {@link System#nanoTime()} in nanoseconds.
+	 * Start of this step in nanoseconds. It is never a wall-clock timestamp and must not be rendered as a date.
 	 *
-	 * This is a monotonic counter with no defined epoch - it is NOT a wall-clock timestamp and must not be
-	 * rendered as a date. It is only meaningful relative to another `start` from the same tree, typically as an
-	 * offset from the root step.
+	 * The exact meaning depends on how the telemetry was obtained:
+	 *
+	 * - **embedded** - the raw {@link System#nanoTime()} reading, i.e. a monotonic counter with no defined epoch.
+	 *   It is only meaningful relative to another `nanoTime` reading taken in the same JVM - either another `start`
+	 *   from this tree, or one the caller took itself.
+	 * - **through a remote client** (gRPC / REST / GraphQL) - the number of nanoseconds elapsed since the root step
+	 *   of this tree began, so the root always reports `0`. The raw reading is taken on the server and carries no
+	 *   epoch, which would make it meaningless to a remote client, so the external APIs normalize it.
 	 */
 	@Getter private final long start;
 	/**
@@ -70,27 +77,62 @@ public class QueryTelemetry implements EvitaResponseExtraResult {
 	 * Duration in nanoseconds.
 	 */
 	@Getter private long spentTime;
+	/**
+	 * Wall-clock instant at which the **root** step of this tree began.
+	 *
+	 * Unlike {@link #start}, this one *is* a real timestamp and can be rendered as a date - it is what anchors the
+	 * whole tree in time, so a telemetry profile can be correlated with logs, traces or another query. It is captured
+	 * once per query and only for the root step; every other node reports `null` and its own wall-clock position is
+	 * derived as `startedAt` plus that node's `start` offset.
+	 */
+	@Nullable @Getter private final OffsetDateTime startedAt;
+
+	/**
+	 * Creates the **root** of a telemetry tree, stamping it with the wall-clock instant at which the query began.
+	 * Use this exactly once per query - inner steps are added through {@link #addStep(QueryPhase, String...)}.
+	 */
+	@Nonnull
+	public static QueryTelemetry root(@Nonnull QueryPhase operation, @Nonnull String... arguments) {
+		return new QueryTelemetry(operation, OffsetDateTime.now(), arguments);
+	}
 
 	/**
 	 * This constructor should be used when the query telemetry is built up from scratch.
 	 */
 	public QueryTelemetry(@Nonnull QueryPhase operation, @Nonnull String... arguments) {
-		this.operation = operation;
-		this.arguments = arguments;
-		this.start = System.nanoTime();
+		this(operation, (OffsetDateTime) null, arguments);
 	}
 
 	/**
 	 * This constructor should be used for query telemetry deserialization.
 	 */
 	public QueryTelemetry(@Nonnull QueryPhase operation, long start, long spentTime, @Nonnull String[] arguments, @Nonnull QueryTelemetry[] steps) {
+		this(operation, start, spentTime, null, arguments, steps);
+	}
+
+	/**
+	 * This constructor should be used for query telemetry deserialization of a tree whose root carries the wall-clock
+	 * instant the query started at.
+	 */
+	public QueryTelemetry(@Nonnull QueryPhase operation, long start, long spentTime, @Nullable OffsetDateTime startedAt, @Nonnull String[] arguments, @Nonnull QueryTelemetry[] steps) {
 		this.operation = operation;
 		this.start = start;
 		this.spentTime = spentTime;
+		this.startedAt = startedAt;
 		this.arguments = arguments;
 		for (final QueryTelemetry step : steps) {
 			addStep(step);
 		}
+	}
+
+	/**
+	 * Internal constructor allowing the root step to be stamped with the wall-clock instant of the query start.
+	 */
+	private QueryTelemetry(@Nonnull QueryPhase operation, @Nullable OffsetDateTime startedAt, @Nonnull String... arguments) {
+		this.operation = operation;
+		this.arguments = arguments;
+		this.startedAt = startedAt;
+		this.start = System.nanoTime();
 	}
 
 	/**

--- a/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
+++ b/evita_engine/src/main/java/io/evitadb/core/catalog/Catalog.java
@@ -2383,7 +2383,7 @@ public final class Catalog
 			this,
 			null,
 			session, evitaRequest,
-			evitaRequest.isQueryTelemetryRequested() ? new QueryTelemetry(QueryPhase.OVERALL) : null,
+			evitaRequest.isQueryTelemetryRequested() ? QueryTelemetry.root(QueryPhase.OVERALL) : null,
 			Collections.emptyMap(),
 			Collections.emptyMap(),
 			this.cacheSupervisor

--- a/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
+++ b/evita_engine/src/main/java/io/evitadb/core/collection/EntityCollection.java
@@ -1572,7 +1572,7 @@ public final class EntityCollection implements
 			this.catalog,
 			this,
 			session, evitaRequest,
-			evitaRequest.isQueryTelemetryRequested() ? new QueryTelemetry(QueryPhase.OVERALL) : null,
+			evitaRequest.isQueryTelemetryRequested() ? QueryTelemetry.root(QueryPhase.OVERALL) : null,
 			this.indexes,
 			this.indexesByPrimaryKey,
 			this.cacheSupervisor

--- a/evita_engine/src/main/java/io/evitadb/core/query/QueryExecutionContext.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/QueryExecutionContext.java
@@ -478,7 +478,7 @@ public class QueryExecutionContext implements Closeable {
 	@Nonnull
 	public Optional<QueryTelemetry> getTelemetryRoot() {
 		if (isDryRun()) {
-			return of(new QueryTelemetry(QueryPhase.OVERALL));
+			return of(QueryTelemetry.root(QueryPhase.OVERALL));
 		} else {
 			return this.queryContext.getEvitaRequest().isQueryTelemetryRequested() ?
 				of(this.queryContext.getTelemetryRoot()) : empty();

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/dto/QueryTelemetryDto.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/dto/QueryTelemetryDto.java
@@ -27,11 +27,18 @@ import io.evitadb.api.requestResponse.extraResult.QueryTelemetry;
 import io.evitadb.utils.StringUtils;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 
 /**
  * External API DTO for {@link QueryTelemetry}.
+ *
+ * Unlike {@link QueryTelemetry#getStart()}, which carries the raw server side {@link System#nanoTime()} reading,
+ * the `start` of this DTO is normalized to the number of nanoseconds elapsed since the root step began - the root
+ * therefore always reports `0`. The raw reading has no defined epoch and is taken on the server, which makes it
+ * meaningless to a remote client; only the offset is.
  *
  * @author Lukáš Hornych, FG Forrest a.s. (c) 2022
  */
@@ -40,16 +47,38 @@ public record QueryTelemetryDto(@Nonnull String operation,
                                 @Nonnull List<QueryTelemetryDto> steps,
                                 @Nonnull List<String> arguments,
                                 long spentTime,
-                                @Nonnull String formattedSpentTime) {
+                                @Nonnull String formattedSpentTime,
+                                @Nullable String startedAt) {
 
+	/**
+	 * Converts the passed telemetry tree to its DTO form.
+	 *
+	 * @param queryTelemetry **root** of the telemetry tree - the start of this very node becomes the zero point
+	 *                       every other node in the tree is expressed against
+	 */
+	@Nonnull
 	public static QueryTelemetryDto from(@Nonnull QueryTelemetry queryTelemetry) {
+		return from(queryTelemetry, queryTelemetry.getStart());
+	}
+
+	/**
+	 * Recursively converts a single node of the telemetry tree, normalizing its start against the root step.
+	 *
+	 * @param queryTelemetry node to be converted
+	 * @param rootStart      raw `nanoTime` reading of the root step of the entire tree
+	 */
+	@Nonnull
+	private static QueryTelemetryDto from(@Nonnull QueryTelemetry queryTelemetry, long rootStart) {
 		return new QueryTelemetryDto(
 			queryTelemetry.getOperation().toString(),
-			queryTelemetry.getStart(),
-			queryTelemetry.getSteps().stream().map(QueryTelemetryDto::from).toList(),
+			queryTelemetry.getStart() - rootStart,
+			queryTelemetry.getSteps().stream().map(it -> from(it, rootStart)).toList(),
 			Arrays.stream(queryTelemetry.getArguments()).map(Object::toString).toList(),
 			queryTelemetry.getSpentTime(),
-			StringUtils.formatNano(queryTelemetry.getSpentTime())
+			StringUtils.formatNano(queryTelemetry.getSpentTime()),
+			// only the root step carries the wall-clock stamp that anchors the whole tree in time
+			queryTelemetry.getStartedAt() == null ?
+				null : DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(queryTelemetry.getStartedAt())
 		);
 	}
 }

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/model/extraResult/QueryTelemetryDescriptor.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/model/extraResult/QueryTelemetryDescriptor.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import static io.evitadb.externalApi.api.model.TypePropertyDataTypeDescriptor.nonNullListRef;
 import static io.evitadb.externalApi.api.model.PrimitivePropertyDataTypeDescriptor.nonNull;
+import static io.evitadb.externalApi.api.model.PrimitivePropertyDataTypeDescriptor.nullable;
 
 /**
  * Represents {@link io.evitadb.api.requestResponse.extraResult.QueryTelemetry}.
@@ -51,9 +52,9 @@ public interface QueryTelemetryDescriptor {
 	PropertyDescriptor START = PropertyDescriptor.builder()
 		.name("start")
 		.description("""
-            Start of this step in nanoseconds, read from a monotonic counter with no defined epoch.
-            This is not a wall-clock timestamp - it is only meaningful relative to another `start`
-            from the same telemetry tree, typically as an offset from the root step.
+            Number of nanoseconds elapsed since the root step of this telemetry tree began - the root
+            step itself therefore always reports `0`. This is not a wall-clock timestamp and must not
+            be rendered as a date.
 			""")
 		.type(nonNull(Long.class))
 		.build();
@@ -78,12 +79,21 @@ public interface QueryTelemetryDescriptor {
 			""")
 		.type(nonNull(String.class))
 		.build();
+	PropertyDescriptor STARTED_AT = PropertyDescriptor.builder()
+		.name("startedAt")
+		.description("""
+            Wall-clock instant at which the query began, in the ISO-8601 offset date-time format. Set only on
+            the root step - it anchors the whole tree in time, so the wall-clock position of any other node is
+            `startedAt` plus that node's `start` offset.
+			""")
+		.type(nullable(String.class))
+		.build();
 
 	ObjectDescriptor THIS = ObjectDescriptor.builder()
 		.name("QueryTelemetry")
 		.description("""
 			This DTO contains detailed information about query processing time and its decomposition to single operations.
 			""")
-		.staticProperties(List.of(OPERATION, START, STEPS, ARGUMENTS, SPENT_TIME))
+		.staticProperties(List.of(OPERATION, START, STEPS, ARGUMENTS, SPENT_TIME, STARTED_AT))
 		.build();
 }

--- a/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/model/extraResult/QueryTelemetryDescriptor.java
+++ b/evita_external_api/evita_external_api_core/src/main/java/io/evitadb/externalApi/api/catalog/dataApi/model/extraResult/QueryTelemetryDescriptor.java
@@ -52,9 +52,9 @@ public interface QueryTelemetryDescriptor {
 	PropertyDescriptor START = PropertyDescriptor.builder()
 		.name("start")
 		.description("""
-            Number of nanoseconds elapsed since the root step of this telemetry tree began - the root
-            step itself therefore always reports `0`. This is not a wall-clock timestamp and must not
-            be rendered as a date.
+			Number of nanoseconds elapsed since the root step of this telemetry tree began - the root
+			step itself therefore always reports `0`. This is not a wall-clock timestamp and must not
+			be rendered as a date.
 			""")
 		.type(nonNull(Long.class))
 		.build();
@@ -82,9 +82,9 @@ public interface QueryTelemetryDescriptor {
 	PropertyDescriptor STARTED_AT = PropertyDescriptor.builder()
 		.name("startedAt")
 		.description("""
-            Wall-clock instant at which the query began, in the ISO-8601 offset date-time format. Set only on
-            the root step - it anchors the whole tree in time, so the wall-clock position of any other node is
-            `startedAt` plus that node's `start` offset.
+			Wall-clock instant at which the query began, in the ISO-8601 offset date-time format. Set only on
+			the root step - it anchors the whole tree in time, so the wall-clock position of any other node is
+			`startedAt` plus that node's `start` offset.
 			""")
 		.type(nullable(String.class))
 		.build();

--- a/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/builders/query/extraResults/GrpcQueryTelemetryBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/server/src/main/java/io/evitadb/externalApi/grpc/builders/query/extraResults/GrpcQueryTelemetryBuilder.java
@@ -24,12 +24,14 @@
 package io.evitadb.externalApi.grpc.builders.query.extraResults;
 
 import io.evitadb.api.requestResponse.extraResult.QueryTelemetry;
+import io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter;
 import io.evitadb.externalApi.grpc.generated.GrpcQueryTelemetry;
 import io.evitadb.externalApi.grpc.requestResponse.EvitaEnumConverter;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import javax.annotation.Nonnull;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -46,19 +48,25 @@ public class GrpcQueryTelemetryBuilder {
 	/**
 	 * Converts {@link QueryTelemetry} to {@link GrpcQueryTelemetry}.
 	 *
-	 * @param queryTelemetry {@link QueryTelemetry} to be converted
+	 * The raw {@link System#nanoTime()} reading held in {@link QueryTelemetry#getStart()} is taken on the server and
+	 * has no defined epoch, which makes it meaningless to a remote client. It is therefore normalized here to the
+	 * number of nanoseconds elapsed since the root step began - the root always reports `0`.
+	 *
+	 * @param queryTelemetry **root** of the telemetry tree to be converted
 	 * @return built {@link GrpcQueryTelemetry}
 	 */
 	@Nonnull
 	public static GrpcQueryTelemetry buildQueryTelemetry(@Nonnull QueryTelemetry queryTelemetry) {
+		// the root step is the zero point every other node in the tree is expressed against
+		final long rootStart = queryTelemetry.getStart();
 		final List<GrpcQueryTelemetry> queryTelemetrySteps = new ArrayList<>();
 
 		for (QueryTelemetry step : queryTelemetry.getSteps()) {
-			queryTelemetrySteps.addAll(buildQueryTelemetrySteps(step));
+			queryTelemetrySteps.addAll(buildQueryTelemetrySteps(step, rootStart));
 		}
 
 		return buildSingleGrpcQueryTelemetry(
-			queryTelemetry, queryTelemetrySteps
+			queryTelemetry, queryTelemetrySteps, rootStart
 		);
 	}
 
@@ -66,18 +74,19 @@ public class GrpcQueryTelemetryBuilder {
 	 * Recursive called method for building {@link GrpcQueryTelemetry} with all of its steps.
 	 *
 	 * @param queryTelemetry of which steps should be converted
+	 * @param rootStart      raw `nanoTime` reading of the root step of the entire tree
 	 */
 	@Nonnull
-	private static List<GrpcQueryTelemetry> buildQueryTelemetrySteps(@Nonnull QueryTelemetry queryTelemetry) {
+	private static List<GrpcQueryTelemetry> buildQueryTelemetrySteps(@Nonnull QueryTelemetry queryTelemetry, long rootStart) {
 		final List<GrpcQueryTelemetry> children = new LinkedList<>();
 		final List<GrpcQueryTelemetry> steps = new LinkedList<>();
 		if (!queryTelemetry.getSteps().isEmpty()) {
 			for (QueryTelemetry step : queryTelemetry.getSteps()) {
-				children.addAll(buildQueryTelemetrySteps(step));
+				children.addAll(buildQueryTelemetrySteps(step, rootStart));
 			}
 		}
 
-		steps.add(buildSingleGrpcQueryTelemetry(queryTelemetry, children));
+		steps.add(buildSingleGrpcQueryTelemetry(queryTelemetry, children, rootStart));
 
 		return steps;
 	}
@@ -86,17 +95,23 @@ public class GrpcQueryTelemetryBuilder {
 	 * Method for creating {@link GrpcQueryTelemetry} from {@link QueryTelemetry}.
 	 *
 	 * @param queryTelemetry to be converted
-	 * @param steps          of the query telemetry which were computed in {@link #buildQueryTelemetrySteps(QueryTelemetry)}
+	 * @param steps          of the query telemetry which were computed in {@link #buildQueryTelemetrySteps(QueryTelemetry, long)}
+	 * @param rootStart      raw `nanoTime` reading of the root step of the entire tree
 	 * @return built {@link GrpcQueryTelemetry}
 	 */
 	@Nonnull
-	private static GrpcQueryTelemetry buildSingleGrpcQueryTelemetry(@Nonnull QueryTelemetry queryTelemetry, @Nonnull List<GrpcQueryTelemetry> steps) {
-		return GrpcQueryTelemetry.newBuilder()
+	private static GrpcQueryTelemetry buildSingleGrpcQueryTelemetry(@Nonnull QueryTelemetry queryTelemetry, @Nonnull List<GrpcQueryTelemetry> steps, long rootStart) {
+		final GrpcQueryTelemetry.Builder builder = GrpcQueryTelemetry.newBuilder()
 			.setOperation(EvitaEnumConverter.toGrpcQueryPhase(queryTelemetry.getOperation()))
-			.setStart(queryTelemetry.getStart())
+			.setStart(queryTelemetry.getStart() - rootStart)
 			.addAllSteps(steps)
 			.addAllArguments(Arrays.stream(queryTelemetry.getArguments()).map(Objects::toString).toList())
-			.setSpentTime(queryTelemetry.getSpentTime())
-			.build();
+			.setSpentTime(queryTelemetry.getSpentTime());
+		// only the root step carries the wall-clock stamp that anchors the whole tree in time
+		final OffsetDateTime startedAt = queryTelemetry.getStartedAt();
+		if (startedAt != null) {
+			builder.setStartedAt(EvitaDataTypesConverter.toGrpcOffsetDateTime(startedAt));
+		}
+		return builder.build();
 	}
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcExtraResultsOuterClass.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcExtraResultsOuterClass.java
@@ -184,35 +184,37 @@ public final class GrpcExtraResultsOuterClass {
       "childrenCount\030\004 \001(\0132\033.google.protobuf.In" +
       "t32Value\022C\n\005items\030\005 \003(\01324.io.evitadb.ext" +
       "ernalApi.grpc.generated.GrpcLevelInfo\022\021\n" +
-      "\trequested\030\006 \001(\010\"\335\001\n\022GrpcQueryTelemetry\022" +
+      "\trequested\030\006 \001(\010\"\253\002\n\022GrpcQueryTelemetry\022" +
       "H\n\toperation\030\001 \001(\01625.io.evitadb.external" +
       "Api.grpc.generated.GrpcQueryPhase\022\r\n\005sta" +
       "rt\030\002 \001(\003\022H\n\005steps\030\003 \003(\01329.io.evitadb.ext" +
       "ernalApi.grpc.generated.GrpcQueryTelemet" +
       "ry\022\021\n\targuments\030\004 \003(\t\022\021\n\tspentTime\030\005 \001(\003" +
-      "\"\353\006\n\020GrpcExtraResults\022k\n\022attributeHistog" +
-      "ram\030\001 \003(\0132O.io.evitadb.externalApi.grpc." +
-      "generated.GrpcExtraResults.AttributeHist" +
-      "ogramEntry\022L\n\016priceHistogram\030\002 \001(\01324.io." +
-      "evitadb.externalApi.grpc.generated.GrpcH" +
-      "istogram\022a\n\024facetGroupStatistics\030\003 \003(\0132?" +
-      ".io.evitadb.externalApi.grpc.generated.G" +
-      "rpcFacetGroupStatisticsB\002\030\001\022K\n\rselfHiera" +
-      "rchy\030\004 \001(\01324.io.evitadb.externalApi.grpc" +
-      ".generated.GrpcHierarchy\022Y\n\thierarchy\030\005 " +
-      "\003(\0132F.io.evitadb.externalApi.grpc.genera" +
-      "ted.GrpcExtraResults.HierarchyEntry\022Q\n\016q" +
-      "ueryTelemetry\030\006 \001(\01329.io.evitadb.externa" +
-      "lApi.grpc.generated.GrpcQueryTelemetry\022e" +
-      "\n\030referenceGroupStatistics\030\007 \003(\0132C.io.ev" +
-      "itadb.externalApi.grpc.generated.GrpcRef" +
-      "erenceGroupStatistics\032o\n\027AttributeHistog" +
-      "ramEntry\022\013\n\003key\030\001 \001(\t\022C\n\005value\030\002 \001(\01324.i" +
+      "\022L\n\tstartedAt\030\006 \001(\01329.io.evitadb.externa" +
+      "lApi.grpc.generated.GrpcOffsetDateTime\"\353" +
+      "\006\n\020GrpcExtraResults\022k\n\022attributeHistogra" +
+      "m\030\001 \003(\0132O.io.evitadb.externalApi.grpc.ge" +
+      "nerated.GrpcExtraResults.AttributeHistog" +
+      "ramEntry\022L\n\016priceHistogram\030\002 \001(\01324.io.ev" +
+      "itadb.externalApi.grpc.generated.GrpcHis" +
+      "togram\022a\n\024facetGroupStatistics\030\003 \003(\0132?.i" +
       "o.evitadb.externalApi.grpc.generated.Grp" +
-      "cHistogram:\0028\001\032f\n\016HierarchyEntry\022\013\n\003key\030" +
-      "\001 \001(\t\022C\n\005value\030\002 \001(\01324.io.evitadb.extern" +
-      "alApi.grpc.generated.GrpcHierarchy:\0028\001B\014" +
-      "P\001\252\002\007EvitaDBb\006proto3"
+      "cFacetGroupStatisticsB\002\030\001\022K\n\rselfHierarc" +
+      "hy\030\004 \001(\01324.io.evitadb.externalApi.grpc.g" +
+      "enerated.GrpcHierarchy\022Y\n\thierarchy\030\005 \003(" +
+      "\0132F.io.evitadb.externalApi.grpc.generate" +
+      "d.GrpcExtraResults.HierarchyEntry\022Q\n\016que" +
+      "ryTelemetry\030\006 \001(\01329.io.evitadb.externalA" +
+      "pi.grpc.generated.GrpcQueryTelemetry\022e\n\030" +
+      "referenceGroupStatistics\030\007 \003(\0132C.io.evit" +
+      "adb.externalApi.grpc.generated.GrpcRefer" +
+      "enceGroupStatistics\032o\n\027AttributeHistogra" +
+      "mEntry\022\013\n\003key\030\001 \001(\t\022C\n\005value\030\002 \001(\01324.io." +
+      "evitadb.externalApi.grpc.generated.GrpcH" +
+      "istogram:\0028\001\032f\n\016HierarchyEntry\022\013\n\003key\030\001 " +
+      "\001(\t\022C\n\005value\030\002 \001(\01324.io.evitadb.external" +
+      "Api.grpc.generated.GrpcHierarchy:\0028\001B\014P\001" +
+      "\252\002\007EvitaDBb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -287,7 +289,7 @@ public final class GrpcExtraResultsOuterClass {
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryTelemetry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_evitadb_externalApi_grpc_generated_GrpcQueryTelemetry_descriptor,
-        new java.lang.String[] { "Operation", "Start", "Steps", "Arguments", "SpentTime", });
+        new java.lang.String[] { "Operation", "Start", "Steps", "Arguments", "SpentTime", "StartedAt", });
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcExtraResults_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_io_evitadb_externalApi_grpc_generated_GrpcExtraResults_fieldAccessorTable = new

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryTelemetry.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryTelemetry.java
@@ -70,6 +70,7 @@ private static final long serialVersionUID = 0L;
             io.evitadb.externalApi.grpc.generated.GrpcQueryTelemetry.class, io.evitadb.externalApi.grpc.generated.GrpcQueryTelemetry.Builder.class);
   }
 
+  private int bitField0_;
   public static final int OPERATION_FIELD_NUMBER = 1;
   private int operation_ = 0;
   /**
@@ -100,7 +101,8 @@ private static final long serialVersionUID = 0L;
   private long start_ = 0L;
   /**
    * <pre>
-   * Date and time of the start of this step in nanoseconds.
+   * Number of nanoseconds elapsed since the root step of this telemetry tree began - the root step itself
+   * therefore always reports 0. This is not a wall-clock timestamp and must not be rendered as a date.
    * </pre>
    *
    * <code>int64 start = 2;</code>
@@ -240,6 +242,47 @@ private static final long serialVersionUID = 0L;
     return spentTime_;
   }
 
+  public static final int STARTEDAT_FIELD_NUMBER = 6;
+  private io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt_;
+  /**
+   * <pre>
+   * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+   * so the wall-clock position of any other node is startedAt plus that node's start offset.
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+   * @return Whether the startedAt field is set.
+   */
+  @java.lang.Override
+  public boolean hasStartedAt() {
+    return ((bitField0_ & 0x00000001) != 0);
+  }
+  /**
+   * <pre>
+   * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+   * so the wall-clock position of any other node is startedAt plus that node's start offset.
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+   * @return The startedAt.
+   */
+  @java.lang.Override
+  public io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getStartedAt() {
+    return startedAt_ == null ? io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.getDefaultInstance() : startedAt_;
+  }
+  /**
+   * <pre>
+   * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+   * so the wall-clock position of any other node is startedAt plus that node's start offset.
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+   */
+  @java.lang.Override
+  public io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder getStartedAtOrBuilder() {
+    return startedAt_ == null ? io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.getDefaultInstance() : startedAt_;
+  }
+
   private byte memoizedIsInitialized = -1;
   @java.lang.Override
   public final boolean isInitialized() {
@@ -268,6 +311,9 @@ private static final long serialVersionUID = 0L;
     }
     if (spentTime_ != 0L) {
       output.writeInt64(5, spentTime_);
+    }
+    if (((bitField0_ & 0x00000001) != 0)) {
+      output.writeMessage(6, getStartedAt());
     }
     getUnknownFields().writeTo(output);
   }
@@ -302,6 +348,10 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeInt64Size(5, spentTime_);
     }
+    if (((bitField0_ & 0x00000001) != 0)) {
+      size += com.google.protobuf.CodedOutputStream
+        .computeMessageSize(6, getStartedAt());
+    }
     size += getUnknownFields().getSerializedSize();
     memoizedSize = size;
     return size;
@@ -326,6 +376,11 @@ private static final long serialVersionUID = 0L;
         .equals(other.getArgumentsList())) return false;
     if (getSpentTime()
         != other.getSpentTime()) return false;
+    if (hasStartedAt() != other.hasStartedAt()) return false;
+    if (hasStartedAt()) {
+      if (!getStartedAt()
+          .equals(other.getStartedAt())) return false;
+    }
     if (!getUnknownFields().equals(other.getUnknownFields())) return false;
     return true;
   }
@@ -353,6 +408,10 @@ private static final long serialVersionUID = 0L;
     hash = (37 * hash) + SPENTTIME_FIELD_NUMBER;
     hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
         getSpentTime());
+    if (hasStartedAt()) {
+      hash = (37 * hash) + STARTEDAT_FIELD_NUMBER;
+      hash = (53 * hash) + getStartedAt().hashCode();
+    }
     hash = (29 * hash) + getUnknownFields().hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -476,13 +535,20 @@ private static final long serialVersionUID = 0L;
 
     // Construct using io.evitadb.externalApi.grpc.generated.GrpcQueryTelemetry.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getStepsFieldBuilder();
+        getStartedAtFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -500,6 +566,11 @@ private static final long serialVersionUID = 0L;
       arguments_ =
           com.google.protobuf.LazyStringArrayList.emptyList();
       spentTime_ = 0L;
+      startedAt_ = null;
+      if (startedAtBuilder_ != null) {
+        startedAtBuilder_.dispose();
+        startedAtBuilder_ = null;
+      }
       return this;
     }
 
@@ -559,6 +630,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000010) != 0)) {
         result.spentTime_ = spentTime_;
       }
+      int to_bitField0_ = 0;
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        result.startedAt_ = startedAtBuilder_ == null
+            ? startedAt_
+            : startedAtBuilder_.build();
+        to_bitField0_ |= 0x00000001;
+      }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -650,6 +729,9 @@ private static final long serialVersionUID = 0L;
       if (other.getSpentTime() != 0L) {
         setSpentTime(other.getSpentTime());
       }
+      if (other.hasStartedAt()) {
+        mergeStartedAt(other.getStartedAt());
+      }
       this.mergeUnknownFields(other.getUnknownFields());
       onChanged();
       return this;
@@ -710,6 +792,13 @@ private static final long serialVersionUID = 0L;
               bitField0_ |= 0x00000010;
               break;
             } // case 40
+            case 50: {
+              input.readMessage(
+                  getStartedAtFieldBuilder().getBuilder(),
+                  extensionRegistry);
+              bitField0_ |= 0x00000020;
+              break;
+            } // case 50
             default: {
               if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                 done = true; // was an endgroup tag
@@ -803,7 +892,8 @@ private static final long serialVersionUID = 0L;
     private long start_ ;
     /**
      * <pre>
-     * Date and time of the start of this step in nanoseconds.
+     * Number of nanoseconds elapsed since the root step of this telemetry tree began - the root step itself
+     * therefore always reports 0. This is not a wall-clock timestamp and must not be rendered as a date.
      * </pre>
      *
      * <code>int64 start = 2;</code>
@@ -815,7 +905,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time of the start of this step in nanoseconds.
+     * Number of nanoseconds elapsed since the root step of this telemetry tree began - the root step itself
+     * therefore always reports 0. This is not a wall-clock timestamp and must not be rendered as a date.
      * </pre>
      *
      * <code>int64 start = 2;</code>
@@ -831,7 +922,8 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Date and time of the start of this step in nanoseconds.
+     * Number of nanoseconds elapsed since the root step of this telemetry tree began - the root step itself
+     * therefore always reports 0. This is not a wall-clock timestamp and must not be rendered as a date.
      * </pre>
      *
      * <code>int64 start = 2;</code>
@@ -1345,6 +1437,172 @@ private static final long serialVersionUID = 0L;
       spentTime_ = 0L;
       onChanged();
       return this;
+    }
+
+    private io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt_;
+    private com.google.protobuf.SingleFieldBuilderV3<
+        io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> startedAtBuilder_;
+    /**
+     * <pre>
+     * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+     * so the wall-clock position of any other node is startedAt plus that node's start offset.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+     * @return Whether the startedAt field is set.
+     */
+    public boolean hasStartedAt() {
+      return ((bitField0_ & 0x00000020) != 0);
+    }
+    /**
+     * <pre>
+     * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+     * so the wall-clock position of any other node is startedAt plus that node's start offset.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+     * @return The startedAt.
+     */
+    public io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getStartedAt() {
+      if (startedAtBuilder_ == null) {
+        return startedAt_ == null ? io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.getDefaultInstance() : startedAt_;
+      } else {
+        return startedAtBuilder_.getMessage();
+      }
+    }
+    /**
+     * <pre>
+     * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+     * so the wall-clock position of any other node is startedAt plus that node's start offset.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+     */
+    public Builder setStartedAt(io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value) {
+      if (startedAtBuilder_ == null) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        startedAt_ = value;
+      } else {
+        startedAtBuilder_.setMessage(value);
+      }
+      bitField0_ |= 0x00000020;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+     * so the wall-clock position of any other node is startedAt plus that node's start offset.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+     */
+    public Builder setStartedAt(
+        io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder builderForValue) {
+      if (startedAtBuilder_ == null) {
+        startedAt_ = builderForValue.build();
+      } else {
+        startedAtBuilder_.setMessage(builderForValue.build());
+      }
+      bitField0_ |= 0x00000020;
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+     * so the wall-clock position of any other node is startedAt plus that node's start offset.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+     */
+    public Builder mergeStartedAt(io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime value) {
+      if (startedAtBuilder_ == null) {
+        if (((bitField0_ & 0x00000020) != 0) &&
+          startedAt_ != null &&
+          startedAt_ != io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.getDefaultInstance()) {
+          getStartedAtBuilder().mergeFrom(value);
+        } else {
+          startedAt_ = value;
+        }
+      } else {
+        startedAtBuilder_.mergeFrom(value);
+      }
+      if (startedAt_ != null) {
+        bitField0_ |= 0x00000020;
+        onChanged();
+      }
+      return this;
+    }
+    /**
+     * <pre>
+     * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+     * so the wall-clock position of any other node is startedAt plus that node's start offset.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+     */
+    public Builder clearStartedAt() {
+      bitField0_ = (bitField0_ & ~0x00000020);
+      startedAt_ = null;
+      if (startedAtBuilder_ != null) {
+        startedAtBuilder_.dispose();
+        startedAtBuilder_ = null;
+      }
+      onChanged();
+      return this;
+    }
+    /**
+     * <pre>
+     * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+     * so the wall-clock position of any other node is startedAt plus that node's start offset.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+     */
+    public io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder getStartedAtBuilder() {
+      bitField0_ |= 0x00000020;
+      onChanged();
+      return getStartedAtFieldBuilder().getBuilder();
+    }
+    /**
+     * <pre>
+     * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+     * so the wall-clock position of any other node is startedAt plus that node's start offset.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+     */
+    public io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder getStartedAtOrBuilder() {
+      if (startedAtBuilder_ != null) {
+        return startedAtBuilder_.getMessageOrBuilder();
+      } else {
+        return startedAt_ == null ?
+            io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.getDefaultInstance() : startedAt_;
+      }
+    }
+    /**
+     * <pre>
+     * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+     * so the wall-clock position of any other node is startedAt plus that node's start offset.
+     * </pre>
+     *
+     * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+     */
+    private com.google.protobuf.SingleFieldBuilderV3<
+        io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder> 
+        getStartedAtFieldBuilder() {
+      if (startedAtBuilder_ == null) {
+        startedAtBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+            io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime.Builder, io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder>(
+                getStartedAt(),
+                getParentForChildren(),
+                isClean());
+        startedAt_ = null;
+      }
+      return startedAtBuilder_;
     }
     @java.lang.Override
     public final Builder setUnknownFields(

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryTelemetryOrBuilder.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/generated/GrpcQueryTelemetryOrBuilder.java
@@ -52,7 +52,8 @@ public interface GrpcQueryTelemetryOrBuilder extends
 
   /**
    * <pre>
-   * Date and time of the start of this step in nanoseconds.
+   * Number of nanoseconds elapsed since the root step of this telemetry tree began - the root step itself
+   * therefore always reports 0. This is not a wall-clock timestamp and must not be rendered as a date.
    * </pre>
    *
    * <code>int64 start = 2;</code>
@@ -154,4 +155,34 @@ public interface GrpcQueryTelemetryOrBuilder extends
    * @return The spentTime.
    */
   long getSpentTime();
+
+  /**
+   * <pre>
+   * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+   * so the wall-clock position of any other node is startedAt plus that node's start offset.
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+   * @return Whether the startedAt field is set.
+   */
+  boolean hasStartedAt();
+  /**
+   * <pre>
+   * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+   * so the wall-clock position of any other node is startedAt plus that node's start offset.
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+   * @return The startedAt.
+   */
+  io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime getStartedAt();
+  /**
+   * <pre>
+   * Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+   * so the wall-clock position of any other node is startedAt plus that node's start offset.
+   * </pre>
+   *
+   * <code>.io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTime startedAt = 6;</code>
+   */
+  io.evitadb.externalApi.grpc.generated.GrpcOffsetDateTimeOrBuilder getStartedAtOrBuilder();
 }

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/ResponseConverter.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/ResponseConverter.java
@@ -77,6 +77,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toBigDecimal;
+import static io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter.toOffsetDateTime;
 import static io.evitadb.externalApi.grpc.requestResponse.EvitaEnumConverter.toQueryPhase;
 import static io.evitadb.externalApi.grpc.requestResponse.data.EntityConverter.SEALED_ENTITY_TYPE_CONVERTER;
 import static io.evitadb.externalApi.grpc.requestResponse.data.EntityConverter.toEntityReference;
@@ -544,6 +545,8 @@ public class ResponseConverter {
 			toQueryPhase(grpcQueryTelemetry.getOperation()),
 			grpcQueryTelemetry.getStart(),
 			grpcQueryTelemetry.getSpentTime(),
+			// only the root step carries the wall-clock stamp that anchors the whole tree in time
+			grpcQueryTelemetry.hasStartedAt() ? toOffsetDateTime(grpcQueryTelemetry.getStartedAt()) : null,
 			grpcQueryTelemetry.getArgumentsList().toArray(String[]::new),
 			grpcQueryTelemetry.getStepsList().stream().map(ResponseConverter::toQueryTelemetry).toArray(QueryTelemetry[]::new)
 		);

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcExtraResults.proto
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/resources/META-INF/io/evitadb/externalApi/grpc/GrpcExtraResults.proto
@@ -150,7 +150,8 @@ message GrpcLevelInfo {
 message GrpcQueryTelemetry {
   // Phase of the query processing.
   GrpcQueryPhase operation = 1;
-  // Date and time of the start of this step in nanoseconds.
+  // Number of nanoseconds elapsed since the root step of this telemetry tree began - the root step itself
+  // therefore always reports 0. This is not a wall-clock timestamp and must not be rendered as a date.
   int64 start = 2;
   // Internal steps of this telemetry step (operation decomposition).
   repeated GrpcQueryTelemetry steps = 3;
@@ -158,6 +159,9 @@ message GrpcQueryTelemetry {
   repeated string arguments = 4;
   // Duration in nanoseconds.
   int64 spentTime = 5;
+  // Wall-clock instant at which the query began. Set only on the root step - it anchors the whole tree in time,
+  // so the wall-clock position of any other node is startedAt plus that node's start offset.
+  GrpcOffsetDateTime startedAt = 6;
 }
 
 // This DTO contains extra results that are computed based on the query results.

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/query/QueryTelemetryRootFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/query/QueryTelemetryRootFunctionalTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.time.OffsetDateTime;
 
 import static io.evitadb.api.query.QueryConstraints.attributeStartsWith;
 import static io.evitadb.api.query.QueryConstraints.collection;
@@ -51,7 +52,9 @@ import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.QUERY;
 import static io.evitadb.test.TestTags.REQUIRE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -116,6 +119,31 @@ class QueryTelemetryRootFunctionalTest implements EvitaTestSupport {
 			telemetry.getSpentTime() > 0,
 			"The root step must report a duration - the client reads it as the total query time!"
 		);
+	}
+
+	@Test
+	@DisplayName("the root node is stamped with the wall-clock instant the query began")
+	void shouldStampRootTelemetryWithWallClockStart() {
+		final OffsetDateTime before = OffsetDateTime.now();
+		final QueryTelemetry telemetry = queryTelemetryOf();
+		final OffsetDateTime after = OffsetDateTime.now();
+
+		final OffsetDateTime startedAt = telemetry.getStartedAt();
+		assertNotNull(
+			startedAt,
+			"The root step must carry the wall-clock instant of the query start - it is what anchors the whole " +
+				"telemetry tree in time!"
+		);
+		assertFalse(
+			startedAt.isBefore(before) || startedAt.isAfter(after),
+			"The wall-clock stamp must be taken while the query runs, but " + startedAt + " lies outside <" +
+				before + ", " + after + ">!"
+		);
+
+		// only the root anchors the tree - inner steps derive their position from `startedAt` plus their own offset
+		for (final QueryTelemetry step : telemetry.getSteps()) {
+			assertNull(step.getStartedAt(), "Only the root step may carry the wall-clock stamp!");
+		}
 	}
 
 	@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadOnlyTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/driver/EvitaClientReadOnlyTest.java
@@ -1283,7 +1283,12 @@ class EvitaClientReadOnlyTest implements TestConstants, EvitaTestSupport {
 		assertNotNull(result);
 		assertTrue(result.getTotalRecordCount() > 0);
 
-		assertNotNull(result.getExtraResult(QueryTelemetry.class));
+		final QueryTelemetry telemetry = result.getExtraResult(QueryTelemetry.class);
+		assertNotNull(telemetry);
+		// the server normalizes `start` to an offset from the root step before it goes on the wire, so the tree
+		// rebuilt on the client side must report zero at its root, anchored by the wall-clock stamp
+		assertEquals(0L, telemetry.getStart());
+		assertNotNull(telemetry.getStartedAt());
 
 		final PriceHistogram priceHistogram = result.getExtraResult(PriceHistogram.class);
 		assertNotNull(priceHistogram);
@@ -1414,7 +1419,12 @@ class EvitaClientReadOnlyTest implements TestConstants, EvitaTestSupport {
 		assertNotNull(result);
 		assertTrue(result.getTotalRecordCount() > 0);
 
-		assertNotNull(result.getExtraResult(QueryTelemetry.class));
+		final QueryTelemetry telemetry = result.getExtraResult(QueryTelemetry.class);
+		assertNotNull(telemetry);
+		// the server normalizes `start` to an offset from the root step before it goes on the wire, so the tree
+		// rebuilt on the client side must report zero at its root, anchored by the wall-clock stamp
+		assertEquals(0L, telemetry.getStart());
+		assertNotNull(telemetry.getStartedAt());
 
 		final PriceHistogram priceHistogram = result.getExtraResult(PriceHistogram.class);
 		assertNotNull(priceHistogram);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/api/catalog/dataApi/dto/QueryTelemetryDtoTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/api/catalog/dataApi/dto/QueryTelemetryDtoTest.java
@@ -1,0 +1,178 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2025
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.externalApi.api.catalog.dataApi.dto;
+
+import io.evitadb.api.requestResponse.extraResult.QueryTelemetry;
+import io.evitadb.api.requestResponse.extraResult.QueryTelemetry.QueryPhase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static io.evitadb.test.TestTags.EXTERNAL_API;
+import static io.evitadb.test.TestTags.QUERY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This test verifies that {@link QueryTelemetryDto} normalizes the raw {@link System#nanoTime()} readings of
+ * {@link QueryTelemetry#getStart()} into offsets relative to the root step. The raw readings are taken on the server
+ * and carry no epoch, so they are meaningless to a REST / GraphQL client - only the offset is.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2025
+ */
+@Tag(EXTERNAL_API)
+@Tag(QUERY)
+@DisplayName("QueryTelemetry DTO conversion for the JSON based APIs")
+class QueryTelemetryDtoTest {
+	/**
+	 * Arbitrary but realistic `nanoTime` base - deliberately large, so that a conversion which forgets to subtract
+	 * the root start cannot accidentally produce the expected offsets.
+	 */
+	private static final long BASE_NANO_TIME = 987_654_321_000L;
+
+	@Test
+	@DisplayName("Root step reports zero start and descendants report their offset from it")
+	void shouldNormalizeStartToOffsetFromRootThroughWholeTree() {
+		final QueryTelemetryDto converted = QueryTelemetryDto.from(createDeepTelemetryTree());
+
+		// the root is by definition the zero point of the query
+		assertEquals(0L, converted.start());
+
+		final QueryTelemetryDto planning = childAt(converted, 0);
+		assertEquals(100L, planning.start());
+
+		final QueryTelemetryDto planningFilter = childAt(planning, 0);
+		assertEquals(150L, planningFilter.start());
+
+		// fourth level - guards the recursion actually threads the root start all the way down
+		final QueryTelemetryDto planningFilterAlternative = childAt(planningFilter, 0);
+		assertEquals(175L, planningFilterAlternative.start());
+
+		final QueryTelemetryDto execution = childAt(converted, 1);
+		assertEquals(400L, execution.start());
+	}
+
+	@Test
+	@DisplayName("Normalization leaves the remaining contents of the node untouched")
+	void shouldKeepOtherPropertiesIntactWhenNormalizingStart() {
+		final QueryTelemetryDto converted = QueryTelemetryDto.from(createDeepTelemetryTree());
+
+		assertEquals(QueryPhase.OVERALL.toString(), converted.operation());
+		assertEquals(500L, converted.spentTime());
+		assertTrue(converted.formattedSpentTime().length() > 0);
+		assertEquals(List.of(), converted.arguments());
+
+		final QueryTelemetryDto planningFilter = childAt(childAt(converted, 0), 0);
+		assertEquals(QueryPhase.PLANNING_FILTER.toString(), planningFilter.operation());
+		assertEquals(30L, planningFilter.spentTime());
+		assertEquals(List.of("Selected index: PRODUCT"), planningFilter.arguments());
+	}
+
+	@Test
+	@DisplayName("Wall-clock start of the query is carried on the root step in ISO-8601 form")
+	void shouldExposeStartedAtOnRootStepOnly() {
+		final OffsetDateTime startedAt = OffsetDateTime.of(2026, 7, 30, 12, 34, 56, 0, ZoneOffset.ofHours(2));
+		final QueryTelemetryDto converted = QueryTelemetryDto.from(createDeepTelemetryTree(startedAt));
+
+		assertEquals(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(startedAt), converted.startedAt());
+
+		// only the root anchors the tree in time - every other node derives its position from `startedAt` + `start`
+		final QueryTelemetryDto planning = childAt(converted, 0);
+		assertNull(planning.startedAt());
+		assertNull(childAt(planning, 0).startedAt());
+		assertNull(childAt(converted, 1).startedAt());
+	}
+
+	@Test
+	@DisplayName("A tree with no wall-clock stamp converts without one")
+	void shouldTolerateMissingStartedAt() {
+		final QueryTelemetryDto converted = QueryTelemetryDto.from(createDeepTelemetryTree());
+
+		assertNull(converted.startedAt());
+	}
+
+	@Test
+	@DisplayName("A childless root still normalizes to zero")
+	void shouldNormalizeStartOfSoleRootStep() {
+		final QueryTelemetry lonelyRoot = new QueryTelemetry(
+			QueryPhase.OVERALL, BASE_NANO_TIME, 42L, new String[0], new QueryTelemetry[0]
+		);
+
+		final QueryTelemetryDto converted = QueryTelemetryDto.from(lonelyRoot);
+
+		assertEquals(0L, converted.start());
+		assertEquals(42L, converted.spentTime());
+		assertEquals(List.of(), converted.steps());
+	}
+
+	/**
+	 * Builds a deterministic four level deep telemetry tree whose starts are known constants, so that the expected
+	 * offsets can be asserted exactly.
+	 */
+	@Nonnull
+	private static QueryTelemetry createDeepTelemetryTree() {
+		return createDeepTelemetryTree(null);
+	}
+
+	/**
+	 * Builds the same tree as {@link #createDeepTelemetryTree()}, additionally stamping the root with the passed
+	 * wall-clock instant of the query start.
+	 */
+	@Nonnull
+	private static QueryTelemetry createDeepTelemetryTree(@Nullable OffsetDateTime startedAt) {
+		final QueryTelemetry planningFilterAlternative = new QueryTelemetry(
+			QueryPhase.PLANNING_FILTER_ALTERNATIVE, BASE_NANO_TIME + 175L, 10L,
+			new String[0], new QueryTelemetry[0]
+		);
+		final QueryTelemetry planningFilter = new QueryTelemetry(
+			QueryPhase.PLANNING_FILTER, BASE_NANO_TIME + 150L, 30L,
+			new String[] {"Selected index: PRODUCT"}, new QueryTelemetry[] {planningFilterAlternative}
+		);
+		final QueryTelemetry planning = new QueryTelemetry(
+			QueryPhase.PLANNING, BASE_NANO_TIME + 100L, 100L,
+			new String[0], new QueryTelemetry[] {planningFilter}
+		);
+		final QueryTelemetry execution = new QueryTelemetry(
+			QueryPhase.EXECUTION, BASE_NANO_TIME + 400L, 80L,
+			new String[0], new QueryTelemetry[0]
+		);
+		return new QueryTelemetry(
+			QueryPhase.OVERALL, BASE_NANO_TIME, 500L, startedAt,
+			new String[0], new QueryTelemetry[] {planning, execution}
+		);
+	}
+
+	@Nonnull
+	private static QueryTelemetryDto childAt(@Nonnull QueryTelemetryDto parent, int index) {
+		return parent.steps().get(index);
+	}
+}

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLAsyncQueriesFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/graphql/api/catalog/dataApi/CatalogGraphQLAsyncQueriesFunctionalTest.java
@@ -74,7 +74,13 @@ public class CatalogGraphQLAsyncQueriesFunctionalTest extends CatalogGraphQLData
 	@Test
 	@UseDataSet(GRAPHQL_THOUSAND_PRODUCTS)
 	@DisplayName("Should correctly handle multiple parallel queries")
-	@Disabled("Proof-of-concept test, if run in parallel with other tests with other evitaDBs, there is not enough threads available to execute all sub queries in parallel.")
+	@Disabled("""
+		Proof-of-concept test, if run in parallel with other tests with other evitaDBs, there is not enough threads \
+		available to execute all sub queries in parallel. Beyond that, its overlap assertion can no longer work as \
+		written: it compares `start` across queries, which only held while `start` was the server's raw \
+		`System.nanoTime()` reading. The JSON based APIs now report it as an offset from the root step of each \
+		query, so every `start` is `0`. Re-enabling this test requires a cross-query timing signal from outside \
+		the telemetry payload.""")
 	void shouldCorrectlyHandleMultipleParallelQueries(GraphQLTester tester, List<SealedEntity> originalProductEntities) {
 		final String singleQueryTemplate = """
 				product%d: queryProduct(
@@ -138,7 +144,7 @@ public class CatalogGraphQLAsyncQueriesFunctionalTest extends CatalogGraphQLData
 			queryExecutions.add(new QueryExecution(start, end));
 		});
 
-		// verify that queries where executes asynchronously
+		// verify that queries where executes asynchronously - see the @Disabled reason, this no longer holds
 		for (int i = 1; i < queryExecutions.size(); i++) {
 			final QueryExecution previousQueryExecution = queryExecutions.get(i - 1);
 			final QueryExecution currentQueryExecution = queryExecutions.get(i);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/builders/query/extraResults/GrpcQueryTelemetryBuilderTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/builders/query/extraResults/GrpcQueryTelemetryBuilderTest.java
@@ -25,11 +25,15 @@ package io.evitadb.externalApi.grpc.builders.query.extraResults;
 
 import io.evitadb.api.requestResponse.extraResult.QueryTelemetry;
 import io.evitadb.api.requestResponse.extraResult.QueryTelemetry.QueryPhase;
+import io.evitadb.externalApi.grpc.dataType.EvitaDataTypesConverter;
 import io.evitadb.externalApi.grpc.generated.GrpcQueryTelemetry;
 import io.evitadb.externalApi.grpc.testUtils.GrpcAssertions;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Random;
 import java.util.UUID;
 import org.junit.jupiter.api.Tag;
@@ -37,6 +41,9 @@ import org.junit.jupiter.api.Tag;
 import static io.evitadb.test.TestTags.GRPC;
 import static io.evitadb.test.TestTags.EXTERNAL_API;
 import static io.evitadb.test.TestTags.QUERY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This test verifies functionalities of methods in {@link GrpcQueryTelemetryBuilder} class.
@@ -50,11 +57,93 @@ class GrpcQueryTelemetryBuilderTest {
 	private static final Random random = new Random();
 	private static final int queryPhaseCount = QueryPhase.values().length;
 
+	/**
+	 * Arbitrary but realistic `nanoTime` base - deliberately large, so that a conversion which forgets to subtract
+	 * the root start cannot accidentally produce the expected offsets.
+	 */
+	private static final long BASE_NANO_TIME = 987_654_321_000L;
+
 	@Test
 	void buildQueryTelemetry() {
 		final QueryTelemetry queryTelemetry = createRandomQueryTelemetry();
 		final GrpcQueryTelemetry grpcQueryTelemetry = GrpcQueryTelemetryBuilder.buildQueryTelemetry(queryTelemetry);
 		GrpcAssertions.assertQueryTelemetry(queryTelemetry, grpcQueryTelemetry);
+	}
+
+	@Test
+	void shouldNormalizeStartToOffsetFromRootThroughWholeTree() {
+		final GrpcQueryTelemetry converted = GrpcQueryTelemetryBuilder.buildQueryTelemetry(createDeepQueryTelemetry());
+
+		// the root is by definition the zero point of the query
+		assertEquals(0L, converted.getStart());
+
+		final GrpcQueryTelemetry planning = converted.getSteps(0);
+		assertEquals(100L, planning.getStart());
+
+		final GrpcQueryTelemetry planningFilter = planning.getSteps(0);
+		assertEquals(150L, planningFilter.getStart());
+
+		// fourth level - guards the recursion actually threads the root start all the way down
+		assertEquals(175L, planningFilter.getSteps(0).getStart());
+
+		assertEquals(400L, converted.getSteps(1).getStart());
+	}
+
+	@Test
+	void shouldCarryStartedAtOnRootStepOnly() {
+		final OffsetDateTime startedAt = OffsetDateTime.of(2026, 7, 30, 12, 34, 56, 0, ZoneOffset.ofHours(2));
+		final GrpcQueryTelemetry converted = GrpcQueryTelemetryBuilder.buildQueryTelemetry(createDeepQueryTelemetry(startedAt));
+
+		assertTrue(converted.hasStartedAt());
+		assertEquals(startedAt, EvitaDataTypesConverter.toOffsetDateTime(converted.getStartedAt()));
+
+		// only the root anchors the tree in time
+		final GrpcQueryTelemetry planning = converted.getSteps(0);
+		assertFalse(planning.hasStartedAt());
+		assertFalse(planning.getSteps(0).hasStartedAt());
+		assertFalse(converted.getSteps(1).hasStartedAt());
+	}
+
+	@Test
+	void shouldTolerateMissingStartedAt() {
+		assertFalse(GrpcQueryTelemetryBuilder.buildQueryTelemetry(createDeepQueryTelemetry()).hasStartedAt());
+	}
+
+	/**
+	 * Builds a deterministic four level deep telemetry tree whose starts are known constants, so that the expected
+	 * offsets can be asserted exactly.
+	 */
+	@Nonnull
+	private static QueryTelemetry createDeepQueryTelemetry() {
+		return createDeepQueryTelemetry(null);
+	}
+
+	/**
+	 * Builds the same tree as {@link #createDeepQueryTelemetry()}, additionally stamping the root with the passed
+	 * wall-clock instant of the query start.
+	 */
+	@Nonnull
+	private static QueryTelemetry createDeepQueryTelemetry(@Nullable OffsetDateTime startedAt) {
+		final QueryTelemetry planningFilterAlternative = new QueryTelemetry(
+			QueryPhase.PLANNING_FILTER_ALTERNATIVE, BASE_NANO_TIME + 175L, 10L,
+			new String[0], new QueryTelemetry[0]
+		);
+		final QueryTelemetry planningFilter = new QueryTelemetry(
+			QueryPhase.PLANNING_FILTER, BASE_NANO_TIME + 150L, 30L,
+			new String[] {"Selected index: PRODUCT"}, new QueryTelemetry[] {planningFilterAlternative}
+		);
+		final QueryTelemetry planning = new QueryTelemetry(
+			QueryPhase.PLANNING, BASE_NANO_TIME + 100L, 100L,
+			new String[0], new QueryTelemetry[] {planningFilter}
+		);
+		final QueryTelemetry execution = new QueryTelemetry(
+			QueryPhase.EXECUTION, BASE_NANO_TIME + 400L, 80L,
+			new String[0], new QueryTelemetry[0]
+		);
+		return new QueryTelemetry(
+			QueryPhase.OVERALL, BASE_NANO_TIME, 500L, startedAt,
+			new String[0], new QueryTelemetry[] {planning, execution}
+		);
 	}
 
 	@Nonnull

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/testUtils/GrpcAssertions.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/externalApi/grpc/testUtils/GrpcAssertions.java
@@ -802,13 +802,23 @@ public class GrpcAssertions {
 	}
 
 	public static void assertQueryTelemetry(@Nonnull QueryTelemetry expectedQueryTelemetry, @Nonnull GrpcQueryTelemetry actualQueryTelemetry) {
+		assertQueryTelemetry(expectedQueryTelemetry, actualQueryTelemetry, expectedQueryTelemetry.getStart());
+	}
+
+	/**
+	 * Recursively compares a single node of the expected telemetry tree with its gRPC counterpart.
+	 *
+	 * @param rootStart raw `nanoTime` reading of the root step of the expected tree - the gRPC form reports starts
+	 *                  as offsets from it rather than as raw readings
+	 */
+	private static void assertQueryTelemetry(@Nonnull QueryTelemetry expectedQueryTelemetry, @Nonnull GrpcQueryTelemetry actualQueryTelemetry, long rootStart) {
 		assertEquals(expectedQueryTelemetry.getOperation(), QueryPhase.valueOf(actualQueryTelemetry.getOperation().name()));
-		assertEquals(expectedQueryTelemetry.getStart(), actualQueryTelemetry.getStart());
+		assertEquals(expectedQueryTelemetry.getStart() - rootStart, actualQueryTelemetry.getStart());
 		assertEquals(expectedQueryTelemetry.getSpentTime(), actualQueryTelemetry.getSpentTime());
 		assertArrayEquals(Arrays.stream(expectedQueryTelemetry.getArguments()).map(Object::toString).toArray(), actualQueryTelemetry.getArgumentsList().toArray());
 		assertEquals(expectedQueryTelemetry.getSteps().size(), actualQueryTelemetry.getStepsCount());
 		for (QueryTelemetry queryTelemetry : expectedQueryTelemetry.getSteps()) {
-			assertQueryTelemetry(queryTelemetry, actualQueryTelemetry.getStepsList().get(expectedQueryTelemetry.getSteps().indexOf(queryTelemetry)));
+			assertQueryTelemetry(queryTelemetry, actualQueryTelemetry.getStepsList().get(expectedQueryTelemetry.getSteps().indexOf(queryTelemetry)), rootStart);
 		}
 	}
 }


### PR DESCRIPTION
## Why

`QueryTelemetry.start` carried the server's raw `System.nanoTime()` reading — a monotonic counter with no defined epoch. Over the wire that value is unusable: it cannot be rendered as a time, cannot be compared to anything the client holds, and only becomes meaningful once the client subtracts the root step's start itself. Every remote client had to know that quirk and do the subtraction by hand.

## What changed

**`start` is now an offset.** The external APIs normalize it to the number of nanoseconds elapsed since the root step began, so the root reports `0` and every node is directly plottable on a timeline. Two conversion points cover all three remote surfaces:

- `QueryTelemetryDto` — REST **and** GraphQL (both serialize this record)
- `GrpcQueryTelemetryBuilder` — gRPC, and therefore `EvitaClient`

**The engine object is deliberately untouched.** `start` is `final`, and the root is handed to the client in `QueryPlan#fabricateExtraResults` *before* `finalizeTelemetry()` runs, so it cannot be rewritten in place. More importantly, for an **embedded** caller the raw reading is genuinely useful — same JVM, same clock — so normalizing there would destroy information. `QueryTelemetry#start` now documents both meanings explicitly.

**New `startedAt` on the root step.** Normalizing alone would have removed the last trace of wall-clock information from the payload, so the root is stamped with the instant the query began, captured once per query via the new `QueryTelemetry#root(...)` factory. The wall-clock position of any node is `startedAt` plus that node's `start` offset. It travels as `GrpcOffsetDateTime` over gRPC and as an **ISO-8601 string** over REST/GraphQL — those APIs use an `ObjectMapper` with no `JavaTimeModule` registered, which would fail on a raw `OffsetDateTime`.

Descriptions on `QueryTelemetryDescriptor.START` and in the `.proto` were corrected too; both previously described `start` as a "date and time".

## Compatibility

Not a breaking change in practice. Any client treating `start` as absolute was already wrong; a correct one computed `node.start - root.start`, which is exactly the new value. The gRPC field type is unchanged (`int64`); `startedAt` is a new optional field 6.

One consciously accepted edge: a **new driver against an old server** reads raw `nanoTime` as an offset and gets nonsense. The field was never usable remotely, so nothing that previously worked breaks.

## One capability is genuinely lost

`start` was the **only cross-query timing signal** the payload carried — comparing two queries' starts to prove they overlapped worked solely because every query read the same server's monotonic clock. That no longer works. `CatalogGraphQLAsyncQueriesFunctionalTest` relied on exactly this; it is `@Disabled` (and was before this change), and its `@Disabled` reason now records that the premise is gone and re-enabling needs a signal from outside the telemetry payload. The assertion itself is left intact for whoever reworks it.

## Verification

TDD throughout — every behavioural change was driven by a test that first failed for the right reason:

- `start` normalization → `expected: <0> but was: <987654321000>`
- `startedAt` wiring → `expected: not <null>`, `expected: <2026-07-30T12:34:56+02:00> but was: <null>`, `expected: <true> but was: <false>`

New/extended coverage:

- `QueryTelemetryDtoTest` (new) — offsets across a deliberately **four-level** tree, `startedAt` on the root only, and tolerance of a tree without a stamp
- `GrpcQueryTelemetryBuilderTest` — same three properties on the gRPC side; `GrpcAssertions` gained a recursive overload that compares against offsets
- `QueryTelemetryRootFunctionalTest` — pins that the **engine** actually stamps the root, that the stamp falls inside the query's own wall-clock window, and that no inner step carries one
- `EvitaClientReadOnlyTest` — previously only `assertNotNull` on the telemetry; now asserts the round-tripped root reports `start == 0` and a non-null `startedAt`, which is the end-to-end proof for gRPC

**383 tests, 0 failures, 3 skipped** across 13 telemetry-touching classes, after a full reactor rebuild.

Honest limits: REST and GraphQL are covered *through* `QueryTelemetryDto` — the record both serialize, with both call sites verified to pass the root — but no live REST/GraphQL response was inspected. gRPC is proven end-to-end by the driver test against a real server. The full suite is left to CI.

## Not addressed

The pre-existing `QueryTelemetryDescriptor` schema defects — `spentTime` declared `String` while the payload is numeric, and `formattedSpentTime` missing from the schema — remain open and are out of scope here.
