### PR TITLE
fix: DataGenerator.pickRandomFromSet hangs instead of terminating for schemas with many reference types

### DIFF
--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/fetch/EntityHierarchyFetchFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/fetch/EntityHierarchyFetchFunctionalTest.java
@@ -269,8 +269,8 @@ class EntityHierarchyFetchFunctionalTest extends AbstractEntityFetchingFunctiona
 						assertEquals(1, references.size());
 						atLeastOnePriceListBodyFound = atLeastOnePriceListBodyFound || references.stream().anyMatch(
 							it -> it.getReferencedEntity().isPresent());
-						parentEntityRef = parentEntity.getParentEntity();
 					}
+					parentEntityRef = parentEntity.getParentEntity();
 				}
 				assertTrue(atLeastOnPriceListFound, "At least one price list should be found in the hierarchy");
 				assertTrue(

--- a/evita_test/evita_test_support/src/main/java/io/evitadb/test/generator/DataGenerator.java
+++ b/evita_test/evita_test_support/src/main/java/io/evitadb/test/generator/DataGenerator.java
@@ -132,6 +132,12 @@ public class DataGenerator {
 	public static final Currency CURRENCY_GBP = Currency.getInstance("GBP");
 	public static final String PRICE_LIST_BASIC = "basic";
 	public static final String PRICE_LIST_REFERENCE = "reference";
+	/**
+	 * Upper bound on rejection-sampling attempts in {@link #pickRandomFromSet(Faker, Set)}. Bounds a loop
+	 * that would otherwise spin forever once the requested item count becomes statistically unreachable
+	 * for a large `set` - see the method's JavaDoc for why the underlying bias is intentionally not fixed.
+	 */
+	private static final int MAX_PICK_RANDOM_FROM_SET_ATTEMPTS = 10_000;
 	public static final BiPredicate<String, Faker> DEFAULT_PRICE_INDEXING_DECIDER = (priceList, faker) -> {
 		final boolean randomIndexedFlag = faker.random().nextInt(8) == 0;
 		final boolean indexed;
@@ -229,6 +235,16 @@ public class DataGenerator {
 		return hierarchies.getOrCreateHierarchy(entityType, (short) 5, (short) 10);
 	}
 
+	/**
+	 * Selects a random number (1 to {@link Set#size()}) of distinct elements from `set` by repeatedly
+	 * drawing a random walk position into the set and retrying on duplicates. The draw-with-rejection
+	 * approach is intentionally left as-is (including its non-uniform bias) to avoid perturbing the
+	 * random draw sequence consumed by every other call on the same {@link Faker} instance — changing it
+	 * would silently regenerate every seeded dataset in the test suite. Instead, the number of rejection
+	 * attempts is capped: once `set` grows large enough that the requested `itemsCount` becomes
+	 * statistically unreachable, generation fails fast with a descriptive exception instead of spinning
+	 * forever at 100% CPU.
+	 */
 	@Nonnull
 	private static <T> List<T> pickRandomFromSet(@Nonnull Faker genericFaker, @Nonnull Set<T> set) {
 		if (set.isEmpty()) {
@@ -236,7 +252,17 @@ public class DataGenerator {
 		}
 		final Integer itemsCount = genericFaker.random().nextInt(1, set.size());
 		final List<T> usedItems = new ArrayList<>(itemsCount);
+		int attempt = 0;
 		while (usedItems.size() < itemsCount) {
+			attempt++;
+			if (attempt > MAX_PICK_RANDOM_FROM_SET_ATTEMPTS) {
+				throw new GenericEvitaInternalError(
+					"Could not pick " + itemsCount + " distinct random elements out of " + set.size() +
+						" within " + MAX_PICK_RANDOM_FROM_SET_ATTEMPTS + " attempts - the requested count is " +
+						"statistically unreachable for a set this large. This is not a hang: it's a systematic " +
+						"limitation of the biased selection algorithm (see DataGenerator#pickRandomFromSet)."
+				);
+			}
 			final Iterator<T> it = set.iterator();
 			T itemToUse = null;
 			for (int i = 0; i <= genericFaker.random().nextInt(set.size()); i++) {


### PR DESCRIPTION
## Summary
- `DataGenerator.pickRandomFromSet` could spin forever at 100% CPU for schemas with many reference types, with no exception and no log output. The biased draw-with-rejection algorithm is left unchanged (any algorithm change would perturb the seeded random-draw sequence and regenerate every dataset in the test suite); a bounded attempt cap now throws `GenericEvitaInternalError` instead of hanging.
- `EntityHierarchyFetchFunctionalTest.shouldReturnDirectHierarchyParentsWithBodiesUpToLevelTwo` had an unrelated pre-existing infinite loop (parent-chain walk only advanced inside an `if` branch), found while reproducing the above. Fixed alongside since it surfaced in the same investigation.

## Test plan
- [x] Verified zero behavior change for currently-working schemas: 0/5000 trials throw at `n=3` (the sample product schema's reference count), exact same random-draw sequence preserved
- [x] Verified fail-fast behavior for the pathological case from the issue: throws within ~86ms at `n=33` instead of hanging
- [x] Full functional test suite (20714 tests) green — only 2 pre-existing environmental failures unrelated to this change (no Docker available; a readiness-probe timing flake)

Closes #1334
