### PR TITLE
Treat locale-missing reference targets as non-existing under ManagedReferencesBehaviour.EXISTING

### DIFF
--- a/evita_engine/src/main/java/io/evitadb/core/query/fetch/ReferencedEntityFetcher.java
+++ b/evita_engine/src/main/java/io/evitadb/core/query/fetch/ReferencedEntityFetcher.java
@@ -636,6 +636,11 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 	 * @param filterByVisitor                     the visitor that will be used for traversing the constraint
 	 * @param managedReferencesBehaviour          defines whether only existing (managed) references should be returned or all
 	 * @param filterBy                            the filtering constraint itself
+	 * @param requiredLocale                      the locale the referenced entity bodies will be fetched with, resolved
+	 *                                            once per reference by {@link #resolveRequiredLocale(FilterBy, QueryExecutionContext)}
+	 *                                            so that both the referenced entities and their groups agree on it;
+	 *                                            {@code null} when the locale-aware existence check must not be applied
+	 *                                            (i.e. for {@link ManagedReferencesBehaviour#ANY} or when no locale applies)
 	 * @param validityMapping                     see detailed description in {@link ValidEntityToReferenceMapping}
 	 * @param entityNestedQueryComparator         comparator that holds information about requested ordering so that we can
 	 *                                            apply it during entity filtering (if it's performed) and pre-initialize it
@@ -659,6 +664,7 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 		@Nonnull ReferenceKeeper<FilterByVisitor> filterByVisitor,
 		@Nonnull ManagedReferencesBehaviour managedReferencesBehaviour,
 		@Nullable FilterBy filterBy,
+		@Nullable Locale requiredLocale,
 		@Nullable ValidEntityToReferenceMapping validityMapping,
 		@Nullable EntityNestedQueryComparator entityNestedQueryComparator,
 		@Nonnull BiFunction<String, Integer, Formula> referencedEntityResolver,
@@ -701,7 +707,8 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 			allReferencedEntityPksInScope = limitToExistingEntities(
 				combineWithOr(allReferencedEntityPksFromEntitiesInScope.values()),
 				queryContext.getEntityCollection(targetEntityType).orElse(null),
-				examinedScopes
+				examinedScopes,
+				requiredLocale
 			);
 			// and also create unified lookup over all referenced entity ids in all requested scopes
 			allReferencedEntityPks = combineWithOr(allReferencedEntityPksInScope.values());
@@ -1041,6 +1048,12 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 	 *                                                   entities exist. If null, no filtering is applied and an empty bitmap is returned.
 	 * @param examinedScopes                             A set of {@link Scope} objects defining the scopes within which to check for
 	 *                                                   existing entities.
+	 * @param requiredLocale                             when not {@code null} and the target schema is localized, entities that
+	 *                                                   have no content in this particular locale are excluded as well - they
+	 *                                                   would otherwise be returned without a body, which defeats the purpose of
+	 *                                                   {@link ManagedReferencesBehaviour#EXISTING}. This mirrors the gate applied
+	 *                                                   later by {@code EntityCollection#fetchEntityDecorator}, which exempts
+	 *                                                   non-localized schemas from the check altogether.
 	 * @return A {@link Bitmap} containing the IDs of entities that exist in the specified scopes of
 	 * the entity collection. If no entities exist for the given parameters, an empty bitmap is returned.
 	 */
@@ -1048,11 +1061,14 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 	private static Map<Scope, Bitmap> limitToExistingEntities(
 		@Nonnull Bitmap allReferencedEntityIdsIncludingNonExisting,
 		@Nullable EntityCollection entityCollection,
-		@Nonnull Set<Scope> examinedScopes
+		@Nonnull Set<Scope> examinedScopes,
+		@Nullable Locale requiredLocale
 	) {
 		if (entityCollection != null) {
 			final PersistentRoaringBitmap allPks = RoaringBitmapBackedBitmap.getRoaringBitmap(
 				allReferencedEntityIdsIncludingNonExisting);
+			// non-localized schemas are exempt from the locale check - exactly as the body fetch gate treats them
+			final boolean localeCheckApplies = requiredLocale != null && entityCollection.getSchema().isLocalized();
 			final Map<Scope, Bitmap> existingEntityIdsByScope = CollectionUtils.createHashMap(examinedScopes.size());
 			for (Scope scope : examinedScopes) {
 				final EntityIndex indexByKeyIfExists = entityCollection
@@ -1060,10 +1076,20 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 						new EntityIndexKey(EntityIndexType.GLOBAL, scope)
 					);
 				if (indexByKeyIfExists != null) {
-					final PersistentRoaringBitmap andResult = PersistentRoaringBitmap.and(
+					PersistentRoaringBitmap andResult = PersistentRoaringBitmap.and(
 						RoaringBitmapBackedBitmap.getRoaringBitmap(indexByKeyIfExists.getAllPrimaryKeys()),
 						allPks
 					);
+					if (localeCheckApplies) {
+						// the per-locale bitmap is stored in the index, so this is a plain intersection against
+						// an already materialized bitmap - no formula evaluation takes place here
+						andResult = PersistentRoaringBitmap.and(
+							andResult,
+							RoaringBitmapBackedBitmap.getRoaringBitmap(
+								indexByKeyIfExists.getRecordsWithLanguageFormula(requiredLocale).compute()
+							)
+						);
+					}
 					existingEntityIdsByScope.put(
 						scope,
 						andResult.isEmpty() ? EmptyBitmap.INSTANCE : new BaseBitmap(andResult)
@@ -1074,6 +1100,33 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 		} else {
 			return Collections.emptyMap();
 		}
+	}
+
+	/**
+	 * Resolves the locale that the referenced entity (or group) bodies will be fetched with, so that the
+	 * {@link ManagedReferencesBehaviour#EXISTING} pre-filtering (see {@link #limitToExistingEntities}) agrees with what
+	 * actually happens later during the body fetch. It deliberately reproduces the chain the body fetch goes through:
+	 * {@link #fetchReferencedEntities} derives the fetch request from {@link #unwrapFilterBy(FilterBy)}, whose locale is
+	 * then resolved by {@link EvitaRequest}'s derived-request constructor and finally consulted by the entity collection
+	 * through {@link EvitaRequest#getRequiredOrImplicitLocale()}.
+	 *
+	 * @param referenceFilterBy the reference-level {@code filterBy} (may contain its own {@link EntityLocaleEquals})
+	 * @param executionContext  the current query execution context
+	 * @return the resolved locale, or {@code null} if none is required
+	 */
+	@Nullable
+	private static Locale resolveRequiredLocale(
+		@Nullable FilterBy referenceFilterBy,
+		@Nonnull QueryExecutionContext executionContext
+	) {
+		final FilterBy unwrappedFilterBy = unwrapFilterBy(referenceFilterBy);
+		if (unwrappedFilterBy != null) {
+			final EntityLocaleEquals localeConstraint = QueryUtils.findConstraint(unwrappedFilterBy, EntityLocaleEquals.class);
+			if (localeConstraint != null) {
+				return localeConstraint.getLocale();
+			}
+		}
+		return executionContext.getEvitaRequest().getRequiredOrImplicitLocale();
 	}
 
 	/**
@@ -1591,6 +1644,12 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 			slicingMode.chunkTransformer()
 		);
 
+		// the referenced entities and their groups are fetched by a single derived request - resolve the locale it will
+		// use once, so that the EXISTING pre-filtering of both agrees with the actual body fetch
+		final Locale requiredLocale = requirements.managedReferencesBehaviour() == ManagedReferencesBehaviour.EXISTING
+			? resolveRequiredLocale(requirements.filterBy(), executionContext)
+			: null;
+
 		final Bitmap filteredReferencedEntityIds = getFilteredReferencedEntityIds(
 			entityPrimaryKey,
 			executionContext,
@@ -1600,6 +1659,7 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 			filterByVisitor,
 			requirements.managedReferencesBehaviour(),
 			requirements.filterBy(),
+			requiredLocale,
 			validityMapping,
 			nestedQueryComparator,
 			referencedEntityIdsFormula,
@@ -1661,6 +1721,7 @@ public class ReferencedEntityFetcher implements ReferenceFetcher {
 				filterByVisitor,
 				requirements.managedReferencesBehaviour(),
 				null,
+				requiredLocale,
 				null,
 				null,
 				(refName, epk) -> slicer.getGroupIds(epk),

--- a/evita_query/src/main/java/io/evitadb/api/query/require/ManagedReferencesBehaviour.java
+++ b/evita_query/src/main/java/io/evitadb/api/query/require/ManagedReferencesBehaviour.java
@@ -35,10 +35,29 @@ import io.evitadb.dataType.SupportedEnum;
  *
  * - `ANY` — all references are returned regardless of whether the target entity currently exists in the database.
  *   This is the default behaviour and is appropriate during data ingestion or when the caller explicitly wants to
- *   enumerate both resolved and unresolved references.
+ *   enumerate both resolved and unresolved references. Note that specifying a `filterBy` in
+ *   `referenceContent` implies the existence check even in this mode — a target that is not
+ *   present cannot be matched by it.
  * - `EXISTING` — only references whose target entity is present in the database at query time are returned; dangling
  *   references are silently suppressed as if they did not exist. This is the correct choice for most read-side
  *   queries where incomplete data should not leak to the API consumer.
+ *
+ * Under `EXISTING` mere presence is not enough — the target entity must also pass the checks
+ * that apply to it. Both of the following sources are honoured:
+ *
+ * 1. the `filterBy` specified directly in the `referenceContent` requirement, and
+ * 2. the required locale, which is taken from an `entityLocaleEquals` inside that `filterBy`
+ *    when one is present, and is inherited from the enveloping query otherwise.
+ *
+ * A target entity that does not pass these checks is assumed to be non-existing for the sake of
+ * this mode and its reference is suppressed exactly like a dangling one. In particular, an entity
+ * that exists but holds no data in the required locale is never returned as a reference without
+ * a body — it is omitted entirely. The suppression applies regardless of whether the referenced
+ * body was requested, so reference visibility never depends on whether the caller asked for
+ * a body. The exemption from the locale check is driven by the schema, not by the individual
+ * entity: targets whose schema declares no localized data at all are never suppressed by it,
+ * whereas within a localized schema even a target holding no localized data whatsoever is
+ * suppressed, because it cannot be fetched in the required locale either.
  *
  * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2024
  */
@@ -50,7 +69,11 @@ public enum ManagedReferencesBehaviour {
 	 */
 	ANY,
 	/**
-	 * The reference to managed entity will be returned only if the target entity exists in the database.
+	 * The reference to managed entity will be returned only if the target entity exists in the
+	 * database and passes the checks that apply to it - the `filterBy` specified in
+	 * `referenceContent` and the required locale, which is inherited from the enveloping query
+	 * unless the `filterBy` states its own. A target that does not pass them is assumed to be
+	 * non-existing - see the class-level documentation for the exact rules.
 	 */
 	EXISTING
 

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/fetch/ManagedReferenceLocaleFunctionalTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/api/functional/fetch/ManagedReferenceLocaleFunctionalTest.java
@@ -1,0 +1,597 @@
+/*
+ *
+ *                         _ _        ____  ____
+ *               _____   _(_) |_ __ _|  _ \| __ )
+ *              / _ \ \ / / | __/ _` | | | |  _ \
+ *             |  __/\ V /| | || (_| | |_| | |_) |
+ *              \___| \_/ |_|\__\__,_|____/|____/
+ *
+ *   Copyright (c) 2023-2026
+ *
+ *   Licensed under the Business Source License, Version 1.1 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   https://github.com/FgForrest/evitaDB/blob/master/LICENSE
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package io.evitadb.api.functional.fetch;
+
+import io.evitadb.api.query.require.ManagedReferencesBehaviour;
+import io.evitadb.api.requestResponse.data.ReferenceContract;
+import io.evitadb.api.requestResponse.data.SealedEntity;
+import io.evitadb.api.requestResponse.schema.AttributeSchemaEditor;
+import io.evitadb.api.requestResponse.schema.Cardinality;
+import io.evitadb.api.requestResponse.schema.ReferenceSchemaEditor;
+import io.evitadb.core.Evita;
+import io.evitadb.test.Entities;
+import io.evitadb.test.annotation.DataSet;
+import io.evitadb.test.annotation.UseDataSet;
+import io.evitadb.test.extension.DataCarrier;
+import io.evitadb.test.extension.EvitaParameterResolver;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Collection;
+import java.util.Locale;
+
+import static io.evitadb.api.query.Query.query;
+import static io.evitadb.api.query.QueryConstraints.*;
+import static io.evitadb.test.TestConstants.TEST_CATALOG;
+import static io.evitadb.test.TestTags.CONTRACT;
+import static io.evitadb.test.TestTags.QUERY;
+import static io.evitadb.test.TestTags.REFERENCE;
+import static io.evitadb.test.generator.DataGenerator.ATTRIBUTE_CODE;
+import static io.evitadb.test.generator.DataGenerator.ATTRIBUTE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduces https://github.com/FgForrest/evitaDB/issues/1343 - when a query defines a query-level
+ * {@link io.evitadb.api.query.filter.EntityLocaleEquals} and requests {@code referenceContent} with
+ * {@link ManagedReferencesBehaviour#EXISTING}, references pointing to entities that exist but have no
+ * data in the requested locale must be omitted entirely, not returned without a body.
+ *
+ * @author Jan Novotný (novotny@fg.cz), FG Forrest a.s. (c) 2026
+ */
+@DisplayName("Evita managed reference locale handling")
+@ExtendWith(EvitaParameterResolver.class)
+@Slf4j
+@Tag(CONTRACT)
+@Tag(QUERY)
+@Tag(REFERENCE)
+class ManagedReferenceLocaleFunctionalTest {
+	private static final String DATA_SET = "managedReferenceLocale";
+	private static final String REFERENCE_CATEGORY = "category";
+	private static final String REFERENCE_BRAND = "brand";
+	private static final String REFERENCE_PARAMETER = "parameter";
+	private static final Locale LOCALE_CZECH = new Locale("cs");
+
+	@DataSet(DATA_SET)
+	DataCarrier setUp(Evita evita) {
+		evita.updateCatalog(
+			TEST_CATALOG,
+			session -> {
+				// category schema is localized, but also carries a non-localized attribute so that an individual
+				// category may end up with no localized data at all
+				session.defineEntitySchema(Entities.CATEGORY)
+					.withoutGeneratedPrimaryKey()
+					.withLocale(Locale.ENGLISH)
+					.withAttribute(ATTRIBUTE_NAME, String.class, thatIs -> thatIs.localized().nullable())
+					.withAttribute(ATTRIBUTE_CODE, String.class, AttributeSchemaEditor::nullable)
+					.updateAndFetchVia(session);
+
+				// brand is a non-localized entity type - no localized attribute, no `withLocale` declared at all,
+				// so its schema reports `isLocalized() == false` and the locale check never applies to it
+				session.defineEntitySchema(Entities.BRAND)
+					.withoutGeneratedPrimaryKey()
+					.withAttribute(ATTRIBUTE_NAME, String.class, thatIs -> {})
+					.updateAndFetchVia(session);
+
+				// parameter is localized in both Czech and English, its group only in English
+				session.defineEntitySchema(Entities.PARAMETER)
+					.withoutGeneratedPrimaryKey()
+					.withLocale(LOCALE_CZECH, Locale.ENGLISH)
+					.withAttribute(ATTRIBUTE_NAME, String.class, AttributeSchemaEditor::localized)
+					.updateAndFetchVia(session);
+
+				session.defineEntitySchema(Entities.PARAMETER_GROUP)
+					.withoutGeneratedPrimaryKey()
+					.withLocale(Locale.ENGLISH)
+					.withAttribute(ATTRIBUTE_NAME, String.class, AttributeSchemaEditor::localized)
+					.updateAndFetchVia(session);
+
+				session.defineEntitySchema(Entities.PRODUCT)
+					.withoutGeneratedPrimaryKey()
+					.withLocale(LOCALE_CZECH, Locale.GERMAN, Locale.ENGLISH)
+					.withAttribute(ATTRIBUTE_NAME, String.class, AttributeSchemaEditor::localized)
+					.withReferenceToEntity(
+						REFERENCE_CATEGORY,
+						Entities.CATEGORY,
+						Cardinality.ZERO_OR_ONE,
+						ReferenceSchemaEditor::indexedForFiltering
+					)
+					.withReferenceToEntity(
+						REFERENCE_BRAND,
+						Entities.BRAND,
+						Cardinality.ZERO_OR_ONE,
+						ReferenceSchemaEditor::indexedForFiltering
+					)
+					.withReferenceToEntity(
+						REFERENCE_PARAMETER,
+						Entities.PARAMETER,
+						Cardinality.ZERO_OR_MORE,
+						whichIs -> whichIs
+							.withGroupTypeRelatedToEntity(Entities.PARAMETER_GROUP)
+							.indexedForFiltering()
+					)
+					.updateAndFetchVia(session);
+
+				// category is localized only in English
+				session.createNewEntity(Entities.CATEGORY, 1)
+					.setAttribute(ATTRIBUTE_NAME, Locale.ENGLISH, "Cameras")
+					.upsertVia(session);
+
+				// this category belongs to a localized schema, yet holds no localized data at all
+				session.createNewEntity(Entities.CATEGORY, 2)
+					.setAttribute(ATTRIBUTE_CODE, "uncategorized")
+					.upsertVia(session);
+
+				// brand has no locale-specific data whatsoever
+				session.createNewEntity(Entities.BRAND, 1)
+					.setAttribute(ATTRIBUTE_NAME, "Sony")
+					.upsertVia(session);
+
+				// parameter has both Czech and English data, its group only English
+				session.createNewEntity(Entities.PARAMETER, 1)
+					.setAttribute(ATTRIBUTE_NAME, LOCALE_CZECH, "Rozlišení")
+					.setAttribute(ATTRIBUTE_NAME, Locale.ENGLISH, "Resolution")
+					.upsertVia(session);
+
+				session.createNewEntity(Entities.PARAMETER_GROUP, 1)
+					.setAttribute(ATTRIBUTE_NAME, Locale.ENGLISH, "Optics")
+					.upsertVia(session);
+
+				// product is localized in Czech, German and English and references the category and brand above
+				session.createNewEntity(Entities.PRODUCT, 1)
+					.setAttribute(ATTRIBUTE_NAME, LOCALE_CZECH, "Foto")
+					.setAttribute(ATTRIBUTE_NAME, Locale.GERMAN, "Kamera")
+					.setAttribute(ATTRIBUTE_NAME, Locale.ENGLISH, "Camera")
+					.setReference(REFERENCE_CATEGORY, 1)
+					.setReference(REFERENCE_BRAND, 1)
+					.setReference(REFERENCE_PARAMETER, 1, whichIs -> whichIs.setGroup(1))
+					.upsertVia(session);
+
+				// second product references the category that carries no localized data at all
+				session.createNewEntity(Entities.PRODUCT, 2)
+					.setAttribute(ATTRIBUTE_NAME, LOCALE_CZECH, "Objektiv")
+					.setAttribute(ATTRIBUTE_NAME, Locale.ENGLISH, "Lens")
+					.setReference(REFERENCE_CATEGORY, 2)
+					.upsertVia(session);
+			}
+		);
+		return new DataCarrier();
+	}
+
+	@DisplayName("Should omit reference to an existing entity that has no data in the requested locale")
+	@UseDataSet(DATA_SET)
+	@Test
+	void shouldOmitExistingReferenceWhenReferencedEntityMissingDataInQueryLocale(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(1),
+								entityLocaleEquals(LOCALE_CZECH)
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									ManagedReferencesBehaviour.EXISTING,
+									REFERENCE_CATEGORY,
+									entityFetch(attributeContentAll())
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				final Collection<ReferenceContract> categoryReferences = productByPk.getReferences(REFERENCE_CATEGORY);
+				assertTrue(
+					categoryReferences.isEmpty(),
+					"Reference to a category without data in the requested locale (cs) must be omitted entirely " +
+						"when ManagedReferencesBehaviour.EXISTING is used, but was: " + categoryReferences
+				);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should include reference to an existing entity that has data in the requested locale")
+	@UseDataSet(DATA_SET)
+	@Test
+	void shouldIncludeExistingReferenceWhenReferencedEntityHasDataInQueryLocale(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(1),
+								entityLocaleEquals(Locale.ENGLISH)
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									ManagedReferencesBehaviour.EXISTING,
+									REFERENCE_CATEGORY,
+									entityFetch(attributeContentAll())
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				final Collection<ReferenceContract> categoryReferences = productByPk.getReferences(REFERENCE_CATEGORY);
+				assertTrue(
+					categoryReferences.size() == 1 &&
+						categoryReferences.iterator().next().getReferencedEntity().isPresent(),
+					"Reference to a category with data in the requested locale (en) must be included with its body."
+				);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should include reference to a non-localized entity type regardless of the requested locale")
+	@UseDataSet(DATA_SET)
+	@Test
+	void shouldIncludeExistingReferenceWhenReferencedEntityTypeIsNotLocalized(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(1),
+								entityLocaleEquals(LOCALE_CZECH)
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									ManagedReferencesBehaviour.EXISTING,
+									REFERENCE_BRAND,
+									entityFetch(attributeContentAll())
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				final Collection<ReferenceContract> brandReferences = productByPk.getReferences(REFERENCE_BRAND);
+				// the brand schema declares no localized data at all, so the locale check does not apply to it -
+				// contrast with the localized category schema, where a locale-less entity IS suppressed
+				assertTrue(
+					brandReferences.size() == 1 &&
+						brandReferences.iterator().next().getReferencedEntity().isPresent(),
+					"Reference to a brand of a non-localized entity type must never be dropped due to locale " +
+						"filtering, but was: " + brandReferences
+				);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should omit reference even when the entity fetch explicitly requests all locales")
+	@UseDataSet(DATA_SET)
+	@Test
+	void shouldOmitExistingReferenceEvenWhenEntityFetchRequestsAllLocales(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(1),
+								entityLocaleEquals(LOCALE_CZECH)
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									ManagedReferencesBehaviour.EXISTING,
+									REFERENCE_CATEGORY,
+									entityFetchAll()
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				// the referenced entity body-fetch gate keys off the query's required/implicit locale regardless of
+				// entityFetch's own requirements, so requesting all locales (dataInLocalesAll) does not make the
+				// category body fetchable here - the reference must still be omitted, not returned without a body
+				final Collection<ReferenceContract> categoryReferences = productByPk.getReferences(REFERENCE_CATEGORY);
+				assertTrue(
+					categoryReferences.isEmpty(),
+					"Reference to a category without data in the requested locale (cs) must be omitted entirely " +
+						"even when the entity fetch requests all locales, but was: " + categoryReferences
+				);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should omit reference to an entity of a localized schema that holds no localized data")
+	@UseDataSet(DATA_SET)
+	@Test
+	void shouldOmitExistingReferenceWhenReferencedEntityOfLocalizedSchemaHasNoLocalizedData(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(2),
+								entityLocaleEquals(LOCALE_CZECH)
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									ManagedReferencesBehaviour.EXISTING,
+									REFERENCE_CATEGORY,
+									entityFetch(attributeContentAll())
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				// the exemption from the locale check is driven by the schema, not by the particular entity - the
+				// category schema is localized, so a category holding no localized data is not fetchable in `cs`
+				// and its reference must be omitted rather than returned without a body
+				final Collection<ReferenceContract> categoryReferences = productByPk.getReferences(REFERENCE_CATEGORY);
+				assertTrue(
+					categoryReferences.isEmpty(),
+					"Reference to a category of a localized schema that holds no localized data must be omitted, " +
+						"but was: " + categoryReferences
+				);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should omit reference even when no reference body is requested at all")
+	@UseDataSet(DATA_SET)
+	@Test
+	void shouldOmitExistingReferenceEvenWhenNoBodyIsRequested(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(1),
+								entityLocaleEquals(LOCALE_CZECH)
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(ManagedReferencesBehaviour.EXISTING, REFERENCE_CATEGORY)
+							)
+						)
+					)
+				).orElseThrow();
+
+				// reference visibility must not depend on whether the caller asked for the referenced body - an
+				// entity missing data in the query locale is consistently treated as non-existing
+				final Collection<ReferenceContract> categoryReferences = productByPk.getReferences(REFERENCE_CATEGORY);
+				assertTrue(
+					categoryReferences.isEmpty(),
+					"Reference to a category without data in the requested locale (cs) must be omitted even when no " +
+						"body was requested, but was: " + categoryReferences
+				);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should honour reference-level locale filter instead of the query-level one")
+	@UseDataSet(DATA_SET)
+	@Test
+	void shouldIncludeExistingReferenceWhenReferenceLevelFilterOverridesQueryLocale(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(1),
+								entityLocaleEquals(LOCALE_CZECH)
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									ManagedReferencesBehaviour.EXISTING,
+									REFERENCE_CATEGORY,
+									filterBy(entityHaving(entityLocaleEquals(Locale.ENGLISH))),
+									entityFetch(attributeContentAll())
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				// the reference-level `entityLocaleEquals` overrides the query-level one for the body fetch, so the
+				// English-only category is fetchable here and must not be excluded
+				final Collection<ReferenceContract> categoryReferences = productByPk.getReferences(REFERENCE_CATEGORY);
+				assertTrue(
+					categoryReferences.size() == 1 &&
+						categoryReferences.iterator().next().getReferencedEntity().isPresent(),
+					"Reference-level locale filter (en) must take precedence over the query-level one (cs), but was: " +
+						categoryReferences
+				);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should honour reference-level locale filter also for the referenced entity group")
+	@UseDataSet(DATA_SET)
+	@Test
+	void shouldIncludeExistingReferenceGroupWhenReferenceLevelFilterOverridesQueryLocale(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(1),
+								entityLocaleEquals(LOCALE_CZECH)
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									ManagedReferencesBehaviour.EXISTING,
+									REFERENCE_PARAMETER,
+									filterBy(entityHaving(entityLocaleEquals(Locale.ENGLISH))),
+									entityFetch(attributeContentAll()),
+									entityGroupFetch(attributeContentAll())
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				// the group body is fetched with the very same derived request as the referenced entity body, so the
+				// English-only group must be resolved against the reference-level locale (en), not the query-level (cs)
+				final Collection<ReferenceContract> parameterReferences = productByPk.getReferences(REFERENCE_PARAMETER);
+				assertEquals(
+					1, parameterReferences.size(),
+					"Reference to a parameter having English data must be present, but was: " + parameterReferences
+				);
+				assertTrue(
+					parameterReferences.iterator().next().getGroupEntity().isPresent(),
+					"Group of the parameter reference must be resolved using the reference-level locale (en) - it is " +
+						"fetchable and must not be dropped by the EXISTING pre-filter."
+				);
+
+				return null;
+			}
+		);
+	}
+
+	@DisplayName("Should compose a non-locale reference filter with the locale-driven existence check")
+	@UseDataSet(DATA_SET)
+	@Test
+	void shouldCombineNonLocaleReferenceFilterWithLocaleExclusion(Evita evita) {
+		evita.queryCatalog(
+			TEST_CATALOG,
+			session -> {
+				// the non-locale reference filter matches the category, yet the query-level locale (cs) still applies
+				final SealedEntity productByPk = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(1),
+								entityLocaleEquals(LOCALE_CZECH)
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									ManagedReferencesBehaviour.EXISTING,
+									REFERENCE_CATEGORY,
+									filterBy(entityHaving(entityPrimaryKeyInSet(1))),
+									entityFetch(attributeContentAll())
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				final Collection<ReferenceContract> categoryReferences = productByPk.getReferences(REFERENCE_CATEGORY);
+				assertTrue(
+					categoryReferences.isEmpty(),
+					"A non-locale reference filter must not suppress the locale-driven existence check, but was: " +
+						categoryReferences
+				);
+
+				// the same non-locale reference filter under an English query keeps the reference with its body
+				final SealedEntity productInEnglish = session.queryOneSealedEntity(
+					query(
+						collection(Entities.PRODUCT),
+						filterBy(
+							and(
+								entityPrimaryKeyInSet(1),
+								entityLocaleEquals(Locale.ENGLISH)
+							)
+						),
+						require(
+							entityFetch(
+								referenceContent(
+									ManagedReferencesBehaviour.EXISTING,
+									REFERENCE_CATEGORY,
+									filterBy(entityHaving(entityPrimaryKeyInSet(1))),
+									entityFetch(attributeContentAll())
+								)
+							)
+						)
+					)
+				).orElseThrow();
+
+				final Collection<ReferenceContract> englishCategoryReferences = productInEnglish.getReferences(REFERENCE_CATEGORY);
+				assertTrue(
+					englishCategoryReferences.size() == 1 &&
+						englishCategoryReferences.iterator().next().getReferencedEntity().isPresent(),
+					"A matching non-locale reference filter must keep the reference with its body when the locale " +
+						"matches, but was: " + englishCategoryReferences
+				);
+
+				return null;
+			}
+		);
+	}
+
+}


### PR DESCRIPTION
Closes #1343

## Problem

`ManagedReferencesBehaviour.EXISTING` decided whether a reference target "exists" by checking only the target collection's global index. The body fetch, however, applies a second and *implicit* gate in `EntityCollection#fetchEntityDecorator`:

```java
!theSchema.isLocalized() || internalEntity.entity().getLocales().contains(it)
```

keyed off `EvitaRequest#getRequiredOrImplicitLocale()`. An entity present in the index but holding no data in the query's locale therefore passed the existence check and was then dropped by the gate — surfacing as a reference **without a body** rather than being omitted, which is what `EXISTING` promises.

Locale is the only criterion evaluated twice. Every other reference-level `filterBy` constraint is resolved against the referenced entity indexes (the `ReferenceHaving` / `getReferencedRecordEntityIndexes` path) before any body fetch, so it cannot produce a body-less reference.

## Fix

`limitToExistingEntities` now applies the same locale predicate as the gate. The locale is resolved **once per reference** by `resolveRequiredLocale` from `unwrapFilterBy(referenceContent.filterBy())`, falling back to the enveloping query's `getRequiredOrImplicitLocale()` — mirroring exactly how `EvitaRequest`'s derived-request constructor computes it for the body fetch. That single value is shared by the referenced entity and its group, so the two branches cannot disagree.

The exemption is **schema-level**, matching the gate: a non-localized entity type is never suppressed, whereas a locale-less entity of a *localized* type is (it is equally unfetchable in the required locale).

Implementation is a single intersection against the index's stored `entityIdsByLanguage` bitmap — `getRecordsWithLanguageFormula` returns a `LocaleFormula` over an already materialized bitmap, so no formula evaluation occurs on this path.

## Intentional behaviour change

The suppression is applied regardless of whether a reference body was requested, so `referenceContent(EXISTING, "category")` with a query-level locale and no `entityFetch` now omits the reference too. This is deliberate — reference visibility should not depend on whether the caller asked for a body — and is wider than the issue strictly reported. It is documented in `ManagedReferencesBehaviour` and pinned by a test.

## Notes for review

- Folding `entityLocaleEquals` into the existing filter instead was considered and rejected: against a non-localized schema it resolves to `EmptyFormula`, which would drop **every** reference to a non-localized target. Guarding it with the same `isLocalized()` check yields two code paths for one predicate, since the folded path exists only when `filterBy != null`.
- The locale-less-entity case is reachable only when the localized attribute is `nullable`; evitaDB otherwise rejects upserting an entity with no locale (`MandatoryAttributesNotProvidedException`), which bounds how much stored data this could have affected.
- `ManagedReferencesBehaviour` documentation was clarified, including a previously undocumented behaviour: specifying a `filterBy` in `referenceContent` forces the existence check even under `ANY`.

## Tests

New `ManagedReferenceLocaleFunctionalTest` (9 cases) covers: the reported bug; the locale-matching control; a non-localized entity type; a locale-less entity of a localized type; `entityFetchAll()`; no body requested; a reference-level locale filter overriding the query-level one for both the entity and its group; and a non-locale reference filter composing with the locale check in both directions.

Verified with `reference & !slow`: 1847 passed, 0 failed, 1 skipped.