### PR TITLE
fix: correct inverted client-version gate in VersionUtils.isAtLeast

### DIFF
--- a/evita_common/src/main/java/io/evitadb/utils/VersionUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/VersionUtils.java
@@ -109,17 +109,18 @@ public class VersionUtils {
 	}
 
 	/**
-	 * Compares the provided major and minor versions against a given SemVer object to check if the
-	 * provided version is greater than or equal to the compared version.
+	 * Checks whether `comparedVersion` is greater than or equal to the given `major.minor` version.
+	 * A missing `comparedVersion` (e.g. a client that declared no version at all) is treated as older
+	 * than any `major.minor` and thus always yields `false`.
 	 *
-	 * @param major the major version to compare
-	 * @param minor the minor version to compare
-	 * @param comparedVersion the SemVer object to compare against; can be null
-	 * @return true if the provided version is greater than or equal to the compared version, false otherwise
+	 * @param major the major version to compare against
+	 * @param minor the minor version to compare against
+	 * @param comparedVersion the SemVer object whose recency is being checked; can be null
+	 * @return true if `comparedVersion` is greater than or equal to `major.minor`, false otherwise
 	 */
 	public static boolean greaterThanEquals(int major, int minor, @Nullable SemVer comparedVersion) {
 		return comparedVersion != null &&
-			(major > comparedVersion.major() || (major == comparedVersion.major() && minor >= comparedVersion.minor()));
+			(comparedVersion.major() > major || (comparedVersion.major() == major && comparedVersion.minor() >= minor));
 	}
 
 	/**

--- a/evita_common/src/main/java/io/evitadb/utils/VersionUtils.java
+++ b/evita_common/src/main/java/io/evitadb/utils/VersionUtils.java
@@ -109,18 +109,18 @@ public class VersionUtils {
 	}
 
 	/**
-	 * Checks whether `comparedVersion` is greater than or equal to the given `major.minor` version.
-	 * A missing `comparedVersion` (e.g. a client that declared no version at all) is treated as older
+	 * Checks whether `version` is greater than or equal to the given `major.minor` version.
+	 * A missing `version` (e.g. a client that declared no version at all) is treated as older
 	 * than any `major.minor` and thus always yields `false`.
 	 *
+	 * @param version the SemVer object whose recency is being checked; can be null
 	 * @param major the major version to compare against
 	 * @param minor the minor version to compare against
-	 * @param comparedVersion the SemVer object whose recency is being checked; can be null
-	 * @return true if `comparedVersion` is greater than or equal to `major.minor`, false otherwise
+	 * @return true if `version` is greater than or equal to `major.minor`, false otherwise
 	 */
-	public static boolean greaterThanEquals(int major, int minor, @Nullable SemVer comparedVersion) {
-		return comparedVersion != null &&
-			(comparedVersion.major() > major || (comparedVersion.major() == major && comparedVersion.minor() >= minor));
+	public static boolean isAtLeast(@Nullable SemVer version, int major, int minor) {
+		return version != null &&
+			(version.major() > major || (version.major() == major && version.minor() >= minor));
 	}
 
 	/**

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/data/EntityConverter.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/data/EntityConverter.java
@@ -521,7 +521,7 @@ public class EntityConverter {
 			for (AssociatedDataValue theAssociatedData : entity.getAssociatedDataValues()) {
 				final GrpcEvitaAssociatedDataValue associatedDataValue = EvitaDataTypesConverter.toGrpcEvitaAssociatedDataValue(
 					Objects.requireNonNull(theAssociatedData.value()), theAssociatedData.version(),
-					VersionUtils.greaterThanEquals(2025, 4, clientVersion) ?
+					VersionUtils.isAtLeast(clientVersion, 2025, 4) ?
 						AssociatedDataForm.STRUCTURED_VALUE : AssociatedDataForm.JSON
 				);
 

--- a/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/data/mutation/associatedData/UpsertAssociatedDataMutationConverter.java
+++ b/evita_external_api/evita_external_api_grpc/shared/src/main/java/io/evitadb/externalApi/grpc/requestResponse/data/mutation/associatedData/UpsertAssociatedDataMutationConverter.java
@@ -62,7 +62,7 @@ public class UpsertAssociatedDataMutationConverter extends AssociatedDataMutatio
 			.setAssociatedDataValue(
 				EvitaDataTypesConverter.toGrpcEvitaAssociatedDataValue(
 					mutation.getAssociatedDataValue(),
-					getClientVersion().map(it -> VersionUtils.greaterThanEquals(2025, 4, it)).orElse(false) ?
+					getClientVersion().map(it -> VersionUtils.isAtLeast(it, 2025, 4)).orElse(false) ?
 						AssociatedDataForm.STRUCTURED_VALUE : AssociatedDataForm.JSON
 				)
 			);

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/VersionUtilsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/VersionUtilsTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Tag;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.evitadb.test.TestTags.ENGINE;
 import static io.evitadb.test.TestTags.DATA_TYPE;
 
@@ -53,6 +54,22 @@ public class VersionUtilsTest {
 		assertEquals(-1, SemVer.fromString("1.1.0").compareTo(SemVer.fromString("1.2.0")));
 		assertEquals(1, SemVer.fromString("2025.1.0").compareTo(SemVer.fromString("2024.12.0")));
 		assertEquals(-1, SemVer.fromString("2024.12.0").compareTo(SemVer.fromString("2025.1.0")));
+	}
+
+	@Test
+	void shouldReturnExpectedGreaterThanEqualsResults() {
+		// client is newer than the compared major.minor
+		assertTrue(VersionUtils.greaterThanEquals(2025, 4, SemVer.fromString("2026.2.0")));
+		// client is on the same major, newer minor
+		assertTrue(VersionUtils.greaterThanEquals(2025, 4, SemVer.fromString("2025.5.0")));
+		// client is exactly on the compared major.minor
+		assertTrue(VersionUtils.greaterThanEquals(2025, 4, SemVer.fromString("2025.4.0")));
+		// client is on the same major, older minor
+		assertFalse(VersionUtils.greaterThanEquals(2025, 4, SemVer.fromString("2025.3.0")));
+		// client is on an older major
+		assertFalse(VersionUtils.greaterThanEquals(2025, 4, SemVer.fromString("2024.12.0")));
+		// client declared no version at all - treated as older than any major.minor
+		assertFalse(VersionUtils.greaterThanEquals(2025, 4, null));
 	}
 
 	@Test

--- a/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/VersionUtilsTest.java
+++ b/evita_test/evita_functional_tests/src/test/java/io/evitadb/utils/VersionUtilsTest.java
@@ -57,19 +57,19 @@ public class VersionUtilsTest {
 	}
 
 	@Test
-	void shouldReturnExpectedGreaterThanEqualsResults() {
+	void shouldReturnExpectedIsAtLeastResults() {
 		// client is newer than the compared major.minor
-		assertTrue(VersionUtils.greaterThanEquals(2025, 4, SemVer.fromString("2026.2.0")));
+		assertTrue(VersionUtils.isAtLeast(SemVer.fromString("2026.2.0"), 2025, 4));
 		// client is on the same major, newer minor
-		assertTrue(VersionUtils.greaterThanEquals(2025, 4, SemVer.fromString("2025.5.0")));
+		assertTrue(VersionUtils.isAtLeast(SemVer.fromString("2025.5.0"), 2025, 4));
 		// client is exactly on the compared major.minor
-		assertTrue(VersionUtils.greaterThanEquals(2025, 4, SemVer.fromString("2025.4.0")));
+		assertTrue(VersionUtils.isAtLeast(SemVer.fromString("2025.4.0"), 2025, 4));
 		// client is on the same major, older minor
-		assertFalse(VersionUtils.greaterThanEquals(2025, 4, SemVer.fromString("2025.3.0")));
+		assertFalse(VersionUtils.isAtLeast(SemVer.fromString("2025.3.0"), 2025, 4));
 		// client is on an older major
-		assertFalse(VersionUtils.greaterThanEquals(2025, 4, SemVer.fromString("2024.12.0")));
+		assertFalse(VersionUtils.isAtLeast(SemVer.fromString("2024.12.0"), 2025, 4));
 		// client declared no version at all - treated as older than any major.minor
-		assertFalse(VersionUtils.greaterThanEquals(2025, 4, null));
+		assertFalse(VersionUtils.isAtLeast(null, 2025, 4));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- `greaterThanEquals(major, minor, comparedVersion)` compared its operands backwards: it computed `(major, minor) >= comparedVersion` instead of `comparedVersion >= (major, minor)`.
- Both call sites invoke it as `greaterThanEquals(2025, 4, clientVersion)` to pick the structured associated-data form for clients on 2025.4 or newer, so the inversion delivered the new structured form to clients too old to read it, and silently kept modern clients on the deprecated, lossy JSON form.
- Fixed the comparison direction and updated the javadoc to state it explicitly. A missing client version is still treated as older than any major.minor, so a client that sends no version header keeps degrading to JSON as before.
- Added a test pinning the exact boundary that broke: newer major, newer minor on the same major, the exact 2025.4 boundary, older minor on the same major, older major, and no declared version at all.
- **Follow-up:** renamed `greaterThanEquals(major, minor, comparedVersion)` to `isAtLeast(version, major, minor)`. The old name/argument order read as `(major, minor) >= comparedVersion` — the exact ordering the original bug got wrong — which is likely why the inversion went unnoticed in the first place. `isAtLeast(clientVersion, 2025, 4)` now reads directly as "clientVersion is at least 2025.4". `io.evitadb.utils` is exported, but the method has not shipped in any release yet, so there's no external contract to preserve.

Closes #1351

## Test plan
- [x] `VersionUtilsTest.shouldReturnExpectedIsAtLeastResults` covers the boundary cases